### PR TITLE
constitution: amend Principle V to permit SPDX 2.3 alongside SPDX 3.x

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -2,23 +2,25 @@
   ============================================================
   SYNC IMPACT REPORT
   ============================================================
-  Version change: 1.2.0 → 1.2.1
-  Bump rationale: PATCH — codified the pre-PR verification
-  workflow that CI already enforces. No principle changes,
-  no new principles. Prompted by a PR that passed
-  `cargo test -p mikebom` locally but failed CI with 14
-  `clippy::unwrap_used` errors in test code.
+  Version change: 1.2.1 → 1.3.0
+  Bump rationale: MINOR — Principle V (Specification Compliance)
+  materially expanded. The SPDX bullet now permits both SPDX 2.3
+  and SPDX 3.x (instead of pinning SPDX 3.1, which is currently
+  rc1). Adds a new normative requirement: experimental / opt-in
+  SPDX 3 emitters MUST be visibly labeled in CLI help, output
+  filename, and document creator metadata. Prompted by milestone
+  010 (SPDX Output Support), which ships SPDX 2.3 as the primary
+  output and an opt-in SPDX 3.0.1 stub.
 
   Modified sections:
-    - Development Workflow → new subsection "Pre-PR
-      Verification (MANDATORY)" naming the two exact commands
-      CI runs and the `#[cfg_attr(test, allow(clippy::unwrap_used))]`
-      guard required on test modules that use `.unwrap()`.
+    - Principle V → SPDX bullet rewritten; rationale extended
+      with deployed-ecosystem context.
 
-  Added sections: none (new subsection under existing section)
+  Added sections: none
   Removed sections: none
 
   Previous SYNC IMPACT history:
+    - 1.2.0 → 1.2.1: PATCH — codified pre-PR verification.
     - 1.1.0 → 1.2.0: MINOR — new principle XII (External Data
       Source Enrichment); principle II + strict boundary #1
       amended to distinguish discovery from enrichment.
@@ -112,7 +114,16 @@ Generated SBOMs MUST strictly conform to:
   "Generation Context" reflecting active build-time trace.
 - **CycloneDX 1.6** — valid JSON or XML serialization via
   `cyclonedx-bom` or the `sbom-rs` ecosystem.
-- **SPDX 3.1** — when SPDX output is requested.
+- **SPDX 2.3 and SPDX 3.x** — when SPDX output is requested.
+  Output MUST conform to the SPDX 2.3 JSON schema for the
+  stable `spdx-2.3-json` format, and to the targeted SPDX
+  3.x JSON schema (currently 3.0.1; subsequent 3.x minors
+  may be adopted in follow-up milestones) for any SPDX 3
+  emitter. Experimental or opt-in SPDX 3 emitters MUST be
+  visibly labeled as such — in CLI `--help` text, in the
+  output filename, and in the produced document's
+  creator/tool metadata — so that consumers cannot mistake
+  them for production-grade output.
 - **PURL Specification** — every Package URL emitted MUST
   conform to the PURL spec. Invalid PURLs MUST NOT appear
   in output.
@@ -125,6 +136,14 @@ a blocking bug.
 technically defensible SBOMs. A spec-conformant document
 containing malformed PURLs is still non-compliant.
 Sub-element validity is as critical as envelope validity.
+SPDX 2.3 remains the dominant deployed SPDX version across
+the SBOM consumer ecosystem — federal procurement pipelines,
+sbomqs, syft/grype/trivy interop, and the LF SPDX tools
+validator all expect 2.3 today. SPDX 3.x (currently 3.0.1
+stable, 3.1-rc1 in flight) is the forward path. Permitting
+both lets mikebom serve current adopters without locking
+out future ones; the experimental-labeling requirement
+preserves consumer trust during the transition.
 
 ### VI. Three-Crate Architecture
 
@@ -395,4 +414,4 @@ changes do not violate any principle. Violations require
 either a code fix or a constitution amendment — never silent
 deviation.
 
-**Version**: 1.2.0 | **Ratified**: 2026-04-15 | **Last Amended**: 2026-04-16
+**Version**: 1.3.0 | **Ratified**: 2026-04-15 | **Last Amended**: 2026-04-23


### PR DESCRIPTION
## Summary

- Amend Principle V (Specification Compliance) to permit both **SPDX 2.3** and **SPDX 3.x** when SPDX output is requested, replacing the prior "SPDX 3.1" pin (which is currently `rc1`).
- Add a new normative requirement: experimental / opt-in SPDX 3 emitters MUST be visibly labeled as such in CLI `--help` text, output filename, and produced document creator/tool metadata.
- Bump constitution version: **1.2.1 → 1.3.0** (MINOR — existing principle materially expanded; new normative requirement added).

## Why now

- SPDX 2.3 is still the overwhelmingly deployed SPDX version across the SBOM consumer ecosystem (federal procurement pipelines, sbomqs, syft/grype/trivy interop, the LF SPDX tools validator).
- SPDX 3.1 is currently `rc1` (2026-01-24); the latest stable 3.x minor is 3.0.1 (2024-12-12). Pinning the constitution to a release candidate doesn't make sense.
- Milestone 010 (SPDX Output Support) ships SPDX 2.3 as the primary output and an opt-in SPDX 3.0.1 stub. This PR brings Principle V in line with that design — without it, milestone 010 would ship under a documented constitutional deviation.

## Changes

- Principle V SPDX bullet rewritten to permit SPDX 2.3 + SPDX 3.x and require visible experimental-emitter labeling.
- Rationale extended to cite the deployed-ecosystem context.
- SYNC IMPACT REPORT block updated with the 1.2.1 → 1.3.0 entry; previous 1.2.0 → 1.2.1 entry moved to history.
- Version footer bumped to 1.3.0 (also fixes a pre-existing inconsistency where the previous patch bumped the SYNC IMPACT REPORT header to 1.2.1 but left the footer at 1.2.0).

## Test plan

- [ ] Confirm Principle V text reads as intended after merge.
- [ ] Confirm version footer + SYNC IMPACT REPORT block reflect 1.3.0.
- [ ] Spot-check that no other constitution sections were touched (\`git diff main..HEAD .specify/memory/constitution.md\` should show changes only to lines 1–35, 106–134, and 398).
- [ ] After merge, milestone 010's plan.md Constitution Check row for Principle V will read ✅ PASS instead of ⚠ DEVIATION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)