### PR TITLE
feat(scan): Maven target/-dir path heuristic (008 US3)

### DIFF
--- a/mikebom-cli/src/scan_fs/package_db/maven.rs
+++ b/mikebom-cli/src/scan_fs/package_db/maven.rs
@@ -1111,6 +1111,38 @@ pub(crate) struct EmbeddedMavenMeta {
 /// the embedded `pom.xml`'s `<dependencies>` list when that file is
 /// present alongside. Refuses zip-slip attempts by rejecting any
 /// entry whose normalised path contains `..`.
+/// Feature 008 US3: true when `jar_path` lives directly inside a
+/// directory named `target/`. This is the canonical Maven build
+/// output location (`<project>/target/<artifactId>-<version>.jar`).
+/// Used alongside `jar_stem_matches_coord` to distinguish an
+/// unclaimed build-output JAR (scan subject) from any other unclaimed
+/// JAR (which may legitimately be a dependency).
+pub(crate) fn jar_is_under_maven_target_dir(jar_path: &Path) -> bool {
+    jar_path
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .map(|n| n == "target")
+        .unwrap_or(false)
+}
+
+/// Feature 008 US3: true when `jar_path`'s filename stem (minus the
+/// `.jar` suffix) equals `<artifact_id>-<version>`. Maven's default
+/// packaging convention produces exactly this naming. A dependency
+/// JAR placed into a `target/` directory wouldn't match both
+/// predicates at once unless it was literally rebuilt there — which
+/// would make it a legitimate scan subject anyway.
+pub(crate) fn jar_stem_matches_coord(jar_path: &Path, coord: &PomProperties) -> bool {
+    let Some(name) = jar_path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    let Some(stem) = name.strip_suffix(".jar") else {
+        return false;
+    };
+    let expected = format!("{}-{}", coord.artifact_id, coord.version);
+    stem == expected
+}
+
 /// Feature 007 US4: check whether a JAR's manifest declares an
 /// executable entry point (`Main-Class: …`). Executable JARs are
 /// almost always build outputs (shade-plugin / spring-boot-plugin /
@@ -2226,16 +2258,43 @@ pub fn read_with_claims(
                 let is_executable_unclaimed_jar = meta.is_primary
                     && co_owned_by.is_none()
                     && jar_has_main_class_manifest(std::path::Path::new(&source_path));
+                // Feature 008 US3: Maven `target/`-dir path heuristic.
+                // Canonical Maven build output: `<project>/target/
+                // <artifactId>-<version>.jar`. When an unclaimed JAR
+                // lives directly inside a directory named `target/`
+                // AND its filename stem exactly matches its primary
+                // coord's `<artifactId>-<version>`, it is — by
+                // convention — the scan subject, not a dependency.
+                //
+                // The combination is very high-specificity: a
+                // dependency JAR at `/usr/share/java/<name>.jar` has
+                // no `target/` parent dir, so no over-suppression.
+                // Closes the sbom-fixture@1.0.0 polyglot FP that
+                // escapes both the `meta_list.len() >= 2` fat-jar
+                // gate (single coord) and the US4 Main-Class gate
+                // (ordinary Maven JAR Plugin output, no Main-Class).
+                let is_maven_target_dir_jar = meta.is_primary
+                    && co_owned_by.is_none()
+                    && jar_is_under_maven_target_dir(
+                        std::path::Path::new(&source_path),
+                    )
+                    && jar_stem_matches_coord(
+                        std::path::Path::new(&source_path),
+                        &meta.coord,
+                    );
                 if target_name_matches
                     || is_unclaimed_fat_jar
                     || is_executable_unclaimed_jar
+                    || is_maven_target_dir_jar
                 {
                     let reason = if target_name_matches {
                         "target-name-match"
                     } else if is_unclaimed_fat_jar {
                         "unclaimed-fat-jar-heuristic"
-                    } else {
+                    } else if is_executable_unclaimed_jar {
                         "executable-jar-heuristic"
+                    } else {
+                        "maven-target-dir-heuristic"
                     };
                     tracing::debug!(
                         artifact_id = %meta.coord.artifact_id,
@@ -2431,6 +2490,73 @@ mod tests {
     fn main_class_manifest_returns_false_when_no_manifest() {
         let tmp = write_jar_with_entries(&[("SomeClass.class", b"not-a-manifest")]);
         assert!(!jar_has_main_class_manifest(tmp.path()));
+    }
+
+    #[test]
+    fn target_dir_detected_for_canonical_maven_path() {
+        assert!(jar_is_under_maven_target_dir(std::path::Path::new(
+            "/opt/javaapp/target/sbom-fixture-1.0.0.jar"
+        )));
+        assert!(jar_is_under_maven_target_dir(std::path::Path::new(
+            "/home/dev/myproj/target/foo-2.0.jar"
+        )));
+    }
+
+    #[test]
+    fn target_dir_rejects_other_paths() {
+        assert!(!jar_is_under_maven_target_dir(std::path::Path::new(
+            "/usr/share/java/guava.jar"
+        )));
+        assert!(!jar_is_under_maven_target_dir(std::path::Path::new(
+            "/usr/lib/java/target-bundle.jar"
+        )));
+        // A JAR nested deeper than the immediate target/ parent
+        // (target/subfolder/X.jar) should NOT trigger — Maven
+        // doesn't produce that layout.
+        assert!(!jar_is_under_maven_target_dir(std::path::Path::new(
+            "/opt/app/target/classes/extra/x.jar"
+        )));
+    }
+
+    #[test]
+    fn stem_matches_coord_canonical() {
+        let coord = PomProperties {
+            group_id: "com.example".to_string(),
+            artifact_id: "sbom-fixture".to_string(),
+            version: "1.0.0".to_string(),
+        };
+        assert!(jar_stem_matches_coord(
+            std::path::Path::new("/opt/javaapp/target/sbom-fixture-1.0.0.jar"),
+            &coord,
+        ));
+    }
+
+    #[test]
+    fn stem_matches_coord_rejects_mismatched_names() {
+        let coord = PomProperties {
+            group_id: "com.example".to_string(),
+            artifact_id: "sbom-fixture".to_string(),
+            version: "1.0.0".to_string(),
+        };
+        // Different artifactId.
+        assert!(!jar_stem_matches_coord(
+            std::path::Path::new("/opt/app/target/other-library-1.0.0.jar"),
+            &coord,
+        ));
+        // Different version.
+        assert!(!jar_stem_matches_coord(
+            std::path::Path::new("/opt/app/target/sbom-fixture-2.0.0.jar"),
+            &coord,
+        ));
+        // Trailing classifier (e.g. `-jar-with-dependencies`) —
+        // intentionally does NOT match. The broader fat-jar
+        // heuristic handles those.
+        assert!(!jar_stem_matches_coord(
+            std::path::Path::new(
+                "/opt/app/target/sbom-fixture-1.0.0-jar-with-dependencies.jar"
+            ),
+            &coord,
+        ));
     }
 
     #[test]

--- a/mikebom-cli/tests/scan_maven_executable_jar.rs
+++ b/mikebom-cli/tests/scan_maven_executable_jar.rs
@@ -91,6 +91,130 @@ fn executable_jar_primary_coord_is_suppressed_from_components() {
     );
 }
 
+// --- 008 US3: Maven `target/`-dir path heuristic ---------------------------
+
+/// Build a synthetic Maven build-output JAR: single primary coord,
+/// NO `Main-Class:` in the manifest (i.e., ordinary `mvn package`
+/// output — matches the polyglot sbom-fixture-1.0.0.jar shape).
+/// The JAR is placed under `<root>/opt/app/target/<a>-<v>.jar`.
+fn build_ordinary_maven_jar(target_dir: &std::path::Path, artifact: &str, version: &str) {
+    use std::io::Write;
+    std::fs::create_dir_all(target_dir).unwrap();
+    let jar_path = target_dir.join(format!("{artifact}-{version}.jar"));
+    let file = std::fs::File::create(&jar_path).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let options = zip::write::FileOptions::default()
+        .compression_method(zip::CompressionMethod::Stored);
+    // Plain Maven JAR Plugin manifest — no Main-Class.
+    zip.start_file("META-INF/MANIFEST.MF", options).unwrap();
+    zip.write_all(
+        b"Manifest-Version: 1.0\n\
+          Created-By: Maven JAR Plugin 3.3.0\n\
+          Build-Jdk-Spec: 21\n",
+    )
+    .unwrap();
+    // The primary coord's pom.properties.
+    let pom_dir = format!("META-INF/maven/com.example/{artifact}/");
+    zip.start_file(format!("{pom_dir}pom.properties"), options)
+        .unwrap();
+    zip.write_all(
+        format!(
+            "groupId=com.example\nartifactId={artifact}\nversion={version}\n"
+        )
+        .as_bytes(),
+    )
+    .unwrap();
+    zip.start_file(format!("{pom_dir}pom.xml"), options).unwrap();
+    zip.write_all(
+        format!(
+            "<?xml version=\"1.0\"?><project xmlns=\"http://maven.apache.org/POM/4.0.0\">\
+             <modelVersion>4.0.0</modelVersion>\
+             <groupId>com.example</groupId>\
+             <artifactId>{artifact}</artifactId>\
+             <version>{version}</version></project>"
+        )
+        .as_bytes(),
+    )
+    .unwrap();
+    zip.finish().unwrap();
+}
+
+#[test]
+fn ordinary_maven_target_jar_is_suppressed_via_target_dir_heuristic() {
+    // Mirrors the polyglot sbom-fixture scenario: a single-coord
+    // Maven JAR under `target/` with no Main-Class. Neither the
+    // classic fat-jar heuristic (needs ≥2 embedded coords) nor
+    // US4's Main-Class gate fires. US3's `target/`-dir heuristic
+    // must catch it.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let target_dir = dir.path().join("opt/javaapp/target");
+    build_ordinary_maven_jar(&target_dir, "sbom-fixture", "1.0.0");
+
+    let sbom = scan_path(dir.path());
+    let purls = maven_purls(&sbom);
+    assert!(
+        !purls
+            .iter()
+            .any(|p| p.contains("com.example/sbom-fixture")),
+        "Maven build-output JAR under target/ must be suppressed by \
+         the 008 US3 target-dir heuristic; got {:?}",
+        purls
+    );
+}
+
+#[test]
+fn ordinary_maven_jar_outside_target_dir_is_emitted() {
+    // Regression guard: a dependency JAR sitting at a non-`target/`
+    // path must NOT be suppressed, even if it has a single primary
+    // coord + no Main-Class (same shape as the suppression case
+    // except for the path).
+    let dir = tempfile::tempdir().expect("tempdir");
+    let lib_dir = dir.path().join("usr/share/java");
+    build_ordinary_maven_jar(&lib_dir, "commons-lib", "2.5.0");
+    // Rename to match `<artifact>-<version>.jar` — already the
+    // default from build_ordinary_maven_jar. The parent dir name
+    // (`java/`, not `target/`) is what keeps US3 from firing.
+
+    let sbom = scan_path(dir.path());
+    let purls = maven_purls(&sbom);
+    assert!(
+        purls
+            .iter()
+            .any(|p| p.contains("com.example/commons-lib")),
+        "dependency JAR outside target/ must still be emitted: {:?}",
+        purls
+    );
+}
+
+#[test]
+fn maven_target_dir_jar_with_mismatched_stem_is_emitted() {
+    // Edge case: a JAR under `target/` whose filename stem does
+    // NOT match the primary coord. This happens with custom
+    // finalName Maven configs. US3 does NOT suppress (only the
+    // narrow canonical-naming case triggers). If the user wants
+    // suppression for renamed JARs, `--scan-target-name` covers it.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let target_dir = dir.path().join("opt/custom/target");
+    std::fs::create_dir_all(&target_dir).unwrap();
+    // Build the JAR at a path that won't match the stem (we rename
+    // after creating).
+    build_ordinary_maven_jar(&target_dir, "sbom-fixture", "1.0.0");
+    let original = target_dir.join("sbom-fixture-1.0.0.jar");
+    let renamed = target_dir.join("my-custom-name.jar");
+    std::fs::rename(&original, &renamed).unwrap();
+
+    let sbom = scan_path(dir.path());
+    let purls = maven_purls(&sbom);
+    assert!(
+        purls
+            .iter()
+            .any(|p| p.contains("com.example/sbom-fixture")),
+        "JAR under target/ with mismatched filename stem must NOT \
+         be suppressed by US3 alone: {:?}",
+        purls
+    );
+}
+
 #[test]
 fn executable_jar_self_coord_promoted_to_metadata_component() {
     // The suppressed primary coord is surfaced via ScanTargetCoord


### PR DESCRIPTION
## Summary

Closes the **`com.example/sbom-fixture@1.0.0` polyglot FP** identified by the 008 US1 investigation (PR #12) as escaping both the classic fat-jar gate (single coord) and the 007 US4 Main-Class gate (ordinary Maven JAR Plugin output — no Main-Class).

## Root cause

Per `investigation.md`, the sbom-fixture JAR is an ordinary `mvn package` output at `/opt/javaapp/target/sbom-fixture-1.0.0.jar`. Its manifest contains only `Manifest-Version` / `Created-By: Maven JAR Plugin 3.3.0` / `Build-Jdk-Spec: 21` — no `Main-Class`. Only one `META-INF/maven/` entry. Neither existing scan-subject heuristic covers this shape.

## Fix

New fourth branch in the scan-subject gate at `maven::read_with_claims`:

```rust
let is_maven_target_dir_jar =
    meta.is_primary
    && co_owned_by.is_none()
    && jar_is_under_maven_target_dir(<jar path>)
    && jar_stem_matches_coord(<jar path>, &meta.coord);
```

Triggers ONLY when all four conditions hold — canonical Maven build layout `<project>/target/<artifactId>-<version>.jar`. Narrow enough that library JARs under `/usr/share/java/` aren't over-suppressed, and custom-finalName Maven configs fail the stem-match (they still have `--scan-target-name` as the escape hatch).

Suppressed coord routes through the existing `ScanTargetCoord` path (M3), so sbom-fixture is also **automatically promoted to CDX `metadata.component`** — FR-008's SHOULD clause satisfied.

## Test plan

- [x] `cargo +stable clippy --workspace --all-targets` — clean
- [x] `cargo +stable test --workspace` — **1119 → 1126 passing**, 0 failing
  - 4 new unit tests covering both helpers' canonical + negative cases
  - 3 new integration tests:
    - `ordinary_maven_target_jar_is_suppressed_via_target_dir_heuristic` — closes the polyglot scenario
    - `ordinary_maven_jar_outside_target_dir_is_emitted` — regression guard for library JARs under `/usr/share/java/`
    - `maven_target_dir_jar_with_mismatched_stem_is_emitted` — custom-finalName edge case stays emitted
- [x] End-to-end scan of extracted polyglot rootfs:
  - Pre-fix: `pkg:maven/com.example/sbom-fixture@1.0.0` in `components[]` as `sbom_tier = "analyzed"`
  - Post-fix: absent from `components[]`; **promoted to `metadata.component.purl`**
  - `components[]` count 868 → 867 (exact)

## Spec references

- feature 008, User Story 3
- `investigation.md` (PR #12) — Maven target-dir heuristic proposed
- FR-007 (local), FR-008 (SHOULD promotion — satisfied), FR-009 (preserve US4 tests)

## Combined state after this PR + PR #13 merge

| FP | Status |
|---|---|
| testify, go-spew, go-difflib, yaml.v3 | **closed** by PR #13 (G6) |
| sbom-fixture | **closed** by this PR (US3 target/-dir heuristic) |
| commons-compress 1.21 vs 1.23.0 | Documented as known behavior in upcoming Story 4 PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)