### PR TITLE
refactor: extract shared project-root walker for pip + npm

### DIFF
--- a/mikebom-cli/src/scan_fs/package_db/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/mod.rs
@@ -22,6 +22,7 @@ pub mod maven;
 pub mod maven_sidecar;
 pub mod npm;
 pub mod pip;
+mod project_roots;
 pub mod rpm;
 pub mod rpm_file;
 pub mod rpmdb_bdb;

--- a/mikebom-cli/src/scan_fs/package_db/npm/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/mod.rs
@@ -150,83 +150,16 @@ const MAX_PROJECT_ROOT_DEPTH: usize = 6;
 /// Dedup by PURL in `read()` handles the common case where a root
 /// lockfile and a sub-package `package.json` reference the same dep.
 fn candidate_project_roots(rootfs: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    let mut visited: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
-    walk_for_project_roots(rootfs, 0, &mut out, &mut visited);
-    out
-}
-
-fn walk_for_project_roots(
-    dir: &Path,
-    depth: usize,
-    out: &mut Vec<PathBuf>,
-    visited: &mut std::collections::HashSet<PathBuf>,
-) {
-    // Guard against symlink loops and duplicate enumeration. Use the
-    // canonical path when it's available; fall back to `dir` as-is so
-    // a missing dir doesn't silently swallow the scan.
-    let key = std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
-    if !visited.insert(key) {
-        return;
-    }
-
-    if has_npm_signal(dir) {
-        out.push(dir.to_path_buf());
-    }
-
-    if depth >= MAX_PROJECT_ROOT_DEPTH {
-        return;
-    }
-
-    let Ok(read_dir) = std::fs::read_dir(dir) else {
-        return;
+    use super::project_roots::{
+        should_skip_default_descent, walk_for_project_roots, WalkConfig,
     };
-    for entry in read_dir.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
-            continue;
-        };
-        if should_skip_descent(name) {
-            continue;
-        }
-        walk_for_project_roots(&path, depth + 1, out, visited);
-    }
-}
-
-/// Directory names we refuse to descend into when looking for project
-/// roots. Split into three reasons:
-///
-/// 1. **Installed-tree subtrees** — `node_modules/` is an installed
-///    dependency graph. Its own `package.json`s are already handled by
-///    the parent project's `node_modules/` walker; descending would
-///    produce N² false-positive "project roots". Same for `vendor/`
-///    and the classic `bower_components/`.
-/// 2. **Hidden / VCS / tooling dirs** — `.git/`, `.hg/`, `.svn/`, and
-///    any dotfile dir. Never a project root; always just noise.
-/// 3. **Build outputs and language caches** — `target/` (Rust + Maven),
-///    `dist/`, `build/`, `out/`, `coverage/`, `.next/`, `.nuxt/`,
-///    `__pycache__/`, `.venv/`, `venv/`. Won't contain upstream-project
-///    metadata worth re-reading.
-fn should_skip_descent(name: &str) -> bool {
-    // Dotfiles (includes .git, .svn, .next, .venv, .cache, etc.).
-    if name.starts_with('.') {
-        return true;
-    }
-    matches!(
-        name,
-        "node_modules"
-            | "bower_components"
-            | "vendor"
-            | "target"
-            | "dist"
-            | "build"
-            | "out"
-            | "coverage"
-            | "__pycache__"
-            | "venv"
+    walk_for_project_roots(
+        rootfs,
+        &WalkConfig {
+            max_depth: MAX_PROJECT_ROOT_DEPTH,
+            is_project_root: &has_npm_signal,
+            should_skip: &should_skip_default_descent,
+        },
     )
 }
 

--- a/mikebom-cli/src/scan_fs/package_db/pip/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/pip/mod.rs
@@ -166,54 +166,24 @@ const MAX_PROJECT_ROOT_DEPTH: usize = 6;
 /// project root (holds a poetry.lock, Pipfile.lock, requirements*.txt,
 /// or pyproject.toml). Always includes `rootfs` itself so the single-
 /// project case is unchanged. Recurses up to `MAX_PROJECT_ROOT_DEPTH`
-/// levels, pruning installed-tree / VCS / cache directories so the
-/// walk stays bounded on real-world trees.
-///
-/// Mirrors the npm walk: symlink-loop safe, skips dotfiles, skips
-/// known heavy subtrees (`node_modules/`, `target/`, `dist/`, `venv/`,
-/// `__pycache__/`, etc.).
+/// levels via the shared
+/// [`super::project_roots::walk_for_project_roots`] helper.
 fn candidate_python_project_roots(rootfs: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    let mut visited: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
-    walk_for_python_roots(rootfs, 0, &mut out, &mut visited);
-    out
-}
-
-fn walk_for_python_roots(
-    dir: &Path,
-    depth: usize,
-    out: &mut Vec<PathBuf>,
-    visited: &mut std::collections::HashSet<PathBuf>,
-) {
-    let key = std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
-    if !visited.insert(key) {
-        return;
-    }
-
-    if has_python_project_marker(dir) {
-        out.push(dir.to_path_buf());
-    }
-
-    if depth >= MAX_PROJECT_ROOT_DEPTH {
-        return;
-    }
-
-    let Ok(read_dir) = std::fs::read_dir(dir) else {
-        return;
+    use super::project_roots::{
+        should_skip_default_descent, walk_for_project_roots, WalkConfig,
     };
-    for entry in read_dir.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
-            continue;
-        };
-        if should_skip_python_descent(name) {
-            continue;
-        }
-        walk_for_python_roots(&path, depth + 1, out, visited);
-    }
+    walk_for_project_roots(
+        rootfs,
+        &WalkConfig {
+            max_depth: MAX_PROJECT_ROOT_DEPTH,
+            is_project_root: &has_python_project_marker,
+            // Default skip set + python's `site-packages` (handled
+            // separately by `read_venv_dist_info`).
+            should_skip: &|name| {
+                should_skip_default_descent(name) || name == "site-packages"
+            },
+        },
+    )
 }
 
 /// True when `dir` holds any Python project-root marker. Installed
@@ -238,30 +208,6 @@ fn has_python_project_marker(dir: &Path) -> bool {
         }
     }
     false
-}
-
-/// Directory names the Python walker refuses to descend into. Mirrors
-/// the npm walker's skip set plus Python-specific caches (`venv/`,
-/// `.venv/` via the dotfile rule, `__pycache__/`, `.tox/`, `.nox/`,
-/// `.pytest_cache/` via the dotfile rule).
-fn should_skip_python_descent(name: &str) -> bool {
-    if name.starts_with('.') {
-        return true;
-    }
-    matches!(
-        name,
-        "node_modules"
-            | "bower_components"
-            | "vendor"
-            | "target"
-            | "dist"
-            | "build"
-            | "out"
-            | "coverage"
-            | "__pycache__"
-            | "venv"
-            | "site-packages"
-    )
 }
 
 /// Merge `additions` into `entries`, dropping any addition whose PURL

--- a/mikebom-cli/src/scan_fs/package_db/project_roots.rs
+++ b/mikebom-cli/src/scan_fs/package_db/project_roots.rs
@@ -1,0 +1,132 @@
+//! Shared project-root walker used by ecosystem readers that scan
+//! arbitrary filesystem layouts (single project, container image,
+//! monorepo, etc.) for ecosystem-specific project markers.
+//!
+//! pip and npm both use this today via per-ecosystem closures; future
+//! readers (cargo workspace member discovery, gem multi-app, …) can
+//! drop in the same way without re-implementing the symlink-safe
+//! canonicalize-then-recurse machinery.
+//!
+//! Pre-shared, both readers carried a near-identical
+//! `walk_for_*_roots` recursive function plus a per-ecosystem skip
+//! predicate. The skip predicates also overlapped almost entirely —
+//! they all want to skip installed-tree subtrees, hidden / VCS /
+//! tooling dirs, and common build/cache outputs. The
+//! [`should_skip_default_descent`] helper centralises that set;
+//! each reader's closure can compose it with ecosystem-specific
+//! additions (pip's `site-packages` for example).
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// Per-call configuration for [`walk_for_project_roots`].
+pub(crate) struct WalkConfig<'a> {
+    /// Max recursion depth. Readers typically pass `6` — enough for
+    /// realistic monorepo + image layouts (`/usr/src/app/services/api/` =
+    /// 4 levels) without running away into deep source trees.
+    pub max_depth: usize,
+    /// Predicate that returns true when `dir` looks like a project
+    /// root for this ecosystem (e.g. has `pyproject.toml`, has
+    /// `package.json`, etc.). The walker pushes `dir` to the output
+    /// list when this returns true, but still recurses into
+    /// children — a parent project + nested workspace package both
+    /// qualify in their own right.
+    pub is_project_root: &'a dyn Fn(&Path) -> bool,
+    /// Predicate that returns true when the walker should NOT descend
+    /// into a directory named `name`. Compose [`should_skip_default_descent`]
+    /// with ecosystem-specific additions.
+    pub should_skip: &'a dyn Fn(&str) -> bool,
+}
+
+/// Find every directory under `rootfs` (depth-limited) that
+/// `cfg.is_project_root` accepts. Always includes `rootfs` itself
+/// when it qualifies.
+///
+/// Symlink-safe via a canonicalize-keyed visited set; tolerant of
+/// unreadable dirs (silently skips, rather than erroring out — a
+/// scan of a partially-restricted filesystem still produces what
+/// it can).
+pub(crate) fn walk_for_project_roots(rootfs: &Path, cfg: &WalkConfig) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    walk_inner(rootfs, 0, cfg, &mut out, &mut visited);
+    out
+}
+
+fn walk_inner(
+    dir: &Path,
+    depth: usize,
+    cfg: &WalkConfig,
+    out: &mut Vec<PathBuf>,
+    visited: &mut HashSet<PathBuf>,
+) {
+    // Guard against symlink loops and duplicate enumeration. Use the
+    // canonical path when available; fall back to `dir` as-is so a
+    // missing dir doesn't silently swallow the scan.
+    let key = std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
+    if !visited.insert(key) {
+        return;
+    }
+
+    if (cfg.is_project_root)(dir) {
+        out.push(dir.to_path_buf());
+    }
+
+    if depth >= cfg.max_depth {
+        return;
+    }
+
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if (cfg.should_skip)(name) {
+            continue;
+        }
+        walk_inner(&path, depth + 1, cfg, out, visited);
+    }
+}
+
+/// Default skip-set: directory names that no ecosystem should
+/// descend into when looking for project roots. Three reasons:
+///
+/// 1. **Installed-tree subtrees** — `node_modules/`, `vendor/`,
+///    `bower_components/`. Their own manifests are already handled
+///    by their parent project's installed-tree walker; descending
+///    would produce N² false-positive "project roots".
+/// 2. **Hidden / VCS / tooling dirs** — anything starting with `.`
+///    (`.git/`, `.next/`, `.venv/`, `.cache/`, …). Never a project
+///    root; always just noise.
+/// 3. **Build outputs and language caches** — `target/` (Rust +
+///    Maven), `dist/`, `build/`, `out/`, `coverage/`,
+///    `__pycache__/`, `venv/`. Won't contain upstream-project
+///    metadata worth re-reading.
+///
+/// Ecosystem-specific additions compose with this — e.g., pip
+/// additionally skips `site-packages/` because its venv-walker
+/// handles dist-info on a separate pass.
+pub(crate) fn should_skip_default_descent(name: &str) -> bool {
+    if name.starts_with('.') {
+        return true;
+    }
+    matches!(
+        name,
+        "node_modules"
+            | "bower_components"
+            | "vendor"
+            | "target"
+            | "dist"
+            | "build"
+            | "out"
+            | "coverage"
+            | "__pycache__"
+            | "venv"
+    )
+}


### PR DESCRIPTION
## Summary

Tier 5 of the post-016 cleanup roadmap, rescoped after surveying actual code. The "EcosystemReader trait pilot" framing in the original audit doesn't survive contact with the readers — `pub fn read` signatures genuinely differ across ecosystems (different args: `distro_version`, `scan_mode`, `deb_namespace`; different return types: `Vec`, `Result<Vec, FooError>`, tuple with `GoScanSignals`). A unifying trait would push variation into associated-type ceremony rather than reduce code. Same scope-recalibration finding as Tiers 3 and 6.

What WAS genuinely duplicated, found by direct code comparison: pip's and npm's project-root walkers had functionally identical 30-line bodies plus near-identical 10-name skip predicate sets. Extracted into a shared helper.

## What changed

New module `mikebom-cli/src/scan_fs/package_db/project_roots.rs` (~125 LOC):

- `pub(crate) struct WalkConfig { max_depth, is_project_root, should_skip }`
- `pub(crate) fn walk_for_project_roots(rootfs, &WalkConfig) -> Vec<PathBuf>` — symlink-safe, depth-limited recursive walker
- `pub(crate) fn should_skip_default_descent(name) -> bool` — the shared 10-name skip set (`node_modules`, `vendor`, `target`, `dist`, `build`, `out`, `coverage`, `__pycache__`, `venv`, `bower_components`) plus dotfile prefix

Each ecosystem reader collapses from a ~50-line walker + skip-list pair to a ~10-line wrapper:

```rust
// pip/mod.rs
fn candidate_python_project_roots(rootfs: &Path) -> Vec<PathBuf> {
    walk_for_project_roots(rootfs, &WalkConfig {
        max_depth: MAX_PROJECT_ROOT_DEPTH,
        is_project_root: &has_python_project_marker,
        should_skip: &|name| should_skip_default_descent(name)
                          || name == "site-packages",
    })
}
```

Net: −146 / +26 LOC across pip + npm; +125 LOC new shared module. Real LOC savings today: ~5. The actual win is the shape: adding cargo-workspace or gem-multi-app discovery later is a 10-line wrapper rather than another 30-line walker copy.

## Test plan

- [x] `cargo +stable check --workspace --tests` passes clean.
- [x] `cargo test pip::` → 52 passed, 0 failed.
- [x] `cargo test npm::` → 39 passed, 0 failed.
- [x] All 27 byte-identity goldens unchanged: `MIKEBOM_UPDATE_*_GOLDENS=1` regen of CDX + SPDX 2.3 + SPDX 3 produces zero `git diff`. **This is the load-bearing proof that scan output didn't change.**
- [ ] CI green on Linux + macOS.

**Pre-existing flakiness**: `spdx_us1_acceptance` and `spdx_determinism` intermittently fail in `./scripts/pre-pr.sh` under concurrent test load (both pass in isolation). Same pattern as `dual_format_perf` documented in #42's milestone-018 PR. Not caused by this refactor — the byte-identity goldens prove scan output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)