### PR TITLE
test: finish workspace_root() dedup + add scripts/pre-pr.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,10 @@ a subset, BOTH:
 1. `cargo +stable clippy --workspace --all-targets` — zero errors
 2. `cargo +stable test --workspace` — every suite `ok. N passed; 0 failed`
 
+`./scripts/pre-pr.sh` runs both in order and exits non-zero on the
+first failure — preferred over invoking them by hand so the flag
+set stays aligned with CI.
+
 These are the exact commands CI runs (`.github/workflows/ci.yml`).
 `cargo test -p mikebom` alone is insufficient: it does not run clippy,
 and clippy's `--all-targets` enforces `clippy::unwrap_used` inside

--- a/mikebom-cli/tests/cdx_regression.rs
+++ b/mikebom-cli/tests/cdx_regression.rs
@@ -19,7 +19,8 @@ use std::process::Command;
 
 
 mod common;
-use common::{EcosystemCase, CASES};
+use common::{workspace_root, EcosystemCase, CASES};
+
 /// Deterministic placeholders used in both the pinned golden files
 /// and the normalized freshly-produced output. The field values
 /// themselves are guaranteed-volatile per the CycloneDX spec (a v4
@@ -33,12 +34,7 @@ const TIMESTAMP_PLACEHOLDER: &str = "1970-01-01T00:00:00Z";
 /// Macs emit `/Users/<user>/Projects/mikebom/...`; CI Linux emits
 /// `/home/runner/work/mikebom/mikebom/...`; both rewrite to
 /// `<WORKSPACE>` for cross-host byte comparison.
-const WORKSPACE_PLACEHOLDER: &str = "<WORKSPACE>";fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+const WORKSPACE_PLACEHOLDER: &str = "<WORKSPACE>";
 
 fn fixture_path(subpath: &str) -> PathBuf {
     workspace_root().join("tests/fixtures").join(subpath)

--- a/mikebom-cli/tests/common/mod.rs
+++ b/mikebom-cli/tests/common/mod.rs
@@ -24,13 +24,21 @@
 //!   integration-test machinery. Before this module, ~10 files
 //!   had a private `fn bin() -> &'static str { env!("CARGO_BIN_EXE_mikebom") }`.
 //!
+//! * [`workspace_root`] — the absolute path to the workspace root
+//!   (the parent of `mikebom-cli/`). Used by tests that need to
+//!   locate `tests/fixtures/` from the workspace root rather than
+//!   from the test crate's own `CARGO_MANIFEST_DIR`. Before this
+//!   module, 21 files carried byte-identical copies.
+//!
 //! Tests that don't need either helper don't need `mod common;`.
-//! Tests that need only one of the two still cost nothing: the
+//! Tests that need only one of the three still cost nothing: the
 //! `#[allow(dead_code)]` annotations below silence the per-test-file
 //! "this item is unused" warnings that would otherwise fire when
 //! a test imports `common` but uses (e.g.) only `bin()`.
 
 #![allow(dead_code)]
+
+use std::path::PathBuf;
 
 /// One row of the cross-format-test fixture matrix. `label` names
 /// the golden file or test report; `fixture_subpath` is appended to
@@ -66,4 +74,20 @@ pub const CASES: &[EcosystemCase] = &[
 /// `Command::new(common::bin())`.
 pub fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_mikebom")
+}
+
+/// Absolute path to the workspace root — the parent of
+/// `mikebom-cli/`, where `tests/fixtures/` lives. Tests that need to
+/// locate fixtures, goldens, or sibling crates start here.
+///
+/// `CARGO_MANIFEST_DIR` for an integration test resolves to the
+/// containing crate's manifest dir (`mikebom-cli/`); the workspace
+/// root is one level up. The `.parent()` lookup is infallible for any
+/// crate that lives in a workspace; tests panicking here would mean a
+/// truly broken cargo invocation.
+pub fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
 }

--- a/mikebom-cli/tests/component_count_parity.rs
+++ b/mikebom-cli/tests/component_count_parity.rs
@@ -23,18 +23,13 @@
 //! regression), or a new synthetic root was introduced (a structural
 //! change that should be caught at review time).
 
-use std::path::PathBuf;
 use std::process::Command;
 
 
 mod common;
-use common::{EcosystemCase, CASES};
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}struct Scan {
+use common::{workspace_root, EcosystemCase, CASES};
+
+struct Scan {
     cdx: serde_json::Value,
     spdx23: serde_json::Value,
     spdx3: serde_json::Value,

--- a/mikebom-cli/tests/cpe_v3_acceptance.rs
+++ b/mikebom-cli/tests/cpe_v3_acceptance.rs
@@ -11,18 +11,10 @@
 //!
 //! One `#[test]` per ecosystem so a failure names the offender.
 
-use std::path::PathBuf;
 use std::process::Command;
 
 mod common;
-use common::{EcosystemCase, CASES};
-
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+use common::{workspace_root, EcosystemCase, CASES};
 
 struct Scan {
     cdx: serde_json::Value,

--- a/mikebom-cli/tests/format_dispatch.rs
+++ b/mikebom-cli/tests/format_dispatch.rs
@@ -13,13 +13,7 @@ use std::process::Command;
 
 
 mod common;
-use common::bin;
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+use common::{bin, workspace_root};
 
 /// Canonical cargo fixture — small, offline-friendly, and already
 /// pinned by `cdx_regression.rs`. Choosing one fixture keeps these

--- a/mikebom-cli/tests/holistic_parity.rs
+++ b/mikebom-cli/tests/holistic_parity.rs
@@ -23,13 +23,7 @@ use mikebom::parity::{catalog, extractors};
 
 
 mod common;
-use common::{EcosystemCase, CASES};
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+use common::{workspace_root, EcosystemCase, CASES};
 
 fn mapping_doc_path() -> PathBuf {
     workspace_root().join("docs/reference/sbom-format-mapping.md")

--- a/mikebom-cli/tests/mapping_doc_bidirectional.rs
+++ b/mikebom-cli/tests/mapping_doc_bidirectional.rs
@@ -30,13 +30,7 @@ use mikebom::parity::catalog::{
 
 
 mod common;
-use common::{EcosystemCase, CASES};
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+use common::{workspace_root, EcosystemCase, CASES};
 
 fn mapping_doc_path() -> PathBuf {
     workspace_root().join("docs/reference/sbom-format-mapping.md")

--- a/mikebom-cli/tests/openvex_sidecar.rs
+++ b/mikebom-cli/tests/openvex_sidecar.rs
@@ -30,13 +30,7 @@ use std::sync::OnceLock;
 
 
 mod common;
-use common::{EcosystemCase, CASES};
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+use common::{workspace_root, EcosystemCase, CASES};
 
 fn openvex_schema() -> &'static jsonschema::Validator {
     static CELL: OnceLock<jsonschema::Validator> = OnceLock::new();

--- a/mikebom-cli/tests/parity_cmd.rs
+++ b/mikebom-cli/tests/parity_cmd.rs
@@ -8,18 +8,11 @@
 //! against a fresh tempdir; HOME / package-cache env vars are
 //! isolated per the cross-host-goldens convention.
 
-use std::path::PathBuf;
 use std::process::Command;
 
 
 mod common;
-use common::bin;
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+use common::{bin, workspace_root};
 
 
 /// Produce the three format outputs for the npm fixture into

--- a/mikebom-cli/tests/sbom_format_mapping_coverage.rs
+++ b/mikebom-cli/tests/sbom_format_mapping_coverage.rs
@@ -27,12 +27,8 @@
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+mod common;
+use common::workspace_root;
 
 fn goldens_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/mikebom-cli/tests/sbomqs_parity.rs
+++ b/mikebom-cli/tests/sbomqs_parity.rs
@@ -25,13 +25,7 @@ use std::process::Command;
 
 
 mod common;
-use common::{EcosystemCase, CASES};
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+use common::{workspace_root, EcosystemCase, CASES};
 
 /// Locate `sbomqs`. Env var overrides the `$PATH` lookup.
 fn sbomqs_bin() -> Option<PathBuf> {

--- a/mikebom-cli/tests/spdx3_annotation_fidelity.rs
+++ b/mikebom-cli/tests/spdx3_annotation_fidelity.rs
@@ -23,18 +23,13 @@
 //! One test per ecosystem so a failure names the offender.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::PathBuf;
 use std::process::Command;
 
 
 mod common;
-use common::{EcosystemCase, CASES};
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}struct Scan {
+use common::{workspace_root, EcosystemCase, CASES};
+
+struct Scan {
     spdx23: serde_json::Value,
     spdx3: serde_json::Value,
 }

--- a/mikebom-cli/tests/spdx3_cdx_parity.rs
+++ b/mikebom-cli/tests/spdx3_cdx_parity.rs
@@ -23,18 +23,13 @@
 //! to any CDX component; they're excluded from the reverse walk.
 
 use std::collections::{BTreeSet, HashMap};
-use std::path::PathBuf;
 use std::process::Command;
 
 
 mod common;
-use common::{EcosystemCase, CASES};
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}struct Scan {
+use common::{workspace_root, EcosystemCase, CASES};
+
+struct Scan {
     cdx: serde_json::Value,
     spdx3: serde_json::Value,
 }

--- a/mikebom-cli/tests/spdx3_determinism.rs
+++ b/mikebom-cli/tests/spdx3_determinism.rs
@@ -13,15 +13,10 @@
 //! normalization needed in practice, but stripping the timestamp
 //! handles any `OutputConfig.created` variance that could creep in.
 
-use std::path::PathBuf;
 use std::process::Command;
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+mod common;
+use common::workspace_root;
 
 fn run_scan(fixture_rel: &str) -> serde_json::Value {
     let fixture = workspace_root().join("tests/fixtures").join(fixture_rel);

--- a/mikebom-cli/tests/spdx3_schema_validation.rs
+++ b/mikebom-cli/tests/spdx3_schema_validation.rs
@@ -19,13 +19,7 @@ use std::sync::OnceLock;
 
 
 mod common;
-use common::{EcosystemCase, CASES};
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+use common::{workspace_root, EcosystemCase, CASES};
 
 fn schema_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/mikebom-cli/tests/spdx3_us3_acceptance.rs
+++ b/mikebom-cli/tests/spdx3_us3_acceptance.rs
@@ -40,12 +40,8 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::process::Command;
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+mod common;
+use common::workspace_root;
 
 // ---------- scenario 1: format-neutral internal types -------------
 

--- a/mikebom-cli/tests/spdx_annotation_fidelity.rs
+++ b/mikebom-cli/tests/spdx_annotation_fidelity.rs
@@ -18,18 +18,14 @@
 //! actually shows up as annotations in SPDX for the same scan."
 
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 
 mod common;
-use common::{EcosystemCase, CASES};
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}struct DualScan {
+use common::{workspace_root, EcosystemCase, CASES};
+
+struct DualScan {
     cdx: serde_json::Value,
     spdx: serde_json::Value,
 }

--- a/mikebom-cli/tests/spdx_cdx_parity.rs
+++ b/mikebom-cli/tests/spdx_cdx_parity.rs
@@ -25,37 +25,11 @@
 //! "same info?" question for the whole surface.
 
 use std::collections::{BTreeSet, HashMap};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
-
-#[derive(Clone, Copy)]
-struct EcosystemCase {
-    label: &'static str,
-    fixture_subpath: &'static str,
-    deb_codename: Option<&'static str>,
-}
-
-// Same 9 cases the Phase 2 cdx_regression and Phase 3
-// spdx_schema_validation tests use. Kept inline per the plan's
-// "don't extract a shared helper for just three call sites" note.
-const CASES: &[EcosystemCase] = &[
-    EcosystemCase { label: "apk",    fixture_subpath: "apk/synthetic",     deb_codename: None },
-    EcosystemCase { label: "cargo",  fixture_subpath: "cargo/lockfile-v3", deb_codename: None },
-    EcosystemCase { label: "deb",    fixture_subpath: "deb/synthetic",     deb_codename: Some("bookworm") },
-    EcosystemCase { label: "gem",    fixture_subpath: "gem/simple-bundle", deb_codename: None },
-    EcosystemCase { label: "golang", fixture_subpath: "go/simple-module",  deb_codename: None },
-    EcosystemCase { label: "maven",  fixture_subpath: "maven/pom-three-deps", deb_codename: None },
-    EcosystemCase { label: "npm",    fixture_subpath: "npm/node-modules-walk", deb_codename: None },
-    EcosystemCase { label: "pip",    fixture_subpath: "python/simple-venv", deb_codename: None },
-    EcosystemCase { label: "rpm",    fixture_subpath: "rpm/bdb-only",      deb_codename: None },
-];
+mod common;
+use common::{workspace_root, EcosystemCase, CASES};
 
 struct Scan {
     cdx: serde_json::Value,

--- a/mikebom-cli/tests/spdx_determinism.rs
+++ b/mikebom-cli/tests/spdx_determinism.rs
@@ -8,15 +8,10 @@
 //! masking only `created`; every other field — `documentNamespace`,
 //! SPDXIDs, package / relationship ordering — must match exactly.
 
-use std::path::PathBuf;
 use std::process::Command;
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+mod common;
+use common::workspace_root;
 
 fn scan_to_spdx_json(fixture: &std::path::Path) -> serde_json::Value {
     let tmp = tempfile::tempdir().expect("tempdir");

--- a/mikebom-cli/tests/spdx_license_ref_extracted.rs
+++ b/mikebom-cli/tests/spdx_license_ref_extracted.rs
@@ -16,18 +16,13 @@
 //! expression on two components).
 
 use std::collections::BTreeSet;
-use std::path::PathBuf;
 use std::process::Command;
 
 
 mod common;
-use common::{EcosystemCase, CASES};
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}struct Scan {
+use common::{workspace_root, EcosystemCase, CASES};
+
+struct Scan {
     cdx: serde_json::Value,
     spdx23: serde_json::Value,
 }

--- a/mikebom-cli/tests/spdx_schema_validation.rs
+++ b/mikebom-cli/tests/spdx_schema_validation.rs
@@ -17,13 +17,7 @@ use std::sync::OnceLock;
 
 
 mod common;
-use common::{EcosystemCase, CASES};
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+use common::{workspace_root, EcosystemCase, CASES};
 
 fn schema_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/mikebom-cli/tests/spdx_us1_acceptance.rs
+++ b/mikebom-cli/tests/spdx_us1_acceptance.rs
@@ -16,18 +16,12 @@
 //!    volatile fields) to two separate invocations.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 
 mod common;
-use common::bin;
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .to_path_buf()
-}
+use common::{bin, workspace_root};
 
 
 struct Scan {

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Pre-PR verification gate. Runs the two checks that CI runs in
+# .github/workflows/ci.yml — clippy with --all-targets (so the
+# `clippy::unwrap_used` deny on the cli crate root applies inside
+# `#[cfg(test)]` modules too) and the workspace test suite.
+#
+# Per CLAUDE.md: BOTH must pass locally before any PR. A passing
+# `cargo test -p mikebom` alone is insufficient — clippy is not run,
+# and `--all-targets` enforces lints on tests.
+#
+# Usage: ./scripts/pre-pr.sh
+# Exits non-zero on the first failing step.
+
+set -euo pipefail
+
+steps=(
+    "cargo +stable clippy --workspace --all-targets"
+    "cargo +stable test --workspace"
+)
+
+for cmd in "${steps[@]}"; do
+    printf '\n>>> %s\n' "$cmd"
+    eval "$cmd"
+done
+
+printf '\n>>> all pre-PR checks passed.\n'


### PR DESCRIPTION
## Summary

- **Finish #36's dedup.** `workspace_root()` was still redefined byte-for-byte in 21 test files under `mikebom-cli/tests/`, and `spdx_cdx_parity.rs` carried a duplicate copy of the `EcosystemCase` + `CASES` block (escaped the earlier dedup because the file lacked `mod common;` entirely). Centralized in `tests/common/mod.rs` — net **−107 LOC across 22 test files**, no behavior change.
- **Add `scripts/pre-pr.sh`.** Wraps the two CLAUDE.md-mandated checks (`cargo +stable clippy --workspace --all-targets` and `cargo +stable test --workspace`) in order with `set -euo pipefail` so the flag set stays aligned with CI without contributors having to memorize it. CLAUDE.md gained a one-line pointer.
- **`dual_format_perf.rs`'s local `fn bin()` stays.** Its inline comment at lines 30–35 documents why nesting under `holistic_parity.rs` via `mod dual_format_perf;` precludes `mod common;` without `#[path]` ceremony — leaving the documented author trade-off intact.

## Test plan

- [x] `./scripts/pre-pr.sh` passes locally — clippy clean, every test target reports `ok. N passed; 0 failed`
- [x] `rg -c 'fn workspace_root' mikebom-cli/tests/` → only `common/mod.rs:1`
- [x] `rg -c 'struct EcosystemCase' mikebom-cli/tests/` → only `common/mod.rs:1`
- [x] `rg -n 'fn bin\(\)' mikebom-cli/tests/` → `common/mod.rs` (canonical) + `dual_format_perf.rs` (intentional, documented)
- [ ] CI green on Linux + macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)