### PR TITLE
refactor: preserve typed error chains + log silent eBPF map failures

### DIFF
--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
 use clap::Args;
 
 use mikebom_common::attestation::integrity::TraceIntegrity;
@@ -534,7 +535,7 @@ pub async fn execute(
         // target identity" for rationale.
         Some(&target_name),
     )
-    .map_err(|e| anyhow::anyhow!("{e}"))?;
+    .with_context(|| format!("scan failed for {}", root_path.display()))?;
     tracing::info!(
         components = components.len(),
         relationships = relationships.len(),

--- a/mikebom-cli/src/trace/loader.rs
+++ b/mikebom-cli/src/trace/loader.rs
@@ -48,34 +48,46 @@ mod inner {
         let mut bpf = Ebpf::load(&data).context("failed to load eBPF bytecode")?;
 
         // Populate PID filter (even though kernel-side is disabled,
-        // keep the map populated for future use)
+        // keep the map populated for future use). Insertion failure
+        // is non-fatal here — the filter is defensive future-proofing —
+        // but log so operators can investigate if a future kernel-side
+        // change starts depending on it.
         {
             let mut pid_filter: aya::maps::HashMap<_, u32, u8> =
                 aya::maps::HashMap::try_from(
                     bpf.map_mut("PID_FILTER").context("PID_FILTER map not found")?,
                 )?;
-            pid_filter.insert(config.target_pid, 1, 0).ok();
+            if let Err(e) = pid_filter.insert(config.target_pid, 1, 0) {
+                warn!(error = %e, target_pid = config.target_pid,
+                    "PID_FILTER insert failed; eBPF map populate is best-effort");
+            }
         }
 
-        // Set runtime configuration
+        // Set runtime configuration. Failure here IS load-bearing —
+        // kernel-side eBPF reads tracer_pid / capture_file_content_hash /
+        // trace_children from this map; a silent failure means the
+        // kernel sees zeroed defaults and traces wrong / missing data.
+        // We currently propagate-as-best-effort to avoid breaking
+        // existing callers, but log loudly so the failure is visible.
         {
             let mut cfg_map: aya::maps::Array<_, TraceConfig> =
                 aya::maps::Array::try_from(
                     bpf.map_mut("CONFIG").context("CONFIG map not found")?,
                 )?;
-            cfg_map
-                .set(
-                    0,
-                    TraceConfig {
-                        max_payload_capture: 512,
-                        tracer_pid: std::process::id(),
-                        capture_file_content_hash: 1,
-                        trace_children: if config.trace_children { 1 } else { 0 },
-                        _padding: [0; 2],
-                    },
-                    0,
-                )
-                .ok();
+            if let Err(e) = cfg_map.set(
+                0,
+                TraceConfig {
+                    max_payload_capture: 512,
+                    tracer_pid: std::process::id(),
+                    capture_file_content_hash: 1,
+                    trace_children: if config.trace_children { 1 } else { 0 },
+                    _padding: [0; 2],
+                },
+                0,
+            ) {
+                warn!(error = %e,
+                    "CONFIG map set failed; kernel-side will see zeroed TraceConfig defaults");
+            }
         }
 
         // Attach uprobes to OpenSSL


### PR DESCRIPTION
## Summary

Tier 3 of the post-016 cleanup roadmap, rescoped after surveying the actual state vs. the original audit's static count.

The audit framed Tier 3 as a sweep of 374 `.expect()` sites. Actual production-code surface after filtering `#[cfg(test)]` (allowed by Constitution Principle IV) is 22 sites — and all 22 use descriptive messages with provable invariants (regex compile of constant patterns, eBPF map shape after build, upstream-validated inputs, standard mutex-poisoning panic). None are panic risks. Tier 3's `.expect()` audit had effectively zero work.

Two real findings remained:

- **`mikebom-cli/src/cli/scan_cmd.rs:537`** — `.map_err(\|e\| anyhow::anyhow!("{e}"))?` discarded the `ScanError` source chain by coercing through Display. `ScanError` is `thiserror`-derived; the `?` operator can convert it to `anyhow::Error` directly via the blanket `From<E: std::error::Error + Send + Sync + 'static>` impl, preserving the chain. Replaced with `.with_context(\|\| format!("scan failed for {}", root_path.display()))?` so the typed error stays available via `source()` and the message gains the path context.
- **`mikebom-cli/src/trace/loader.rs:78`** — `cfg_map.set(...).ok()` silently swallowed a real correctness signal. The CONFIG eBPF map carries `tracer_pid`, `capture_file_content_hash`, `trace_children`, all read by kernel-side probes; a failed set means kernel-side sees zeroed defaults. Now logs `tracing::warn!(error, ...)` on failure. Same treatment for the PID_FILTER insert at line 57 (defensive future-proofing per the inline comment).

The audit's third finding — silent `.ok()` in `copyright.rs:140` — turned out to be idiomatic `Result -> Option` for filter-map-style filtering, not error swallow. Left alone.

## Test plan

- [x] `./scripts/pre-pr.sh` passes locally — zero clippy warnings under `-D warnings`; every test target reports `ok. N passed; 0 failed`.
- [x] No test outputs change (this is a non-behavioral refactor of error-construction; production scan-success path unchanged).
- [ ] CI green on Linux + macOS — Linux's `cfg(target_os = "linux")` block in `loader.rs` is the only platform-conditional path touched.

## Out of scope

Tiers 4 (module splits), 5 (`EcosystemReader` trait pilot), and 6 (eBPF Cargo feature gate) remain. Each is a separate future milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)