### PR TITLE
refactor(019): binary/mod.rs split — design-first, 5 files

### DIFF
--- a/mikebom-cli/src/scan_fs/binary/discover.rs
+++ b/mikebom-cli/src/scan_fs/binary/discover.rs
@@ -1,0 +1,89 @@
+//! Filesystem walker that finds candidate binary files.
+//!
+//! Walks `rootfs` looking for regular files whose first 16 bytes
+//! match a known binary magic (ELF / Mach-O / PE). Skips hidden
+//! and build directories; ignores files outside the size envelope.
+
+use std::path::{Path, PathBuf};
+
+/// Walk `rootfs` for regular files, probing the first 16 bytes of
+/// each for a known binary magic. Skips hidden / build dirs. Ignores
+/// files <1 KB or >500 MB (defense-in-depth).
+pub(super) fn discover_binaries(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if root.is_file() {
+        if is_supported_binary(root) {
+            out.push(root.to_path_buf());
+        }
+        return out;
+    }
+    walk_dir(root, &mut out);
+    out
+}
+
+fn walk_dir(dir: &Path, acc: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if matches!(
+                name,
+                ".git" | "target" | "node_modules" | ".cargo" | "__pycache__" | ".venv"
+            ) {
+                continue;
+            }
+            walk_dir(&path, acc);
+        } else if path.is_file() && is_supported_binary(&path) {
+            acc.push(path);
+        }
+    }
+}
+
+fn is_supported_binary(path: &Path) -> bool {
+    use std::io::Read;
+    let Ok(mut f) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut magic = [0u8; 4];
+    match f.read_exact(&mut magic) {
+        Ok(()) => detect_format(&magic).is_some(),
+        Err(_) => false,
+    }
+}
+
+/// Detect binary format by first-4-bytes magic. Returns the
+/// canonical `binary-class` string per FR-021.
+pub(crate) fn detect_format(magic: &[u8]) -> Option<&'static str> {
+    if magic.len() < 4 {
+        return None;
+    }
+    // ELF: 0x7F 'E' 'L' 'F'
+    if magic == [0x7F, b'E', b'L', b'F'] {
+        return Some("elf");
+    }
+    // Mach-O: MH_MAGIC (0xFEEDFACE), MH_CIGAM (0xCEFAEDFE), MH_MAGIC_64
+    // (0xFEEDFACF), MH_CIGAM_64 (0xCFFAEDFE), fat-binary variants
+    // (0xCAFEBABE / 0xBEBAFECA).
+    if matches!(
+        magic,
+        [0xFE, 0xED, 0xFA, 0xCE]
+            | [0xCE, 0xFA, 0xED, 0xFE]
+            | [0xFE, 0xED, 0xFA, 0xCF]
+            | [0xCF, 0xFA, 0xED, 0xFE]
+            | [0xCA, 0xFE, 0xBA, 0xBE]
+            | [0xBE, 0xBA, 0xFE, 0xCA]
+    ) {
+        return Some("macho");
+    }
+    // PE: starts with "MZ" (0x4D 0x5A) in the DOS header; a real PE
+    // also has a PE\0\0 signature at the offset stored at 0x3C.
+    // First-4-bytes probe is necessarily optimistic — full PE
+    // validation happens at parse time via `object::read::File::parse`.
+    if &magic[..2] == b"MZ" {
+        return Some("pe");
+    }
+    None
+}

--- a/mikebom-cli/src/scan_fs/binary/entry.rs
+++ b/mikebom-cli/src/scan_fs/binary/entry.rs
@@ -1,0 +1,580 @@
+//! BinaryScan + binary-scan-result-to-PackageDbEntry conversion.
+//!
+//! Owns the intermediate `BinaryScan` type that the per-file scanner
+//! in `scan.rs` produces, plus the three conversion functions that
+//! turn scan results into `PackageDbEntry` rows: `version_match_to_entry`
+//! (curated version strings), `make_file_level_component` (the binary
+//! itself), and `note_package_to_entry` (ELF .note.package parsing).
+
+use std::path::Path;
+
+use mikebom_common::types::hash::ContentHash;
+use mikebom_common::types::purl::Purl;
+use sha2::{Digest, Sha256};
+
+use super::elf;
+use super::packer;
+use super::version_strings;
+use super::super::package_db::{rpm_vendor_from_id, PackageDbEntry};
+
+/// Convert a curated-scanner match into a `PackageDbEntry`.
+pub(super) fn version_match_to_entry(
+    m: &version_strings::EmbeddedVersionMatch,
+    path: &Path,
+) -> Option<PackageDbEntry> {
+    let purl_str = format!(
+        "pkg:generic/{}@{}",
+        mikebom_common::types::purl::encode_purl_segment(m.library.slug()),
+        mikebom_common::types::purl::encode_purl_segment(&m.version),
+    );
+    let purl = Purl::new(&purl_str).ok()?;
+    Some(PackageDbEntry {
+        purl,
+        name: m.library.slug().to_string(),
+        version: m.version.clone(),
+        arch: None,
+        source_path: path.to_string_lossy().into_owned(),
+        depends: Vec::new(),
+        maintainer: None,
+        licenses: vec![],
+        is_dev: None,
+        requirement_range: None,
+        source_type: None,
+        sbom_tier: Some("analyzed".to_string()),
+        shade_relocation: None,
+        buildinfo_status: None,
+        evidence_kind: Some("embedded-version-string".to_string()),
+        binary_class: None,
+        binary_stripped: None,
+        linkage_kind: None,
+        detected_go: None,
+        confidence: Some("heuristic".to_string()),
+        binary_packed: None,
+        raw_version: None,
+        parent_purl: None,
+        npm_role: None,
+        co_owned_by: None,
+        hashes: Vec::new(),
+    })
+}
+
+/// Cross-format scan result. Common fields populated from all three
+/// formats via `object::read::File::imports()`; `note_package` is
+/// ELF-specific and `None` for Mach-O / PE.
+pub(crate) struct BinaryScan {
+    pub binary_class: &'static str,
+    pub imports: Vec<String>,
+    pub has_dynamic: bool,
+    pub stripped: bool,
+    pub note_package: Option<elf::ElfNotePackage>,
+    /// Concatenated read-only string-section bytes per FR-025 /
+    /// research R6. Fed to the curated version-string scanner.
+    /// Capped at 16 MB per binary.
+    pub string_region: Vec<u8>,
+    /// UPX or similar packer signature if detected (R7). `None`
+    /// means no packer recognised; the linkage list is complete.
+    pub packer: Option<packer::PackerKind>,
+}
+
+pub(super) fn make_file_level_component(
+    path: &Path,
+    bytes: &[u8],
+    scan: &BinaryScan,
+    detected_go: bool,
+) -> PackageDbEntry {
+    let sha256 = {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        format!("{:x}", hasher.finalize())
+    };
+    let hash = ContentHash::sha256(&sha256)
+        .expect("Sha256 hex is always well-formed");
+
+    // File-level binary components get a synthetic pkg:generic PURL
+    // keyed on sha256 so they have a stable identity. The filename
+    // is preserved via the `name` field for human readability.
+    let filename = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    // Filename can carry arbitrary chars; percent-encode for PURL
+    // name-segment conformance.
+    let encoded_filename = mikebom_common::types::purl::encode_purl_segment(&filename);
+    let purl_str = format!("pkg:generic/{encoded_filename}?file-sha256={sha256}");
+    let purl = Purl::new(&purl_str).unwrap_or_else(|_| {
+        // Fallback: use a bare generic purl if filename has chars PURL
+        // can't handle. Keyed on sha256 alone.
+        Purl::new(&format!("pkg:generic/binary?file-sha256={sha256}"))
+            .expect("bare pkg:generic must parse")
+    });
+
+    let linkage = if scan.has_dynamic && !scan.imports.is_empty() {
+        "dynamic"
+    } else if !scan.has_dynamic {
+        "static"
+    } else {
+        "dynamic"
+    }
+    .to_string();
+
+    PackageDbEntry {
+        purl,
+        name: filename,
+        version: String::new(),
+        arch: None,
+        source_path: path.to_string_lossy().into_owned(),
+        depends: Vec::new(),
+        maintainer: None,
+        licenses: vec![],
+        is_dev: None,
+        requirement_range: None,
+        source_type: None,
+        sbom_tier: Some("analyzed".to_string()),
+        shade_relocation: None,
+        buildinfo_status: None,
+        evidence_kind: None,
+        binary_class: Some(scan.binary_class.to_string()),
+        binary_stripped: Some(scan.stripped),
+        linkage_kind: Some(linkage),
+        // G1: milestone 004 US2 R8 cross-link — set when the same
+        // bytes carry `runtime/debug.BuildInfo` so downstream
+        // consumers can pair the file-level `pkg:generic/<name>`
+        // component with its `pkg:golang/<module>@<version>`
+        // siblings from `go_binary.rs`.
+        detected_go: if detected_go { Some(true) } else { None },
+        confidence: None,
+        binary_packed: scan.packer.map(|p| p.as_str().to_string()),
+        raw_version: None,
+        parent_purl: None,
+        npm_role: None,
+        co_owned_by: None,
+        hashes: Vec::new(),
+    }
+    .with_sha256_placeholder(hash)
+}
+
+/// Extension helper: attach the file-SHA-256 as a `hashes` field.
+
+impl PackageDbEntry {
+    fn with_sha256_placeholder(self, _hash: ContentHash) -> Self {
+        // `PackageDbEntry` doesn't currently carry hashes directly;
+        // hashes land on the `ResolvedComponent` via the scan_fs
+        // conversion layer from the artefact-file walker. Binary
+        // file-level components bypass that walker (they're produced
+        // here), so a follow-on could extend `PackageDbEntry` with a
+        // hashes field. For this turn, hashes on binary components
+        // are omitted — consumers see the file-level component with
+        // the filename + bom-ref identity but without content hashes.
+        // Future: hook into the milestone-003 `file_hashes` plumbing.
+        self
+    }
+}
+
+/// Convert a parsed `.note.package` payload into a `PackageDbEntry`
+/// per FR-024. Vendor derived from `distro` via the milestone-003
+/// `rpm_vendor_from_id` map for RPM-family notes.
+pub(super) fn note_package_to_entry(
+    note: &elf::ElfNotePackage,
+    path: &Path,
+    os_release_id: Option<&str>,
+    os_release_version_id: Option<&str>,
+) -> Option<PackageDbEntry> {
+    if note.name.is_empty() || note.version.is_empty() {
+        return None;
+    }
+    let mut qualifiers = note
+        .architecture
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .map(|a| format!("?arch={a}"))
+        .unwrap_or_default();
+
+    // v6 fix (conformance bug 1 / ELF-note ghosts): vendor namespace
+    // precedence is (1) the ELF note's own `distro` field when
+    // populated, then (2) the scan-wide `/etc/os-release` ID, then
+    // (3) a hardcoded default. Prior to this change, an unclaimed
+    // Fedora binary with no `distro` in its ELF note emitted
+    // `pkg:rpm/rpm/<name>@<ver>` — no OS context. Threading the
+    // os-release ID recovers the correct namespace for the fallback
+    // path.
+    let resolve_vendor = |note_distro: Option<&str>, default_fallback: &str| -> String {
+        let from_note = note_distro
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|d| d.to_lowercase());
+        if let Some(d) = from_note {
+            return d;
+        }
+        if let Some(id) = os_release_id.filter(|s| !s.is_empty()) {
+            return id.to_lowercase();
+        }
+        default_fallback.to_string()
+    };
+    let append_distro_qualifier = |qualifiers: &mut String, vendor: &str| {
+        // Emit `distro=<vendor>-<VERSION_ID>` only when both halves
+        // are available. Mirrors the dpkg / rpm / apk package-db
+        // readers' qualifier shape.
+        if let Some(version_id) = os_release_version_id.filter(|s| !s.is_empty()) {
+            let prefix = if qualifiers.is_empty() { '?' } else { '&' };
+            qualifiers.push(prefix);
+            qualifiers.push_str("distro=");
+            qualifiers.push_str(vendor);
+            qualifiers.push('-');
+            qualifiers.push_str(version_id);
+        }
+    };
+
+    // purl-spec § Character encoding: `+` and other non-allowed chars
+    // MUST be percent-encoded in BOTH the name and version segments.
+    // The note.{name,version} came out of an ELF `.note.package`
+    // section and can carry real-world package coords with `+` (RPMs
+    // like `libstdc++`, semver versions like `1.0+build.1`). Route
+    // both through the canonical encoder so all five arms below emit
+    // spec-conformant PURLs.
+    let encoded_name = mikebom_common::types::purl::encode_purl_segment(&note.name);
+    let encoded_version = mikebom_common::types::purl::encode_purl_segment(&note.version);
+    let purl_str = match note.note_type.as_str() {
+        "rpm" => {
+            let raw_vendor = resolve_vendor(note.distro.as_deref(), "rpm");
+            // rpm_vendor_from_id normalizes `rhel`→`redhat`, `ol`→`oracle`,
+            // etc. Same mapping used by rpm.rs for the rpmdb reader.
+            let vendor = rpm_vendor_from_id(&raw_vendor);
+            append_distro_qualifier(&mut qualifiers, &vendor);
+            format!("pkg:rpm/{vendor}/{encoded_name}@{encoded_version}{qualifiers}")
+        }
+        "deb" => {
+            let vendor = resolve_vendor(note.distro.as_deref(), "debian");
+            append_distro_qualifier(&mut qualifiers, &vendor);
+            format!("pkg:deb/{vendor}/{encoded_name}@{encoded_version}{qualifiers}")
+        }
+        "apk" => {
+            let vendor = resolve_vendor(note.distro.as_deref(), "alpine");
+            append_distro_qualifier(&mut qualifiers, &vendor);
+            format!("pkg:apk/{vendor}/{encoded_name}@{encoded_version}{qualifiers}")
+        }
+        "alpm" | "pacman" => {
+            format!("pkg:alpm/arch/{encoded_name}@{encoded_version}{qualifiers}")
+        }
+        _ => format!("pkg:generic/{encoded_name}@{encoded_version}"),
+    };
+
+    let purl = Purl::new(&purl_str).ok()?;
+    Some(PackageDbEntry {
+        purl,
+        name: note.name.clone(),
+        version: note.version.clone(),
+        arch: note.architecture.clone(),
+        source_path: path.to_string_lossy().into_owned(),
+        depends: Vec::new(),
+        maintainer: None,
+        licenses: vec![],
+        is_dev: None,
+        requirement_range: None,
+        source_type: None,
+        sbom_tier: Some("source".to_string()),
+        shade_relocation: None,
+        buildinfo_status: None,
+        evidence_kind: Some("elf-note-package".to_string()),
+        binary_class: None,
+        binary_stripped: None,
+        linkage_kind: None,
+        detected_go: None,
+        confidence: None,
+        binary_packed: None,
+        raw_version: None,
+        parent_purl: None,
+        npm_role: None,
+        co_owned_by: None,
+        hashes: Vec::new(),
+    })
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+    #[test]
+    fn note_package_rpm_produces_canonical_purl() {
+        let note = elf::ElfNotePackage {
+            note_type: "rpm".into(),
+            name: "curl".into(),
+            version: "8.2.1".into(),
+            architecture: Some("x86_64".into()),
+            distro: Some("fedora".into()),
+            os_cpe: None,
+        };
+        let entry =
+            note_package_to_entry(&note, Path::new("/opt/curl"), None, None).unwrap();
+        assert_eq!(
+            entry.purl.as_str(),
+            "pkg:rpm/fedora/curl@8.2.1?arch=x86_64"
+        );
+        assert_eq!(entry.evidence_kind.as_deref(), Some("elf-note-package"));
+        assert_eq!(entry.sbom_tier.as_deref(), Some("source"));
+    }
+
+    #[test]
+    fn note_package_rpm_uses_os_release_namespace_when_note_distro_absent() {
+        // Conformance bug 1 fix: when the ELF note has no distro field
+        // but the scan's /etc/os-release ID is known, use the os-release
+        // ID instead of the bare "rpm" fallback. Fixes Fedora ghosts
+        // emitting pkg:rpm/rpm/<name>.
+        let note = elf::ElfNotePackage {
+            note_type: "rpm".into(),
+            name: "ModemManager".into(),
+            version: "1.22.0-3.fc40".into(),
+            architecture: Some("aarch64".into()),
+            distro: None,
+            os_cpe: None,
+        };
+        let entry = note_package_to_entry(
+            &note,
+            Path::new("/usr/libexec/mm-plugin-broadband"),
+            Some("fedora"),
+            Some("40"),
+        )
+        .unwrap();
+        assert_eq!(
+            entry.purl.as_str(),
+            "pkg:rpm/fedora/ModemManager@1.22.0-3.fc40?arch=aarch64&distro=fedora-40"
+        );
+    }
+
+    #[test]
+    fn note_package_rpm_prefers_note_distro_over_os_release() {
+        // Precedence: ELF note's own `distro` wins over os-release ID.
+        let note = elf::ElfNotePackage {
+            note_type: "rpm".into(),
+            name: "curl".into(),
+            version: "8.2.1".into(),
+            architecture: Some("x86_64".into()),
+            distro: Some("rocky".into()),
+            os_cpe: None,
+        };
+        // Note says rocky, os-release (hypothetically wrong) says fedora.
+        // rocky wins; rpm_vendor_from_id keeps rocky→rocky, then appends
+        // distro=rocky-9 from VERSION_ID.
+        let entry = note_package_to_entry(
+            &note,
+            Path::new("/usr/bin/curl"),
+            Some("fedora"),
+            Some("9"),
+        )
+        .unwrap();
+        assert_eq!(
+            entry.purl.as_str(),
+            "pkg:rpm/rocky/curl@8.2.1?arch=x86_64&distro=rocky-9"
+        );
+    }
+
+    #[test]
+    fn note_package_rpm_percent_encodes_plus_in_name() {
+        let note = elf::ElfNotePackage {
+            note_type: "rpm".into(),
+            name: "libstdc++".into(),
+            version: "14.2.1-3.fc40".into(),
+            architecture: Some("aarch64".into()),
+            distro: Some("fedora".into()),
+            os_cpe: None,
+        };
+        let entry = note_package_to_entry(
+            &note,
+            Path::new("/usr/lib64/libstdc++.so.6"),
+            Some("fedora"),
+            Some("40"),
+        )
+        .unwrap();
+        let purl = entry.purl.as_str();
+        assert!(
+            purl.contains("/libstdc%2B%2B@"),
+            "expected percent-encoded `++` in ELF-note PURL; got {purl}",
+        );
+        assert!(
+            !purl.contains("libstdc++"),
+            "literal `++` must not appear; got {purl}",
+        );
+    }
+
+    #[test]
+    fn note_package_rpm_percent_encodes_mid_name_plus() {
+        let note = elf::ElfNotePackage {
+            note_type: "rpm".into(),
+            name: "perl-Text-Tabs+Wrap".into(),
+            version: "2024.001-1.fc40".into(),
+            architecture: Some("noarch".into()),
+            distro: Some("fedora".into()),
+            os_cpe: None,
+        };
+        let entry = note_package_to_entry(
+            &note,
+            Path::new("/usr/share/perl5/Text/Tabs.pm"),
+            Some("fedora"),
+            Some("40"),
+        )
+        .unwrap();
+        assert!(
+            entry.purl.as_str().contains("/perl-Text-Tabs%2BWrap@"),
+            "mid-name `+` must percent-encode; got {}",
+            entry.purl.as_str()
+        );
+    }
+
+    #[test]
+    fn note_package_rpm_falls_back_to_rpm_when_no_context() {
+        // Final fallback: no note distro, no os-release. Emits the
+        // original bare "rpm" namespace. In practice this should never
+        // happen on a real scan (os-release is read first), but the
+        // defensive default preserves PURL validity.
+        let note = elf::ElfNotePackage {
+            note_type: "rpm".into(),
+            name: "foo".into(),
+            version: "1.0".into(),
+            architecture: None,
+            distro: None,
+            os_cpe: None,
+        };
+        let entry =
+            note_package_to_entry(&note, Path::new("/bin/foo"), None, None).unwrap();
+        assert_eq!(entry.purl.as_str(), "pkg:rpm/rpm/foo@1.0");
+    }
+
+    #[test]
+    fn note_package_alpm_uses_arch_namespace() {
+        let note = elf::ElfNotePackage {
+            note_type: "alpm".into(),
+            name: "bash".into(),
+            version: "5.2.015-1".into(),
+            architecture: Some("x86_64".into()),
+            distro: Some("Arch Linux".into()),
+            os_cpe: None,
+        };
+        let entry = note_package_to_entry(
+            &note,
+            Path::new("/usr/bin/bash"),
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            entry.purl.as_str(),
+            "pkg:alpm/arch/bash@5.2.015-1?arch=x86_64"
+        );
+    }
+
+    #[test]
+    fn note_package_deb_falls_back_to_debian_vendor() {
+        let note = elf::ElfNotePackage {
+            note_type: "deb".into(),
+            name: "vim".into(),
+            version: "9.0.0".into(),
+            architecture: Some("amd64".into()),
+            distro: None,
+            os_cpe: None,
+        };
+        // No os-release context either → "debian" fallback.
+        let entry = note_package_to_entry(
+            &note,
+            Path::new("/usr/bin/vim"),
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            entry.purl.as_str(),
+            "pkg:deb/debian/vim@9.0.0?arch=amd64"
+        );
+    }
+
+    #[test]
+    fn note_package_deb_uses_os_release_namespace_for_ubuntu() {
+        // Ubuntu image: ELF note lacks distro, os-release says ubuntu.
+        let note = elf::ElfNotePackage {
+            note_type: "deb".into(),
+            name: "openssh-server".into(),
+            version: "1:9.6p1-3ubuntu13".into(),
+            architecture: Some("amd64".into()),
+            distro: None,
+            os_cpe: None,
+        };
+        let entry = note_package_to_entry(
+            &note,
+            Path::new("/usr/sbin/sshd"),
+            Some("ubuntu"),
+            Some("24.04"),
+        )
+        .unwrap();
+        assert_eq!(
+            entry.purl.as_str(),
+            "pkg:deb/ubuntu/openssh-server@1:9.6p1-3ubuntu13?arch=amd64&distro=ubuntu-24.04"
+        );
+    }
+
+    #[test]
+    fn note_package_unknown_type_becomes_generic() {
+        let note = elf::ElfNotePackage {
+            note_type: "xbps".into(),
+            name: "foo".into(),
+            version: "1.0".into(),
+            architecture: None,
+            distro: None,
+            os_cpe: None,
+        };
+        let entry =
+            note_package_to_entry(&note, Path::new("/bin/foo"), None, None).unwrap();
+        assert_eq!(entry.purl.as_str(), "pkg:generic/foo@1.0");
+    }
+
+    fn fake_binary_scan() -> BinaryScan {
+        BinaryScan {
+            binary_class: "elf",
+            imports: Vec::new(),
+            has_dynamic: false,
+            stripped: false,
+            note_package: None,
+            string_region: Vec::new(),
+            packer: None,
+        }
+    }
+
+    #[test]
+    fn make_file_level_component_sets_detected_go_when_flag_set() {
+        // G1 wiring: `make_file_level_component` receives
+        // `detected_go = true` when the caller's `go_in_linux`
+        // check fires. The emitted PackageDbEntry carries
+        // `detected_go = Some(true)` so the CDX emitter surfaces
+        // `mikebom:detected-go = true` on the file-level
+        // component, cross-linking it with the sibling
+        // `pkg:golang/.../module@version` entries from
+        // `go_binary.rs`.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("goapp");
+        std::fs::write(&path, b"dummy-bytes").unwrap();
+        let scan = fake_binary_scan();
+        let entry =
+            make_file_level_component(&path, b"dummy-bytes", &scan, true);
+        assert_eq!(entry.name, "goapp");
+        assert_eq!(entry.detected_go, Some(true));
+        assert_eq!(entry.binary_class.as_deref(), Some("elf"));
+        assert!(
+            entry.purl.as_str().starts_with("pkg:generic/goapp"),
+            "expected pkg:generic/goapp PURL: {}",
+            entry.purl.as_str(),
+        );
+    }
+
+    #[test]
+    fn make_file_level_component_leaves_detected_go_none_for_non_go() {
+        // Regression guard: non-Go file-level entries (plain ELF,
+        // Mach-O binaries without BuildInfo) keep `detected_go =
+        // None` so the CDX property is only emitted when the
+        // cross-link is real.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("plain-tool");
+        std::fs::write(&path, b"plain-bytes").unwrap();
+        let scan = fake_binary_scan();
+        let entry =
+            make_file_level_component(&path, b"plain-bytes", &scan, false);
+        assert_eq!(entry.detected_go, None);
+    }
+}

--- a/mikebom-cli/src/scan_fs/binary/entry.rs
+++ b/mikebom-cli/src/scan_fs/binary/entry.rs
@@ -155,7 +155,6 @@ pub(super) fn make_file_level_component(
 }
 
 /// Extension helper: attach the file-SHA-256 as a `hashes` field.
-
 impl PackageDbEntry {
     fn with_sha256_placeholder(self, _hash: ContentHash) -> Self {
         // `PackageDbEntry` doesn't currently carry hashes directly;

--- a/mikebom-cli/src/scan_fs/binary/mod.rs
+++ b/mikebom-cli/src/scan_fs/binary/mod.rs
@@ -27,53 +27,20 @@ pub mod version_strings; // stub
 
 use std::path::Path;
 
-use object::ObjectSection;
 
 use super::package_db::PackageDbEntry;
 
 mod discover;
 mod entry;
 mod predicates;
+mod scan;
 
 use discover::discover_binaries;
-use entry::{
-    make_file_level_component, note_package_to_entry, version_match_to_entry, BinaryScan,
-};
+use entry::{make_file_level_component, note_package_to_entry, version_match_to_entry};
 use predicates::{
     detect_rootfs_kind, has_rpmdb_at, is_host_system_path, is_os_managed_directory, RootfsKind,
 };
-
-/// Quick probe: does this ELF carry Go BuildInfo? Used by the Linux-
-/// rootfs Go-suppression rule — when Go BuildInfo succeeds, the Go
-/// modules emitted by `package_db::go_binary` carry the container
-/// content; the file-level binary component is redundant noise.
-///
-/// Lightweight byte-scan for the BuildInfo magic prefix `\xff Go buildinf:`
-/// — avoids re-parsing the binary. Same magic the `go_binary` reader
-/// looks for (source: Go stdlib `debug/buildinfo`).
-fn is_go_binary(bytes: &[u8]) -> bool {
-    // Scan the first 64 MB — BuildInfo lives in the `.go.buildinfo`
-    // section, which the Go linker places AFTER the text/data
-    // sections. Real-world offsets commonly exceed the old 2 MB
-    // probe cap: a 6 MB Go binary puts BuildInfo around 3.9 MB; a
-    // larger service binary can push it past 10 MB. 64 MB covers
-    // virtually all Go binaries while keeping bounded worst-case
-    // cost on pathological non-Go files. The probe is a
-    // `windows().any()` scan which modern rustc/LLVM optimizes
-    // aggressively — measurable cost on a 64 MB file is tens of
-    // milliseconds, acceptable for the correctness win.
-    //
-    // For comparison, `go_binary.rs::detect_is_go` first does a
-    // section-name lookup via the object crate (fast, precise), then
-    // falls back to memmem over the entire file (up to 500 MB). This
-    // cheaper byte-scan covers the common case without pulling in
-    // ELF parsing here.
-    const PROBE: usize = 64 * 1024 * 1024;
-    let end = bytes.len().min(PROBE);
-    bytes[..end]
-        .windows(14)
-        .any(|w| w == b"\xff Go buildinf:")
-}
+use scan::{is_go_binary, scan_binary};
 
 /// Check whether the walker's discovered path is covered by a claim
 /// recorded by any installed-package-db reader.
@@ -465,224 +432,6 @@ pub fn read(
 
 
 
-fn scan_binary(path: &Path, bytes: &[u8]) -> Option<BinaryScan> {
-    use object::Object;
-
-    // Fat Mach-O requires slice iteration — object's top-level
-    // `File::parse` doesn't handle the fat format directly.
-    if bytes.len() >= 4 {
-        let magic = [bytes[0], bytes[1], bytes[2], bytes[3]];
-        if matches!(
-            magic,
-            [0xCA, 0xFE, 0xBA, 0xBE]
-                | [0xBE, 0xBA, 0xFE, 0xCA]
-                | [0xCA, 0xFE, 0xBA, 0xBF]
-                | [0xBF, 0xBA, 0xFE, 0xCA]
-        ) {
-            return scan_fat_macho(path, bytes);
-        }
-    }
-
-    let file = match object::read::File::parse(bytes) {
-        Ok(f) => f,
-        Err(e) => {
-            tracing::warn!(path = %path.display(), error = %e, "skipping binary parse");
-            return None;
-        }
-    };
-    let class = match file.format() {
-        object::BinaryFormat::Elf => "elf",
-        object::BinaryFormat::MachO => "macho",
-        object::BinaryFormat::Pe => "pe",
-        _ => return None,
-    };
-
-    // Linkage: object's high-level imports() returns `Vec<Import>`
-    // where `library()` is the DT_NEEDED soname (ELF), LC_LOAD_DYLIB
-    // install-name (Mach-O), or IMPORT DLL name (PE). Dedup by string.
-    let mut imports = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    if let Ok(imps) = file.imports() {
-        for imp in imps {
-            let lib = imp.library();
-            if lib.is_empty() {
-                continue;
-            }
-            if let Ok(s) = std::str::from_utf8(lib) {
-                if seen.insert(s.to_string()) {
-                    imports.push(s.to_string());
-                }
-            }
-        }
-    }
-
-    // has_dynamic = linkage list non-empty OR ELF has .dynamic
-    // section. Close enough for the dynamic/static classifier.
-    let has_dynamic = !imports.is_empty()
-        || (class == "elf" && file.section_by_name_bytes(b".dynamic").is_some());
-
-    // Stripped classification per format:
-    // - ELF: no .symtab / .dynsym AND no .note.package
-    // - Mach-O: no LC_SYMTAB (indicated by absence of symbols)
-    // - PE: no IMAGE_DEBUG_DIRECTORY entries AND no VS_VERSION_INFO
-    //   (approximated via: has_debug_info() returning false)
-    let stripped = match class {
-        "elf" => {
-            let has_sym = file.section_by_name_bytes(b".symtab").is_some()
-                || file.section_by_name_bytes(b".dynsym").is_some();
-            let has_note_pkg = file.section_by_name_bytes(b".note.package").is_some();
-            !has_sym && !has_note_pkg
-        }
-        "macho" => file.symbols().next().is_none(),
-        "pe" => !file.has_debug_symbols(),
-        _ => false,
-    };
-
-    let note_package = if class == "elf" {
-        file.section_by_name_bytes(b".note.package")
-            .and_then(|s| s.data().ok())
-            .and_then(elf::parse_note_package_public)
-    } else {
-        None
-    };
-
-    // Read-only string region per FR-025 / Q4 — format-appropriate
-    // sections only. Used by the curated version-string scanner.
-    let string_region = collect_string_region(&file, class);
-
-    // Packer-signature probe (R7). UPX packs its stub early in the
-    // file; a 4 KB byte-level probe catches it. PE-specific section
-    // names `UPX0`/`UPX1` also match.
-    let packer_kind = packer::detect(bytes);
-
-    Some(BinaryScan {
-        binary_class: class,
-        imports,
-        has_dynamic,
-        stripped,
-        note_package,
-        string_region,
-        packer: packer_kind,
-    })
-}
-
-/// Collect bytes from the read-only string sections appropriate to
-/// the binary format. Caps total accumulated bytes at 16 MB.
-fn collect_string_region(file: &object::read::File<'_>, class: &str) -> Vec<u8> {
-    use object::Object;
-
-    const CAP: usize = 16 * 1024 * 1024;
-    let candidates: &[&[u8]] = match class {
-        "elf" => &[b".rodata", b".data.rel.ro"],
-        "macho" => &[b"__cstring", b"__const"],
-        "pe" => &[b".rdata"],
-        _ => &[],
-    };
-
-    let mut out: Vec<u8> = Vec::new();
-    for name in candidates {
-        if out.len() >= CAP {
-            break;
-        }
-        if let Some(section) = file.section_by_name_bytes(name) {
-            if let Ok(data) = section.data() {
-                let room = CAP.saturating_sub(out.len());
-                let take = data.len().min(room);
-                out.extend_from_slice(&data[..take]);
-            }
-        }
-    }
-    out
-}
-
-/// Scan a fat Mach-O binary per FR-023 edge case — iterate every
-/// architecture slice, parse each as a regular Mach-O, merge the
-/// linkage evidence (install-names are arch-invariant in practice,
-/// so dedup by string collapses redundant entries).
-fn scan_fat_macho(path: &Path, bytes: &[u8]) -> Option<BinaryScan> {
-    use object::read::macho::{FatArch, MachOFatFile32, MachOFatFile64};
-
-    let mut imports = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    let mut has_dynamic = false;
-    let mut stripped = true; // AND-reduce across slices
-    let mut string_region: Vec<u8> = Vec::new();
-
-    // Try 32-bit fat first, fall back to 64-bit fat.
-    let slice_datas: Vec<&[u8]> = if let Ok(fat) = MachOFatFile32::parse(bytes) {
-        fat.arches()
-            .iter()
-            .filter_map(|a| a.data(bytes).ok())
-            .collect()
-    } else if let Ok(fat) = MachOFatFile64::parse(bytes) {
-        fat.arches()
-            .iter()
-            .filter_map(|a| a.data(bytes).ok())
-            .collect()
-    } else {
-        tracing::warn!(path = %path.display(), "fat Mach-O parse failed");
-        return None;
-    };
-
-    if slice_datas.is_empty() {
-        return None;
-    }
-
-    for slice_bytes in &slice_datas {
-        let Ok(file) = object::read::File::parse(*slice_bytes) else {
-            continue;
-        };
-        if !matches!(file.format(), object::BinaryFormat::MachO) {
-            continue;
-        }
-        if let Ok(imps) = file.imports() {
-            for imp in imps {
-                if let Ok(s) = std::str::from_utf8(imp.library()) {
-                    if !s.is_empty() && seen.insert(s.to_string()) {
-                        imports.push(s.to_string());
-                    }
-                }
-            }
-        }
-        if !has_dynamic {
-            has_dynamic = !imports.is_empty();
-        }
-        // A slice with symbols un-strips the whole fat binary.
-        use object::Object;
-        if file.symbols().next().is_some() {
-            stripped = false;
-        }
-        // Accumulate string regions across slices. Same sections
-        // typically carry identical content but dedup happens
-        // downstream in the version-string scanner (which dedups
-        // by library+version).
-        const CAP: usize = 16 * 1024 * 1024;
-        for name in [b"__cstring".as_ref(), b"__const".as_ref()] {
-            if string_region.len() >= CAP {
-                break;
-            }
-            if let Some(section) = file.section_by_name_bytes(name) {
-                if let Ok(data) = section.data() {
-                    let room = CAP.saturating_sub(string_region.len());
-                    let take = data.len().min(room);
-                    string_region.extend_from_slice(&data[..take]);
-                }
-            }
-        }
-    }
-
-    Some(BinaryScan {
-        binary_class: "macho",
-        imports,
-        has_dynamic,
-        stripped,
-        note_package: None, // Mach-O doesn't carry .note.package
-        string_region,
-        packer: packer::detect(bytes),
-    })
-}
-
-
 
 
 #[cfg(test)]
@@ -728,65 +477,6 @@ mod tests {
         )
         .is_empty());
     }
-
-
-
-
-    /// v9 Phase M — Fedora ≥34 / RHEL ≥9.4 ship rpmdb at the
-    /// `usr/lib/sysimage/rpm/` location. detect_rootfs_kind must
-    /// recognize this as Linux so rpm_dir_heuristic fires.
-
-    // --- v8 Phase K1: has_rpmdb_at covers both old and sysimage paths ---
-
-
-
-
-
-
-
-
-
-
-    #[test]
-    fn is_go_binary_detects_buildinfo_magic() {
-        // Minimal fixture: BuildInfo magic embedded in a larger buffer.
-        let mut bytes = vec![0u8; 4096];
-        bytes[2000..2014].copy_from_slice(b"\xff Go buildinf:");
-        assert!(is_go_binary(&bytes));
-    }
-
-    #[test]
-    fn is_go_binary_returns_false_without_magic() {
-        let bytes = vec![0x7Fu8; 4096];
-        assert!(!is_go_binary(&bytes));
-    }
-
-    #[test]
-    fn is_go_binary_detects_magic_past_old_2mb_cap() {
-        // Regression guard: the old 2 MB probe window missed real
-        // Go binaries where BuildInfo lives past that offset
-        // (common for Go binaries ≥5 MB). Probe cap is now 64 MB.
-        let mut bytes = vec![0u8; 5 * 1024 * 1024];
-        bytes[3_900_000..3_900_014].copy_from_slice(b"\xff Go buildinf:");
-        assert!(is_go_binary(&bytes));
-    }
-
-    #[test]
-    fn is_go_binary_bounded_probe_at_64mb() {
-        // Magic past the 64 MB probe window should NOT match —
-        // defense against scanning huge non-Go files completely.
-        // 64 MB = 67,108,864 bytes; place magic at 68 MB so it's
-        // clearly outside the window.
-        let mut bytes = vec![0u8; 70 * 1024 * 1024];
-        bytes[68 * 1024 * 1024..68 * 1024 * 1024 + 14]
-            .copy_from_slice(b"\xff Go buildinf:");
-        assert!(!is_go_binary(&bytes));
-    }
-
-    // --- G1: dual-identity file-level emission for Go binaries ----------
-
-
-
 
 
     /// Regression test for the Docker-image usrmerge failure mode

--- a/mikebom-cli/src/scan_fs/binary/mod.rs
+++ b/mikebom-cli/src/scan_fs/binary/mod.rs
@@ -27,17 +27,18 @@ pub mod version_strings; // stub
 
 use std::path::Path;
 
-use mikebom_common::types::hash::ContentHash;
-use mikebom_common::types::purl::Purl;
 use object::ObjectSection;
-use sha2::{Digest, Sha256};
 
-use super::package_db::{rpm_vendor_from_id, PackageDbEntry};
+use super::package_db::PackageDbEntry;
 
 mod discover;
+mod entry;
 mod predicates;
 
 use discover::discover_binaries;
+use entry::{
+    make_file_level_component, note_package_to_entry, version_match_to_entry, BinaryScan,
+};
 use predicates::{
     detect_rootfs_kind, has_rpmdb_at, is_host_system_path, is_os_managed_directory, RootfsKind,
 };
@@ -462,64 +463,7 @@ pub fn read(
     out
 }
 
-/// Convert a curated-scanner match into a `PackageDbEntry`.
-fn version_match_to_entry(
-    m: &version_strings::EmbeddedVersionMatch,
-    path: &Path,
-) -> Option<PackageDbEntry> {
-    let purl_str = format!(
-        "pkg:generic/{}@{}",
-        mikebom_common::types::purl::encode_purl_segment(m.library.slug()),
-        mikebom_common::types::purl::encode_purl_segment(&m.version),
-    );
-    let purl = Purl::new(&purl_str).ok()?;
-    Some(PackageDbEntry {
-        purl,
-        name: m.library.slug().to_string(),
-        version: m.version.clone(),
-        arch: None,
-        source_path: path.to_string_lossy().into_owned(),
-        depends: Vec::new(),
-        maintainer: None,
-        licenses: vec![],
-        is_dev: None,
-        requirement_range: None,
-        source_type: None,
-        sbom_tier: Some("analyzed".to_string()),
-        shade_relocation: None,
-        buildinfo_status: None,
-        evidence_kind: Some("embedded-version-string".to_string()),
-        binary_class: None,
-        binary_stripped: None,
-        linkage_kind: None,
-        detected_go: None,
-        confidence: Some("heuristic".to_string()),
-        binary_packed: None,
-        raw_version: None,
-        parent_purl: None,
-        npm_role: None,
-        co_owned_by: None,
-        hashes: Vec::new(),
-    })
-}
 
-/// Cross-format scan result. Common fields populated from all three
-/// formats via `object::read::File::imports()`; `note_package` is
-/// ELF-specific and `None` for Mach-O / PE.
-pub(crate) struct BinaryScan {
-    pub binary_class: &'static str,
-    pub imports: Vec<String>,
-    pub has_dynamic: bool,
-    pub stripped: bool,
-    pub note_package: Option<elf::ElfNotePackage>,
-    /// Concatenated read-only string-section bytes per FR-025 /
-    /// research R6. Fed to the curated version-string scanner.
-    /// Capped at 16 MB per binary.
-    pub string_region: Vec<u8>,
-    /// UPX or similar packer signature if detected (R7). `None`
-    /// means no packer recognised; the linkage list is complete.
-    pub packer: Option<packer::PackerKind>,
-}
 
 fn scan_binary(path: &Path, bytes: &[u8]) -> Option<BinaryScan> {
     use object::Object;
@@ -739,457 +683,25 @@ fn scan_fat_macho(path: &Path, bytes: &[u8]) -> Option<BinaryScan> {
 }
 
 
-fn make_file_level_component(
-    path: &Path,
-    bytes: &[u8],
-    scan: &BinaryScan,
-    detected_go: bool,
-) -> PackageDbEntry {
-    let sha256 = {
-        let mut hasher = Sha256::new();
-        hasher.update(bytes);
-        format!("{:x}", hasher.finalize())
-    };
-    let hash = ContentHash::sha256(&sha256)
-        .expect("Sha256 hex is always well-formed");
 
-    // File-level binary components get a synthetic pkg:generic PURL
-    // keyed on sha256 so they have a stable identity. The filename
-    // is preserved via the `name` field for human readability.
-    let filename = path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("unknown")
-        .to_string();
-    // Filename can carry arbitrary chars; percent-encode for PURL
-    // name-segment conformance.
-    let encoded_filename = mikebom_common::types::purl::encode_purl_segment(&filename);
-    let purl_str = format!("pkg:generic/{encoded_filename}?file-sha256={sha256}");
-    let purl = Purl::new(&purl_str).unwrap_or_else(|_| {
-        // Fallback: use a bare generic purl if filename has chars PURL
-        // can't handle. Keyed on sha256 alone.
-        Purl::new(&format!("pkg:generic/binary?file-sha256={sha256}"))
-            .expect("bare pkg:generic must parse")
-    });
-
-    let linkage = if scan.has_dynamic && !scan.imports.is_empty() {
-        "dynamic"
-    } else if !scan.has_dynamic {
-        "static"
-    } else {
-        "dynamic"
-    }
-    .to_string();
-
-    PackageDbEntry {
-        purl,
-        name: filename,
-        version: String::new(),
-        arch: None,
-        source_path: path.to_string_lossy().into_owned(),
-        depends: Vec::new(),
-        maintainer: None,
-        licenses: vec![],
-        is_dev: None,
-        requirement_range: None,
-        source_type: None,
-        sbom_tier: Some("analyzed".to_string()),
-        shade_relocation: None,
-        buildinfo_status: None,
-        evidence_kind: None,
-        binary_class: Some(scan.binary_class.to_string()),
-        binary_stripped: Some(scan.stripped),
-        linkage_kind: Some(linkage),
-        // G1: milestone 004 US2 R8 cross-link — set when the same
-        // bytes carry `runtime/debug.BuildInfo` so downstream
-        // consumers can pair the file-level `pkg:generic/<name>`
-        // component with its `pkg:golang/<module>@<version>`
-        // siblings from `go_binary.rs`.
-        detected_go: if detected_go { Some(true) } else { None },
-        confidence: None,
-        binary_packed: scan.packer.map(|p| p.as_str().to_string()),
-        raw_version: None,
-        parent_purl: None,
-        npm_role: None,
-        co_owned_by: None,
-        hashes: Vec::new(),
-    }
-    .with_sha256_placeholder(hash)
-}
-
-/// Extension helper: attach the file-SHA-256 as a `hashes` field.
-impl PackageDbEntry {
-    fn with_sha256_placeholder(self, _hash: ContentHash) -> Self {
-        // `PackageDbEntry` doesn't currently carry hashes directly;
-        // hashes land on the `ResolvedComponent` via the scan_fs
-        // conversion layer from the artefact-file walker. Binary
-        // file-level components bypass that walker (they're produced
-        // here), so a follow-on could extend `PackageDbEntry` with a
-        // hashes field. For this turn, hashes on binary components
-        // are omitted — consumers see the file-level component with
-        // the filename + bom-ref identity but without content hashes.
-        // Future: hook into the milestone-003 `file_hashes` plumbing.
-        self
-    }
-}
-
-/// Convert a parsed `.note.package` payload into a `PackageDbEntry`
-/// per FR-024. Vendor derived from `distro` via the milestone-003
-/// `rpm_vendor_from_id` map for RPM-family notes.
-fn note_package_to_entry(
-    note: &elf::ElfNotePackage,
-    path: &Path,
-    os_release_id: Option<&str>,
-    os_release_version_id: Option<&str>,
-) -> Option<PackageDbEntry> {
-    if note.name.is_empty() || note.version.is_empty() {
-        return None;
-    }
-    let mut qualifiers = note
-        .architecture
-        .as_deref()
-        .filter(|s| !s.is_empty())
-        .map(|a| format!("?arch={a}"))
-        .unwrap_or_default();
-
-    // v6 fix (conformance bug 1 / ELF-note ghosts): vendor namespace
-    // precedence is (1) the ELF note's own `distro` field when
-    // populated, then (2) the scan-wide `/etc/os-release` ID, then
-    // (3) a hardcoded default. Prior to this change, an unclaimed
-    // Fedora binary with no `distro` in its ELF note emitted
-    // `pkg:rpm/rpm/<name>@<ver>` — no OS context. Threading the
-    // os-release ID recovers the correct namespace for the fallback
-    // path.
-    let resolve_vendor = |note_distro: Option<&str>, default_fallback: &str| -> String {
-        let from_note = note_distro
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(|d| d.to_lowercase());
-        if let Some(d) = from_note {
-            return d;
-        }
-        if let Some(id) = os_release_id.filter(|s| !s.is_empty()) {
-            return id.to_lowercase();
-        }
-        default_fallback.to_string()
-    };
-    let append_distro_qualifier = |qualifiers: &mut String, vendor: &str| {
-        // Emit `distro=<vendor>-<VERSION_ID>` only when both halves
-        // are available. Mirrors the dpkg / rpm / apk package-db
-        // readers' qualifier shape.
-        if let Some(version_id) = os_release_version_id.filter(|s| !s.is_empty()) {
-            let prefix = if qualifiers.is_empty() { '?' } else { '&' };
-            qualifiers.push(prefix);
-            qualifiers.push_str("distro=");
-            qualifiers.push_str(vendor);
-            qualifiers.push('-');
-            qualifiers.push_str(version_id);
-        }
-    };
-
-    // purl-spec § Character encoding: `+` and other non-allowed chars
-    // MUST be percent-encoded in BOTH the name and version segments.
-    // The note.{name,version} came out of an ELF `.note.package`
-    // section and can carry real-world package coords with `+` (RPMs
-    // like `libstdc++`, semver versions like `1.0+build.1`). Route
-    // both through the canonical encoder so all five arms below emit
-    // spec-conformant PURLs.
-    let encoded_name = mikebom_common::types::purl::encode_purl_segment(&note.name);
-    let encoded_version = mikebom_common::types::purl::encode_purl_segment(&note.version);
-    let purl_str = match note.note_type.as_str() {
-        "rpm" => {
-            let raw_vendor = resolve_vendor(note.distro.as_deref(), "rpm");
-            // rpm_vendor_from_id normalizes `rhel`→`redhat`, `ol`→`oracle`,
-            // etc. Same mapping used by rpm.rs for the rpmdb reader.
-            let vendor = rpm_vendor_from_id(&raw_vendor);
-            append_distro_qualifier(&mut qualifiers, &vendor);
-            format!("pkg:rpm/{vendor}/{encoded_name}@{encoded_version}{qualifiers}")
-        }
-        "deb" => {
-            let vendor = resolve_vendor(note.distro.as_deref(), "debian");
-            append_distro_qualifier(&mut qualifiers, &vendor);
-            format!("pkg:deb/{vendor}/{encoded_name}@{encoded_version}{qualifiers}")
-        }
-        "apk" => {
-            let vendor = resolve_vendor(note.distro.as_deref(), "alpine");
-            append_distro_qualifier(&mut qualifiers, &vendor);
-            format!("pkg:apk/{vendor}/{encoded_name}@{encoded_version}{qualifiers}")
-        }
-        "alpm" | "pacman" => {
-            format!("pkg:alpm/arch/{encoded_name}@{encoded_version}{qualifiers}")
-        }
-        _ => format!("pkg:generic/{encoded_name}@{encoded_version}"),
-    };
-
-    let purl = Purl::new(&purl_str).ok()?;
-    Some(PackageDbEntry {
-        purl,
-        name: note.name.clone(),
-        version: note.version.clone(),
-        arch: note.architecture.clone(),
-        source_path: path.to_string_lossy().into_owned(),
-        depends: Vec::new(),
-        maintainer: None,
-        licenses: vec![],
-        is_dev: None,
-        requirement_range: None,
-        source_type: None,
-        sbom_tier: Some("source".to_string()),
-        shade_relocation: None,
-        buildinfo_status: None,
-        evidence_kind: Some("elf-note-package".to_string()),
-        binary_class: None,
-        binary_stripped: None,
-        linkage_kind: None,
-        detected_go: None,
-        confidence: None,
-        binary_packed: None,
-        raw_version: None,
-        parent_purl: None,
-        npm_role: None,
-        co_owned_by: None,
-        hashes: Vec::new(),
-    })
-}
 
 #[cfg(test)]
 #[cfg_attr(test, allow(clippy::unwrap_used))]
 mod tests {
     use super::*;
 
-    #[test]
-    fn note_package_rpm_produces_canonical_purl() {
-        let note = elf::ElfNotePackage {
-            note_type: "rpm".into(),
-            name: "curl".into(),
-            version: "8.2.1".into(),
-            architecture: Some("x86_64".into()),
-            distro: Some("fedora".into()),
-            os_cpe: None,
-        };
-        let entry =
-            note_package_to_entry(&note, Path::new("/opt/curl"), None, None).unwrap();
-        assert_eq!(
-            entry.purl.as_str(),
-            "pkg:rpm/fedora/curl@8.2.1?arch=x86_64"
-        );
-        assert_eq!(entry.evidence_kind.as_deref(), Some("elf-note-package"));
-        assert_eq!(entry.sbom_tier.as_deref(), Some("source"));
-    }
 
-    #[test]
-    fn note_package_rpm_uses_os_release_namespace_when_note_distro_absent() {
-        // Conformance bug 1 fix: when the ELF note has no distro field
-        // but the scan's /etc/os-release ID is known, use the os-release
-        // ID instead of the bare "rpm" fallback. Fixes Fedora ghosts
-        // emitting pkg:rpm/rpm/<name>.
-        let note = elf::ElfNotePackage {
-            note_type: "rpm".into(),
-            name: "ModemManager".into(),
-            version: "1.22.0-3.fc40".into(),
-            architecture: Some("aarch64".into()),
-            distro: None,
-            os_cpe: None,
-        };
-        let entry = note_package_to_entry(
-            &note,
-            Path::new("/usr/libexec/mm-plugin-broadband"),
-            Some("fedora"),
-            Some("40"),
-        )
-        .unwrap();
-        assert_eq!(
-            entry.purl.as_str(),
-            "pkg:rpm/fedora/ModemManager@1.22.0-3.fc40?arch=aarch64&distro=fedora-40"
-        );
-    }
 
-    #[test]
-    fn note_package_rpm_prefers_note_distro_over_os_release() {
-        // Precedence: ELF note's own `distro` wins over os-release ID.
-        let note = elf::ElfNotePackage {
-            note_type: "rpm".into(),
-            name: "curl".into(),
-            version: "8.2.1".into(),
-            architecture: Some("x86_64".into()),
-            distro: Some("rocky".into()),
-            os_cpe: None,
-        };
-        // Note says rocky, os-release (hypothetically wrong) says fedora.
-        // rocky wins; rpm_vendor_from_id keeps rocky→rocky, then appends
-        // distro=rocky-9 from VERSION_ID.
-        let entry = note_package_to_entry(
-            &note,
-            Path::new("/usr/bin/curl"),
-            Some("fedora"),
-            Some("9"),
-        )
-        .unwrap();
-        assert_eq!(
-            entry.purl.as_str(),
-            "pkg:rpm/rocky/curl@8.2.1?arch=x86_64&distro=rocky-9"
-        );
-    }
 
     /// purl-spec § Character encoding: `+` in the ELF-note name must
     /// percent-encode to `%2B` just like the rpmdb path. Mirror of the
     /// regression tests in `scan_fs::package_db::rpm::tests`.
-    #[test]
-    fn note_package_rpm_percent_encodes_plus_in_name() {
-        let note = elf::ElfNotePackage {
-            note_type: "rpm".into(),
-            name: "libstdc++".into(),
-            version: "14.2.1-3.fc40".into(),
-            architecture: Some("aarch64".into()),
-            distro: Some("fedora".into()),
-            os_cpe: None,
-        };
-        let entry = note_package_to_entry(
-            &note,
-            Path::new("/usr/lib64/libstdc++.so.6"),
-            Some("fedora"),
-            Some("40"),
-        )
-        .unwrap();
-        let purl = entry.purl.as_str();
-        assert!(
-            purl.contains("/libstdc%2B%2B@"),
-            "expected percent-encoded `++` in ELF-note PURL; got {purl}",
-        );
-        assert!(
-            !purl.contains("libstdc++"),
-            "literal `++` must not appear; got {purl}",
-        );
-    }
 
-    #[test]
-    fn note_package_rpm_percent_encodes_mid_name_plus() {
-        let note = elf::ElfNotePackage {
-            note_type: "rpm".into(),
-            name: "perl-Text-Tabs+Wrap".into(),
-            version: "2024.001-1.fc40".into(),
-            architecture: Some("noarch".into()),
-            distro: Some("fedora".into()),
-            os_cpe: None,
-        };
-        let entry = note_package_to_entry(
-            &note,
-            Path::new("/usr/share/perl5/Text/Tabs.pm"),
-            Some("fedora"),
-            Some("40"),
-        )
-        .unwrap();
-        assert!(
-            entry.purl.as_str().contains("/perl-Text-Tabs%2BWrap@"),
-            "mid-name `+` must percent-encode; got {}",
-            entry.purl.as_str()
-        );
-    }
 
-    #[test]
-    fn note_package_rpm_falls_back_to_rpm_when_no_context() {
-        // Final fallback: no note distro, no os-release. Emits the
-        // original bare "rpm" namespace. In practice this should never
-        // happen on a real scan (os-release is read first), but the
-        // defensive default preserves PURL validity.
-        let note = elf::ElfNotePackage {
-            note_type: "rpm".into(),
-            name: "foo".into(),
-            version: "1.0".into(),
-            architecture: None,
-            distro: None,
-            os_cpe: None,
-        };
-        let entry =
-            note_package_to_entry(&note, Path::new("/bin/foo"), None, None).unwrap();
-        assert_eq!(entry.purl.as_str(), "pkg:rpm/rpm/foo@1.0");
-    }
 
-    #[test]
-    fn note_package_alpm_uses_arch_namespace() {
-        let note = elf::ElfNotePackage {
-            note_type: "alpm".into(),
-            name: "bash".into(),
-            version: "5.2.015-1".into(),
-            architecture: Some("x86_64".into()),
-            distro: Some("Arch Linux".into()),
-            os_cpe: None,
-        };
-        let entry = note_package_to_entry(
-            &note,
-            Path::new("/usr/bin/bash"),
-            None,
-            None,
-        )
-        .unwrap();
-        assert_eq!(
-            entry.purl.as_str(),
-            "pkg:alpm/arch/bash@5.2.015-1?arch=x86_64"
-        );
-    }
 
-    #[test]
-    fn note_package_deb_falls_back_to_debian_vendor() {
-        let note = elf::ElfNotePackage {
-            note_type: "deb".into(),
-            name: "vim".into(),
-            version: "9.0.0".into(),
-            architecture: Some("amd64".into()),
-            distro: None,
-            os_cpe: None,
-        };
-        // No os-release context either → "debian" fallback.
-        let entry = note_package_to_entry(
-            &note,
-            Path::new("/usr/bin/vim"),
-            None,
-            None,
-        )
-        .unwrap();
-        assert_eq!(
-            entry.purl.as_str(),
-            "pkg:deb/debian/vim@9.0.0?arch=amd64"
-        );
-    }
 
-    #[test]
-    fn note_package_deb_uses_os_release_namespace_for_ubuntu() {
-        // Ubuntu image: ELF note lacks distro, os-release says ubuntu.
-        let note = elf::ElfNotePackage {
-            note_type: "deb".into(),
-            name: "openssh-server".into(),
-            version: "1:9.6p1-3ubuntu13".into(),
-            architecture: Some("amd64".into()),
-            distro: None,
-            os_cpe: None,
-        };
-        let entry = note_package_to_entry(
-            &note,
-            Path::new("/usr/sbin/sshd"),
-            Some("ubuntu"),
-            Some("24.04"),
-        )
-        .unwrap();
-        assert_eq!(
-            entry.purl.as_str(),
-            "pkg:deb/ubuntu/openssh-server@1:9.6p1-3ubuntu13?arch=amd64&distro=ubuntu-24.04"
-        );
-    }
 
-    #[test]
-    fn note_package_unknown_type_becomes_generic() {
-        let note = elf::ElfNotePackage {
-            note_type: "xbps".into(),
-            name: "foo".into(),
-            version: "1.0".into(),
-            architecture: None,
-            distro: None,
-            os_cpe: None,
-        };
-        let entry =
-            note_package_to_entry(&note, Path::new("/bin/foo"), None, None).unwrap();
-        assert_eq!(entry.purl.as_str(), "pkg:generic/foo@1.0");
-    }
 
     #[test]
     fn empty_rootfs_yields_zero_binary_components() {
@@ -1273,58 +785,8 @@ mod tests {
 
     // --- G1: dual-identity file-level emission for Go binaries ----------
 
-    fn fake_binary_scan() -> BinaryScan {
-        BinaryScan {
-            binary_class: "elf",
-            imports: Vec::new(),
-            has_dynamic: false,
-            stripped: false,
-            note_package: None,
-            string_region: Vec::new(),
-            packer: None,
-        }
-    }
 
-    #[test]
-    fn make_file_level_component_sets_detected_go_when_flag_set() {
-        // G1 wiring: `make_file_level_component` receives
-        // `detected_go = true` when the caller's `go_in_linux`
-        // check fires. The emitted PackageDbEntry carries
-        // `detected_go = Some(true)` so the CDX emitter surfaces
-        // `mikebom:detected-go = true` on the file-level
-        // component, cross-linking it with the sibling
-        // `pkg:golang/.../module@version` entries from
-        // `go_binary.rs`.
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("goapp");
-        std::fs::write(&path, b"dummy-bytes").unwrap();
-        let scan = fake_binary_scan();
-        let entry =
-            make_file_level_component(&path, b"dummy-bytes", &scan, true);
-        assert_eq!(entry.name, "goapp");
-        assert_eq!(entry.detected_go, Some(true));
-        assert_eq!(entry.binary_class.as_deref(), Some("elf"));
-        assert!(
-            entry.purl.as_str().starts_with("pkg:generic/goapp"),
-            "expected pkg:generic/goapp PURL: {}",
-            entry.purl.as_str(),
-        );
-    }
 
-    #[test]
-    fn make_file_level_component_leaves_detected_go_none_for_non_go() {
-        // Regression guard: non-Go file-level entries (plain ELF,
-        // Mach-O binaries without BuildInfo) keep `detected_go =
-        // None` so the CDX property is only emitted when the
-        // cross-link is real.
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("plain-tool");
-        std::fs::write(&path, b"plain-bytes").unwrap();
-        let scan = fake_binary_scan();
-        let entry =
-            make_file_level_component(&path, b"plain-bytes", &scan, false);
-        assert_eq!(entry.detected_go, None);
-    }
 
 
     /// Regression test for the Docker-image usrmerge failure mode

--- a/mikebom-cli/src/scan_fs/binary/mod.rs
+++ b/mikebom-cli/src/scan_fs/binary/mod.rs
@@ -25,7 +25,7 @@ pub mod pe; // stub
 pub mod python_collapse;
 pub mod version_strings; // stub
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use mikebom_common::types::hash::ContentHash;
 use mikebom_common::types::purl::Purl;
@@ -34,7 +34,10 @@ use sha2::{Digest, Sha256};
 
 use super::package_db::{rpm_vendor_from_id, PackageDbEntry};
 
+mod discover;
 mod predicates;
+
+use discover::discover_binaries;
 use predicates::{
     detect_rootfs_kind, has_rpmdb_at, is_host_system_path, is_os_managed_directory, RootfsKind,
 };
@@ -735,87 +738,6 @@ fn scan_fat_macho(path: &Path, bytes: &[u8]) -> Option<BinaryScan> {
     })
 }
 
-/// Walk `rootfs` for regular files, probing the first 16 bytes of
-/// each for a known binary magic. Skips hidden / build dirs. Ignores
-/// files <1 KB or >500 MB (defense-in-depth).
-fn discover_binaries(root: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    if root.is_file() {
-        if is_supported_binary(root) {
-            out.push(root.to_path_buf());
-        }
-        return out;
-    }
-    walk_dir(root, &mut out);
-    out
-}
-
-fn walk_dir(dir: &Path, acc: &mut Vec<PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if matches!(
-                name,
-                ".git" | "target" | "node_modules" | ".cargo" | "__pycache__" | ".venv"
-            ) {
-                continue;
-            }
-            walk_dir(&path, acc);
-        } else if path.is_file() && is_supported_binary(&path) {
-            acc.push(path);
-        }
-    }
-}
-
-fn is_supported_binary(path: &Path) -> bool {
-    use std::io::Read;
-    let Ok(mut f) = std::fs::File::open(path) else {
-        return false;
-    };
-    let mut magic = [0u8; 4];
-    match f.read_exact(&mut magic) {
-        Ok(()) => detect_format(&magic).is_some(),
-        Err(_) => false,
-    }
-}
-
-/// Detect binary format by first-4-bytes magic. Returns the
-/// canonical `binary-class` string per FR-021.
-pub(crate) fn detect_format(magic: &[u8]) -> Option<&'static str> {
-    if magic.len() < 4 {
-        return None;
-    }
-    // ELF: 0x7F 'E' 'L' 'F'
-    if magic == [0x7F, b'E', b'L', b'F'] {
-        return Some("elf");
-    }
-    // Mach-O: MH_MAGIC (0xFEEDFACE), MH_CIGAM (0xCEFAEDFE), MH_MAGIC_64
-    // (0xFEEDFACF), MH_CIGAM_64 (0xCFFAEDFE), fat-binary variants
-    // (0xCAFEBABE / 0xBEBAFECA).
-    if matches!(
-        magic,
-        [0xFE, 0xED, 0xFA, 0xCE]
-            | [0xCE, 0xFA, 0xED, 0xFE]
-            | [0xFE, 0xED, 0xFA, 0xCF]
-            | [0xCF, 0xFA, 0xED, 0xFE]
-            | [0xCA, 0xFE, 0xBA, 0xBE]
-            | [0xBE, 0xBA, 0xFE, 0xCA]
-    ) {
-        return Some("macho");
-    }
-    // PE: starts with "MZ" (0x4D 0x5A) in the DOS header; a real PE
-    // also has a PE\0\0 signature at the offset stored at 0x3C.
-    // First-4-bytes probe is necessarily optimistic — full PE
-    // validation happens at parse time via `object::read::File::parse`.
-    if &magic[..2] == b"MZ" {
-        return Some("pe");
-    }
-    None
-}
 
 fn make_file_level_component(
     path: &Path,

--- a/mikebom-cli/src/scan_fs/binary/mod.rs
+++ b/mikebom-cli/src/scan_fs/binary/mod.rs
@@ -34,130 +34,10 @@ use sha2::{Digest, Sha256};
 
 use super::package_db::{rpm_vendor_from_id, PackageDbEntry};
 
-/// Detected OS family of the scan root. Drives the OS-aware binary-
-/// format filter — we skip Mach-O / PE when scanning a Linux rootfs
-/// because binaries of other formats inside a Linux container are
-/// always contamination (test fixtures, build artefacts from a
-/// developer's host that got packaged in). Their linkage entries
-/// reference host paths like `/System/Library/Frameworks/...` that
-/// don't exist in the container and shouldn't appear in its SBOM.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum RootfsKind {
-    Linux,
-    Macos,
-    Windows,
-    /// No OS-specific signal found — treat as "any binary format allowed"
-    /// (caller likely scanning a mixed directory, not a container rootfs).
-    Unknown,
-}
-
-fn detect_rootfs_kind(rootfs: &Path) -> RootfsKind {
-    // Linux rootfs signals: `/etc/os-release` with a recognised
-    // Linux-family ID, `/lib/apk/db/installed`, `/var/lib/dpkg/status`,
-    // or an rpmdb at any of the candidate locations (var/lib/rpm or
-    // usr/lib/sysimage/rpm — Fedora ≥34 / RHEL ≥9.4).
-    //
-    // v9 Phase M: the rpmdb check was previously hardcoded to
-    // `var/lib/rpm/`, which missed Fedora 40 (sysimage location). That
-    // caused `rpm_dir_heuristic` to never fire on Fedora images
-    // because `rootfs_kind` came back as `Unknown`. Now uses the same
-    // candidate lists `rpm.rs` uses so the two can't drift apart.
-    if rootfs.join("lib/apk/db/installed").exists()
-        || rootfs.join("var/lib/dpkg/status").exists()
-    {
-        return RootfsKind::Linux;
-    }
-    {
-        use crate::scan_fs::package_db::rpm;
-        if rpm::RPMDB_SQLITE_CANDIDATES
-            .iter()
-            .any(|c| rootfs.join(c).is_file())
-            || rpm::RPMDB_BDB_CANDIDATES
-                .iter()
-                .any(|c| rootfs.join(c).is_file())
-        {
-            return RootfsKind::Linux;
-        }
-    }
-    // Generic os-release probe. Linux is by far the dominant ID.
-    // Uses the rootfs-aware reader so Ubuntu/Fedora images whose
-    // /etc/os-release is a symlink into /usr/lib/os-release still
-    // resolve (see os_release::read_id_from_rootfs).
-    if let Some(id) = crate::scan_fs::os_release::read_id_from_rootfs(rootfs) {
-        let id_lower = id.to_lowercase();
-        // Every RPM/DEB/APK-family distro + common musl / busybox ids.
-        const LINUX_IDS: &[&str] = &[
-            "alpine", "amzn", "arch", "centos", "debian", "fedora", "gentoo",
-            "linux", "mageia", "nixos", "openmandriva", "opensuse",
-            "opensuse-leap", "opensuse-tumbleweed", "ol", "ubuntu", "rhel",
-            "rocky", "almalinux", "sles", "wolfi", "chainguard",
-        ];
-        if LINUX_IDS.iter().any(|&s| id_lower == s || id_lower.starts_with(s)) {
-            return RootfsKind::Linux;
-        }
-    }
-    RootfsKind::Unknown
-}
-
-/// Drop linkage-evidence entries whose install-names look like host-
-/// OS absolute system paths. Mach-O binaries normally carry absolute
-/// install-names (`/usr/lib/libSystem.B.dylib`) — inside a Linux
-/// container these are host leakage; outside one they're real. We
-/// err on the side of dropping obvious noise.
-fn is_host_system_path(soname: &str) -> bool {
-    soname.starts_with("/System/Library/")
-        || soname.starts_with("/usr/lib/system/")
-        || soname.starts_with("/System/iOSSupport/")
-}
-
-/// RPM directory heuristic per the milestone-004 post-ship plan. RPM
-/// file-list extraction from HeaderBlob BASENAMES/DIRNAMES/DIRINDEXES
-/// is deferred to a follow-on milestone; meanwhile, when we know a
-/// rootfs has an rpmdb (so rpm OWNS the package-install story), any
-/// binary under a well-known OS-managed directory is presumed owned
-/// even if we can't enumerate its specific claim.
-///
-/// Well-known OS-managed directories chosen to match filesystem-
-/// hierarchy standards — `/bin`, `/sbin`, `/usr/{bin,sbin,lib,lib64,libexec}`,
-/// `/lib`, `/lib64`. Binaries in `/opt`, `/usr/local`, `/home`, etc.
-/// are NOT presumed owned — those are typical locations for manually-
-/// installed tools we DO want to flag.
-/// v8 Phase K1 — does this rootfs carry an rpmdb (sqlite or legacy BDB)
-/// at ANY of the locations rpm.rs supports? Replaces a historical
-/// hard-coded `/var/lib/rpm/rpmdb.sqlite` check that missed Fedora ≥34
-/// / RHEL ≥9.4 (which moved to `/usr/lib/sysimage/rpm/`).
-///
-/// Shares the candidate lists with `rpm.rs` so the two places can't
-/// drift out of sync again.
-fn has_rpmdb_at(rootfs: &std::path::Path) -> bool {
-    use crate::scan_fs::package_db::rpm;
-    rpm::RPMDB_SQLITE_CANDIDATES
-        .iter()
-        .any(|c| rootfs.join(c).is_file())
-        || rpm::RPMDB_BDB_CANDIDATES
-            .iter()
-            .any(|c| rootfs.join(c).is_file())
-}
-
-fn is_os_managed_directory(rootfs: &std::path::Path, path: &std::path::Path) -> bool {
-    let Ok(rel) = path.strip_prefix(rootfs) else {
-        return false;
-    };
-    let rel_str = rel.to_string_lossy();
-    const MANAGED_PREFIXES: &[&str] = &[
-        "bin/",
-        "sbin/",
-        "lib/",
-        "lib64/",
-        "usr/bin/",
-        "usr/sbin/",
-        "usr/lib/",
-        "usr/lib64/",
-        "usr/libexec/",
-        "usr/share/",
-    ];
-    MANAGED_PREFIXES.iter().any(|p| rel_str.starts_with(p))
-}
+mod predicates;
+use predicates::{
+    detect_rootfs_kind, has_rpmdb_at, is_host_system_path, is_os_managed_directory, RootfsKind,
+};
 
 /// Quick probe: does this ELF carry Go BuildInfo? Used by the Linux-
 /// rootfs Go-suppression rule — when Go BuildInfo succeeds, the Go
@@ -1415,160 +1295,23 @@ mod tests {
         .is_empty());
     }
 
-    #[test]
-    fn detect_rootfs_kind_alpine_from_apk_db() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join("lib/apk/db")).unwrap();
-        std::fs::write(dir.path().join("lib/apk/db/installed"), b"C:Q1...\n").unwrap();
-        assert_eq!(detect_rootfs_kind(dir.path()), RootfsKind::Linux);
-    }
 
-    #[test]
-    fn detect_rootfs_kind_debian_from_dpkg_status() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join("var/lib/dpkg")).unwrap();
-        std::fs::write(dir.path().join("var/lib/dpkg/status"), b"Package: foo\n").unwrap();
-        assert_eq!(detect_rootfs_kind(dir.path()), RootfsKind::Linux);
-    }
 
-    #[test]
-    fn detect_rootfs_kind_rhel_from_rpmdb() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join("var/lib/rpm")).unwrap();
-        std::fs::write(dir.path().join("var/lib/rpm/rpmdb.sqlite"), b"stub").unwrap();
-        assert_eq!(detect_rootfs_kind(dir.path()), RootfsKind::Linux);
-    }
 
     /// v9 Phase M — Fedora ≥34 / RHEL ≥9.4 ship rpmdb at the
     /// `usr/lib/sysimage/rpm/` location. detect_rootfs_kind must
     /// recognize this as Linux so rpm_dir_heuristic fires.
-    #[test]
-    fn detect_rootfs_kind_fedora_sysimage_path() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join("usr/lib/sysimage/rpm")).unwrap();
-        std::fs::write(
-            dir.path().join("usr/lib/sysimage/rpm/rpmdb.sqlite"),
-            b"stub",
-        )
-        .unwrap();
-        assert_eq!(detect_rootfs_kind(dir.path()), RootfsKind::Linux);
-    }
 
     // --- v8 Phase K1: has_rpmdb_at covers both old and sysimage paths ---
 
-    #[test]
-    fn has_rpmdb_at_detects_legacy_var_lib_path() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join("var/lib/rpm")).unwrap();
-        std::fs::write(dir.path().join("var/lib/rpm/rpmdb.sqlite"), b"stub").unwrap();
-        assert!(has_rpmdb_at(dir.path()));
-    }
 
-    #[test]
-    fn has_rpmdb_at_detects_sysimage_path() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join("usr/lib/sysimage/rpm")).unwrap();
-        std::fs::write(
-            dir.path().join("usr/lib/sysimage/rpm/rpmdb.sqlite"),
-            b"stub",
-        )
-        .unwrap();
-        assert!(
-            has_rpmdb_at(dir.path()),
-            "Fedora/RHEL9.4 sysimage rpmdb path must be detected"
-        );
-    }
 
-    #[test]
-    fn has_rpmdb_at_returns_false_on_bare_rootfs() {
-        let dir = tempfile::tempdir().unwrap();
-        assert!(!has_rpmdb_at(dir.path()));
-    }
 
-    #[test]
-    fn has_rpmdb_at_detects_legacy_bdb_packages_file() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join("var/lib/rpm")).unwrap();
-        std::fs::write(dir.path().join("var/lib/rpm/Packages"), b"BDB").unwrap();
-        assert!(has_rpmdb_at(dir.path()));
-    }
 
-    #[test]
-    fn detect_rootfs_kind_from_os_release_id() {
-        for id in &["alpine", "ubuntu", "debian", "rhel", "rocky", "fedora"] {
-            let dir = tempfile::tempdir().unwrap();
-            std::fs::create_dir_all(dir.path().join("etc")).unwrap();
-            std::fs::write(
-                dir.path().join("etc/os-release"),
-                format!("ID={id}\n").as_bytes(),
-            )
-            .unwrap();
-            assert_eq!(
-                detect_rootfs_kind(dir.path()),
-                RootfsKind::Linux,
-                "ID={id} should detect as Linux"
-            );
-        }
-    }
 
-    #[test]
-    fn detect_rootfs_kind_unknown_for_plain_directory() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("random.txt"), b"hello").unwrap();
-        assert_eq!(detect_rootfs_kind(dir.path()), RootfsKind::Unknown);
-    }
 
-    #[test]
-    fn is_host_system_path_blocks_macos_frameworks() {
-        assert!(is_host_system_path(
-            "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation"
-        ));
-        assert!(is_host_system_path("/usr/lib/system/libsystem_kernel.dylib"));
-        assert!(is_host_system_path(
-            "/System/iOSSupport/System/Library/Frameworks/UIKit.framework/UIKit"
-        ));
-    }
 
-    #[test]
-    fn is_os_managed_directory_matches_standard_paths() {
-        let rootfs = Path::new("/tmp/fakeroot");
-        assert!(is_os_managed_directory(
-            rootfs,
-            &rootfs.join("usr/bin/base64")
-        ));
-        assert!(is_os_managed_directory(rootfs, &rootfs.join("bin/ls")));
-        assert!(is_os_managed_directory(
-            rootfs,
-            &rootfs.join("usr/lib/libc.so.6")
-        ));
-        assert!(is_os_managed_directory(
-            rootfs,
-            &rootfs.join("usr/lib64/libcrypto.so.3")
-        ));
-        assert!(is_os_managed_directory(
-            rootfs,
-            &rootfs.join("usr/libexec/coreutils/libstdbuf.so")
-        ));
-    }
 
-    #[test]
-    fn is_os_managed_directory_allows_opt_and_local_paths() {
-        let rootfs = Path::new("/tmp/fakeroot");
-        // Manually-installed / user binaries should NOT be presumed owned.
-        assert!(!is_os_managed_directory(
-            rootfs,
-            &rootfs.join("opt/myapp/bin/jq")
-        ));
-        assert!(!is_os_managed_directory(
-            rootfs,
-            &rootfs.join("usr/local/bin/custom-tool")
-        ));
-        assert!(!is_os_managed_directory(
-            rootfs,
-            &rootfs.join("home/user/bin/tool")
-        ));
-        assert!(!is_os_managed_directory(rootfs, &rootfs.join("app/server")));
-    }
 
     #[test]
     fn is_go_binary_detects_buildinfo_magic() {
@@ -1661,19 +1404,6 @@ mod tests {
         assert_eq!(entry.detected_go, None);
     }
 
-    #[test]
-    fn is_host_system_path_allows_real_sonames() {
-        assert!(!is_host_system_path("libc.so.6"));
-        assert!(!is_host_system_path("libssl.so.3"));
-        assert!(!is_host_system_path("@rpath/libfoo.dylib"));
-        assert!(!is_host_system_path("/usr/lib/libSystem.B.dylib"));
-        // Note the last one is technically a host path BUT it's also
-        // the identity Mach-O binaries always use; we keep it because
-        // standalone macOS scans need it. The Linux-rootfs filter is
-        // the primary defense against host-OS leak.
-        assert!(!is_host_system_path("KERNEL32.dll"));
-        assert!(!is_host_system_path("advapi32.dll"));
-    }
 
     /// Regression test for the Docker-image usrmerge failure mode
     /// (reported: 917 of 954 `pkg:generic/` FPs had basename matches in

--- a/mikebom-cli/src/scan_fs/binary/predicates.rs
+++ b/mikebom-cli/src/scan_fs/binary/predicates.rs
@@ -1,0 +1,303 @@
+//! OS-aware predicates: rootfs kind detection + path classification.
+//!
+//! Used by the binary-scan orchestrator to decide which file formats
+//! to accept (Linux rootfs → only ELF; macOS rootfs → only Mach-O;
+//! Unknown rootfs → all formats) and which directories to filter as
+//! OS-managed (skip when emitting file-level binary components).
+
+use std::path::Path;
+
+
+/// Detected OS family of the scan root. Drives the OS-aware binary-
+/// format filter — we skip Mach-O / PE when scanning a Linux rootfs
+/// because binaries of other formats inside a Linux container are
+/// always contamination (test fixtures, build artefacts from a
+/// developer's host that got packaged in). Their linkage entries
+/// reference host paths like `/System/Library/Frameworks/...` that
+/// don't exist in the container and shouldn't appear in its SBOM.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RootfsKind {
+    Linux,
+    Macos,
+    Windows,
+    /// No OS-specific signal found — treat as "any binary format allowed"
+    /// (caller likely scanning a mixed directory, not a container rootfs).
+    Unknown,
+}
+
+pub(super) fn detect_rootfs_kind(rootfs: &Path) -> RootfsKind {
+    // Linux rootfs signals: `/etc/os-release` with a recognised
+    // Linux-family ID, `/lib/apk/db/installed`, `/var/lib/dpkg/status`,
+    // or an rpmdb at any of the candidate locations (var/lib/rpm or
+    // usr/lib/sysimage/rpm — Fedora ≥34 / RHEL ≥9.4).
+    //
+    // v9 Phase M: the rpmdb check was previously hardcoded to
+    // `var/lib/rpm/`, which missed Fedora 40 (sysimage location). That
+    // caused `rpm_dir_heuristic` to never fire on Fedora images
+    // because `rootfs_kind` came back as `Unknown`. Now uses the same
+    // candidate lists `rpm.rs` uses so the two can't drift apart.
+    if rootfs.join("lib/apk/db/installed").exists()
+        || rootfs.join("var/lib/dpkg/status").exists()
+    {
+        return RootfsKind::Linux;
+    }
+    {
+        use crate::scan_fs::package_db::rpm;
+        if rpm::RPMDB_SQLITE_CANDIDATES
+            .iter()
+            .any(|c| rootfs.join(c).is_file())
+            || rpm::RPMDB_BDB_CANDIDATES
+                .iter()
+                .any(|c| rootfs.join(c).is_file())
+        {
+            return RootfsKind::Linux;
+        }
+    }
+    // Generic os-release probe. Linux is by far the dominant ID.
+    // Uses the rootfs-aware reader so Ubuntu/Fedora images whose
+    // /etc/os-release is a symlink into /usr/lib/os-release still
+    // resolve (see os_release::read_id_from_rootfs).
+    if let Some(id) = crate::scan_fs::os_release::read_id_from_rootfs(rootfs) {
+        let id_lower = id.to_lowercase();
+        // Every RPM/DEB/APK-family distro + common musl / busybox ids.
+        const LINUX_IDS: &[&str] = &[
+            "alpine", "amzn", "arch", "centos", "debian", "fedora", "gentoo",
+            "linux", "mageia", "nixos", "openmandriva", "opensuse",
+            "opensuse-leap", "opensuse-tumbleweed", "ol", "ubuntu", "rhel",
+            "rocky", "almalinux", "sles", "wolfi", "chainguard",
+        ];
+        if LINUX_IDS.iter().any(|&s| id_lower == s || id_lower.starts_with(s)) {
+            return RootfsKind::Linux;
+        }
+    }
+    RootfsKind::Unknown
+}
+
+/// Drop linkage-evidence entries whose install-names look like host-
+/// OS absolute system paths. Mach-O binaries normally carry absolute
+/// install-names (`/usr/lib/libSystem.B.dylib`) — inside a Linux
+/// container these are host leakage; outside one they're real. We
+/// err on the side of dropping obvious noise.
+pub(super) fn is_host_system_path(soname: &str) -> bool {
+    soname.starts_with("/System/Library/")
+        || soname.starts_with("/usr/lib/system/")
+        || soname.starts_with("/System/iOSSupport/")
+}
+
+/// RPM directory heuristic per the milestone-004 post-ship plan. RPM
+/// file-list extraction from HeaderBlob BASENAMES/DIRNAMES/DIRINDEXES
+/// is deferred to a follow-on milestone; meanwhile, when we know a
+/// rootfs has an rpmdb (so rpm OWNS the package-install story), any
+/// binary under a well-known OS-managed directory is presumed owned
+/// even if we can't enumerate its specific claim.
+///
+/// Well-known OS-managed directories chosen to match filesystem-
+/// hierarchy standards — `/bin`, `/sbin`, `/usr/{bin,sbin,lib,lib64,libexec}`,
+/// `/lib`, `/lib64`. Binaries in `/opt`, `/usr/local`, `/home`, etc.
+/// are NOT presumed owned — those are typical locations for manually-
+/// installed tools we DO want to flag.
+/// v8 Phase K1 — does this rootfs carry an rpmdb (sqlite or legacy BDB)
+/// at ANY of the locations rpm.rs supports? Replaces a historical
+/// hard-coded `/var/lib/rpm/rpmdb.sqlite` check that missed Fedora ≥34
+/// / RHEL ≥9.4 (which moved to `/usr/lib/sysimage/rpm/`).
+///
+/// Shares the candidate lists with `rpm.rs` so the two places can't
+/// drift out of sync again.
+pub(super) fn has_rpmdb_at(rootfs: &std::path::Path) -> bool {
+    use crate::scan_fs::package_db::rpm;
+    rpm::RPMDB_SQLITE_CANDIDATES
+        .iter()
+        .any(|c| rootfs.join(c).is_file())
+        || rpm::RPMDB_BDB_CANDIDATES
+            .iter()
+            .any(|c| rootfs.join(c).is_file())
+}
+
+pub(super) fn is_os_managed_directory(rootfs: &std::path::Path, path: &std::path::Path) -> bool {
+    let Ok(rel) = path.strip_prefix(rootfs) else {
+        return false;
+    };
+    let rel_str = rel.to_string_lossy();
+    const MANAGED_PREFIXES: &[&str] = &[
+        "bin/",
+        "sbin/",
+        "lib/",
+        "lib64/",
+        "usr/bin/",
+        "usr/sbin/",
+        "usr/lib/",
+        "usr/lib64/",
+        "usr/libexec/",
+        "usr/share/",
+    ];
+    MANAGED_PREFIXES.iter().any(|p| rel_str.starts_with(p))
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+    #[test]
+    fn detect_rootfs_kind_alpine_from_apk_db() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("lib/apk/db")).unwrap();
+        std::fs::write(dir.path().join("lib/apk/db/installed"), b"C:Q1...\n").unwrap();
+        assert_eq!(detect_rootfs_kind(dir.path()), RootfsKind::Linux);
+    }
+
+    #[test]
+    fn detect_rootfs_kind_debian_from_dpkg_status() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("var/lib/dpkg")).unwrap();
+        std::fs::write(dir.path().join("var/lib/dpkg/status"), b"Package: foo\n").unwrap();
+        assert_eq!(detect_rootfs_kind(dir.path()), RootfsKind::Linux);
+    }
+
+    #[test]
+    fn detect_rootfs_kind_rhel_from_rpmdb() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("var/lib/rpm")).unwrap();
+        std::fs::write(dir.path().join("var/lib/rpm/rpmdb.sqlite"), b"stub").unwrap();
+        assert_eq!(detect_rootfs_kind(dir.path()), RootfsKind::Linux);
+    }
+
+    #[test]
+    fn detect_rootfs_kind_fedora_sysimage_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("usr/lib/sysimage/rpm")).unwrap();
+        std::fs::write(
+            dir.path().join("usr/lib/sysimage/rpm/rpmdb.sqlite"),
+            b"stub",
+        )
+        .unwrap();
+        assert_eq!(detect_rootfs_kind(dir.path()), RootfsKind::Linux);
+    }
+
+    #[test]
+    fn has_rpmdb_at_detects_legacy_var_lib_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("var/lib/rpm")).unwrap();
+        std::fs::write(dir.path().join("var/lib/rpm/rpmdb.sqlite"), b"stub").unwrap();
+        assert!(has_rpmdb_at(dir.path()));
+    }
+
+    #[test]
+    fn has_rpmdb_at_detects_sysimage_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("usr/lib/sysimage/rpm")).unwrap();
+        std::fs::write(
+            dir.path().join("usr/lib/sysimage/rpm/rpmdb.sqlite"),
+            b"stub",
+        )
+        .unwrap();
+        assert!(
+            has_rpmdb_at(dir.path()),
+            "Fedora/RHEL9.4 sysimage rpmdb path must be detected"
+        );
+    }
+
+    #[test]
+    fn has_rpmdb_at_returns_false_on_bare_rootfs() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!has_rpmdb_at(dir.path()));
+    }
+
+    #[test]
+    fn has_rpmdb_at_detects_legacy_bdb_packages_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("var/lib/rpm")).unwrap();
+        std::fs::write(dir.path().join("var/lib/rpm/Packages"), b"BDB").unwrap();
+        assert!(has_rpmdb_at(dir.path()));
+    }
+
+    #[test]
+    fn detect_rootfs_kind_from_os_release_id() {
+        for id in &["alpine", "ubuntu", "debian", "rhel", "rocky", "fedora"] {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(dir.path().join("etc")).unwrap();
+            std::fs::write(
+                dir.path().join("etc/os-release"),
+                format!("ID={id}\n").as_bytes(),
+            )
+            .unwrap();
+            assert_eq!(
+                detect_rootfs_kind(dir.path()),
+                RootfsKind::Linux,
+                "ID={id} should detect as Linux"
+            );
+        }
+    }
+
+    #[test]
+    fn detect_rootfs_kind_unknown_for_plain_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("random.txt"), b"hello").unwrap();
+        assert_eq!(detect_rootfs_kind(dir.path()), RootfsKind::Unknown);
+    }
+
+    #[test]
+    fn is_host_system_path_blocks_macos_frameworks() {
+        assert!(is_host_system_path(
+            "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation"
+        ));
+        assert!(is_host_system_path("/usr/lib/system/libsystem_kernel.dylib"));
+        assert!(is_host_system_path(
+            "/System/iOSSupport/System/Library/Frameworks/UIKit.framework/UIKit"
+        ));
+    }
+
+    #[test]
+    fn is_os_managed_directory_matches_standard_paths() {
+        let rootfs = Path::new("/tmp/fakeroot");
+        assert!(is_os_managed_directory(
+            rootfs,
+            &rootfs.join("usr/bin/base64")
+        ));
+        assert!(is_os_managed_directory(rootfs, &rootfs.join("bin/ls")));
+        assert!(is_os_managed_directory(
+            rootfs,
+            &rootfs.join("usr/lib/libc.so.6")
+        ));
+        assert!(is_os_managed_directory(
+            rootfs,
+            &rootfs.join("usr/lib64/libcrypto.so.3")
+        ));
+        assert!(is_os_managed_directory(
+            rootfs,
+            &rootfs.join("usr/libexec/coreutils/libstdbuf.so")
+        ));
+    }
+
+    #[test]
+    fn is_os_managed_directory_allows_opt_and_local_paths() {
+        let rootfs = Path::new("/tmp/fakeroot");
+        // Manually-installed / user binaries should NOT be presumed owned.
+        assert!(!is_os_managed_directory(
+            rootfs,
+            &rootfs.join("opt/myapp/bin/jq")
+        ));
+        assert!(!is_os_managed_directory(
+            rootfs,
+            &rootfs.join("usr/local/bin/custom-tool")
+        ));
+        assert!(!is_os_managed_directory(
+            rootfs,
+            &rootfs.join("home/user/bin/tool")
+        ));
+        assert!(!is_os_managed_directory(rootfs, &rootfs.join("app/server")));
+    }
+
+    #[test]
+    fn is_host_system_path_allows_real_sonames() {
+        assert!(!is_host_system_path("libc.so.6"));
+        assert!(!is_host_system_path("libssl.so.3"));
+        assert!(!is_host_system_path("@rpath/libfoo.dylib"));
+        assert!(!is_host_system_path("/usr/lib/libSystem.B.dylib"));
+        // Note the last one is technically a host path BUT it's also
+        // the identity Mach-O binaries always use; we keep it because
+        // standalone macOS scans need it. The Linux-rootfs filter is
+        // the primary defense against host-OS leak.
+        assert!(!is_host_system_path("KERNEL32.dll"));
+        assert!(!is_host_system_path("advapi32.dll"));
+    }
+}

--- a/mikebom-cli/src/scan_fs/binary/scan.rs
+++ b/mikebom-cli/src/scan_fs/binary/scan.rs
@@ -1,0 +1,306 @@
+//! Single-file binary scanner — ELF / Mach-O / fat-Mach-O / PE.
+//!
+//! Reads the file bytes, identifies the format via the `object` crate,
+//! and produces a `BinaryScan` (defined in `entry.rs`) holding the
+//! cross-format common fields plus ELF-specific note-package data.
+
+use std::path::Path;
+
+use object::ObjectSection;
+
+use super::elf;
+use super::entry::BinaryScan;
+use super::packer;
+
+/// Quick probe: does this ELF carry Go BuildInfo? Used by the Linux-
+/// rootfs Go-suppression rule — when Go BuildInfo succeeds, the Go
+/// modules emitted by `package_db::go_binary` carry the container
+/// content; the file-level binary component is redundant noise.
+///
+/// Lightweight byte-scan for the BuildInfo magic prefix `\xff Go buildinf:`
+/// — avoids re-parsing the binary. Same magic the `go_binary` reader
+/// looks for (source: Go stdlib `debug/buildinfo`).
+pub(super) fn is_go_binary(bytes: &[u8]) -> bool {
+    // Scan the first 64 MB — BuildInfo lives in the `.go.buildinfo`
+    // section, which the Go linker places AFTER the text/data
+    // sections. Real-world offsets commonly exceed the old 2 MB
+    // probe cap: a 6 MB Go binary puts BuildInfo around 3.9 MB; a
+    // larger service binary can push it past 10 MB. 64 MB covers
+    // virtually all Go binaries while keeping bounded worst-case
+    // cost on pathological non-Go files. The probe is a
+    // `windows().any()` scan which modern rustc/LLVM optimizes
+    // aggressively — measurable cost on a 64 MB file is tens of
+    // milliseconds, acceptable for the correctness win.
+    //
+    // For comparison, `go_binary.rs::detect_is_go` first does a
+    // section-name lookup via the object crate (fast, precise), then
+    // falls back to memmem over the entire file (up to 500 MB). This
+    // cheaper byte-scan covers the common case without pulling in
+    // ELF parsing here.
+    const PROBE: usize = 64 * 1024 * 1024;
+    let end = bytes.len().min(PROBE);
+    bytes[..end]
+        .windows(14)
+        .any(|w| w == b"\xff Go buildinf:")
+}
+
+
+pub(super) fn scan_binary(path: &Path, bytes: &[u8]) -> Option<BinaryScan> {
+    use object::Object;
+
+    // Fat Mach-O requires slice iteration — object's top-level
+    // `File::parse` doesn't handle the fat format directly.
+    if bytes.len() >= 4 {
+        let magic = [bytes[0], bytes[1], bytes[2], bytes[3]];
+        if matches!(
+            magic,
+            [0xCA, 0xFE, 0xBA, 0xBE]
+                | [0xBE, 0xBA, 0xFE, 0xCA]
+                | [0xCA, 0xFE, 0xBA, 0xBF]
+                | [0xBF, 0xBA, 0xFE, 0xCA]
+        ) {
+            return scan_fat_macho(path, bytes);
+        }
+    }
+
+    let file = match object::read::File::parse(bytes) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "skipping binary parse");
+            return None;
+        }
+    };
+    let class = match file.format() {
+        object::BinaryFormat::Elf => "elf",
+        object::BinaryFormat::MachO => "macho",
+        object::BinaryFormat::Pe => "pe",
+        _ => return None,
+    };
+
+    // Linkage: object's high-level imports() returns `Vec<Import>`
+    // where `library()` is the DT_NEEDED soname (ELF), LC_LOAD_DYLIB
+    // install-name (Mach-O), or IMPORT DLL name (PE). Dedup by string.
+    let mut imports = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    if let Ok(imps) = file.imports() {
+        for imp in imps {
+            let lib = imp.library();
+            if lib.is_empty() {
+                continue;
+            }
+            if let Ok(s) = std::str::from_utf8(lib) {
+                if seen.insert(s.to_string()) {
+                    imports.push(s.to_string());
+                }
+            }
+        }
+    }
+
+    // has_dynamic = linkage list non-empty OR ELF has .dynamic
+    // section. Close enough for the dynamic/static classifier.
+    let has_dynamic = !imports.is_empty()
+        || (class == "elf" && file.section_by_name_bytes(b".dynamic").is_some());
+
+    // Stripped classification per format:
+    // - ELF: no .symtab / .dynsym AND no .note.package
+    // - Mach-O: no LC_SYMTAB (indicated by absence of symbols)
+    // - PE: no IMAGE_DEBUG_DIRECTORY entries AND no VS_VERSION_INFO
+    //   (approximated via: has_debug_info() returning false)
+    let stripped = match class {
+        "elf" => {
+            let has_sym = file.section_by_name_bytes(b".symtab").is_some()
+                || file.section_by_name_bytes(b".dynsym").is_some();
+            let has_note_pkg = file.section_by_name_bytes(b".note.package").is_some();
+            !has_sym && !has_note_pkg
+        }
+        "macho" => file.symbols().next().is_none(),
+        "pe" => !file.has_debug_symbols(),
+        _ => false,
+    };
+
+    let note_package = if class == "elf" {
+        file.section_by_name_bytes(b".note.package")
+            .and_then(|s| s.data().ok())
+            .and_then(elf::parse_note_package_public)
+    } else {
+        None
+    };
+
+    // Read-only string region per FR-025 / Q4 — format-appropriate
+    // sections only. Used by the curated version-string scanner.
+    let string_region = collect_string_region(&file, class);
+
+    // Packer-signature probe (R7). UPX packs its stub early in the
+    // file; a 4 KB byte-level probe catches it. PE-specific section
+    // names `UPX0`/`UPX1` also match.
+    let packer_kind = packer::detect(bytes);
+
+    Some(BinaryScan {
+        binary_class: class,
+        imports,
+        has_dynamic,
+        stripped,
+        note_package,
+        string_region,
+        packer: packer_kind,
+    })
+}
+
+/// Collect bytes from the read-only string sections appropriate to
+/// the binary format. Caps total accumulated bytes at 16 MB.
+fn collect_string_region(file: &object::read::File<'_>, class: &str) -> Vec<u8> {
+    use object::Object;
+
+    const CAP: usize = 16 * 1024 * 1024;
+    let candidates: &[&[u8]] = match class {
+        "elf" => &[b".rodata", b".data.rel.ro"],
+        "macho" => &[b"__cstring", b"__const"],
+        "pe" => &[b".rdata"],
+        _ => &[],
+    };
+
+    let mut out: Vec<u8> = Vec::new();
+    for name in candidates {
+        if out.len() >= CAP {
+            break;
+        }
+        if let Some(section) = file.section_by_name_bytes(name) {
+            if let Ok(data) = section.data() {
+                let room = CAP.saturating_sub(out.len());
+                let take = data.len().min(room);
+                out.extend_from_slice(&data[..take]);
+            }
+        }
+    }
+    out
+}
+
+/// Scan a fat Mach-O binary per FR-023 edge case — iterate every
+/// architecture slice, parse each as a regular Mach-O, merge the
+/// linkage evidence (install-names are arch-invariant in practice,
+/// so dedup by string collapses redundant entries).
+fn scan_fat_macho(path: &Path, bytes: &[u8]) -> Option<BinaryScan> {
+    use object::read::macho::{FatArch, MachOFatFile32, MachOFatFile64};
+
+    let mut imports = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut has_dynamic = false;
+    let mut stripped = true; // AND-reduce across slices
+    let mut string_region: Vec<u8> = Vec::new();
+
+    // Try 32-bit fat first, fall back to 64-bit fat.
+    let slice_datas: Vec<&[u8]> = if let Ok(fat) = MachOFatFile32::parse(bytes) {
+        fat.arches()
+            .iter()
+            .filter_map(|a| a.data(bytes).ok())
+            .collect()
+    } else if let Ok(fat) = MachOFatFile64::parse(bytes) {
+        fat.arches()
+            .iter()
+            .filter_map(|a| a.data(bytes).ok())
+            .collect()
+    } else {
+        tracing::warn!(path = %path.display(), "fat Mach-O parse failed");
+        return None;
+    };
+
+    if slice_datas.is_empty() {
+        return None;
+    }
+
+    for slice_bytes in &slice_datas {
+        let Ok(file) = object::read::File::parse(*slice_bytes) else {
+            continue;
+        };
+        if !matches!(file.format(), object::BinaryFormat::MachO) {
+            continue;
+        }
+        if let Ok(imps) = file.imports() {
+            for imp in imps {
+                if let Ok(s) = std::str::from_utf8(imp.library()) {
+                    if !s.is_empty() && seen.insert(s.to_string()) {
+                        imports.push(s.to_string());
+                    }
+                }
+            }
+        }
+        if !has_dynamic {
+            has_dynamic = !imports.is_empty();
+        }
+        // A slice with symbols un-strips the whole fat binary.
+        use object::Object;
+        if file.symbols().next().is_some() {
+            stripped = false;
+        }
+        // Accumulate string regions across slices. Same sections
+        // typically carry identical content but dedup happens
+        // downstream in the version-string scanner (which dedups
+        // by library+version).
+        const CAP: usize = 16 * 1024 * 1024;
+        for name in [b"__cstring".as_ref(), b"__const".as_ref()] {
+            if string_region.len() >= CAP {
+                break;
+            }
+            if let Some(section) = file.section_by_name_bytes(name) {
+                if let Ok(data) = section.data() {
+                    let room = CAP.saturating_sub(string_region.len());
+                    let take = data.len().min(room);
+                    string_region.extend_from_slice(&data[..take]);
+                }
+            }
+        }
+    }
+
+    Some(BinaryScan {
+        binary_class: "macho",
+        imports,
+        has_dynamic,
+        stripped,
+        note_package: None, // Mach-O doesn't carry .note.package
+        string_region,
+        packer: packer::detect(bytes),
+    })
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_go_binary_detects_buildinfo_magic() {
+        // Minimal fixture: BuildInfo magic embedded in a larger buffer.
+        let mut bytes = vec![0u8; 4096];
+        bytes[2000..2014].copy_from_slice(b"\xff Go buildinf:");
+        assert!(is_go_binary(&bytes));
+    }
+
+    #[test]
+    fn is_go_binary_returns_false_without_magic() {
+        let bytes = vec![0x7Fu8; 4096];
+        assert!(!is_go_binary(&bytes));
+    }
+
+    #[test]
+    fn is_go_binary_detects_magic_past_old_2mb_cap() {
+        // Regression guard: the old 2 MB probe window missed real
+        // Go binaries where BuildInfo lives past that offset
+        // (common for Go binaries ≥5 MB). Probe cap is now 64 MB.
+        let mut bytes = vec![0u8; 5 * 1024 * 1024];
+        bytes[3_900_000..3_900_014].copy_from_slice(b"\xff Go buildinf:");
+        assert!(is_go_binary(&bytes));
+    }
+
+    #[test]
+    fn is_go_binary_bounded_probe_at_64mb() {
+        // Magic past the 64 MB probe window should NOT match —
+        // defense against scanning huge non-Go files completely.
+        // 64 MB = 67,108,864 bytes; place magic at 68 MB so it's
+        // clearly outside the window.
+        let mut bytes = vec![0u8; 70 * 1024 * 1024];
+        bytes[68 * 1024 * 1024..68 * 1024 * 1024 + 14]
+            .copy_from_slice(b"\xff Go buildinf:");
+        assert!(!is_go_binary(&bytes));
+    }
+}
+

--- a/specs/019-binary-split/checklists/requirements.md
+++ b/specs/019-binary-split/checklists/requirements.md
@@ -1,0 +1,63 @@
+# Spec Quality Checklist: binary/mod.rs Split
+
+**Checklist for** `/specs/019-binary-split/spec.md`
+
+## Coverage
+
+- [X] Background section explains *why* the split is needed (carries milestone-018's deferred US3 context + new finding about test-LOC budget driving the 5-file split).
+- [X] User story has a P-priority and a "why this priority" justification.
+- [X] Independent Test is concrete (specific file paths + LOC ceiling + golden-regen check).
+- [X] Acceptance scenarios use Given/When/Then framing.
+- [X] Edge Cases section names ≥ 5 corner cases (`is_path_claimed` location, `BinaryScan` location, `detect_format` retention, sibling-module references, test-distribution rules, `tests/scan_binary.rs` exemption).
+- [X] Functional Requirements are numbered (FR-001 through FR-010), each independently verifiable.
+- [X] Key Entities section explicitly notes there's no new data — structural refactor only.
+- [X] Success Criteria are measurable (SC-001 through SC-006), each with a verification mechanism.
+- [X] Clarifications section captures three scope decisions (5 files vs 4; `is_path_claimed` location; `tests/scan_binary.rs` not split).
+- [X] Assumptions are explicit (byte-identity goldens are the regression gate; `tests/scan_binary.rs` covers the public API; pre-existing flakiness in `dual_format_perf` etc.).
+- [X] Out of Scope section names every adjacent concern (test file split, sub-splits, behavior changes, renames, stub completion, maven).
+
+## Independence
+
+- [X] The single user story is self-contained — no dependencies on other in-flight work.
+- [X] Each per-submodule extraction commit is independently verifiable (per FR-008 each commit's `./scripts/pre-pr.sh` passes).
+
+## Concreteness
+
+- [X] FRs cite specific file paths (`mikebom-cli/src/scan_fs/binary/{discover,entry,predicates,scan}.rs`).
+- [X] FR-001 quantifies the LOC target (≤ 800).
+- [X] FR-004 names the verification command verbatim.
+- [X] FR-003 names the 4 specific external call sites that must not change.
+- [X] Success Criteria reference the existing pre-PR gate.
+
+## Internal consistency
+
+- [X] FR-006 (visibility expansion only) aligns with research.md R4 (visibility ladder).
+- [X] FR-005 (test names preserved) aligns with SC-002 (sorted-name diff).
+- [X] FR-008 (per-commit pre-PR clean) aligns with quickstart.md commit chunking.
+- [X] The visibility-ladder tables in `data-model.md` align with the cross-sibling-surface contract in `contracts/module-boundaries.md`.
+- [X] research.md's R5 (atomic per-submodule commits) aligns with quickstart.md's commit chunking.
+
+## Lessons from milestone 018
+
+- [X] research.md R2 captures why `is_path_claimed` stays in mod.rs — the failure mode that defeated 018/US3 was trying to move it to scan.rs and re-route external callers.
+- [X] research.md R3 captures where `BinaryScan` lives + why scan.rs imports it from entry.rs (not mod.rs).
+- [X] research.md R5 captures the atomic-per-submodule-commit lesson.
+- [X] quickstart.md "Common pitfalls" enumerates the failure modes.
+- [X] FR-008 enforces the per-commit verification convention that protected milestone 018's pip + npm splits.
+
+## Pre-implementation
+
+- [ ] [PHASE-1] Snapshot baseline: `./scripts/pre-pr.sh` test-name list captured (post-#43 baseline).
+- [ ] [PHASE-1] LOC pre-split confirmed: 1858 (verified during reconnaissance — current as of 2026-04-25, post-#43).
+- [ ] [PHASE-2] predicates.rs landed; mod.rs ~1500 LOC.
+- [ ] [PHASE-3] discover.rs landed; mod.rs ~1415 LOC.
+- [ ] [PHASE-4] entry.rs landed; mod.rs ~925 LOC.
+- [ ] [PHASE-5] scan.rs landed; mod.rs ≤ 800 LOC.
+- [ ] [POLISH] FR-001 LOC ceiling met (verified via `wc -l` per the quickstart).
+- [ ] [POLISH] SC-002 test-name parity check returns no removed-without-rename names.
+- [ ] [POLISH] Goldens regen produces zero diff.
+- [ ] [POLISH] Both CI legs (Linux + macOS) green on the open PR.
+
+## Post-merge (per spec SC-006)
+
+- [ ] [QUALITATIVE] Next time a Mach-O fat-binary or PE-format bug is fixed, observe whether navigation feels faster vs. pre-split. If yes, milestone delivered.

--- a/specs/019-binary-split/contracts/module-boundaries.md
+++ b/specs/019-binary-split/contracts/module-boundaries.md
@@ -1,0 +1,128 @@
+# Contract: Module Boundaries — `binary/`
+
+**Phase 1 contract for** `/specs/019-binary-split/spec.md`
+
+This document is the formal contract for the per-submodule entry points and visibility surface introduced by milestone 019. Anyone touching the `binary/` directory AFTER this milestone ships should preserve these boundaries.
+
+## `binary/` directory module
+
+### Public surface
+
+```rust
+// binary/mod.rs:
+pub fn read(
+    rootfs: &Path,
+    deb_codename: Option<&str>,
+    max_file_size: u64,
+    deep_hash: bool,
+    /* additional args */
+) -> Vec<PackageDbEntry>;
+```
+
+External callers (1):
+- `crate::scan_fs::mod.rs:218` — `binary::read(...)`
+
+### Crate-visible surface
+
+```rust
+// binary/mod.rs (kept):
+pub(crate) fn is_path_claimed(
+    path: &Path,
+    claimed: &HashSet<PathBuf>,
+    inodes: &HashSet<(u64, u64)>,
+) -> bool;
+
+// binary/entry.rs (moved):
+pub(crate) struct BinaryScan { /* fields */ }
+
+// binary/discover.rs (moved):
+pub(crate) fn detect_format(magic: &[u8]) -> Option<&'static str>;
+```
+
+External callers of `is_path_claimed` (3):
+- `crate::scan_fs::package_db::maven.rs:2274`
+- `crate::scan_fs::package_db::go_binary.rs:517`
+- `crate::scan_fs::binary::linkage.rs:45` (sibling)
+
+`BinaryScan` and `detect_format` have no external crate callers today. Their `pub(crate)` visibility is preserved per FR-006 (no contraction).
+
+### Cross-sibling surface (`pub(super)` in submodules)
+
+```rust
+// binary/predicates.rs:
+pub(super) enum RootfsKind { /* variants */ }
+pub(super) fn detect_rootfs_kind(rootfs: &Path) -> RootfsKind;
+pub(super) fn is_host_system_path(soname: &str) -> bool;
+pub(super) fn has_rpmdb_at(rootfs: &Path) -> bool;
+pub(super) fn is_os_managed_directory(rootfs: &Path, path: &Path) -> bool;
+
+// binary/discover.rs:
+pub(super) fn discover_binaries(root: &Path) -> Vec<PathBuf>;
+
+// binary/scan.rs:
+pub(super) fn scan_binary(path: &Path, bytes: &[u8]) -> Option<BinaryScan>;
+
+// binary/entry.rs:
+pub(super) fn version_match_to_entry(/* args */) -> Option<PackageDbEntry>;
+pub(super) fn make_file_level_component(scan: &BinaryScan, /* args */) -> PackageDbEntry;
+pub(super) fn note_package_to_entry(note: &elf::ElfNotePackage, /* args */) -> Option<PackageDbEntry>;
+```
+
+All called from `mod.rs::read()` — single sibling caller, hence `pub(super)` is the minimum.
+
+### Module declarations
+
+`binary/mod.rs` declares:
+
+```rust
+// EXISTING — unchanged:
+pub mod elf;
+pub mod jdk_collapse;
+pub mod linkage;
+pub mod macho;            // stub
+pub mod packer;           // stub
+pub mod pe;               // stub
+pub mod python_collapse;
+pub mod version_strings;  // stub
+
+// NEW (this milestone):
+mod discover;
+mod entry;
+mod predicates;
+mod scan;
+```
+
+The new submodules are NOT declared `pub mod` because nothing outside the `binary/` directory references them by path — all access is through `mod.rs`'s `pub fn read` and `pub(crate) fn is_path_claimed`.
+
+### Orchestration contract
+
+`binary::read` runs:
+
+1. `predicates::detect_rootfs_kind(rootfs)` → tags the rootfs's package-management style.
+2. `discover::discover_binaries(rootfs)` → list of candidate file paths.
+3. For each candidate: `scan::scan_binary(path, bytes)` → `Option<BinaryScan>`.
+4. For each scan result: convert to `PackageDbEntry` via `entry::version_match_to_entry` / `entry::make_file_level_component` / `entry::note_package_to_entry`.
+5. Apply cross-cutting predicates (`predicates::is_host_system_path`, `predicates::is_os_managed_directory`) before final dedup.
+6. Apply `is_path_claimed` to filter out files the package_db readers already claimed.
+
+The `linkage::dedup_globally` pass (in the existing sibling `binary/linkage.rs`) runs at the end — unchanged from pre-split.
+
+---
+
+## Visibility expansion rules
+
+Same as milestone 018:
+
+1. **First choice**: `pub(super) fn` for sibling-only access.
+2. **Second choice**: move the item into `mod.rs` if used by ≥ 2 sibling submodules (none in this milestone).
+3. **NEVER**: `pub` for items not in the documented public surface above.
+
+---
+
+## Anti-patterns to avoid
+
+- **Adding a `mod.rs::pub use scan::is_path_claimed;` re-export to "make symmetry"**. `is_path_claimed` lives in `mod.rs` directly per research.md R2. Re-exporting from a submodule it doesn't live in is misleading.
+- **Reducing `BinaryScan` to private**. It's `pub(crate)` for a reason (internal-to-crate sharing across `binary/` and potentially `package_db/` in future enrichments). Don't tighten without thinking.
+- **Moving `is_path_claimed` to `predicates.rs`**. It's path-classification-shaped but its callers (`read()` and external crate paths) couple it to mod.rs's loop. Different cohort from the OS-aware predicates.
+- **Renaming `pub fn read`**. External callers depend on the path; don't change it without a separate milestone.
+- **Adding `pub mod` for the new submodules**. Nothing outside `binary/` should reference `discover::*` / `scan::*` / `entry::*` / `predicates::*` directly. All access is through `mod.rs`.

--- a/specs/019-binary-split/data-model.md
+++ b/specs/019-binary-split/data-model.md
@@ -1,0 +1,208 @@
+# Data Model: binary/mod.rs Split
+
+**Phase 1 output for** `/specs/019-binary-split/spec.md`
+
+## Scope
+
+Source-tree refactor only — no new runtime data. The only artifacts captured here are (a) the per-item visibility ladder mapping every existing item in `binary/mod.rs` to its target submodule + post-split visibility, and (b) the inline-test distribution table.
+
+---
+
+## Visibility ladder
+
+**Pre-split file**: `mikebom-cli/src/scan_fs/binary/mod.rs` (1858 LOC)
+
+**Post-split**: `binary/mod.rs` (~575 LOC) + 4 new siblings.
+
+### Items staying in `binary/mod.rs`
+
+| Pre-split item | Visibility | Post-split visibility | Reason |
+|---|---|---|---|
+| `pub fn read(rootfs, deb_codename, max_file_size, deep_hash, ...)` | `pub` | `pub` (unchanged) | External caller in `scan_fs/mod.rs:218` |
+| `pub(crate) fn is_path_claimed(path, claimed, inodes)` | `pub(crate)` | `pub(crate)` (unchanged) | External callers in `maven.rs:2274`, `go_binary.rs:517`, `linkage.rs:45`. Stays in mod.rs to keep callers' paths stable (per research.md R2). |
+
+### Items landing in `binary/predicates.rs` (NEW)
+
+| Pre-split item | Pre-split visibility | Post-split visibility | Reason |
+|---|---|---|---|
+| `enum RootfsKind` | `enum` (private) | `pub(super) enum` | Used by `read()` in mod.rs |
+| `fn detect_rootfs_kind(rootfs) -> RootfsKind` | `fn` | `pub(super) fn` | Called from `read()` |
+| `fn is_host_system_path(soname) -> bool` | `fn` | `pub(super) fn` | Called from `read()` (filtering linkage entries) |
+| `fn has_rpmdb_at(rootfs) -> bool` | `fn` | `pub(super) fn` | Called from `detect_rootfs_kind` (same file) AND from `read()` |
+| `fn is_os_managed_directory(rootfs, path) -> bool` | `fn` | `pub(super) fn` | Called from `read()` (skip-list construction) |
+
+### Items landing in `binary/discover.rs` (NEW)
+
+| Pre-split item | Pre-split visibility | Post-split visibility | Reason |
+|---|---|---|---|
+| `fn discover_binaries(root) -> Vec<PathBuf>` | `fn` | `pub(super) fn` | Called from `read()` |
+| `fn walk_dir(dir, &mut Vec<PathBuf>)` | `fn` | `fn` (private) | Only called from `discover_binaries` (same file) |
+| `fn is_supported_binary(path) -> bool` | `fn` | `fn` (private) | Only called from `walk_dir` (same file) |
+| `pub(crate) fn detect_format(magic) -> Option<&'static str>` | `pub(crate)` | `pub(crate)` (unchanged per FR-006 strict reading) | Currently unused externally but visibility-contraction is out of scope |
+
+### Items landing in `binary/scan.rs` (NEW)
+
+| Pre-split item | Pre-split visibility | Post-split visibility | Reason |
+|---|---|---|---|
+| `fn scan_binary(path, bytes) -> Option<BinaryScan>` | `fn` | `pub(super) fn` | Called from `read()` |
+| `fn scan_fat_macho(path, bytes) -> Option<BinaryScan>` | `fn` | `fn` (private) | Only called from `scan_binary` (same file) |
+| `fn collect_string_region(file, class) -> Vec<u8>` | `fn` | `fn` (private) | Only called from `scan_binary` (same file) |
+| `fn is_go_binary(bytes) -> bool` | `fn` | `fn` (private) | Only called from `scan_binary` (same file) |
+
+### Items landing in `binary/entry.rs` (NEW)
+
+| Pre-split item | Pre-split visibility | Post-split visibility | Reason |
+|---|---|---|---|
+| `pub(crate) struct BinaryScan { ... }` | `pub(crate)` | `pub(crate)` (unchanged) | Used by `scan.rs::scan_binary` (constructs it) and `entry.rs::make_file_level_component` (consumes it) |
+| `fn version_match_to_entry(...)` | `fn` | `pub(super) fn` | Called from `read()` |
+| `fn make_file_level_component(scan: &BinaryScan, ...)` | `fn` | `pub(super) fn` | Called from `read()` |
+| `fn note_package_to_entry(note, ...)` | `fn` | `pub(super) fn` | Called from `read()` |
+| `impl PackageDbEntry { ... }` | `impl` | `impl` (unchanged) | The methods stay attached to the type; the impl block lands in entry.rs and Rust resolves the type via path |
+
+---
+
+## Cross-submodule import inventory
+
+Concrete `use` lines that each new submodule needs at the top:
+
+### `binary/predicates.rs`
+
+```rust
+use std::path::Path;
+```
+
+No cross-submodule dependencies. Self-contained.
+
+### `binary/discover.rs`
+
+```rust
+use std::path::{Path, PathBuf};
+```
+
+No cross-submodule dependencies. Self-contained.
+
+### `binary/scan.rs`
+
+```rust
+use std::path::Path;
+
+use mikebom_common::types::hash::ContentHash;
+use mikebom_common::types::purl::Purl;
+use object::ObjectSection;
+use sha2::{Digest, Sha256};
+
+use super::entry::BinaryScan;       // cross-sibling type
+use super::elf;                     // existing sibling
+use super::packer;                  // existing sibling
+use super::version_strings;         // existing sibling
+use super::super::package_db::rpm_vendor_from_id;  // ../package_db
+```
+
+### `binary/entry.rs`
+
+```rust
+use std::path::Path;
+
+use mikebom_common::types::hash::ContentHash;
+use mikebom_common::types::purl::Purl;
+use object::ObjectSection;
+use sha2::{Digest, Sha256};
+
+use super::elf::ElfNotePackage;     // BinaryScan struct depends on ElfNotePackage
+use super::super::package_db::{rpm_vendor_from_id, PackageDbEntry};
+```
+
+### `binary/mod.rs` (post-split, header)
+
+```rust
+use std::path::{Path, PathBuf};
+
+use mikebom_common::types::hash::ContentHash;
+use mikebom_common::types::purl::Purl;
+// (object, sha2 may drop here if no longer used directly in mod.rs)
+
+use super::package_db::PackageDbEntry;
+// (rpm_vendor_from_id moves out — no longer needed in mod.rs)
+
+mod discover;
+mod entry;
+mod predicates;
+mod scan;
+```
+
+---
+
+## Inline test distribution
+
+Per FR-005, the 38 inline tests in `binary/mod.rs::tests` distribute by which production code each test exercises. Names preserved verbatim.
+
+### Tests staying in `binary/mod.rs::tests` (8)
+
+These exercise `read()` orchestration and `is_path_claimed`:
+
+- `empty_rootfs_yields_zero_binary_components`
+- `non_elf_files_are_skipped`
+- `claim_skip_recognizes_usrmerge_symlink_path`
+- `claim_skip_without_symlink_still_works`
+- `claim_skip_broken_symlink_does_not_panic`
+- `claim_skip_via_inode_on_symlinked_library`
+- `inode_match_survives_hard_link`
+- (one more to be confirmed during T-step verification)
+
+### Tests landing in `binary/predicates.rs::tests` (14)
+
+These exercise `RootfsKind` / `detect_rootfs_kind` / `has_rpmdb_at` / `is_os_managed_directory` / `is_host_system_path`:
+
+- `detect_rootfs_kind_alpine_from_apk_db`
+- `detect_rootfs_kind_debian_from_dpkg_status`
+- `detect_rootfs_kind_rhel_from_rpmdb`
+- `detect_rootfs_kind_fedora_sysimage_path`
+- `detect_rootfs_kind_from_os_release_id`
+- `detect_rootfs_kind_unknown_for_plain_directory`
+- `has_rpmdb_at_detects_legacy_var_lib_path`
+- `has_rpmdb_at_detects_sysimage_path`
+- `has_rpmdb_at_returns_false_on_bare_rootfs`
+- `has_rpmdb_at_detects_legacy_bdb_packages_file`
+- `is_host_system_path_blocks_macos_frameworks`
+- `is_host_system_path_allows_real_sonames`
+- `is_os_managed_directory_matches_standard_paths`
+- `is_os_managed_directory_allows_opt_and_local_paths`
+
+### Tests landing in `binary/scan.rs::tests` (4)
+
+These exercise `is_go_binary`:
+
+- `is_go_binary_detects_buildinfo_magic`
+- `is_go_binary_returns_false_without_magic`
+- `is_go_binary_detects_magic_past_old_2mb_cap`
+- `is_go_binary_bounded_probe_at_64mb`
+
+### Tests landing in `binary/entry.rs::tests` (12)
+
+These exercise `note_package_to_entry`, `make_file_level_component`, and the `fake_binary_scan` helper:
+
+- `note_package_rpm_produces_canonical_purl`
+- `note_package_rpm_uses_os_release_namespace_when_note_distro_absent`
+- `note_package_rpm_prefers_note_distro_over_os_release`
+- `note_package_rpm_percent_encodes_plus_in_name`
+- `note_package_rpm_percent_encodes_mid_name_plus`
+- `note_package_rpm_falls_back_to_rpm_when_no_context`
+- `note_package_alpm_uses_arch_namespace`
+- `note_package_deb_falls_back_to_debian_vendor`
+- `note_package_deb_uses_os_release_namespace_for_ubuntu`
+- `note_package_unknown_type_becomes_generic`
+- `make_file_level_component_sets_detected_go_when_flag_set`
+- `make_file_level_component_leaves_detected_go_none_for_non_go`
+- `fake_binary_scan` (helper — used by `make_file_level_component_*` tests)
+
+### Tests landing in `binary/discover.rs::tests` (0)
+
+The current inline test mod has no specific tests for `discover_binaries`, `walk_dir`, `is_supported_binary`, or `detect_format`. The `tests/scan_binary.rs` integration test exercises them end-to-end. No inline tests move to `discover.rs::tests`.
+
+---
+
+## Validation rules
+
+- Every item in pre-split `binary/mod.rs` MUST have a row in the appropriate visibility-ladder table above. A code reviewer can verify completeness by `git diff --stat` showing the original file shrinking and the four new files appearing with summed LOC ≈ pre-split + ~150 (mod declarations / `use` lines / per-file headers).
+- Every visibility ladder entry MUST be the minimum needed for the post-split call graph. `pub(super)` for sibling-only callers; `pub(crate)` only for items already at that level (per FR-006 strict reading).
+- Inline test names MUST be preserved verbatim. SC-002 enforces with sorted-name diff against post-#43 baseline.

--- a/specs/019-binary-split/plan.md
+++ b/specs/019-binary-split/plan.md
@@ -1,0 +1,131 @@
+# Implementation Plan: binary/mod.rs Split — Design-First
+
+**Branch**: `019-binary-split` | **Date**: 2026-04-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/019-binary-split/spec.md`
+
+## Summary
+
+Address milestone 018's deferred US3 with a design-first approach. Split `mikebom-cli/src/scan_fs/binary/mod.rs` (1858 LOC) into a 5-file directory module by extracting four cohesive concerns into siblings of the existing `elf.rs`/`linkage.rs`/etc. files: `discover.rs` (filesystem walker), `scan.rs` (single-file binary scanner), `entry.rs` (`BinaryScan` + entry conversion), `predicates.rs` (OS-aware rootfs predicates). The orchestrator `read()` and the cross-cutting `is_path_claimed` stay in `mod.rs`. Visibility ladder + cross-submodule import design happens before any code moves; commits land one submodule at a time, each leaving the tree green and the byte-identity goldens unchanged.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001-018; no nightly required for user-space scan-pipeline code).
+**Primary Dependencies**: existing only — `object` (ELF/Mach-O/PE parsing), `sha2` (SHA-256 hashing), `mikebom_common::types::{hash::ContentHash, purl::Purl}`. No `Cargo.toml` changes. Per Constitution Principle VI.
+**Storage**: source-tree restructure only. ~1858 LOC moves from one file into 5 files with mechanical visibility adjustments. ~150 LOC of new submodule headers (per-file doc, imports, `mod` declarations); net production-LOC change is ~+150.
+**Testing**: `./scripts/pre-pr.sh` (clippy + workspace test). The 27 byte-identity goldens are the load-bearing regression test. The 1337-LOC integration test `tests/scan_binary.rs` is the second gate — every binary-format scenario it covers (ELF / Mach-O / fat-Mach-O / PE / Go / RPM-note / DEB / APK) passes through the public API unchanged.
+**Target Platform**: macOS 14+ + Linux x86_64. The split is platform-neutral — no `cfg(target_os = "linux")` gates in the moved code (binary scanning is cross-platform).
+**Project Type**: Source-tree refactor — no new public APIs, no new tests, no new crates, no behavioral changes.
+**Performance Goals**: Compile time should not regress materially. Per-module compilation in Rust may improve parallelism within `mikebom-cli` (5 small files compile in parallel within the bin's dep graph) but this is incidental — not a stated goal.
+**Constraints**:
+
+- Zero behavioral changes to scan output. The 27 byte-identity goldens are the gate. If `MIKEBOM_UPDATE_*_GOLDENS=1` regen produces a non-empty diff at any commit, the commit is wrong.
+- Zero new public APIs, zero pre-existing `pub`/`pub(crate)` items un-`pub`'d. Visibility may *expand* mechanically (a `fn` becomes `pub(super) fn` to be reachable from a sibling submodule); contraction is out of scope.
+- `is_path_claimed` MUST stay reachable as `crate::scan_fs::binary::is_path_claimed` for external callers in `maven.rs`, `go_binary.rs`, `linkage.rs` — accomplished by keeping it in `mod.rs` (no re-export needed).
+- `BinaryScan` (`pub(crate)` struct) keeps its visibility level. It moves to `entry.rs`; `scan.rs` accesses it via `use super::entry::BinaryScan;`. No external crate references the type today (verified by `rg`).
+- Constitution Principle V (Specification Compliance) — the byte-identity goldens encode current SBOM-emission contract; splitting the production code MUST NOT change scan output.
+- The milestone-018 lesson: each user-story commit is one atomic move. Don't try to incrementally extract one submodule at a time — Rust's module system breaks under partial moves (file exists in two places, name resolution conflicts).
+
+**Scale/Scope**: 1 source file (`binary/mod.rs`) becomes 5 files (`mod.rs` + 4 siblings). 38 inline tests redistributed across the 5 files. ~1858 LOC moved; net production-code LOC unchanged. No test files renamed or added. Estimated PR diff: +1858 / -1858 with ~+150 of import/header churn.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Bearing on this feature | Pass? |
+|-----------|-------------------------|-------|
+| I. Pure Rust, Zero C | No deps changes; no C surface. | ✓ |
+| II. eBPF-Only Observation | Untouched — no observation-semantics changes. | ✓ |
+| III. Fail Closed | Untouched — no failure-mode changes in production. | ✓ |
+| IV. Type-Driven Correctness | No new `.unwrap()` introduced. `.expect()` relocates verbatim with descriptive messages preserved. | ✓ |
+| V. Specification Compliance | Byte-identity goldens (#38 + #40) are the regression gate. Zero scan-output drift required. | ✓ |
+| VI. Three-Crate Architecture | No new crates. Workspace stays at `mikebom-cli` (lib + bin), `mikebom-common`, `mikebom-ebpf`. | ✓ |
+| VII. Test Isolation | Inline `#[cfg(test)]` modules move with their owning code. `tests/scan_binary.rs` integration test unchanged. | ✓ |
+| VIII–XII | Untouched. | ✓ |
+| Strict Boundary 4 (`No .unwrap()` in production) | Same as IV. | ✓ |
+| Pre-PR Verification | Each commit on the milestone branch passes `./scripts/pre-pr.sh` cleanly. The split is meaningless if any commit ships broken state. | ✓ |
+
+**Initial gate**: PASS. No principle violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/019-binary-split/
+├── spec.md                  # Feature spec
+├── plan.md                  # This file
+├── research.md              # Phase 0 — re-export surface design, why 5 files (not 4), is_path_claimed staying in mod.rs
+├── data-model.md            # Phase 1 — visibility ladder + per-item file destination + test distribution
+├── quickstart.md            # Phase 1 — atomic-move recipe + per-commit verification
+├── contracts/
+│   └── module-boundaries.md # Per-submodule entry points + visibility contract (analogous to milestone 018's)
+├── checklists/
+│   └── requirements.md      # Spec quality checklist
+└── tasks.md                 # Phase 2 — numbered task list
+```
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/src/scan_fs/binary/
+├── mod.rs                   # MODIFIED: shrunk from 1858 → ~575 LOC. Keeps: pub fn read, pub(crate) fn is_path_claimed, mod declarations, doc + imports.
+├── discover.rs              # NEW: discover_binaries + walk_dir + is_supported_binary + detect_format (~85 LOC)
+├── entry.rs                 # NEW: pub(crate) struct BinaryScan + version_match_to_entry + make_file_level_component + note_package_to_entry + impl PackageDbEntry (~290 LOC)
+├── predicates.rs            # NEW: enum RootfsKind + detect_rootfs_kind + is_host_system_path + has_rpmdb_at + is_os_managed_directory (~150 LOC)
+├── scan.rs                  # NEW: scan_binary + scan_fat_macho + collect_string_region + is_go_binary (~290 LOC)
+├── elf.rs                   # UNCHANGED (existing sibling)
+├── jdk_collapse.rs          # UNCHANGED
+├── linkage.rs               # UNCHANGED — `crate::scan_fs::binary::is_path_claimed` reference at line 45 keeps working
+├── macho.rs                 # UNCHANGED (stub)
+├── packer.rs                # UNCHANGED (stub)
+├── pe.rs                    # UNCHANGED (stub)
+├── python_collapse.rs       # UNCHANGED
+└── version_strings.rs       # UNCHANGED (stub)
+```
+
+**Structure Decision**: 5-file split (4 new siblings + 1 shrunk `mod.rs`). The new submodules join the existing siblings (which were already split per format/concern in earlier milestones); they don't replace them. `mod.rs` becomes an orchestrator + cross-cutting helpers + 8 inline tests for those helpers.
+
+## Phase 0 — Research questions (resolved in research.md)
+
+- **R1**: Why 5 files instead of milestone-018's planned 4? (Test-LOC budget — the OS-predicate tests are ~200 LOC and need their own submodule to land mod.rs under 800.)
+- **R2**: Why `is_path_claimed` stays in `mod.rs` (not `scan.rs` per milestone-018 plan)? (External-caller path stability + read() proximity.)
+- **R3**: Where does `BinaryScan` live? (entry.rs — that's where its consumers live; scan.rs imports via `super::entry::BinaryScan`.)
+- **R4**: Visibility ladder for cross-sibling access. (Same rule as milestone 018: `pub(super) fn` for sibling-only callers; `pub(crate)` only for items already at that level.)
+- **R5**: Atomic vs incremental commits per submodule. (Atomic per-submodule extraction — milestone 018's lesson.)
+- **R6**: How to verify "no scan output drift" — same as milestone 018 (regen byte-identity goldens, expect zero diff).
+
+## Phase 1 — Design artifacts (resolved in data-model.md, contracts/module-boundaries.md, quickstart.md)
+
+- **Visibility ladder** — every item in `binary/mod.rs` mapped to its target submodule + post-split visibility level.
+- **Cross-submodule imports** — explicit list of `use super::entry::BinaryScan;` etc. that each new submodule needs.
+- **Test distribution table** — each of the 38 inline tests assigned to its owning submodule.
+- **Atomic-move recipe** — quickstart.md cookbook for executing one submodule extraction without breaking compilation mid-step.
+
+## Complexity Tracking
+
+> No constitution violations. Complexity is in (a) the *care* needed to design the re-export surface (only 2 items: `read` and `is_path_claimed`), (b) the *count* of cross-submodule type/function references that need explicit imports (~15 sites), (c) the *iteration* per-submodule extraction needs to avoid breaking compilation mid-split. Each is mechanical-with-judgment; none is architectural.
+
+The single judgment-heavy moment is FR-004 — verifying that scan output is byte-identical post-split. This is the same gate that caught 017's T013b emitter bug + that protected the milestone-018 splits from drift; if a split changes behavior, the goldens trip. Verification is `MIKEBOM_UPDATE_*_GOLDENS=1` regen → `git diff` empty. Per milestone-018's experience this catches misorderings, accidentally-changed iteration patterns, and any non-determinism leaking through.
+
+## Post-implementation verification
+
+After all 5 commits land, before opening PR:
+
+```bash
+# (a) FR-001 LOC ceiling.
+test "$(wc -l < mikebom-cli/src/scan_fs/binary/mod.rs)" -le 800
+
+# (b) FR-004 byte-identity goldens still match.
+MIKEBOM_UPDATE_CDX_GOLDENS=1 cargo +stable test -p mikebom --test cdx_regression > /dev/null
+MIKEBOM_UPDATE_SPDX_GOLDENS=1 cargo +stable test -p mikebom --test spdx_regression > /dev/null
+MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test -p mikebom --test spdx3_regression > /dev/null
+git diff --stat mikebom-cli/tests/fixtures/golden/   # expected: empty
+
+# (c) FR-008 / SC-004 full pre-PR.
+./scripts/pre-pr.sh   # expected: clean (modulo pre-existing flakiness)
+
+# (d) FR-005 / SC-002 test-name parity.
+./scripts/pre-pr.sh 2>&1 | grep -E '^test [a-z_:]+ \.\.\. ok' | sort -u > /tmp/post-019-tests.txt
+# expect: removed entries are renames (e.g., binary::tests::is_go_binary_* → binary::scan::tests::is_go_binary_*)
+# zero entries removed without a corresponding rename
+```

--- a/specs/019-binary-split/quickstart.md
+++ b/specs/019-binary-split/quickstart.md
@@ -1,0 +1,153 @@
+# Quickstart: Implement and Verify Milestone 019
+
+**Phase 1 quickstart for** `/specs/019-binary-split/spec.md`
+
+This is the cookbook for executing the binary/mod.rs split end-to-end. Each submodule extraction is one atomic commit; the milestone-018 lesson is that piecemeal extraction breaks Rust's module system.
+
+## Prerequisites
+
+- macOS dev machine with stable Rust + clippy installed.
+- Repo at `main`, branch `019-binary-split` already created.
+- Post-#43 baseline: `./scripts/pre-pr.sh` passes from a fresh tree (modulo pre-existing flaky tests).
+
+## Workflow per submodule
+
+The five-step recipe. Apply once per submodule extraction, in order: `predicates.rs`, `discover.rs`, `entry.rs`, `scan.rs`. Final commit: full pre-PR + verification.
+
+```bash
+# Step 1 — Snapshot baseline test names (once, before any split).
+./scripts/pre-pr.sh 2>&1 | grep -E '^test [a-z_:]+ \.\.\. ok' | sort -u > /tmp/baseline-019-tests.txt
+
+# Step 2 — For each submodule, plan the move on paper using
+# data-model.md "Visibility ladder" + "Cross-submodule import inventory".
+#
+# IMPORTANT — execute one submodule per commit, atomically. Don't
+# try to incrementally extract sub-functions; Rust's module system
+# rejects intermediate states (file exists in two places, name
+# resolution conflicts).
+
+# Step 3 — Construct the new submodule file. Use sed -n M,Np to
+# extract the source-line range from binary/mod.rs:
+#
+#   predicates: lines 45-168 (RootfsKind, detect_rootfs_kind,
+#                              is_host_system_path, has_rpmdb_at,
+#                              is_os_managed_directory)
+#   discover:   lines 861-938 (discover_binaries, walk_dir,
+#                              is_supported_binary, detect_format)
+#   entry:      lines 583-639 + 940-1152 (BinaryScan, version_match_to_entry,
+#                                          make_file_level_component,
+#                                          note_package_to_entry, impl)
+#   scan:       lines 170-249 + 641-859 (is_go_binary, scan_binary,
+#                                         scan_fat_macho, collect_string_region)
+#
+# Each new file gets:
+#   1. Module-doc header (1-line description)
+#   2. Imports (per data-model.md "Cross-submodule import inventory")
+#   3. The extracted production code with visibility adjustments
+#      (private fn → pub(super) fn for cross-sibling callers)
+#   4. The corresponding tests block with use super::*; etc.
+
+# Step 4 — Update binary/mod.rs to:
+#   1. Add `mod predicates;` (etc.) declaration near the existing pub mod block
+#   2. Delete the moved code
+#   3. Qualify cross-submodule call sites in read():
+#        detect_rootfs_kind(...) → predicates::detect_rootfs_kind(...)
+#        discover_binaries(...) → discover::discover_binaries(...)
+#        scan_binary(...) → scan::scan_binary(...)
+#        version_match_to_entry(...) → entry::version_match_to_entry(...)
+#        etc.
+
+# Step 5 — Verify via byte-identity goldens (the load-bearing check).
+cargo +stable check --workspace --tests
+MIKEBOM_UPDATE_CDX_GOLDENS=1 cargo +stable test -p mikebom --test cdx_regression > /dev/null 2>&1
+MIKEBOM_UPDATE_SPDX_GOLDENS=1 cargo +stable test -p mikebom --test spdx_regression > /dev/null 2>&1
+MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test -p mikebom --test spdx3_regression > /dev/null 2>&1
+git diff --stat mikebom-cli/tests/fixtures/golden/   # MUST be empty
+
+# Step 6 — Run pre-PR.
+./scripts/pre-pr.sh 2>&1 | tail -3
+
+# Step 7 — Commit per FR-008.
+git add mikebom-cli/src/scan_fs/binary/<new_file>.rs \
+        mikebom-cli/src/scan_fs/binary/mod.rs
+git commit -m "refactor(019/extract-<concern>): move <items> from binary/mod.rs to <new_file>.rs"
+```
+
+## Recommended commit chunking
+
+Per FR-008 — one atomic commit per submodule extraction. Total: 4 extraction commits + 1 spec commit.
+
+| Commit | Scope | Files affected | Estimated LOC moved |
+|---|---|---|---|
+| 1. spec set | `specs/019-binary-split/*` | (docs only) | — |
+| 2. extract predicates.rs | RootfsKind + 4 OS predicates + 14 tests | predicates.rs (NEW), mod.rs | -350 from mod.rs |
+| 3. extract discover.rs | discover_binaries + walk_dir + is_supported_binary + detect_format | discover.rs (NEW), mod.rs | -85 from mod.rs |
+| 4. extract entry.rs | BinaryScan + 3 conversion fns + impl PackageDbEntry + 12 tests | entry.rs (NEW), mod.rs | -490 from mod.rs |
+| 5. extract scan.rs | scan_binary + scan_fat_macho + collect_string_region + is_go_binary + 4 tests | scan.rs (NEW), mod.rs | -440 from mod.rs |
+
+**Order matters**: extract `entry.rs` BEFORE `scan.rs`, because scan.rs's new file needs `use super::entry::BinaryScan;` — that import resolves only after entry.rs exists. Other orderings (predicates first, then discover, then entry+scan) are constraint-free.
+
+After all 5 extractions: mod.rs ≈ 1858 - 350 - 85 - 490 - 440 = 493 LOC + ~80 LOC of new `mod` declarations + remaining tests. Net: ~575 LOC. ✓ under 800.
+
+## Final-state verification (acceptance test)
+
+After all 4 extraction commits land:
+
+```bash
+# (a) FR-001 LOC ceiling
+test "$(wc -l < mikebom-cli/src/scan_fs/binary/mod.rs)" -le 800 && echo "✓ mod.rs LOC OK"
+for f in mikebom-cli/src/scan_fs/binary/{discover,entry,predicates,scan}.rs; do
+  loc=$(wc -l < "$f")
+  if [ "$loc" -gt 800 ]; then echo "FAIL: $f = $loc LOC > 800"; fi
+done
+
+# (b) FR-004 byte-identity goldens
+MIKEBOM_UPDATE_CDX_GOLDENS=1 cargo +stable test -p mikebom --test cdx_regression > /dev/null
+MIKEBOM_UPDATE_SPDX_GOLDENS=1 cargo +stable test -p mikebom --test spdx_regression > /dev/null
+MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test -p mikebom --test spdx3_regression > /dev/null
+git diff --stat mikebom-cli/tests/fixtures/golden/   # MUST be empty
+
+# (c) SC-002 test-name parity
+./scripts/pre-pr.sh 2>&1 | grep -E '^test [a-z_:]+ \.\.\. ok' | sort -u > /tmp/post-019-tests.txt
+echo "removed test names:"
+comm -23 /tmp/baseline-019-tests.txt /tmp/post-019-tests.txt
+# expected: only renames (e.g., binary::tests::is_go_binary_* removed
+# because they appeared as binary::scan::tests::is_go_binary_* added)
+
+# (d) FR-008 / SC-004 full pre-PR
+./scripts/pre-pr.sh   # expected: clean (modulo pre-existing flakiness in
+                     # dual_format_perf, spdx_us1_acceptance, spdx_determinism)
+
+# (e) SC-005 external call sites unchanged
+git diff main..019-binary-split -- mikebom-cli/src/scan_fs/mod.rs \
+                                    mikebom-cli/src/scan_fs/package_db/maven.rs \
+                                    mikebom-cli/src/scan_fs/package_db/go_binary.rs \
+                                    mikebom-cli/src/scan_fs/binary/linkage.rs
+# expected: empty (no edits to these files)
+```
+
+## CI verification
+
+After pushing the branch:
+
+```bash
+gh pr create --title "refactor(019): binary/mod.rs split — design-first, 5 files" --body ...
+gh run watch
+# Expect: both lint-and-test (linux-x86_64) AND lint-and-test-macos pass.
+```
+
+The 27 byte-identity goldens are the cross-host canary, same gate that protected milestones 017 and 018.
+
+## Common pitfalls
+
+1. **Extracting `scan.rs` before `entry.rs`**. `scan.rs` needs `use super::entry::BinaryScan;` — that import resolves only after entry.rs exists as a module. Order matters.
+2. **Forgetting to qualify call sites in `read()`**. After extracting `discover.rs`, `read()` still says `discover_binaries(...)` (unqualified). Cargo will error: "function not found in this scope." Update to `discover::discover_binaries(...)` in the same commit.
+3. **Tests that use `BinaryScan` in mod.rs::tests**. The `claim_skip_*` and `inode_match_*` tests (which stay in mod.rs) don't reference `BinaryScan` — they test `is_path_claimed`. Confirmed by spot-checking the test bodies during reconnaissance. If a test that DOES reference `BinaryScan` ends up in mod.rs::tests, it needs `use super::entry::BinaryScan;` — verify during T-step.
+4. **Sibling-module references like `super::elf` in moved code**. From entry.rs, `super::elf::ElfNotePackage` resolves to `binary/elf.rs` (existing sibling). This works because new submodules are direct siblings of `elf.rs`. No change needed — the imports just look like `use super::elf;` after move.
+5. **`is_path_claimed` accidentally moved to scan.rs**. Per research.md R2, it stays in mod.rs. Don't move it just because it's a "predicate-shaped" function; its callers (read + external crate paths) make mod.rs the right home.
+
+## After PR merge
+
+- The post-019 baseline becomes the new `tests/scan_binary.rs` regression set.
+- Update `docs/architecture/scanning.md` if it references `binary/mod.rs` as a single file (spot-check; not blocking the PR).
+- Verify SC-006 the next time you fix a Mach-O fat-binary or PE-format bug — does `find binary -name 'scan*.rs'` jump straight to it? If yes, the milestone delivered.

--- a/specs/019-binary-split/research.md
+++ b/specs/019-binary-split/research.md
@@ -1,0 +1,159 @@
+# Research: binary/mod.rs Split — Design-First
+
+**Phase 0 output for** `/specs/019-binary-split/spec.md`
+
+This document resolves the open technical questions from `plan.md`. Each section follows: **Decision** / **Rationale** / **Alternatives considered**. The lessons from milestone 018's deferred US3 inform every decision below.
+
+---
+
+## R1. Why 5 files instead of milestone-018's planned 4?
+
+**Context**: Milestone 018's spec planned a 4-file split: `mod.rs` + `discover.rs` + `scan.rs` + `entry.rs`. Reconnaissance after #43 merged showed the inline `#[cfg(test)] mod tests` block in `binary/mod.rs` is ~700 LOC carrying 38 functions (37 tests + 1 helper). About 14 of those tests exercise OS-aware predicates (`RootfsKind`, `detect_rootfs_kind`, `is_host_system_path`, `has_rpmdb_at`, `is_os_managed_directory`) — a cohesive group of ~150 LOC of production code.
+
+If those predicates stay in `mod.rs` along with their tests, the LOC math is:
+
+```
+production code (read + is_path_claimed + RootfsKind/predicates):  ~485
+inline tests staying in mod.rs (22 of 38):                         ~600
+total mod.rs:                                                     ~1085
+```
+
+That blows the FR-001 800-LOC ceiling.
+
+**Decision**: Extract the OS-aware predicates and their tests into a fifth submodule `predicates.rs`. Post-split mod.rs lands at ~575 LOC.
+
+**Rationale**:
+
+- The predicates form a coherent group: every one of them answers "is this rootfs / file path part of the operating-system layer?" — used to filter binary scanning to user-space components and to skip OS-managed directories.
+- Their 14 tests group equally cohesively (the test names cluster: `detect_rootfs_kind_*`, `has_rpmdb_at_*`, `is_os_managed_directory_*`, `is_host_system_path_*`).
+- 150 LOC of production + ~200 LOC of tests = ~350 LOC for `predicates.rs` — comfortably under the 800-LOC ceiling, and the resulting `mod.rs` lands ~575 LOC also under the ceiling.
+- An alternative — letting `mod.rs` exceed 800 — would require updating FR-001 to ~1100 (similar to how milestone 018's `requirements_txt.rs` got an exception). That carries weight; better to avoid it when a clean fifth submodule is right there.
+
+**Alternatives considered**:
+
+- **4-file split, accept mod.rs ~1100 LOC**: Rejected. The ceiling exists to bound reading cost. 1100 LOC is what the audit was trying to escape; landing within 200 LOC of the original size defeats the milestone's goal.
+- **4-file split, prune tests**: Rejected. FR-005 requires tests preserved verbatim. Removing tests to fit under the ceiling violates the contract.
+- **6+ file split (e.g., `predicates.rs` further subdivided into `rootfs_kind.rs` + `os_paths.rs`)**: Rejected as over-decomposition. The predicate group is cohesive — they all use `Path` introspection to classify; splitting further wouldn't improve readability.
+
+---
+
+## R2. Why does `is_path_claimed` stay in `mod.rs`?
+
+**Context**: Milestone 018's plan suggested moving `is_path_claimed` into `scan.rs`. Reconnaissance shows three external crate-path callers (`maven.rs:2274`, `go_binary.rs:517`, `linkage.rs:45`) reference it as `crate::scan_fs::binary::is_path_claimed`. If we move it to `scan.rs`, callers see `crate::scan_fs::binary::scan::is_path_claimed` — a path change that either requires editing all 3 call sites OR adding a `pub(crate) use scan::is_path_claimed;` re-export in `mod.rs`.
+
+**Decision**: **Keep `is_path_claimed` in `binary/mod.rs`** at its current `pub(crate)` visibility.
+
+**Rationale**:
+
+- It's called by `read()` (which stays in `mod.rs`) at line 363 — proximity to its primary internal caller is a value.
+- External callers' paths don't change — FR-003 holds.
+- Re-export via `pub(crate) use scan::is_path_claimed;` is a workable alternative but adds a synthetic layer that the next contributor has to chase when navigating call sites. Direct location is cleaner.
+- The function's purpose ("did the package_db reader already claim this file path? → don't double-emit a binary component") sits at the orchestrator layer (combining package_db state with binary discovery), not the per-file scan layer. Logically it belongs at `mod.rs`, not `scan.rs`.
+
+**Alternatives considered**:
+
+- **Move to scan.rs + re-export**: Rejected per the proximity + clean-location argument.
+- **Move to predicates.rs**: It IS a path-classification predicate. But its callers (`read` in mod.rs + tests for claim_skip / inode_match) tightly couple it to mod.rs's loop. Plus it's testable independent of OS-detection state, unlike the rootfs predicates. Different cohort.
+
+---
+
+## R3. Where does `BinaryScan` live?
+
+**Context**: `pub(crate) struct BinaryScan` (line 626 in current `mod.rs`) is the intermediate type returned by `scan_binary` and `scan_fat_macho` (the per-file scanners) and consumed by `make_file_level_component` (the entry-conversion code). `scan_binary` lives in scan.rs post-split; `make_file_level_component` lives in entry.rs.
+
+**Decision**: **`BinaryScan` lives in `entry.rs`.** `scan.rs` accesses it via `use super::entry::BinaryScan;`. Visibility stays `pub(crate)`.
+
+**Rationale**:
+
+- `entry.rs` is the conceptual "owner" of binary-scan-result modeling — it's where the BinaryScan→PackageDbEntry transformation happens. Putting the type next to its primary transformation is the natural location.
+- `scan.rs` is the producer of `BinaryScan` values; it naturally imports the type from where the consumer lives.
+- The alternative — keeping `BinaryScan` in `mod.rs` and having both `scan.rs` and `entry.rs` import it — is also workable but adds a cross-import for a type that's not used by `read()` itself.
+
+**Alternatives considered**:
+
+- **`BinaryScan` in scan.rs (the producer)**: Plausible. Producer-side ownership is also a valid pattern. Decided against because consumers traditionally outnumber producers; `entry.rs` will likely accumulate more code that wraps `BinaryScan` over time, and proximity to that growth makes more sense.
+- **`BinaryScan` in mod.rs**: Rejected — would mean `mod.rs` owns a type that neither it nor `read()` directly consumes (post-split). Tracks against the goal of mod.rs being the orchestrator.
+- **`BinaryScan` as its own file (`binary/scan_result.rs`)**: Over-decomposition. The type is a 15-line struct + 1 method; a dedicated file is junk-drawer-tier ceremony for that.
+
+---
+
+## R4. Visibility ladder
+
+**Context**: Same rule as milestone 018: `pub(super) fn` for cross-sibling-only callers; `pub(crate)` reserved for items already at that level OR with legitimate crate-wide callers; `pub` only for the documented public surface (`fn read`).
+
+**Decision**: Per `data-model.md` "Visibility ladder" table. Summary:
+
+| Item | Pre-split | Post-split | File |
+|---|---|---|---|
+| `pub fn read` | `pub` | `pub` (unchanged) | mod.rs |
+| `pub(crate) fn is_path_claimed` | `pub(crate)` | `pub(crate)` (unchanged) | mod.rs |
+| `pub(crate) struct BinaryScan` | `pub(crate)` | `pub(crate)` (unchanged) | entry.rs |
+| `pub(crate) fn detect_format` | `pub(crate)` | reduced to `fn` (private) — only caller is `is_supported_binary` in same file | discover.rs |
+| `enum RootfsKind` | `enum` (private) | `pub(super) enum` — used by mod.rs's `read()` | predicates.rs |
+| `fn detect_rootfs_kind` | `fn` | `pub(super) fn` — called from mod.rs's `read()` | predicates.rs |
+| `fn is_host_system_path` | `fn` | `pub(super) fn` — called from mod.rs's `read()` | predicates.rs |
+| `fn has_rpmdb_at` | `fn` | `pub(super) fn` — called from `detect_rootfs_kind` (same file, but also from mod.rs) | predicates.rs |
+| `fn is_os_managed_directory` | `fn` | `pub(super) fn` — called from mod.rs's `read()` | predicates.rs |
+| `fn discover_binaries` | `fn` | `pub(super) fn` — called from mod.rs's `read()` | discover.rs |
+| `fn scan_binary` | `fn` | `pub(super) fn` — called from mod.rs's `read()` | scan.rs |
+| `fn version_match_to_entry` | `fn` | `pub(super) fn` — called from mod.rs's `read()` | entry.rs |
+| `fn make_file_level_component` | `fn` | `pub(super) fn` — called from mod.rs's `read()` | entry.rs |
+| `fn note_package_to_entry` | `fn` | `pub(super) fn` — called from mod.rs's `read()` | entry.rs |
+
+`detect_format`'s reduction from `pub(crate)` to private is unique. It's a misnamed item — currently `pub(crate)` but no external callers. Reconnaissance with `rg detect_format` shows only one site: line 901 inside `is_supported_binary` (same file post-split). Visibility *contraction* is normally out of scope (FR-006 says only expansion), but here it's correcting a stale `pub(crate)` that has no callers. Following the spirit of FR-006 ("minimum visibility needed"), I'll demote it to private.
+
+Wait — actually let me reconsider. FR-006 explicitly says "Visibility contraction is out of scope." Strict reading says keep `detect_format` as `pub(crate)` even though it has no current external callers. I'll follow the strict rule: keep `pub(crate)`. Future contributor can demote if they're so inclined.
+
+**Decision (revised)**: `detect_format` stays `pub(crate)` per FR-006 strict reading. Move it to `discover.rs` with visibility unchanged.
+
+**Alternatives considered**:
+
+- **Move all the OS predicates to `pub(super)` only when externally needed** (vs blanket pub(super) for everything in predicates.rs): Marginal preference; both work. Going with blanket `pub(super)` for predicates.rs because it makes the contract uniform — every fn in predicates.rs is reachable from mod.rs.
+- **Make `BinaryScan` `pub` instead of `pub(crate)`**: Out of scope per FR-006 (no contraction). Keep `pub(crate)`.
+
+---
+
+## R5. Atomic-per-submodule commits, not incremental
+
+**Context**: Milestone 018's deferred US3 attempt failed in part because it tried to extract submodules incrementally (one chunk at a time, leaving intermediate state where `binary/mod.rs` had partially-removed code AND a sibling file with the just-extracted version simultaneously). Rust's module system rejects this — name resolution conflicts kick in.
+
+**Decision**: One atomic commit per submodule extraction. Within a commit, `mod.rs` and the new sibling file are both fully consistent. Five commits total: predicates.rs, then discover.rs, scan.rs, entry.rs, plus a final pre-PR / verification commit if needed.
+
+**Rationale**:
+
+- Same lesson as milestone 018's pip and npm splits (which followed this pattern and worked cleanly).
+- Per-commit `./scripts/pre-pr.sh` passes (FR-008). Reviewers can `git diff <commit>~..<commit>` to see one logical chunk at a time.
+- Cross-submodule dependencies are unidirectional: predicates.rs has no dependencies on the other new siblings; discover.rs depends on nothing new; scan.rs depends on entry.rs (for `BinaryScan`); entry.rs has no dependencies on the other new siblings. Order of extraction is therefore: predicates → discover → entry → scan (so scan can `use super::entry::BinaryScan`).
+
+**Alternatives considered**:
+
+- **One mega-commit for all 4 submodules**: Less reviewable. Per-submodule diff doesn't isolate one extraction's correctness.
+- **Sub-commits per function within a submodule**: Rejected per the milestone-018 lesson. Half-moved state breaks compilation.
+
+---
+
+## R6. Verifying "no scan output drift"
+
+**Context**: The 27 byte-identity goldens (`mikebom-cli/tests/fixtures/golden/{cyclonedx,spdx-2.3,spdx-3}/`) shipped in #38 + #40 are the canonical regression test for "scan output is unchanged."
+
+**Decision**: After each commit on the milestone branch, run:
+
+```bash
+MIKEBOM_UPDATE_CDX_GOLDENS=1 cargo +stable test -p mikebom --test cdx_regression > /dev/null 2>&1
+MIKEBOM_UPDATE_SPDX_GOLDENS=1 cargo +stable test -p mikebom --test spdx_regression > /dev/null 2>&1
+MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test -p mikebom --test spdx3_regression > /dev/null 2>&1
+git diff --stat mikebom-cli/tests/fixtures/golden/   # MUST be empty
+```
+
+**Rationale**:
+
+- Same gate that caught milestone 017's T013b emitter bug.
+- Same gate that protected milestone 018's pip and npm splits.
+- Same gate that confirmed #43's walker dedup didn't drift scan output.
+- More stringent than `cargo test` alone, because the goldens are byte-comparison, not just "tests pass."
+
+If a commit's regen produces a non-empty diff, the commit is wrong; reconcile before proceeding to the next submodule.
+
+**Alternatives considered**:
+
+- **Trust `cargo test` alone**: Rejected — `cargo test` doesn't catch byte-level drift in JSON output ordering, only assertion failures. Goldens catch what `cargo test` misses.

--- a/specs/019-binary-split/spec.md
+++ b/specs/019-binary-split/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: binary/mod.rs Split — Design-First
+
+**Feature Branch**: `019-binary-split`
+**Created**: 2026-04-25
+**Status**: Draft
+**Input**: User audit follow-on to milestone 018; addresses the **deferred US3** from milestone 018 ("018/US3 — binary/mod.rs split"). Tier 4.5 of the post-016 cleanup roadmap.
+
+## Background
+
+Milestone 018 (#42) split `pip.rs` (1965 LOC) and `npm.rs` (1616 LOC) into directory submodules but **deferred** the third planned split: `binary/mod.rs` (1858 LOC). The PR description recorded the entanglement that defeated the mechanical-split approach used for pip and npm:
+
+- `BinaryScan` and `is_path_claimed` are referenced by external callers (`linkage.rs`, `go_binary.rs`, `maven.rs`) via `crate::scan_fs::binary::*` paths — splitting requires explicit re-export design at the new `binary/mod.rs`.
+- The production code is non-contiguous (file-discovery + scan-one + entry-conversion interleave with the orchestrator's `read()` loop).
+- Shared imports (`super::elf`, `super::packer`, `super::version_strings`) need re-routing through every new submodule.
+
+Milestone 018's commentary explicitly recommended a follow-up "design-first" milestone where the re-export surface and cross-submodule visibility are designed before any code moves. This is that milestone.
+
+A new finding from reconnaissance after #43 merged: the inline `#[cfg(test)]` block in `binary/mod.rs` is ~700 LOC carrying 38 test functions. About 14 of those exercise OS-aware predicates (`RootfsKind`, `detect_rootfs_kind`, `is_host_system_path`, `has_rpmdb_at`, `is_os_managed_directory`) — a cohesive group of ~150 LOC of production code. Treating this group as a fifth submodule (`binary/predicates.rs`) is the only way to land `binary/mod.rs` under the FR-010 800-LOC ceiling without test-pruning.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — binary/mod.rs ≤ 800 LOC via 5-file split (Priority: P1) 🎯 MVP
+
+As a maintainer adding support for a new binary format (PE, fat-Mach-O variant, future container-runtime ELF) or fixing a Mach-O fat-binary edge case, I want the file-discovery, single-file scan, and entry-conversion logic separated from the orchestrator's `read()` loop so I don't have to scroll through 1858 lines to locate the 200-line section relevant to my change.
+
+**Why this priority**: Direct continuation of milestone 018's deferred US3. The split unblocks future `binary/*` work (PE+macho stub completion, additional binary-format readers) by making each concern independently editable.
+
+**Independent Test**: After this story ships:
+
+- `mikebom-cli/src/scan_fs/binary/` gains four new sibling files: `discover.rs`, `entry.rs`, `predicates.rs`, `scan.rs`. The existing siblings (`elf.rs`, `jdk_collapse.rs`, `linkage.rs`, `macho.rs`, `packer.rs`, `pe.rs`, `python_collapse.rs`, `version_strings.rs`) are unchanged.
+- `mikebom-cli/src/scan_fs/binary/mod.rs` shrinks to ≤ 800 LOC (currently 1858).
+- The 27 byte-identity goldens are unchanged: `MIKEBOM_UPDATE_*_GOLDENS=1` regen for CDX + SPDX 2.3 + SPDX 3 produces zero `git diff`.
+- `tests/scan_binary.rs` (the integration test, 1337 LOC) passes identically — every assertion that exercises a binary code path keeps working.
+
+**Acceptance Scenarios**:
+
+1. **Given** the post-#43 main, **When** the binary split lands, **Then** `./scripts/pre-pr.sh` passes clean (modulo the pre-existing `dual_format_perf` / `spdx_us1_acceptance` / `spdx_determinism` flakiness pattern documented in #42 and #43).
+2. **Given** the split lands, **When** a maintainer regenerates the byte-identity goldens, **Then** `git diff mikebom-cli/tests/fixtures/golden/` is empty.
+3. **Given** the existing external callers (`maven.rs:2274`, `go_binary.rs:517`, `linkage.rs:45`) reference `crate::scan_fs::binary::is_path_claimed`, **When** the split lands, **Then** none of those call sites change — `is_path_claimed` remains reachable at the same path.
+4. **Given** `tests/scan_binary.rs` (the integration test for binary scanning across ELF / Mach-O / fat-Mach-O / PE / Go-built-binary / RPM-note / DEB / APK / RHEL/Alpine), **When** it runs, **Then** every test passes identically — the split is purely organizational.
+
+---
+
+### Edge Cases
+
+- **`is_path_claimed` stays in `binary/mod.rs`**, not in `scan.rs` (despite milestone-018's plan suggesting otherwise). Rationale: it's used by `read()` (which stays in mod.rs) AND by external callers via `crate::scan_fs::binary::is_path_claimed`. Keeping it in mod.rs avoids a re-export and keeps the canonical location matching the external-caller path. The submodule can call `super::is_path_claimed` if it ever needs to (currently it doesn't).
+- **`BinaryScan` lives in `entry.rs`** because that's where the entry-conversion code that owns the type's transformation lives. `scan.rs` constructs it via `use super::entry::BinaryScan;`. The struct stays `pub(crate)` (unchanged from current visibility); no re-export needed because no external crate references it.
+- **`detect_format` (line 908)** is used only by `is_supported_binary` (line 901). Both move to `discover.rs` together; neither needs `pub(super)` because their only call site is internal to `discover.rs`.
+- **Sibling-module references** (`super::elf`, `super::linkage`, `super::packer`, `super::version_strings`) keep working because the new submodules are direct siblings of `elf.rs`/`linkage.rs`/etc. — `super::elf::ElfNotePackage` from `entry.rs` resolves to `binary/elf.rs`.
+- **Inline test distribution**: the 38-test `#[cfg(test)] mod tests` block in mod.rs distributes by which production code each test exercises. Tests that exercise functions in mod.rs (read, is_path_claimed, claim_skip_*, inode_match_*) stay there; tests for moved code move with it.
+- **`fake_binary_scan` test helper**: moves to `entry.rs::tests` because it constructs `BinaryScan` and is used by `make_file_level_component_*` tests (which also move to entry.rs).
+- **`tests/scan_binary.rs`** (1337 LOC integration test) is **not touched**. It uses only the public API (`binary::read`); the split doesn't change that.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: After this milestone ships, `mikebom-cli/src/scan_fs/binary/mod.rs` MUST be ≤ 800 LOC. Verified by `wc -l`.
+- **FR-002**: After this milestone ships, the `binary/` directory MUST contain at least these files: `mod.rs`, `discover.rs`, `entry.rs`, `predicates.rs`, `scan.rs`. The existing siblings (`elf.rs`, `jdk_collapse.rs`, `linkage.rs`, `macho.rs`, `packer.rs`, `pe.rs`, `python_collapse.rs`, `version_strings.rs`) MUST be unchanged.
+- **FR-003**: External callers MUST NOT change. Specifically: `crate::scan_fs::binary::read(...)` and `crate::scan_fs::binary::is_path_claimed(...)` MUST resolve to the same items at the same paths. The 4 call sites in `scan_fs/mod.rs:218`, `package_db/maven.rs:2274`, `package_db/go_binary.rs:517`, `binary/linkage.rs:45` are not edited.
+- **FR-004**: Zero behavioral changes. The 27 byte-identity goldens (`mikebom-cli/tests/fixtures/golden/`) MUST be byte-identical after the split. Verified by `MIKEBOM_UPDATE_*_GOLDENS=1` regen producing zero `git diff`.
+- **FR-005**: All inline `#[cfg(test)]` test names from `binary/mod.rs::tests` (38 functions including the 1 helper) MUST be preserved verbatim. Tests that move into a new submodule's `#[cfg(test)] mod tests` block keep their function names. SC-002 verifies this with a sorted-name diff.
+- **FR-006**: Visibility ladder per `data-model.md` "Visibility ladder" table. Pre-existing `pub` and `pub(crate)` items keep their level; cross-submodule `fn` items expand to `pub(super) fn` at minimum. **Visibility contraction is out of scope.**
+- **FR-007**: `binary/mod.rs` declares `mod discover; mod entry; mod predicates; mod scan;` for the new submodules. Existing `pub mod elf;` etc. declarations are unchanged.
+- **FR-008**: Each user-story commit on the milestone branch passes `./scripts/pre-pr.sh` cleanly. Reviewers can `git diff <commit>~..<commit>` and see one logical chunk at a time. Per the milestone-018 lesson, the split is one atomic commit per submodule extraction (not piecemeal moves that risk broken intermediate state).
+- **FR-009**: No new runtime crates. No `Cargo.toml` changes for `mikebom-cli`. Per Constitution Principle VI.
+- **FR-010**: `tests/scan_binary.rs` (1337 LOC integration test) is unchanged. The integration test exercises `binary::read` and the public binary-format coverage; it passes the split as a black-box gate.
+
+### Key Entities *(include if feature involves data)*
+
+This milestone has no new data — same as milestone 018, it's source-tree organization. The single relevant pre-existing type is `BinaryScan` (a struct used internally to pass scan results from `scan_binary` to `make_file_level_component`); it relocates to `entry.rs` but keeps its current `pub(crate)` visibility.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `wc -l mikebom-cli/src/scan_fs/binary/mod.rs` ≤ 800. Each new submodule (`discover.rs`, `entry.rs`, `predicates.rs`, `scan.rs`) ≤ 800 LOC. Verified by `wc -l`.
+- **SC-002**: Test-name parity. After the split, sorted test-name diff against the post-#43 baseline shows: zero removed names from before-baseline; added names are renamed-only (e.g., `binary::tests::is_go_binary_*` → `binary::scan::tests::is_go_binary_*`). Same FR-007-style verification used in milestone 018.
+- **SC-003**: 27 byte-identity goldens unchanged. Verified by regen + `git diff --stat mikebom-cli/tests/fixtures/golden/` returning empty.
+- **SC-004**: `./scripts/pre-pr.sh` exits 0 from a clean tree on macOS and Linux (pre-existing flaky tests aside; see "Known flakiness" in the assumptions). Verified by both CI legs.
+- **SC-005**: External call sites unchanged. `git diff` against `scan_fs/mod.rs`, `package_db/maven.rs`, `package_db/go_binary.rs`, `binary/linkage.rs` shows zero edits to those files (the binary split touches `binary/` only).
+- **SC-006**: A maintainer chasing a Mach-O fat-binary or PE-format bug post-merge finds the relevant code in `binary/scan.rs` (single-file scanner) within **under 30 seconds** via `find` or fuzzy-search on the new file structure. Same qualitative criterion as milestone 018's SC-005.
+
+## Clarifications
+
+### Session 2026-04-25
+
+- Q: Why 5 files instead of milestone-018's planned 4? → A: Reconnaissance after #43 merged showed the inline tests in `binary/mod.rs::tests` are ~700 LOC; ~14 of 38 tests test OS-aware predicates (`RootfsKind`, `has_rpmdb_at`, `is_os_managed_directory`, `is_host_system_path`) which are themselves ~150 LOC of production code. Without extracting those into `predicates.rs`, `mod.rs` lands ~1100 LOC post-split — well over the 800-LOC ceiling. The 5th submodule is necessary to meet FR-001.
+- Q: Why does `is_path_claimed` stay in `mod.rs` instead of moving to `scan.rs` per milestone-018's plan? → A: It's called by `read()` (which stays in mod.rs) AND by external callers via `crate::scan_fs::binary::is_path_claimed`. Keeping it in mod.rs avoids a `pub(crate) use ...` re-export and keeps the canonical location matching where external callers already point.
+- Q: Should `tests/scan_binary.rs` (1337 LOC integration test) also be split? → A: No (same answer as milestone 018 for `tests/scan_*.rs`). Integration tests are organized by feature/scenario, not by parser shape. Out of scope.
+
+## Assumptions
+
+- The byte-identity goldens (#38 + #40) are the load-bearing regression test for "no behavior change." If goldens trip during the split, the split is wrong and must be reconciled before commit. Same gate that caught milestone 017's T013b emitter bug.
+- Milestone 018's pip + npm splits set the convention for inline `#[cfg(test)]` test distribution: tests move with the production code they exercise. We follow the same pattern; SC-002 enforces preservation.
+- `tests/scan_binary.rs` (1337 LOC) exercises every binary code path through the public API. If `tests/scan_binary.rs` passes, the split's external behavior is unchanged regardless of where the moved code physically lives.
+- Pre-existing flakiness in `dual_format_perf`, `spdx_us1_acceptance`, and `spdx_determinism` (documented in #42 and #43) may surface intermittently in `./scripts/pre-pr.sh` on busy dev boxes. These are concurrent-test-load issues, not regressions from this milestone — verified by running each test in isolation.
+- No `Cargo.toml` changes needed. Each new submodule declares `use super::*;` patterns where helpful and explicit `use super::entry::BinaryScan;` etc. for cross-sibling types.
+
+## Out of Scope
+
+- `tests/scan_binary.rs` split. Per the clarification above.
+- Sub-splitting any individual new submodule below the FR-001 ceiling. (Future polish if it surfaces a real readability win.)
+- Refactoring the binary-scan logic itself. The split is purely "move code into siblings"; behavior unchanged.
+- Renaming `pub fn read` or `pub(crate) fn is_path_claimed` or `pub(crate) struct BinaryScan`. Their existing visibility levels and names stay.
+- Touching `cdx_regression.rs`, `spdx_regression.rs`, or `spdx3_regression.rs` test files. They run as-is; the goldens drive the verification.
+- Completing the existing stub modules (`macho.rs`, `pe.rs`, `packer.rs`, `version_strings.rs`). They stay stubs.
+- Splitting `maven.rs` (5702 LOC). Same rationale as in milestone 018: maven's sub-concerns are coupled by Maven's build model, not by accidental file growth. Separate consideration.

--- a/specs/019-binary-split/tasks.md
+++ b/specs/019-binary-split/tasks.md
@@ -1,0 +1,133 @@
+---
+description: "Task list — binary/mod.rs split (milestone 019)"
+---
+
+# Tasks: binary/mod.rs Split — Design-First
+
+**Input**: Design documents from `/specs/019-binary-split/`
+**Prerequisites**: spec.md (✅), plan.md (✅), research.md (✅), data-model.md (✅), contracts/module-boundaries.md (✅), quickstart.md (✅)
+
+**Tests**: No new automated tests. The 27 byte-identity goldens (#38 + #40) and the 1337-LOC `tests/scan_binary.rs` integration test are the regression surface.
+
+**Organization**: Single user story (US1). Five extraction commits in dependency order.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel — N/A here, extractions are dependency-ordered.
+- **[Story]**: All maps to US1.
+
+## Path Conventions
+
+Source-tree refactor only. Touches `mikebom-cli/src/scan_fs/binary/{mod,discover,entry,predicates,scan}.rs`. No `Cargo.toml`, no test files, no other modules.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Snapshot the post-#43 baseline so SC-002 can verify zero test-name regression.
+
+- [ ] T001 Snapshot baseline: `./scripts/pre-pr.sh 2>&1 | tee /tmp/baseline-019.txt | grep -E '^test [a-z_:]+ \.\.\. ok' | sort -u > /tmp/baseline-019-tests.txt`. Confirm the post-#43 test-name list. Output is local-only — not committed.
+- [ ] T002 Verify baseline LOC: `wc -l mikebom-cli/src/scan_fs/binary/mod.rs`. Expected: 1858. If drifted, update FR-001 budget accordingly.
+
+---
+
+## Phase 2: Extract `predicates.rs` (Priority: P1) 🎯 First extraction
+
+**Goal**: Move `RootfsKind`, `detect_rootfs_kind`, `is_host_system_path`, `has_rpmdb_at`, `is_os_managed_directory` and their 14 inline tests from `binary/mod.rs` into a new sibling `binary/predicates.rs`.
+
+**Independent Test**: After T006, `mikebom-cli/src/scan_fs/binary/predicates.rs` exists with the 5 production fns + 14 tests; `mod.rs` shrinks by ~350 LOC; `./scripts/pre-pr.sh` passes; goldens unchanged.
+
+- [ ] T003 [US1] Plan the move using `data-model.md` "Items landing in binary/predicates.rs" table.
+- [ ] T004 [US1] Construct `binary/predicates.rs`. Header: `//!` doc + `use std::path::Path;`. Body: 5 functions with `pub(super)` visibility (per visibility ladder); enum `RootfsKind` becomes `pub(super)`. Tests block follows same `#[cfg(test)] #[cfg_attr(test, allow(clippy::unwrap_used))] mod tests { use super::*; ... }` pattern as milestone-018 splits.
+- [ ] T005 [US1] Update `binary/mod.rs`: remove the moved code; add `mod predicates;` declaration; qualify all call sites in `read()` (e.g., `detect_rootfs_kind(...)` → `predicates::detect_rootfs_kind(...)`). Same atomic-edit discipline as milestone 018 — one commit, no piecemeal moves.
+- [ ] T006 [US1] Verify byte-identity. `cargo +stable check --workspace --tests` passes; the three goldens regen (`MIKEBOM_UPDATE_*_GOLDENS=1`) produces empty `git diff`. Run `./scripts/pre-pr.sh` — clean.
+- [ ] T007 [US1] Commit: `refactor(019/extract-predicates): move RootfsKind + OS predicates from binary/mod.rs to predicates.rs`.
+
+---
+
+## Phase 3: Extract `discover.rs`
+
+**Goal**: Move `discover_binaries`, `walk_dir`, `is_supported_binary`, `detect_format` from `binary/mod.rs` into `binary/discover.rs`.
+
+**Independent Test**: After T011, `mikebom-cli/src/scan_fs/binary/discover.rs` exists; `mod.rs` shrinks by ~85 LOC; pre-PR clean; goldens unchanged.
+
+- [ ] T008 [US1] Plan the move using `data-model.md` "Items landing in binary/discover.rs" table.
+- [ ] T009 [US1] Construct `binary/discover.rs`. Header: `//!` doc + `use std::path::{Path, PathBuf};`. Body: 4 functions; `discover_binaries` is `pub(super) fn`; `walk_dir` and `is_supported_binary` stay private; `detect_format` keeps `pub(crate)` (per FR-006 strict reading).
+- [ ] T010 [US1] Update `binary/mod.rs`: remove moved code; add `mod discover;` declaration; qualify call sites in `read()` (`discover_binaries(...)` → `discover::discover_binaries(...)`).
+- [ ] T011 [US1] Verify byte-identity (same pattern as T006). Run `./scripts/pre-pr.sh`.
+- [ ] T012 [US1] Commit: `refactor(019/extract-discover): move filesystem walker from binary/mod.rs to discover.rs`.
+
+---
+
+## Phase 4: Extract `entry.rs`
+
+**Goal**: Move `BinaryScan` struct + `version_match_to_entry`, `make_file_level_component`, `note_package_to_entry`, `impl PackageDbEntry` + 12 tests from `binary/mod.rs` into `binary/entry.rs`. **Critical**: must come before scan.rs extraction because scan.rs depends on `BinaryScan` from entry.rs.
+
+**Independent Test**: After T016, `mikebom-cli/src/scan_fs/binary/entry.rs` exists; `mod.rs` shrinks by ~490 LOC; pre-PR clean; goldens unchanged.
+
+- [ ] T013 [US1] Plan the move using `data-model.md` "Items landing in binary/entry.rs" table.
+- [ ] T014 [US1] Construct `binary/entry.rs`. Header: `//!` doc + imports per `data-model.md` "Cross-submodule import inventory" entry.rs section. Body: `pub(crate) struct BinaryScan` + 3 conversion fns (`pub(super)`) + `impl PackageDbEntry` + 12 tests + `fake_binary_scan` helper.
+- [ ] T015 [US1] Update `binary/mod.rs`: remove moved code; add `mod entry;` declaration; qualify call sites in `read()` (`version_match_to_entry(...)` → `entry::version_match_to_entry(...)`, etc.). `mod.rs` may still need `use entry::BinaryScan;` if any test in mod.rs references it (verify during this step).
+- [ ] T016 [US1] Verify byte-identity. Pre-PR clean.
+- [ ] T017 [US1] Commit: `refactor(019/extract-entry): move BinaryScan + entry conversion from binary/mod.rs to entry.rs`.
+
+---
+
+## Phase 5: Extract `scan.rs`
+
+**Goal**: Move `scan_binary`, `scan_fat_macho`, `collect_string_region`, `is_go_binary` + 4 tests from `binary/mod.rs` into `binary/scan.rs`. **Depends on entry.rs already existing** so scan.rs can `use super::entry::BinaryScan`.
+
+**Independent Test**: After T021, `mikebom-cli/src/scan_fs/binary/scan.rs` exists; `mod.rs` ≤ 800 LOC (FR-001 met); pre-PR clean; goldens unchanged.
+
+- [ ] T018 [US1] Plan the move using `data-model.md` "Items landing in binary/scan.rs" table.
+- [ ] T019 [US1] Construct `binary/scan.rs`. Header: `//!` doc + imports per `data-model.md` scan.rs section, including `use super::entry::BinaryScan;` and the existing-sibling refs `use super::{elf, packer, version_strings};`. Body: 4 functions; `scan_binary` is `pub(super) fn`; others stay private; 4 tests + helper.
+- [ ] T020 [US1] Update `binary/mod.rs`: remove moved code; add `mod scan;` declaration; qualify call sites in `read()` (`scan_binary(...)` → `scan::scan_binary(...)`).
+- [ ] T021 [US1] Verify byte-identity + LOC ceiling: `wc -l mikebom-cli/src/scan_fs/binary/mod.rs` ≤ 800. Pre-PR clean.
+- [ ] T022 [US1] Commit: `refactor(019/extract-scan): move single-file binary scanner from binary/mod.rs to scan.rs — completes the split`.
+
+---
+
+## Phase 6: Polish & Verification
+
+**Purpose**: Final-state acceptance proof per spec SC-001 through SC-006.
+
+- [ ] T023 Run `./scripts/pre-pr.sh` from a clean tree. Capture post-019 test-name list. Diff against /tmp/baseline-019-tests.txt — expected: zero removed-without-rename. Renamed entries (e.g., `binary::tests::is_go_binary_*` → `binary::scan::tests::is_go_binary_*`) are normal.
+- [ ] T024 SC-005 verification: `git diff main..019-binary-split -- mikebom-cli/src/scan_fs/mod.rs mikebom-cli/src/scan_fs/package_db/maven.rs mikebom-cli/src/scan_fs/package_db/go_binary.rs mikebom-cli/src/scan_fs/binary/linkage.rs` — expected: empty.
+- [ ] T025 Cross-host CI verification. Push the branch; observe both Linux and macOS CI legs pass. The 27 byte-identity goldens are the cross-host canary, same as milestones 017 and 018.
+- [ ] T026 Author the PR description. Per-commit summary table (5 extraction commits), per-submodule LOC inventory, byte-identity attestation, test-name diff attestation. PR title: `refactor(019): binary/mod.rs split — design-first, 5 files`.
+
+---
+
+## Dependency Graph
+
+```text
+T001 (snapshot baseline)
+└─ T002 (verify pre-split LOC) ← Phase 1 done
+   ├─ T003 (predicates plan) → T004 (predicates construct) → T005 (mod.rs update) → T006 (verify) → T007 (commit) ← Phase 2 done
+   │
+   ├─ T008 (discover plan) → T009 → T010 → T011 → T012 ← Phase 3 done
+   │
+   ├─ T013 (entry plan) → T014 → T015 → T016 → T017 ← Phase 4 done    ← MUST come before Phase 5
+   │
+   └─ T018 (scan plan) → T019 → T020 → T021 → T022 ← Phase 5 done     ← scan.rs imports BinaryScan from entry.rs
+      └─ T023 (post-019 pre-PR + diff)
+         ├─ T024 (SC-005 external-callers verify)
+         ├─ T025 (cross-host CI)
+         └─ T026 (PR description) ← Phase 6 done
+```
+
+Phases 2 and 3 are independent of each other (predicates ⊥ discover). Phase 4 must precede Phase 5 (entry must exist before scan imports BinaryScan from it). Recommended order: 2 → 3 → 4 → 5 (but 2 and 3 could swap without consequence).
+
+## Estimated effort
+
+| Phase | Estimated effort | Notes |
+|---|---|---|
+| Phase 1 (setup) | 10 min | Mechanical baseline snapshot. |
+| Phase 2 (predicates) | 1-2 hr | First extraction; the visibility-ladder pattern is established here. |
+| Phase 3 (discover) | 30-45 min | Smaller and self-contained. |
+| Phase 4 (entry) | 2-3 hr | Largest extraction; the BinaryScan-relocation is the careful step. |
+| Phase 5 (scan) | 2 hr | Cross-sibling import to entry.rs is the new wrinkle. |
+| Phase 6 (polish + PR) | 30 min | If CI is green on first push. |
+| **Total** | **6-8 hr** | One focused day. |
+
+If goldens trip at any T006 / T011 / T016 / T021 verification, add 1-2 hr per ecosystem to diff the moved code against pre-split byte-for-byte and find the unintended reorder/edit.


### PR DESCRIPTION
## Summary

Splits the 1858-LOC `binary/mod.rs` god-module into 5 focused submodules. Per-submodule extraction commits in dependency order, atomic per cohort. External call sites (3) are untouched. Goldens are byte-identical.

This delivers milestone 018's deferred US3 with a design-first spec set (`specs/019-binary-split/`, 8 files, 1083 LOC of design before any production code touched).

## Per-commit chain

| Commit | Cohort | mod.rs LOC after |
|---|---|---|
| `1b7ce7c` | docs(019): full spec set | 1858 |
| `f1b7604` | extract `predicates.rs` (RootfsKind + OS predicates + 14 tests) | 1502 |
| `896a8a1` | extract `discover.rs` (walker + format detection) | 1416 |
| `f07fe7d` | extract `entry.rs` (BinaryScan + 3 conversions + 13 tests) | 925 |
| `ccdc91b` | extract `scan.rs` (scan_binary + scan_fat_macho + 4 tests) | **662** ✓ |

FR-001 ceiling (≤800) met with margin.

## Per-submodule LOC inventory (final)

| File | LOC | Role |
|---|---|---|
| `binary/mod.rs` | 662 | orchestration + `is_path_claimed` + integration tests |
| `binary/predicates.rs` | 303 | rootfs detection + OS predicates |
| `binary/discover.rs` | 89 | filesystem walker + format detection |
| `binary/entry.rs` | 579 | `BinaryScan` struct + entry conversions |
| `binary/scan.rs` | 306 | `scan_binary` + `scan_fat_macho` + helpers |

## Byte-identity attestation

`MIKEBOM_UPDATE_CDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test --workspace --tests -- --test-threads=1` followed by `git diff -- mikebom-cli/tests/golden` produces zero diff. All 27 byte-identity goldens (9 CDX + 9 SPDX 2.3 + 9 SPDX 3) confirm no behavior change.

## Test-name diff attestation (SC-002)

Renames are normal (e.g., `binary::tests::is_go_binary_*` → `binary::scan::tests::is_go_binary_*`). No removed-without-rename names.

## SC-005 attestation (external callers untouched)

```
git diff main..HEAD -- \
  mikebom-cli/src/scan_fs/mod.rs \
  mikebom-cli/src/scan_fs/package_db/maven.rs \
  mikebom-cli/src/scan_fs/package_db/go_binary.rs \
  mikebom-cli/src/scan_fs/binary/linkage.rs
```

returns empty. The 3 external callers of `is_path_claimed` and the 1 caller of `binary::read` see identical signatures + types.

## Visibility ladder

- `pub fn read` and `pub(crate) fn is_path_claimed` stay in `mod.rs` (research R2).
- `pub(crate) struct BinaryScan` lives in `entry.rs`; `scan.rs` imports it cross-sibling (research R3).
- All other moved items get `pub(super)` — minimum visibility for sibling-only access.
- Submodules declared `mod`, not `pub mod` — nothing outside `binary/` references them by path.

## Test plan

- [x] `./scripts/pre-pr.sh` clean locally (clippy `-D warnings`, full test suite)
- [x] Goldens regen produces zero diff (byte-identity verified)
- [x] FR-001 LOC ceiling met (mod.rs = 662 ≤ 800)
- [x] SC-005 external-callers diff empty
- [ ] Linux CI leg green
- [ ] macOS CI leg green (cross-host byte-identity canary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)