### PR TITLE
fix(pre-pr): add -D warnings to match CI and constitution v1.3.1

### DIFF
--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 steps=(
-    "cargo +stable clippy --workspace --all-targets"
+    "cargo +stable clippy --workspace --all-targets -- -D warnings"
     "cargo +stable test --workspace"
 )
 


### PR DESCRIPTION
## Summary

- **One-line fix.** `scripts/pre-pr.sh` now runs `cargo +stable clippy --workspace --all-targets -- -D warnings`, matching CI (`.github/workflows/ci.yml:121, 149`) and Constitution v1.3.1 §"Pre-PR Verification" (line 367) exactly.
- **Why this matters.** The PR #38 script ran the same clippy command *without* `-D warnings`. That meant clippy warnings would fail CI but pass the local gate — the very divergence the script's own header claimed not to have (\"the two checks that CI runs\"). A contributor running `./scripts/pre-pr.sh` could see a green local run and still get rejected at CI for warnings. Constitution v1.3.1 explicitly mandates \"Zero errors and zero warnings\" as the passing condition.
- **Surfaced by `/speckit-analyze` on the 017 milestone branch.** Flagged as CRITICAL because milestone 017's FR-009 (\"zero new clippy warnings\") relies on `./scripts/pre-pr.sh` as the gate; under-enforcement cascades into 017 enforcement gaps.

## Test plan

- [x] `cargo +stable clippy --workspace --all-targets -- -D warnings` exits 0 from a clean tree (post-016 zero-warnings baseline holds)
- [x] `./scripts/pre-pr.sh` runs end-to-end clean: every test target reports `ok. N passed; 0 failed`
- [ ] CI green on Linux + macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)