### PR TITLE
feat(scan): G6 cache-ZIP Go filter (008 US2)

### DIFF
--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -486,6 +486,26 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
         }
     }
 
+    // Feature 008 US2 (G6): cache-ZIP-sourced Go components bypass
+    // G3/G4/G5 because those filters live in `package_db::read_all`
+    // and only touch `DbScanResult.entries`. The generic artifact
+    // walker above (lines 126-190) emits every file at
+    // `/go/pkg/mod/cache/download/<mod>/@v/<ver>.zip` as a
+    // `pkg:golang/<mod>@<ver>` analyzed-tier component via
+    // `path_resolver::resolve_go_path`. On polyglot-style images
+    // where `go mod tidy` populated the cache with test-scope
+    // transitives (testify / go-spew / go-difflib / yaml.v3), those
+    // transitives leak to `components[]` even though they aren't
+    // linked into the binary.
+    //
+    // When a Go binary's BuildInfo is ALSO on the same rootfs, it's
+    // authoritative for "what ships" (same rationale as G3). Drop
+    // cache-ZIP Go entries whose coord isn't confirmed by a non-cache
+    // analyzed-tier entry. Pure-scratch scans (cache present, no
+    // binary) retain all cache-ZIP entries — they're the only
+    // available signal there.
+    apply_go_cache_zip_filter(&mut components);
+
     let mut components = deduplicate(components);
     // Post-dedup CPE synthesis — runs on the merged set so a component
     // that exists in both the filename pass and the dpkg pass gets one
@@ -516,6 +536,67 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
 /// - **deb / apk / everything else** — lowercase. Debian and Alpine
 ///   treat names case-insensitively in practice; the installed db
 ///   stores them lowercase anyway but we stay tolerant.
+/// Feature 008 US2 (G6): drop `pkg:golang` analyzed-tier components
+/// whose source files are exclusively under `/go/pkg/mod/cache/download/`
+/// when a non-cache analyzed-tier Go entry (from a binary's BuildInfo)
+/// is also present on the rootfs. Cache-ZIP entries reflect what
+/// `go mod tidy` downloaded — a superset of linked modules — and leak
+/// test-scope transitives. BuildInfo reflects what the linker actually
+/// embedded.
+///
+/// When no non-cache analyzed-tier Go entry exists at all (pure scratch
+/// scan: cache present, no binary), the filter no-ops and cache-ZIP
+/// entries remain the authoritative signal. This matches the design
+/// comment at `path_resolver::resolve_go_path` line 284-294.
+///
+/// A component's source files are considered "from cache" when EVERY
+/// path listed in `evidence.source_file_paths` contains
+/// `/cache/download/`. A mixed entry (one cache source + one BuildInfo
+/// source, merged by upstream dedup) is NOT from cache and passes
+/// through.
+fn apply_go_cache_zip_filter(components: &mut Vec<mikebom_common::resolution::ResolvedComponent>) {
+    use std::collections::HashSet;
+    let buildinfo_linked: HashSet<(String, String)> = components
+        .iter()
+        .filter(|c| {
+            c.purl.ecosystem() == "golang"
+                && c.sbom_tier.as_deref() == Some("analyzed")
+                && !c
+                    .evidence
+                    .source_file_paths
+                    .iter()
+                    .all(|p| p.contains("/cache/download/"))
+        })
+        .map(|c| (c.name.clone(), c.version.clone()))
+        .collect();
+    if buildinfo_linked.is_empty() {
+        return;
+    }
+    let before = components.len();
+    components.retain(|c| {
+        if c.purl.ecosystem() != "golang" {
+            return true;
+        }
+        let from_cache_only = !c.evidence.source_file_paths.is_empty()
+            && c.evidence
+                .source_file_paths
+                .iter()
+                .all(|p| p.contains("/cache/download/"));
+        if !from_cache_only {
+            return true;
+        }
+        buildinfo_linked.contains(&(c.name.clone(), c.version.clone()))
+    });
+    let dropped = before.saturating_sub(components.len());
+    if dropped > 0 {
+        tracing::info!(
+            dropped,
+            buildinfo_linked_count = buildinfo_linked.len(),
+            "G6 filter: dropped cache-ZIP Go components not confirmed by BuildInfo",
+        );
+    }
+}
+
 fn normalize_dep_name(ecosystem: &str, name: &str) -> String {
     match ecosystem {
         "pypi" => name.replace('_', "-").to_lowercase(),

--- a/mikebom-cli/tests/scan_go.rs
+++ b/mikebom-cli/tests/scan_go.rs
@@ -666,3 +666,78 @@ fn scan_go_main_module_from_binary_buildinfo_is_suppressed() {
         "BuildInfo dep logrus must be retained: {golang:?}",
     );
 }
+
+// --- 008 US2: G6 cache-ZIP filter ---------------------------------------
+
+#[test]
+fn scan_go_cache_zip_not_in_buildinfo_is_dropped() {
+    // Feature 008 US2 polyglot scenario: rootfs contains a Go binary
+    // whose BuildInfo lists a set of linked modules, AND a
+    // `/go/pkg/mod/cache/download/` tree with EXTRA test-scope
+    // modules that the artifact walker would otherwise emit as
+    // analyzed-tier golang components. G6 must drop the cache-ZIP-
+    // only entries whose coord isn't also in BuildInfo.
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Place the Go binary so its BuildInfo provides the linked set:
+    // example.com/simple links logrus + ~8 other modules (see
+    // `go version -m tests/fixtures/go/binaries/hello-linux-amd64`).
+    let src = fixture("binaries").join("hello-linux-amd64");
+    std::fs::copy(&src, dir.path().join("app")).expect("copy binary");
+    // Synthesize cache-ZIP entries for modules NOT in the binary's
+    // BuildInfo. Both must be dropped by G6. (Every module the
+    // hello-linux-amd64 fixture actually links is uninteresting
+    // here — it's the non-linked extras that should get dropped.)
+    let cache_dir = dir.path().join("root/go/pkg/mod/cache/download");
+    let orphan_a = cache_dir.join("github.com/never-linked/fake/@v");
+    let orphan_b = cache_dir.join("gopkg.in/bogus-test-helper.v2/@v");
+    std::fs::create_dir_all(&orphan_a).unwrap();
+    std::fs::create_dir_all(&orphan_b).unwrap();
+    // The path_resolver only needs the filename to match the
+    // `<version>.zip` pattern; file contents aren't inspected.
+    std::fs::write(orphan_a.join("v9.9.9.zip"), b"\x50\x4b\x03\x04fake zip").unwrap();
+    std::fs::write(orphan_b.join("v2.0.0.zip"), b"\x50\x4b\x03\x04fake zip").unwrap();
+
+    let sbom = scan_path(dir.path());
+    let golang = golang_purls(&sbom);
+
+    // Both orphan modules are in cache but NOT in BuildInfo → G6
+    // drops them.
+    assert!(
+        !golang.iter().any(|p| p.contains("never-linked/fake")),
+        "never-linked/fake from cache/download/ must be dropped by \
+         G6 since it isn't in the binary's BuildInfo: {golang:?}",
+    );
+    assert!(
+        !golang
+            .iter()
+            .any(|p| p.contains("bogus-test-helper")),
+        "bogus-test-helper from cache/download/ must be dropped: {golang:?}",
+    );
+    // BuildInfo deps must still be emitted (regression guard — G6
+    // must not over-suppress).
+    assert!(
+        golang.iter().any(|p| p.contains("sirupsen/logrus")),
+        "logrus from BuildInfo must be retained: {golang:?}",
+    );
+}
+
+#[test]
+fn scan_go_cache_zip_alone_is_retained_when_no_binary() {
+    // Scratch/distroless scenario: ONLY cache-ZIP entries, no Go
+    // binary on the rootfs. G6 must no-op and preserve cache-ZIP
+    // entries as the authoritative signal (the "distroless win"
+    // preserved per path_resolver::resolve_go_path design).
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache_dir = dir.path().join("root/go/pkg/mod/cache/download");
+    let logrus_dir = cache_dir.join("github.com/sirupsen/logrus/@v");
+    std::fs::create_dir_all(&logrus_dir).unwrap();
+    std::fs::write(logrus_dir.join("v1.9.4.zip"), b"\x50\x4b\x03\x04fake zip").unwrap();
+
+    let sbom = scan_path(dir.path());
+    let golang = golang_purls(&sbom);
+    assert!(
+        golang.iter().any(|p| p.contains("sirupsen/logrus@v1.9.4")),
+        "scratch scan must retain cache-ZIP entry when no \
+         BuildInfo contradicts: {golang:?}",
+    );
+}


### PR DESCRIPTION
## Summary

Closes **4 of the 6 remaining polyglot-builder-image FPs** (testify, go-spew, go-difflib, yaml.v3) identified by the 008 US1 investigation (PR #12).

## Root cause

Per `investigation.md`: G3, G4, G5 all live inside `package_db::read_all` and only touch `DbScanResult.entries`. The four Go FPs appear at `sbom_tier = "analyzed"` but are NOT emitted by `go_binary::read` — they come from the **generic artifact walker** in `scan_fs/mod.rs:126-190`, which calls `path_resolver::resolve_go_path` to map any file at `/go/pkg/mod/cache/download/<mod>/@v/<ver>.zip` to a `pkg:golang/<mod>@<ver>` component. That emission path bypasses every package_db filter.

Synthetic US2/US3 fixtures never populated the `/cache/download/` tree, so the lab tests passed — same M4 → G3 lab-vs-real pattern the post-mortem called out.

## Fix

New `apply_go_cache_zip_filter` (G6) in `scan_fs/mod.rs::scan_path` runs on the merged components list before dedup:

1. Build "BuildInfo-confirmed" set = golang analyzed-tier entries with at least one source-file path OUTSIDE `/cache/download/` (i.e., from `go_binary::read`'s BuildInfo output).
2. If empty → no-op (scratch scan preserving the `path_resolver::resolve_go_path:284-294` "distroless win").
3. Otherwise drop any golang component whose source-file paths are ENTIRELY under `/cache/download/` AND whose coord isn't in the BuildInfo-confirmed set.

## Test plan

- [x] `cargo +stable clippy --workspace --all-targets` — clean
- [x] `cargo +stable test --workspace` — **1119 → 1121 passing**, 0 failing
  - `scan_go_cache_zip_not_in_buildinfo_is_dropped` — cache-ZIP orphans dropped, BuildInfo deps retained
  - `scan_go_cache_zip_alone_is_retained_when_no_binary` — scratch scan preserved
- [x] End-to-end scan of actual extracted polyglot rootfs:
  - Pre-fix: 4 FPs present as `pkg:golang/...@analyzed` sourced from `/cache/download/.../@v/*.zip`
  - Post-fix: all 4 FPs absent; `components[]` drops 868 → 864 (exactly the 4 expected, no collateral damage)

## Spec references

- feature 008, User Story 2
- `investigation.md` (PR #12 merged) — "R5 Option D" fix identified
- FR-004, FR-006 (preserve US2 synthetic-fixture test behaviors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)