### PR TITLE
probe: deliberately broken (DO NOT MERGE — SC-003 verification)

### DIFF
--- a/mikebom-cli/src/lib.rs
+++ b/mikebom-cli/src/lib.rs
@@ -28,3 +28,11 @@
 //! function code that benefits from being importable by tests.
 
 pub mod parity;
+
+
+// Probe for milestone-016 SC-003: deliberately-dead private function to
+// verify the new CI gate fails on a new clippy warning. To be deleted
+// before merge — this branch is opened ONLY to confirm CI rejects new
+// warnings. `pub` items don't trigger `dead_code` (they're part of the
+// public API surface), so the probe must be private to fire the lint.
+fn deliberate_dead_code_probe_for_sc003() {}


### PR DESCRIPTION
## Purpose

Verify that the milestone-016 \`-D warnings\` CI gate (Linux + macOS jobs) actually fails when a new clippy warning is introduced. This is the SC-003 acceptance test from \`specs/016-remaining-clippy-cleanup/spec.md\`.

**This PR will be closed without merging.** Both CI jobs are EXPECTED to fail. Once that's confirmed, this PR + branch get deleted.

## What it does

Adds a deliberately-dead private function to \`mikebom-cli/src/lib.rs\`:

\`\`\`rust
fn deliberate_dead_code_probe_for_sc003() {}
\`\`\`

The function is private (so \`pub\`-API exemption doesn't apply) and unused (so \`dead_code\` fires).

## Expected outcome

Both \`Lint + test (linux-x86_64)\` and \`Lint + test (macos-latest)\` MUST fail with:

> error: function \`deliberate_dead_code_probe_for_sc003\` is never used
> note: \`-D dead-code\` implied by \`-D warnings\`

If both jobs fail with this message, the gate is verified working as designed and this PR is closed.

If either job passes, the gate has a hole and milestone-016 needs a follow-up to fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)