### PR TITLE
feat(scan): Go test-scope + main-module filters (007 US2+US3)

### DIFF
--- a/mikebom-cli/src/scan_fs/package_db/go_binary.rs
+++ b/mikebom-cli/src/scan_fs/package_db/go_binary.rs
@@ -414,14 +414,20 @@ pub fn read(
     _include_dev: bool,
     claimed_paths: &std::collections::HashSet<std::path::PathBuf>,
     #[cfg(unix)] claimed_inodes: &std::collections::HashSet<(u64, u64)>,
-) -> Vec<PackageDbEntry> {
+) -> (
+    Vec<PackageDbEntry>,
+    std::collections::HashSet<String>,
+) {
     let mut out: Vec<PackageDbEntry> = Vec::new();
     let mut seen_purls: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut main_modules: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
     walk_for_binaries(
         rootfs,
         0,
         &mut out,
         &mut seen_purls,
+        &mut main_modules,
         claimed_paths,
         #[cfg(unix)]
         claimed_inodes,
@@ -430,12 +436,13 @@ pub fn read(
         tracing::info!(
             rootfs = %rootfs.display(),
             entries = out.len(),
+            main_modules = main_modules.len(),
             "extracted Go binary BuildInfo components",
         );
     } else {
         tracing::debug!(rootfs = %rootfs.display(), "no Go binaries found");
     }
-    out
+    (out, main_modules)
 }
 
 const MAX_BINARY_WALK_DEPTH: usize = 10;
@@ -445,6 +452,7 @@ fn walk_for_binaries(
     depth: usize,
     out: &mut Vec<PackageDbEntry>,
     seen_purls: &mut std::collections::HashSet<String>,
+    main_modules: &mut std::collections::HashSet<String>,
     claimed_paths: &std::collections::HashSet<std::path::PathBuf>,
     #[cfg(unix)] claimed_inodes: &std::collections::HashSet<(u64, u64)>,
 ) {
@@ -468,6 +476,7 @@ fn walk_for_binaries(
                 depth + 1,
                 out,
                 seen_purls,
+                main_modules,
                 claimed_paths,
                 #[cfg(unix)]
                 claimed_inodes,
@@ -485,6 +494,9 @@ fn walk_for_binaries(
                 // claim status, since real module information beats
                 // a package-db claim that lacks module granularity.
                 if let Some(info) = info {
+                    if let Some((ref main_path, _, _)) = info.main_module {
+                        main_modules.insert(main_path.clone());
+                    }
                     emit_entries_from_info(&info, out, seen_purls);
                 }
             }
@@ -874,7 +886,7 @@ mod tests {
         let noise = dir.path().join("README.txt");
         std::fs::write(&noise, vec![b'n'; 4096]).unwrap();
 
-        let entries = read(
+        let (entries, _) = read(
             dir.path(),
             false,
             &std::collections::HashSet::new(),
@@ -899,7 +911,7 @@ mod tests {
         blob.extend_from_slice(&[0u8; 30]);
         bin.extend_from_slice(&blob);
         std::fs::write(&p, &bin).unwrap();
-        let entries = read(
+        let (entries, _) = read(
             dir.path(),
             false,
             &std::collections::HashSet::new(),
@@ -933,7 +945,7 @@ mod tests {
         std::fs::write(&p, &bin).unwrap();
 
         // Unclaimed: diagnostic emits.
-        let unclaimed = read(
+        let (unclaimed, _) = read(
             dir.path(),
             false,
             &std::collections::HashSet::new(),
@@ -954,7 +966,7 @@ mod tests {
         #[cfg(unix)]
         let claimed_inodes: std::collections::HashSet<(u64, u64)> =
             std::collections::HashSet::new();
-        let claimed_entries = read(
+        let (claimed_entries, _) = read(
             dir.path(),
             false,
             &claimed,

--- a/mikebom-cli/src/scan_fs/package_db/golang.rs
+++ b/mikebom-cli/src/scan_fs/package_db/golang.rs
@@ -586,9 +586,27 @@ fn cache_lookup_depends(cache: &GoModCache, module: &str, version: &str) -> Vec<
 /// walk is bounded by [`MAX_PROJECT_ROOT_DEPTH`] and skips descents into
 /// `vendor/`, `.git/`, `node_modules/`, `target/`, `dist/`, and
 /// `__pycache__/` — the same shape the npm + pip readers use.
-pub fn read(rootfs: &Path, _include_dev: bool) -> Vec<PackageDbEntry> {
+/// Cross-reader signals collected during Go source-tree scanning.
+/// Consumed by the aggregation filters in `package_db::read_all`:
+///
+/// * `main_modules` — Go module paths declared as the project's own
+///   `module` directive in any scanned go.mod. Feeds the G5 filter
+///   (feature 007 US3): a project is never its own dependency.
+/// * `production_imports` — Go module paths that are reachable from
+///   at least one non-`_test.go` import anywhere in the scanned
+///   source tree. Feeds the G4 filter (feature 007 US2): modules
+///   only imported from `_test.go` files are test-scope transitives
+///   and shouldn't surface as runtime dependencies.
+#[derive(Debug, Default)]
+pub struct GoScanSignals {
+    pub main_modules: HashSet<String>,
+    pub production_imports: HashSet<String>,
+}
+
+pub fn read(rootfs: &Path, _include_dev: bool) -> (Vec<PackageDbEntry>, GoScanSignals) {
     let mut out: Vec<PackageDbEntry> = Vec::new();
     let mut seen_purls: HashSet<String> = HashSet::new();
+    let mut signals = GoScanSignals::default();
     // Discover module cache roots once per scan — N module lookups
     // would otherwise stat the same non-existent paths repeatedly.
     let cache = GoModCache::discover(rootfs);
@@ -600,7 +618,14 @@ pub fn read(rootfs: &Path, _include_dev: bool) -> Vec<PackageDbEntry> {
         );
     }
 
-    for project_root in candidate_project_roots(rootfs) {
+    // First pass: collect every project root's (doc, sums) so we can
+    // build the union of known module paths BEFORE the import-scan
+    // pass. The production-import filter (G4) needs to longest-
+    // prefix-match import strings against this union.
+    let project_roots = candidate_project_roots(rootfs);
+    let mut parsed_roots: Vec<(PathBuf, GoModDocument, Vec<GoSumEntry>)> = Vec::new();
+    let mut known_modules: Vec<String> = Vec::new();
+    for project_root in &project_roots {
         let go_mod_path = project_root.join("go.mod");
         let go_sum_path = project_root.join("go.sum");
         if !go_mod_path.is_file() {
@@ -617,27 +642,197 @@ pub fn read(rootfs: &Path, _include_dev: bool) -> Vec<PackageDbEntry> {
         } else {
             Vec::new()
         };
+        if let Some(ref main_path) = doc.module_path {
+            signals.main_modules.insert(main_path.clone());
+        }
+        for req in &doc.requires {
+            known_modules.push(req.path.clone());
+        }
+        for sum in &sums {
+            if sum.kind == GoSumKind::Module {
+                known_modules.push(sum.module.clone());
+            }
+        }
+        parsed_roots.push((project_root.clone(), doc, sums));
+    }
+    // Longest-prefix match requires the longest path to be tried first.
+    known_modules.sort_by_key(|m| std::cmp::Reverse(m.len()));
+    known_modules.dedup();
 
-        let source_path = go_sum_path
-            .to_string_lossy()
-            .into_owned();
-        let entries = build_entries_from_go_module(&doc, &sums, &source_path, &cache);
+    // Second pass: emit entries AND walk .go files for production
+    // imports.
+    for (project_root, doc, sums) in &parsed_roots {
+        let go_sum_path = project_root.join("go.sum");
+        let source_path = go_sum_path.to_string_lossy().into_owned();
+        let entries = build_entries_from_go_module(doc, sums, &source_path, &cache);
         for entry in entries {
             let purl_key = entry.purl.as_str().to_string();
             if seen_purls.insert(purl_key) {
                 out.push(entry);
             }
         }
+        // Feature 007 US2: walk .go source files under this project
+        // root (excluding `_test.go` files and test-adjacent subtrees)
+        // and record every imported module path that matches a known
+        // module in `known_modules`. Imports of stdlib or unknown
+        // paths are silently ignored.
+        collect_production_imports(
+            project_root,
+            0,
+            &known_modules,
+            &mut signals.production_imports,
+        );
     }
 
     if !out.is_empty() {
         tracing::info!(
             rootfs = %rootfs.display(),
             modules = out.len(),
+            production_imports = signals.production_imports.len(),
+            main_modules = signals.main_modules.len(),
             "parsed Go source tree",
         );
     }
+    (out, signals)
+}
+
+/// Walk a Go project root collecting production-scope imports. Skips
+/// `_test.go` files (test-scope) and any directory `should_skip_descent`
+/// says to skip. For each remaining `.go` file, extracts import paths
+/// via [`extract_go_imports`] and longest-prefix-matches each one
+/// against `known_modules`. Matches are inserted into `out`.
+///
+/// The `known_modules` slice MUST be sorted by length descending so
+/// the first prefix match is the longest (e.g., import
+/// `github.com/foo/bar/baz` correctly attributes to module
+/// `github.com/foo/bar` when both `github.com/foo` and
+/// `github.com/foo/bar` are known modules).
+fn collect_production_imports(
+    dir: &Path,
+    depth: usize,
+    known_modules: &[String],
+    out: &mut HashSet<String>,
+) {
+    if depth >= MAX_PROJECT_ROOT_DEPTH {
+        return;
+    }
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        if meta.is_dir() {
+            if should_skip_descent(&path) {
+                continue;
+            }
+            collect_production_imports(&path, depth + 1, known_modules, out);
+            continue;
+        }
+        if !meta.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if !name.ends_with(".go") {
+            continue;
+        }
+        if name.ends_with("_test.go") {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(&path) else {
+            continue;
+        };
+        for import_path in extract_go_imports(&bytes) {
+            for module in known_modules {
+                if import_path == *module
+                    || import_path.starts_with(&format!("{}/", module))
+                {
+                    out.insert(module.clone());
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Extract every `import "…"` or grouped `import ( … )` path from a Go
+/// source file. Returns the raw import path strings (e.g.,
+/// `"github.com/sirupsen/logrus"`). Hand-rolled byte scanner — Go's
+/// import syntax is simple enough that we don't need a full parser
+/// and an external crate is overkill for "find import strings."
+pub(crate) fn extract_go_imports(bytes: &[u8]) -> Vec<String> {
+    let text = match std::str::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    let mut remaining = text;
+    while let Some(idx) = remaining.find("import") {
+        let after = &remaining[idx + "import".len()..];
+        // "import" must be a keyword, not part of a longer identifier.
+        let before_is_boundary = idx == 0
+            || matches!(
+                remaining.as_bytes().get(idx.wrapping_sub(1)),
+                Some(c) if !c.is_ascii_alphanumeric() && *c != b'_'
+            );
+        let after_is_boundary = after
+            .as_bytes()
+            .first()
+            .map(|c| !c.is_ascii_alphanumeric() && *c != b'_')
+            .unwrap_or(false);
+        if !before_is_boundary || !after_is_boundary {
+            let Some(next) = remaining.get(idx + 1..) else {
+                break;
+            };
+            remaining = next;
+            continue;
+        }
+        let trimmed = after.trim_start();
+        if let Some(rest) = trimmed.strip_prefix('(') {
+            // Grouped block: consume up to matching ')'.
+            if let Some(end_rel) = rest.find(')') {
+                let block = &rest[..end_rel];
+                for line in block.lines() {
+                    if let Some(path) = parse_import_line(line) {
+                        out.push(path);
+                    }
+                }
+                remaining = &rest[end_rel + 1..];
+            } else {
+                break;
+            }
+        } else if let Some(path) = parse_import_line(trimmed) {
+            // Single-line import. Advance past the line.
+            out.push(path);
+            let Some(nl) = trimmed.find('\n') else {
+                break;
+            };
+            remaining = &trimmed[nl + 1..];
+        } else {
+            let Some(next) = remaining.get(idx + 1..) else {
+                break;
+            };
+            remaining = next;
+        }
+    }
     out
+}
+
+/// Parse a single import line. Handles optional alias (`foo "path"`,
+/// `. "path"`, `_ "path"`) and returns just the quoted path.
+fn parse_import_line(line: &str) -> Option<String> {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with("//") {
+        return None;
+    }
+    let quote_start = line.find('"')?;
+    let after = &line[quote_start + 1..];
+    let quote_end = after.find('"')?;
+    Some(after[..quote_end].to_string())
 }
 
 fn candidate_project_roots(rootfs: &Path) -> Vec<PathBuf> {
@@ -1084,7 +1279,8 @@ replace github.com/old/lib v1.0.0 => github.com/new/lib v2.0.0
     #[test]
     fn read_empty_rootfs_returns_zero() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(read(dir.path(), false).is_empty());
+        let (entries, _signals) = read(dir.path(), false);
+        assert!(entries.is_empty());
     }
 
     #[test]
@@ -1099,7 +1295,7 @@ replace github.com/old/lib v1.0.0 => github.com/new/lib v2.0.0
         .unwrap();
         std::fs::write(svc.join("go.sum"), "github.com/x/y v1.0.0 h1:ok=\n")
             .unwrap();
-        let entries = read(dir.path(), false);
+        let (entries, _) = read(dir.path(), false);
         // Workspace root (`example.com/api`) is NOT emitted; only the
         // transitive dep surfaces as a component.
         assert!(!entries.iter().any(|e| e.name == "example.com/api"));
@@ -1137,7 +1333,7 @@ replace github.com/old/lib v1.0.0 => github.com/new/lib v2.0.0
         let cache =
             dir.path().join("root/go/pkg/mod/github.com/foo/bar@v1.0.0");
         write_go_project(&cache, "github.com/foo/bar", &[("github.com/x/y", "v2.0.0")]);
-        let entries = read(dir.path(), false);
+        let (entries, _) = read(dir.path(), false);
         assert!(
             entries.is_empty(),
             "walker must skip /root/go/pkg/mod cache tree: {entries:?}",
@@ -1150,7 +1346,7 @@ replace github.com/old/lib v1.0.0 => github.com/new/lib v2.0.0
         let cache =
             dir.path().join("home/alice/go/pkg/mod/github.com/foo/bar@v1.0.0");
         write_go_project(&cache, "github.com/foo/bar", &[("github.com/x/y", "v2.0.0")]);
-        let entries = read(dir.path(), false);
+        let (entries, _) = read(dir.path(), false);
         assert!(
             entries.is_empty(),
             "walker must skip $HOME/go/pkg/mod cache tree: {entries:?}",
@@ -1164,7 +1360,7 @@ replace github.com/old/lib v1.0.0 => github.com/new/lib v2.0.0
         let dir = tempfile::tempdir().unwrap();
         let app = dir.path().join("app");
         write_go_project(&app, "example.com/app", &[("github.com/real/dep", "v1.2.3")]);
-        let entries = read(dir.path(), false);
+        let (entries, _) = read(dir.path(), false);
         assert!(
             entries.iter().any(|e| e.name == "github.com/real/dep"),
             "legitimate project root must still emit: {entries:?}",
@@ -1180,7 +1376,7 @@ replace github.com/old/lib v1.0.0 => github.com/new/lib v2.0.0
             .path()
             .join("workspace/go/pkg/mod/github.com/foo/bar@v1.0.0");
         write_go_project(&cache, "github.com/foo/bar", &[("github.com/x/y", "v2.0.0")]);
-        let entries = read(dir.path(), false);
+        let (entries, _) = read(dir.path(), false);
         assert!(
             entries.is_empty(),
             "walker must skip /workspace/go/pkg/mod cache tree: {entries:?}",

--- a/mikebom-cli/src/scan_fs/package_db/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/mod.rs
@@ -326,6 +326,78 @@ pub(crate) fn insert_claim_with_canonical(
 /// preference in `resolve::deduplicator::deduplicate` (source wins
 /// over analyzed on same-coord collision) still applies to
 /// surviving entries.
+/// G4 (feature 007 US2): drop `pkg:golang` source-tier entries whose
+/// module path is NOT reachable from any non-`_test.go` import in the
+/// scanned source tree(s). Combined with G3 (BuildInfo intersection)
+/// this implements the FR-007a intersection semantics: a module is
+/// emitted iff it's in BuildInfo (when a binary is present) AND in a
+/// production import (when source is present).
+///
+/// The filter is a no-op when `production_imports` is empty — that
+/// happens on pure-binary scans (no .go source to parse), which G3
+/// alone already handles correctly.
+fn apply_go_production_set_filter(
+    entries: &mut Vec<PackageDbEntry>,
+    production_imports: &std::collections::HashSet<String>,
+) {
+    if production_imports.is_empty() {
+        return;
+    }
+    let before = entries.len();
+    entries.retain(|e| {
+        if e.purl.ecosystem() != "golang" {
+            return true;
+        }
+        if e.sbom_tier.as_deref() != Some("source") {
+            // Analyzed-tier (BuildInfo) entries pass through; G3 is
+            // their authority.
+            return true;
+        }
+        production_imports.contains(&e.name)
+    });
+    let dropped = before.saturating_sub(entries.len());
+    if dropped > 0 {
+        tracing::info!(
+            dropped,
+            production_imports = production_imports.len(),
+            "G4 filter: dropped go.sum entries not reachable from non-_test.go imports",
+        );
+    }
+}
+
+/// G5 (feature 007 US3): drop `pkg:golang` entries whose module path
+/// matches the project's own go.mod `module` directive or a Go
+/// binary's BuildInfo `mod` line. A project is never its own
+/// dependency (spec FR-010 through FR-012).
+///
+/// Applies to ALL tiers (source + analyzed) — unlike G3/G4 which only
+/// touch source-tier entries. BuildInfo emits the main module as an
+/// analyzed-tier entry; the project-self filter must strip it
+/// regardless of tier.
+fn apply_go_main_module_filter(
+    entries: &mut Vec<PackageDbEntry>,
+    main_modules: &std::collections::HashSet<String>,
+) {
+    if main_modules.is_empty() {
+        return;
+    }
+    let before = entries.len();
+    entries.retain(|e| {
+        if e.purl.ecosystem() != "golang" {
+            return true;
+        }
+        !main_modules.contains(&e.name)
+    });
+    let dropped = before.saturating_sub(entries.len());
+    if dropped > 0 {
+        tracing::info!(
+            dropped,
+            main_modules = main_modules.len(),
+            "G5 filter: dropped main-module self-references",
+        );
+    }
+}
+
 fn apply_go_linked_filter(entries: &mut Vec<PackageDbEntry>) {
     let linked: std::collections::HashSet<(String, String)> = entries
         .iter()
@@ -469,7 +541,8 @@ pub fn read_all(
     // Gem). The stubs below return empty vectors today so the dispatcher
     // compose-order is settled and future story work only needs to touch
     // the individual reader module — no revisit of `read_all`.
-    out.extend(golang::read(rootfs, include_dev));
+    let (golang_entries, go_signals) = golang::read(rootfs, include_dev);
+    out.extend(golang_entries);
     out.extend(rpm::read(rootfs, include_dev, distro_version.as_deref()));
     // v5 Phase B: rpm-owned file claim-skip — mirrors the dpkg / apk /
     // pip pattern. Real RHEL / Fedora rpmdbs store file paths inside
@@ -489,13 +562,14 @@ pub fn read_all(
     // the time go_binary iterates, and golang-owned `link`/`compile`/
     // `asm` tools (which ship with intentionally unreadable BuildInfo)
     // would leak as `pkg:generic/link` etc.
-    out.extend(go_binary::read(
+    let (go_binary_entries, go_binary_main_modules) = go_binary::read(
         rootfs,
         include_dev,
         &claimed,
         #[cfg(unix)]
         &claimed_inodes,
-    ));
+    );
+    out.extend(go_binary_entries);
     // Milestone 004 US1: standalone `.rpm` artefact reader (stub until
     // T015–T018 land). No-op today; wiring in place so the dispatcher
     // is settled and future story work only touches rpm_file.rs.
@@ -534,6 +608,25 @@ pub fn read_all(
     // the filter no-ops when the analyzed set is empty, and go.sum
     // remains the only signal.
     apply_go_linked_filter(&mut out);
+
+    // G4 (feature 007 US2): intersection with non-`_test.go` imports.
+    // Production-import signals come only from the source-tree scanner
+    // (`golang::read`). When no Go source is parsed, this no-ops and
+    // G3 alone drives the Go filtering.
+    apply_go_production_set_filter(&mut out, &go_signals.production_imports);
+
+    // G5 (feature 007 US3): drop the project's own main module from
+    // the dependency listing. Main modules come from BOTH go.mod
+    // `module` directives (via `golang::read`) AND binary BuildInfo
+    // `mod` lines (via `go_binary::read`); union for safety when a
+    // rootfs carries multiple projects.
+    let main_modules: std::collections::HashSet<String> = go_signals
+        .main_modules
+        .iter()
+        .chain(go_binary_main_modules.iter())
+        .cloned()
+        .collect();
+    apply_go_main_module_filter(&mut out, &main_modules);
 
     Ok(DbScanResult {
         entries: out,

--- a/mikebom-cli/tests/scan_go.rs
+++ b/mikebom-cli/tests/scan_go.rs
@@ -490,3 +490,179 @@ fn scan_go_source_only_preserves_full_go_sum() {
         "also-never-linked/other must survive in source-only scan: {golang:?}",
     );
 }
+
+// --- 007 US2: Go test-scope intersection filter (G4) ------------------
+
+#[test]
+fn scan_go_source_test_only_import_is_dropped() {
+    // FR-006 / FR-007a: when a module is imported only from a
+    // `_test.go` file, the G4 filter drops its source-tier emission.
+    // Modules imported from production `.go` files are retained.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = dir.path().join("app");
+    std::fs::create_dir_all(&app).unwrap();
+    std::fs::write(
+        app.join("go.mod"),
+        "module example.com/us2\n\
+         go 1.22\n\
+         require github.com/sirupsen/logrus v1.9.4\n\
+         require github.com/stretchr/testify v1.11.1\n",
+    )
+    .unwrap();
+    std::fs::write(
+        app.join("go.sum"),
+        concat!(
+            "github.com/sirupsen/logrus v1.9.4 h1:fakeSHA/k1PS7AGV8HAP9mRGQ==\n",
+            "github.com/stretchr/testify v1.11.1 h1:fakeSHA/k1PS7AGV8HAP9mRGQ==\n",
+        ),
+    )
+    .unwrap();
+    // main.go imports logrus from production code.
+    std::fs::write(
+        app.join("main.go"),
+        "package main\n\
+         import \"github.com/sirupsen/logrus\"\n\
+         func main() { logrus.Info(\"hi\") }\n",
+    )
+    .unwrap();
+    // main_test.go imports testify — test-scope only.
+    std::fs::write(
+        app.join("main_test.go"),
+        "package main\n\
+         import (\n\
+             \"testing\"\n\
+             \"github.com/stretchr/testify/assert\"\n\
+         )\n\
+         func TestMain(t *testing.T) { assert.Equal(t, 1, 1) }\n",
+    )
+    .unwrap();
+
+    let sbom = scan_path(dir.path());
+    let golang = golang_purls(&sbom);
+    assert!(
+        golang.iter().any(|p| p.contains("sirupsen/logrus")),
+        "logrus (production import) must be retained: {golang:?}",
+    );
+    assert!(
+        !golang.iter().any(|p| p.contains("stretchr/testify")),
+        "testify (test-only import) must be dropped: {golang:?}",
+    );
+}
+
+#[test]
+fn scan_go_source_production_and_test_import_dominates() {
+    // FR-008: when a module is imported from BOTH production and
+    // test files, production wins and the module is retained.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = dir.path().join("app");
+    std::fs::create_dir_all(&app).unwrap();
+    std::fs::write(
+        app.join("go.mod"),
+        "module example.com/us2b\n\
+         go 1.22\n\
+         require github.com/sirupsen/logrus v1.9.4\n",
+    )
+    .unwrap();
+    std::fs::write(
+        app.join("go.sum"),
+        "github.com/sirupsen/logrus v1.9.4 h1:fakeSHA/k1PS7AGV8HAP9mRGQ==\n",
+    )
+    .unwrap();
+    std::fs::write(
+        app.join("main.go"),
+        "package main\n\
+         import \"github.com/sirupsen/logrus\"\n\
+         func main() { logrus.Info(\"hi\") }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        app.join("main_test.go"),
+        "package main\n\
+         import (\n\
+             \"testing\"\n\
+             \"github.com/sirupsen/logrus\"\n\
+         )\n\
+         func TestMain(t *testing.T) { logrus.Info(\"test\") }\n",
+    )
+    .unwrap();
+
+    let sbom = scan_path(dir.path());
+    let golang = golang_purls(&sbom);
+    assert!(
+        golang.iter().any(|p| p.contains("sirupsen/logrus")),
+        "logrus imported from both main.go and main_test.go must be retained: {golang:?}",
+    );
+}
+
+// --- 007 US3: Go main-module exclusion (G5) ---------------------------
+
+#[test]
+fn scan_go_main_module_from_gomod_is_suppressed() {
+    // FR-010 / FR-012: go.mod's `module` directive names the project
+    // itself. Even when go.sum somehow lists it, mikebom must drop
+    // the self-reference.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = dir.path().join("app");
+    std::fs::create_dir_all(&app).unwrap();
+    std::fs::write(
+        app.join("go.mod"),
+        "module example.com/polyglot-fixture\n\
+         go 1.22\n\
+         require github.com/sirupsen/logrus v1.9.4\n",
+    )
+    .unwrap();
+    std::fs::write(
+        app.join("go.sum"),
+        concat!(
+            "github.com/sirupsen/logrus v1.9.4 h1:fakeSHA/k1PS7AGV8HAP9mRGQ==\n",
+            // Simulated self-reference in go.sum — unusual but has
+            // happened in the wild (and it's the polyglot case):
+            "example.com/polyglot-fixture v0.0.0-000 h1:fakeSHA/k1PS7AGV8HAP9mRGQ==\n",
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        app.join("main.go"),
+        "package main\n\
+         import \"github.com/sirupsen/logrus\"\n\
+         func main() { logrus.Info(\"hi\") }\n",
+    )
+    .unwrap();
+
+    let sbom = scan_path(dir.path());
+    let golang = golang_purls(&sbom);
+    assert!(
+        !golang
+            .iter()
+            .any(|p| p.contains("example.com/polyglot-fixture")),
+        "main module self-reference must be dropped: {golang:?}",
+    );
+    // Real dep still there.
+    assert!(
+        golang.iter().any(|p| p.contains("sirupsen/logrus")),
+        "real dep must not be affected by main-module filter: {golang:?}",
+    );
+}
+
+#[test]
+fn scan_go_main_module_from_binary_buildinfo_is_suppressed() {
+    // FR-010 via BuildInfo: the hello-linux-amd64 fixture's BuildInfo
+    // declares `mod example.com/simple (devel)`. That should be
+    // dropped as a main-module self-reference.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = fixture("binaries").join("hello-linux-amd64");
+    let dst = dir.path().join("app");
+    std::fs::copy(&src, &dst).expect("copy binary");
+
+    let sbom = scan_path(dir.path());
+    let golang = golang_purls(&sbom);
+    assert!(
+        !golang.iter().any(|p| p.contains("example.com/simple")),
+        "binary's main module (example.com/simple) must be dropped: {golang:?}",
+    );
+    // Dependencies from BuildInfo must still be present.
+    assert!(
+        golang.iter().any(|p| p.contains("sirupsen/logrus")),
+        "BuildInfo dep logrus must be retained: {golang:?}",
+    );
+}


### PR DESCRIPTION
## Summary

Closes **5 of the 7 remaining polyglot-builder-image bake-off FPs** by adding two aggregation filters alongside the existing G3 filter. Both slices ship together because they touch the same files (`golang.rs`, `go_binary.rs`, `mod.rs`) and would otherwise conflict if merged separately.

### G4 — Go test-scope intersection (US2, 4 FPs)

Walks `.go` files in each Go project root, excluding `_test.go`. Extracts import paths via a hand-rolled byte scanner and longest-prefix-matches them against the union of go.sum-declared modules. The resulting production-import set intersects source-tier emissions: a module is kept iff it's reachable from non-`_test.go` code.

Closes: `testify`, `go-spew`, `go-difflib`, `yaml.v3`.

### G5 — Main-module self-reference (US3, 1 FP)

Collects the project's own module path from go.mod's `module` directive AND each Go binary's BuildInfo `mod` line (union). Drops any emitted entry whose `name` matches — applies to ALL tiers.

Closes: `example.com/polyglot-fixture@(devel)`.

### No Go toolchain invocation

Per FR-007, all signals are derived from static sources mikebom already reads. Filter order: G3 (BuildInfo intersection, pre-existing) → G4 (production imports) → G5 (main-module strip).

## Signature changes

- `golang::read` → `(Vec<PackageDbEntry>, GoScanSignals)`
- `go_binary::read` → `(Vec<PackageDbEntry>, HashSet<String>)`

Only `package_db::read_all` and in-file tests call these; all callers updated.

## Test plan

- [x] `cargo +stable clippy --workspace --all-targets` — clean
- [x] `cargo +stable test --workspace` — 1108 → 1112 passing, 0 failing
- [x] 4 new integration tests in `scan_go.rs`:
  - `scan_go_source_test_only_import_is_dropped` (US2)
  - `scan_go_source_production_and_test_import_dominates` (US2, FR-008)
  - `scan_go_main_module_from_gomod_is_suppressed` (US3)
  - `scan_go_main_module_from_binary_buildinfo_is_suppressed` (US3)
- [x] Synthetic repros:
  - `/tmp/us2repro/` — logrus retained, testify dropped ✓
  - `/tmp/us3repro/` — `example.com/polyglot-fixture` dropped, logrus retained ✓
- [ ] Bake-off on polyglot-builder-image: expect `declared_not_cached` bucket 5 → 0

## Spec references

- feature 007, User Stories 2 + 3
- FR-006 through FR-012
- Contracts: `go-production-set.md`, `main-module-exclusion.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)