### PR TITLE
refactor(020): ebpf-tracing feature gate — design-first, 4 commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,16 @@ jobs:
   # PR #34. To upgrade: bump the SHA + comment together; verify the
   # comment matches what `gh api /repos/<owner>/<repo>/git/ref/tags/<tag>`
   # returns (or the dereferenced commit for annotated tags).
+  #
+  # CI matrix (post-milestone-020):
+  #   - lint-and-test           (Linux, default features, stable only)
+  #   - lint-and-test-macos     (macOS, default features, stable only)
+  #   - lint-and-test-ebpf      (Linux, --features ebpf-tracing, stable + nightly + bpf-linker)
+  #
+  # The default lanes drop the nightly + bpf-linker + xtask ebpf cost
+  # entirely. The ebpf lane runs in parallel and is the regression gate
+  # for the user-space eBPF integration. See
+  # specs/020-ebpf-feature-gate/ for the full rationale.
   lint-and-test:
     name: Lint + test (linux-x86_64)
     runs-on: ubuntu-latest
@@ -40,38 +50,13 @@ jobs:
           # CICD-SEC-1 + Kusari Inspector hardening guidance.
           persist-credentials: false
 
-      - name: Install eBPF build deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang llvm libelf-dev pkg-config libssl-dev
-
-      # Install nightly first so stable ends up as the default toolchain
-      # for unpinned `cargo` invocations. dtolnay/rust-toolchain sets the
-      # default to whichever it installed last.
-      - name: Install nightly Rust with rust-src
-        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly (2026-04-25)
-        with:
-          components: rust-src
-
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-25)
         with:
           components: clippy
 
-      - name: Make stable the default toolchain
-        run: rustup default stable
-
       - name: Cache cargo + build artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
-
-      - name: Install bpf-linker
-        run: |
-          if ! command -v bpf-linker >/dev/null 2>&1; then
-            cargo +nightly install bpf-linker --locked
-          fi
-
-      - name: Build eBPF object
-        run: cargo run --package xtask -- ebpf
 
       # sbomqs is the cross-format SBOM-quality scorer that
       # enforces spec SC-001: mikebom's SPDX output must meet or
@@ -150,3 +135,61 @@ jobs:
 
       - name: Tests
         run: cargo +stable test --workspace
+
+  # Opt-in eBPF lane. Pays the nightly + bpf-linker + xtask ebpf cost
+  # so the user-space eBPF integration (mikebom-cli/src/trace/* +
+  # `mikebom trace` subcommand) keeps working. Default lanes above
+  # do not invoke this path — see specs/020-ebpf-feature-gate/.
+  lint-and-test-ebpf:
+    name: Lint + test (linux-x86_64, --features ebpf-tracing)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false  # see lint-and-test job for rationale
+
+      - name: Install eBPF build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libelf-dev pkg-config libssl-dev
+
+      # Install nightly first so stable ends up as the default toolchain
+      # for unpinned `cargo` invocations. dtolnay/rust-toolchain sets the
+      # default to whichever it installed last.
+      - name: Install nightly Rust with rust-src
+        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly (2026-04-25)
+        with:
+          components: rust-src
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-25)
+        with:
+          components: clippy
+
+      - name: Make stable the default toolchain
+        run: rustup default stable
+
+      - name: Cache cargo + build artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+
+      - name: Install bpf-linker
+        run: |
+          if ! command -v bpf-linker >/dev/null 2>&1; then
+            cargo +nightly install bpf-linker --locked
+          fi
+
+      - name: Build eBPF object
+        run: cargo run --package xtask -- ebpf
+
+      - name: Install sbomqs
+        run: |
+          GOMODCACHE="${RUNNER_TEMP}/go-mod-cache-sbomqs" \
+            go install github.com/interlynk-io/sbomqs/v2@v2.0.6
+      - name: Add Go bin to PATH
+        run: echo "${HOME}/go/bin" >> "$GITHUB_PATH"
+
+      - name: Clippy (--features ebpf-tracing)
+        run: cargo +stable clippy --workspace --all-targets --features ebpf-tracing -- -D warnings
+
+      - name: Tests (--features ebpf-tracing)
+        run: cargo +stable test --workspace --features ebpf-tracing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,20 @@ Auto-generated from all feature plans. Last updated: 2026-04-25
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
+## Feature flags
+
+- **`ebpf-tracing`** (off by default; milestone 020): gates the user-space
+  eBPF integration that powers `mikebom trace`. When off (the default
+  everywhere — local dev, default CI lanes), aya/aya-log/libc are dropped
+  from the dep graph and nightly + bpf-linker are not required. When on
+  (Linux + `--features ebpf-tracing`), build the kernel-side artifact
+  first via `cargo run -p xtask -- ebpf`, then test with
+  `cargo +stable test --workspace --features ebpf-tracing`. Local pre-PR
+  opt-in: `MIKEBOM_PREPR_EBPF=1 ./scripts/pre-pr.sh`. CI runs the
+  feature-on path in the dedicated `lint-and-test-ebpf` job. See
+  `specs/020-ebpf-feature-gate/contracts/feature-flag.md` for the full
+  contract.
+
 ## Project Structure
 
 ```text

--- a/mikebom-cli/Cargo.toml
+++ b/mikebom-cli/Cargo.toml
@@ -20,8 +20,30 @@ path = "src/main.rs"
 name = "mikebom"
 path = "src/lib.rs"
 
+[features]
+default = []
+
+# Enable user-space eBPF tracing for the `mikebom trace` subcommand.
+# Activates aya/aya-log/libc + the `aya-user` feature on mikebom-common,
+# all of which are otherwise dropped from the dependency graph.
+#
+# Requirements when active:
+#   - Linux host (the optional deps are also `target_os = "linux"`-gated).
+#   - Nightly Rust + bpf-linker for the kernel-side artifact built by
+#     `cargo run -p xtask -- ebpf` (separate target triple, separate crate).
+#
+# See specs/020-ebpf-feature-gate/contracts/feature-flag.md for the
+# formal contract. Default builds (Linux + macOS + CI default lane)
+# stay stable-only and do not pay the nightly + bpf-linker tax.
+ebpf-tracing = [
+    "dep:aya",
+    "dep:aya-log",
+    "dep:libc",
+    "mikebom-common/aya-user",
+]
+
 [dependencies]
-mikebom-common = { path = "../mikebom-common", features = ["std", "aya-user"] }
+mikebom-common = { path = "../mikebom-common", features = ["std"] }
 
 flate2 = "1"
 serde_yaml = "0.9"
@@ -101,6 +123,9 @@ tempfile = "3"
 jsonschema = { version = "0.46", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-aya = "0.13"
-aya-log = "0.2"
-libc = "0.2"
+# Activated by the `ebpf-tracing` feature. Combined with the target
+# predicate, these are pulled in only when the host is Linux AND the
+# feature is enabled. Dropped from default builds per milestone 020.
+aya = { version = "0.13", optional = true }
+aya-log = { version = "0.2", optional = true }
+libc = { version = "0.2", optional = true }

--- a/mikebom-cli/src/cli/scan.rs
+++ b/mikebom-cli/src/cli/scan.rs
@@ -101,7 +101,7 @@ impl ScanArgs {
     /// Returns an error when `--require-signing` is set but no identity
     /// was configured. Only invoked from the Linux-only
     /// `execute_scan` block; gate the method itself.
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]
     pub fn build_signing_identity(
         &self,
     ) -> anyhow::Result<crate::attestation::signer::SigningIdentity> {
@@ -155,7 +155,7 @@ pub async fn execute(args: ScanArgs) -> anyhow::Result<()> {
 /// Uses `argv[0]` basename — matches the convention `go-witness` uses
 /// when you pass `--step <name>`, but auto-derived. Only invoked from
 /// the Linux-only execute_scan block.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]
 fn default_collection_name(cmd: &str) -> String {
     cmd.split_whitespace()
         .next()
@@ -166,7 +166,7 @@ fn default_collection_name(cmd: &str) -> String {
         .to_string()
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]
 async fn execute_scan(args: ScanArgs) -> anyhow::Result<()> {
     use std::time::{Duration, Instant};
 
@@ -541,7 +541,7 @@ async fn execute_scan(args: ScanArgs) -> anyhow::Result<()> {
 /// The underlying directory walk + hash logic lives in
 /// [`crate::scan_fs::walker::walk_and_hash`] and is shared with the
 /// standalone `sbom scan` subcommand.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]
 fn scan_artifact_dirs(
     dirs: &[PathBuf],
     since: std::time::SystemTime,
@@ -574,7 +574,7 @@ fn scan_artifact_dirs(
 /// suffix, (b) still exists on disk, and (c) is under the size cap. Each
 /// hash is keyed by the exact path string the aggregator saw so
 /// `apply_file_hashes` can match it back.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]
 fn hash_captured_artifacts(
     agg: &crate::trace::aggregator::EventAggregator,
 ) -> std::collections::HashMap<String, mikebom_common::types::hash::ContentHash> {
@@ -609,7 +609,7 @@ fn hash_captured_artifacts(
 /// nanosecond timestamp (what `bpf_ktime_get_ns` returns) into a
 /// CLOCK_REALTIME Unix-epoch nanosecond timestamp. Returns 0 on error so
 /// callers still get a best-effort wall-clock rather than panicking.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]
 fn compute_boot_offset_ns() -> u64 {
     fn sample(clock: libc::clockid_t) -> Option<u64> {
         let mut ts = libc::timespec { tv_sec: 0, tv_nsec: 0 };
@@ -629,7 +629,7 @@ fn compute_boot_offset_ns() -> u64 {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(target_os = "linux", feature = "ebpf-tracing")))]
 async fn execute_scan(_args: ScanArgs) -> anyhow::Result<()> {
     anyhow::bail!(
         "eBPF tracing requires Linux. Use a Lima VM for tracing.\n\

--- a/mikebom-cli/src/cli/scan.rs
+++ b/mikebom-cli/src/cli/scan.rs
@@ -632,7 +632,10 @@ fn compute_boot_offset_ns() -> u64 {
 #[cfg(not(all(target_os = "linux", feature = "ebpf-tracing")))]
 async fn execute_scan(_args: ScanArgs) -> anyhow::Result<()> {
     anyhow::bail!(
-        "eBPF tracing requires Linux. Use a Lima VM for tracing.\n\
-         Non-tracing commands (generate, enrich, validate) work on any platform."
+        "this build was compiled without eBPF support; rebuild with \
+         --features ebpf-tracing on a Linux host to enable trace capture.\n\
+         (macOS users: spin up a Lima VM and rebuild there. Non-tracing \
+         commands — sbom scan/verify, attestation generate/verify, policy — \
+         work on any platform without the feature.)"
     )
 }

--- a/mikebom-cli/src/trace/loader.rs
+++ b/mikebom-cli/src/trace/loader.rs
@@ -13,7 +13,7 @@ pub struct LoaderConfig {
     pub ebpf_object: Option<PathBuf>,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]
 mod inner {
     use std::path::{Path, PathBuf};
 
@@ -176,15 +176,15 @@ mod inner {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]
 pub use inner::load_and_attach;
 // `EbpfHandle` lives inside the inner Linux-only module and isn't used
 // by any external caller; left non-re-exported to keep clippy clean.
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(target_os = "linux", feature = "ebpf-tracing")))]
 pub struct EbpfHandle;
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(target_os = "linux", feature = "ebpf-tracing")))]
 pub fn load_and_attach(_: &LoaderConfig) -> anyhow::Result<EbpfHandle> {
     anyhow::bail!("eBPF tracing requires Linux.")
 }

--- a/mikebom-cli/src/trace/pid_tracker.rs
+++ b/mikebom-cli/src/trace/pid_tracker.rs
@@ -89,7 +89,7 @@ impl PidTracker {
 
 // ── Linux implementation ──────────────────────────────────────────────
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]
 impl PidTracker {
     fn refresh_platform(&mut self) -> anyhow::Result<()> {
         let mut new_pids = HashSet::new();
@@ -158,7 +158,7 @@ impl PidTracker {
 
 // ── Non-Linux stub ────────────────────────────────────────────────────
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(target_os = "linux", feature = "ebpf-tracing")))]
 impl PidTracker {
     fn refresh_platform(&mut self) -> anyhow::Result<()> {
         anyhow::bail!(

--- a/mikebom-cli/src/trace/processor.rs
+++ b/mikebom-cli/src/trace/processor.rs
@@ -65,7 +65,7 @@ impl Default for LiveStats {
 
 // ── Linux implementation ──────────────────────────────────────────────
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]
 mod inner {
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
@@ -174,7 +174,7 @@ mod inner {
 
 // ── Non-Linux stub ────────────────────────────────────────────────────
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(target_os = "linux", feature = "ebpf-tracing")))]
 mod inner {
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;

--- a/mikebom-cli/tests/feature_gate.rs
+++ b/mikebom-cli/tests/feature_gate.rs
@@ -1,0 +1,45 @@
+//! Integration test for the `ebpf-tracing` feature flag (milestone 020).
+//!
+//! Verifies the runtime guard contract from
+//! `specs/020-ebpf-feature-gate/contracts/feature-flag.md`: when the feature
+//! is OFF (the default), invoking `mikebom trace capture` exits non-zero with
+//! a stderr message that names both the missing feature and the rebuild
+//! instruction.
+//!
+//! The test itself is gated `cfg(not(feature = "ebpf-tracing"))`, so it runs
+//! ONLY in default builds. Under `--features ebpf-tracing` the guard is
+//! unreachable (the real Linux execute_scan takes over), and asserting on a
+//! feature-off error message would be meaningless — so we compile this file
+//! out.
+
+#[cfg(not(feature = "ebpf-tracing"))]
+mod common;
+
+#[cfg(not(feature = "ebpf-tracing"))]
+#[test]
+fn trace_capture_returns_feature_off_error_in_default_build() {
+    use std::process::Command;
+
+    let output = Command::new(common::bin())
+        .args(["trace", "capture", "--target-pid", "1"])
+        .output()
+        .expect("spawn mikebom trace capture");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit; got {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("compiled without eBPF support"),
+        "stderr missing 'compiled without eBPF support' substring:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("--features ebpf-tracing"),
+        "stderr missing '--features ebpf-tracing' rebuild instruction:\n{stderr}",
+    );
+}

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -8,14 +8,33 @@
 # `cargo test -p mikebom` alone is insufficient — clippy is not run,
 # and `--all-targets` enforces lints on tests.
 #
-# Usage: ./scripts/pre-pr.sh
+# Usage:
+#   ./scripts/pre-pr.sh
+#       Default lane — matches the `lint-and-test` CI job. Stable
+#       toolchain only, no eBPF, no nightly required.
+#
+#   MIKEBOM_PREPR_EBPF=1 ./scripts/pre-pr.sh
+#       Opt-in eBPF lane — matches the `lint-and-test-ebpf` CI job.
+#       Adds `--features ebpf-tracing` to both clippy and test.
+#       Linux only (the optional aya/aya-log/libc deps are also
+#       target-gated). Requires `cargo run -p xtask -- ebpf` to have
+#       been run at least once if any test reaches into the kernel
+#       artifact path. See specs/020-ebpf-feature-gate/.
+#
 # Exits non-zero on the first failing step.
 
 set -euo pipefail
 
+if [[ "${MIKEBOM_PREPR_EBPF:-0}" == "1" ]]; then
+    printf '>>> running pre-PR checks with --features ebpf-tracing (eBPF lane)\n'
+    feature_args=(--features ebpf-tracing)
+else
+    feature_args=()
+fi
+
 steps=(
-    "cargo +stable clippy --workspace --all-targets -- -D warnings"
-    "cargo +stable test --workspace"
+    "cargo +stable clippy --workspace --all-targets ${feature_args[*]} -- -D warnings"
+    "cargo +stable test --workspace ${feature_args[*]}"
 )
 
 for cmd in "${steps[@]}"; do

--- a/specs/020-ebpf-feature-gate/checklists/requirements.md
+++ b/specs/020-ebpf-feature-gate/checklists/requirements.md
@@ -1,0 +1,62 @@
+# Spec Quality Checklist: ebpf-tracing Feature Gate
+
+**Checklist for** `/specs/020-ebpf-feature-gate/spec.md`
+
+## Coverage
+
+- [X] Background section explains *why* the gate is needed (carries the Tier 6 finding from PR #38's roadmap + concrete CI-cost numbers).
+- [X] User story has a P-priority and a "why this priority" justification.
+- [X] Independent Test is concrete (specific commands + expected output).
+- [X] Acceptance scenarios use Given/When/Then framing (5 scenarios).
+- [X] Edge Cases section names ≥ 5 corner cases (discoverability, cross-feature regressions, xtask invocation, mikebom-ebpf crate, test wiring).
+- [X] Functional Requirements are numbered (FR-001 through FR-010), each independently verifiable.
+- [X] Key Entities section explicitly notes there's no new data — build-system + module-gating refactor only.
+- [X] Success Criteria are measurable (SC-001 through SC-006), each with a verification mechanism.
+- [X] Clarifications section captures four scope decisions (default features, feature name, subcommand visibility, xtask scope).
+- [X] Out of Scope section names every adjacent concern (mikebom-ebpf split, new trace features, UX rewrite, aya replacement, loader-path change, macOS DYLD/EndpointSecurity, non-eBPF Linux gates).
+
+## Independence
+
+- [X] The single user story is self-contained — no dependencies on other in-flight work.
+- [X] Each per-commit deliverable (4 commits) is independently verifiable (per FR-008 each commit's `./scripts/pre-pr.sh` passes).
+
+## Concreteness
+
+- [X] FRs cite specific file paths (`mikebom-cli/Cargo.toml`, `.github/workflows/ci.yml`, `scripts/pre-pr.sh`, `mikebom-cli/src/trace/*`, `mikebom-cli/src/cli/scan.rs`).
+- [X] FR-007 quantifies the dependency-tree assertion (`cargo tree -p mikebom -e normal`).
+- [X] FR-005 names the verification env var verbatim (`MIKEBOM_PREPR_EBPF=1`).
+- [X] FR-003 names the exact runtime-guard error string (the integration test in FR-010 asserts on this).
+- [X] Success Criteria reference the existing pre-PR gate + the existing 27-golden byte-identity surface.
+
+## Internal consistency
+
+- [X] FR-001 (umbrella feature shape) aligns with research.md R2 (mikebom-common/aya-user resolution) + data-model.md "feature declaration".
+- [X] FR-003 (runtime guard error) aligns with research.md R5 (Option A — twin execute fns) + data-model.md "runtime guard".
+- [X] FR-006 (subcommand discoverability) aligns with the rejection of clap-level cfg gating in research.md R5 / contracts/feature-flag.md "What this contract forbids".
+- [X] FR-008 (per-commit pre-PR clean) aligns with quickstart.md commit chunking.
+- [X] research.md R3 (atomic Cargo.toml + cfg-gates commit) aligns with tasks.md Phase 2 (single commit, not two).
+
+## Lessons from milestones 016, 018, 019
+
+- [X] research.md R3 captures why Cargo.toml + cfg gates ship together — splitting them produces an intermediate state that doesn't compile (analogous to lesson from 018: never half-move a Rust module).
+- [X] FR-008 enforces the per-commit verification convention that protected milestones 018 (pip + npm splits) and 019 (binary split).
+- [X] quickstart.md "Common pitfalls" enumerates the failure modes (don't drop target predicate, don't gate `LoaderConfig`, don't gate `mod tests` indiscriminately).
+- [X] research.md R4 verified that `ScanArgs` clap struct is feature-independent — the lesson from 019's `is_path_claimed` decision: keep cross-cutting plumbing un-gated, only gate the feature-specific implementation.
+
+## Pre-implementation
+
+- [ ] [PHASE-1] T001 R2 resolved (mikebom-common aya-user inventory).
+- [ ] [PHASE-1] T002 baseline snapshot captured.
+- [ ] [PHASE-2] Commit 1 landed; default `cargo tree | rg '^aya'` empty.
+- [ ] [PHASE-3] Commit 2 landed; `cargo +stable test -p mikebom --test feature_gate` passes.
+- [ ] [PHASE-4] Commit 3 landed; pre-pr.sh clean; opt-in env var works locally (if Linux+nightly available).
+- [ ] [PHASE-5] Commit 4 landed; CLAUDE.md updated.
+- [ ] [POLISH] SC-001 default-toolchain-only build passes.
+- [ ] [POLISH] SC-002 `lint-and-test` Linux ≤ 2m.
+- [ ] [POLISH] SC-003 `lint-and-test-ebpf` green on the PR.
+- [ ] [POLISH] SC-005 dep-tree assertion holds.
+- [ ] [POLISH] SC-006 27-golden regen produces zero diff.
+
+## Post-merge (per spec SC-006 spirit)
+
+- [ ] [QUALITATIVE] Next time a non-trace PR opens, observe Linux CI runtime. If consistently ≤ 2m vs the pre-020 ~2m30s, milestone delivered.

--- a/specs/020-ebpf-feature-gate/contracts/feature-flag.md
+++ b/specs/020-ebpf-feature-gate/contracts/feature-flag.md
@@ -1,0 +1,67 @@
+# Contract: `ebpf-tracing` Feature Flag
+
+**Phase 1 contract for** `/specs/020-ebpf-feature-gate/spec.md`
+
+This document is the formal contract for the `ebpf-tracing` Cargo feature introduced by milestone 020. Anyone touching the `mikebom-cli` crate's feature surface AFTER this milestone ships should preserve these boundaries.
+
+## Feature declaration
+
+```toml
+[features]
+default = []
+ebpf-tracing = ["dep:aya", "dep:aya-log", "dep:libc"]
+```
+
+**Default features**: empty list. Default builds drop nightly toolchain, bpf-linker, and the user-space aya stack.
+
+**`ebpf-tracing` activates**:
+- Direct dep `aya` (0.13.x)
+- Direct dep `aya-log` (0.2.x)
+- Direct dep `libc` (0.2.x)
+- Compilation of `mikebom-cli/src/trace/*` (kernel-event aggregator, ring-buffer processor, eBPF loader)
+- Compilation of the `mikebom trace` capture pipeline in `mikebom-cli/src/cli/scan.rs`
+
+**`ebpf-tracing` does NOT activate**:
+- The `mikebom-ebpf` kernel-side crate (always built via `cargo run -p xtask -- ebpf`, separate target triple, separate toolchain).
+- Any non-trace code path. SBOM scanning, attestation generation, policy execution, etc. are unconditionally compiled.
+
+## Compatibility matrix
+
+| Platform | Feature | aya in dep graph | `mikebom trace` | nightly required |
+|---|---|---|---|---|
+| Linux | off (default) | ✗ | runtime error (FR-003) | ✗ |
+| Linux | on | ✓ | functional | ✗ for stable build; ✓ for kernel-side `xtask ebpf` |
+| macOS | off (default) | ✗ | runtime error (FR-003) | ✗ |
+| macOS | on | ✗ (target gate skips) | runtime error (FR-003) | n/a |
+| Other Unix | off | ✗ | runtime error | ✗ |
+| Other Unix | on | ✗ | runtime error | n/a |
+
+The `target.'cfg(target_os = "linux")'` gate on the deps means even `--features ebpf-tracing` on macOS does NOT pull in aya. The combined `cfg(all(target_os = "linux", feature = "ebpf-tracing"))` on the trace modules ensures the modules compile only when both conditions hold; the runtime guard catches every other case.
+
+## Public CLI surface
+
+`mikebom trace --help` is **discoverable in all builds**. The subcommand parses normally; only execution returns the FR-003 error when the feature is off.
+
+```
+$ mikebom trace capture --target-pid 1234
+Error: this build was compiled without eBPF support; rebuild with --features ebpf-tracing on a Linux host to enable trace capture
+$ echo $?
+1
+```
+
+This exact error string is part of the contract — `tests/feature_gate.rs` asserts on it (FR-010).
+
+## What this contract forbids
+
+- **Adding `ebpf-tracing` to `default`**. Defeats the milestone's purpose.
+- **Renaming the feature**. Downstream tooling, contributor docs, and CI all reference `ebpf-tracing` by name.
+- **Adding non-eBPF deps to the feature umbrella**. `ebpf-tracing` activates only the eBPF-specific stack. Cross-cutting deps stay unconditional.
+- **Removing the `target.'cfg(target_os = "linux")'` constraint** from the optional deps. macOS contributors who happen to invoke `cargo build --features ebpf-tracing` get a clean no-op (deps skipped) rather than a build failure.
+- **Replacing the runtime guard with a clap-level `Commands::Trace` cfg-gate**. The runtime guard preserves discoverability per FR-006.
+
+## Anti-patterns to avoid
+
+- **Splitting the umbrella into `aya`-only and `libc`-only sub-features**. They're co-required; splitting is YAGNI.
+- **Introducing a `default-ebpf` feature for "Linux opt-in by default"**. Cargo doesn't have target-conditional defaults. Workspace contributors and CI authors set `--features ebpf-tracing` explicitly when they want it.
+- **Adding `mikebom-common/aya-user` to the feature umbrella without R2 confirmation**. May or may not be needed depending on what `aya-user` actually does in mikebom-common — verified at task T001.
+- **Re-using the feature for unrelated trace-like work** (e.g., a future "logging-trace" or "sentry-trace"). If we ship those, give them their own feature names. `ebpf-tracing` means kernel-side instrumentation, full stop.

--- a/specs/020-ebpf-feature-gate/data-model.md
+++ b/specs/020-ebpf-feature-gate/data-model.md
@@ -1,0 +1,105 @@
+---
+description: "Data model — milestone 020 ebpf-tracing feature gate (cfg-gate inventory)"
+status: data-model
+milestone: 020
+---
+
+# Data Model: ebpf-tracing Feature Gate
+
+This is a build-system + module-gating refactor — no runtime data model changes. The "data model" here is the inventory of cfg gates that need expansion and the shape of the new `[features]` block.
+
+## `[features]` block (target shape)
+
+```toml
+[features]
+default = []
+
+# Enable user-space eBPF tracing (Linux + nightly + bpf-linker required).
+# Activates the `mikebom trace` subcommand and pulls in aya/aya-log/libc.
+# Build the kernel-side object first: `cargo run -p xtask -- ebpf`.
+# See specs/020-ebpf-feature-gate/spec.md for the full surface contract.
+ebpf-tracing = ["dep:aya", "dep:aya-log", "dep:libc"]
+```
+
+## Optional-dep transformation
+
+```toml
+# Before:
+[target.'cfg(target_os = "linux")'.dependencies]
+aya = "0.13"
+aya-log = "0.2"
+libc = "0.2"
+
+# After:
+[target.'cfg(target_os = "linux")'.dependencies]
+aya = { version = "0.13", optional = true }
+aya-log = { version = "0.2", optional = true }
+libc = { version = "0.2", optional = true }
+```
+
+Note: the `target` predicate stays. Combined with `optional = true`, the deps are pulled in only when **both** the target is Linux **and** the feature is on.
+
+## cfg-gate inventory (10 expansions)
+
+| File | Line | Before | After |
+|---|---|---|---|
+| `mikebom-cli/src/trace/loader.rs` | 16 | `#[cfg(target_os = "linux")]` | `#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]` |
+| `mikebom-cli/src/trace/loader.rs` | 179 | `#[cfg(target_os = "linux")]` | same as above |
+| `mikebom-cli/src/trace/loader.rs` | 184 | `#[cfg(not(target_os = "linux"))]` | `#[cfg(not(all(target_os = "linux", feature = "ebpf-tracing")))]` |
+| `mikebom-cli/src/trace/loader.rs` | 187 | `#[cfg(not(target_os = "linux"))]` | same as line 184 |
+| `mikebom-cli/src/trace/processor.rs` | 68 | `#[cfg(target_os = "linux")]` | `#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]` |
+| `mikebom-cli/src/trace/pid_tracker.rs` | 92 | same | same |
+| `mikebom-cli/src/cli/scan.rs` | 104 | same | same |
+| `mikebom-cli/src/cli/scan.rs` | 158 | same | same |
+| `mikebom-cli/src/cli/scan.rs` | 169 | same | same |
+| `mikebom-cli/src/cli/scan.rs` | 544 | same | same |
+| `mikebom-cli/src/cli/scan.rs` | 577 | same | same |
+| `mikebom-cli/src/cli/scan.rs` | 612 | same | same |
+
+12 lines actually (10 positive gates + 2 negative gates in `loader.rs`). The negative gates may consolidate into one if the two `cfg(not(target_os = "linux"))` blocks are adjacent — verified at implementation time.
+
+## Out-of-scope cfg gates
+
+These stay platform-only (NOT feature-gated), per spec FR-002:
+
+| File | Line | Reason |
+|---|---|---|
+| `mikebom-cli/src/scan_fs/os_release.rs` | 134 | `/etc/os-release` reading; host detection independent of trace |
+| `mikebom-cli/src/attestation/builder.rs` | 109 | `/proc/version` reading; kernel-version detection for attestations |
+| `mikebom-cli/src/trace/aggregator.rs` | 6 | comment-only reference, not a real gate |
+
+## Runtime guard (FR-003)
+
+`mikebom-cli/src/cli/scan.rs::execute` gets a feature-off twin:
+
+```rust
+#[cfg(not(all(target_os = "linux", feature = "ebpf-tracing")))]
+pub async fn execute(_args: ScanArgs) -> anyhow::Result<()> {
+    anyhow::bail!(
+        "this build was compiled without eBPF support; \
+         rebuild with --features ebpf-tracing on a Linux host \
+         to enable trace capture"
+    )
+}
+```
+
+Exact error string is part of the contract — the integration test in `tests/feature_gate.rs` asserts on it.
+
+## CI matrix (target shape)
+
+| Job | Runner | Toolchain | Features | Cost |
+|---|---|---|---|---|
+| `lint-and-test` | ubuntu-latest | stable | default (empty) | ~1m45s (target) |
+| `lint-and-test-macos` | macos-latest | stable | default (empty) | ~1m20s (unchanged) |
+| `lint-and-test-ebpf` | ubuntu-latest | stable + nightly | `ebpf-tracing` | ~2m30s (matches pre-020 baseline) |
+
+All three run in parallel. PR is green when all three pass.
+
+## Public surface impact
+
+No public-API change. The only user-visible difference is:
+
+1. `cargo build` from a default checkout requires only stable.
+2. `mikebom trace capture --help` from a default build prints the help, but `mikebom trace capture --target-pid X` exits non-zero with the FR-003 message.
+3. `mikebom --version` is unchanged.
+4. `mikebom sbom scan / verify`, `mikebom attestation generate / verify`, `mikebom policy *` — all unchanged.

--- a/specs/020-ebpf-feature-gate/plan.md
+++ b/specs/020-ebpf-feature-gate/plan.md
@@ -1,0 +1,101 @@
+---
+description: "Implementation plan — milestone 020 ebpf-tracing feature gate"
+status: plan
+milestone: 020
+---
+
+# Plan: ebpf-tracing Feature Gate
+
+## Architecture
+
+A single Cargo feature, `ebpf-tracing`, gates the user-space eBPF integration in `mikebom-cli`. The feature pulls in three otherwise-optional dependencies (`aya`, `aya-log`, `libc`) and conditionally compiles the trace pipeline + the trace-capture CLI command.
+
+The kernel-side crate (`mikebom-ebpf`) is unaffected — it remains `exclude`d from the workspace and built on demand via `cargo run -p xtask -- ebpf`. The xtask invocation moves from the default CI lane to a dedicated opt-in lane (`lint-and-test-ebpf`).
+
+## Dependency change
+
+| Dep | Before | After |
+|---|---|---|
+| `aya` | `[target.'cfg(target_os = "linux")'.dependencies]`, unconditional | same target gate, `optional = true`, activated by `ebpf-tracing` |
+| `aya-log` | same as aya | same as aya |
+| `libc` | same as aya | same as aya |
+
+`mikebom-common`'s `aya-user` feature (`mikebom-cli/Cargo.toml:24`) — needs verification: does it transitively pull in aya itself? If yes, that feature also becomes part of the `ebpf-tracing` umbrella. If no (it's just a marker), no change needed. **Action item for research.md R2.**
+
+## Code-gate transformation
+
+Mechanical rewrite — no behavior change:
+
+```rust
+// Before:
+#[cfg(target_os = "linux")]
+
+// After (only in trace/* and cli/scan.rs):
+#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]
+```
+
+Files touched:
+
+| File | Lines (before) | Gates to expand |
+|---|---|---|
+| `mikebom-cli/src/trace/loader.rs` | 16, 179 | 2 |
+| `mikebom-cli/src/trace/processor.rs` | 68 | 1 |
+| `mikebom-cli/src/trace/pid_tracker.rs` | 92 | 1 |
+| `mikebom-cli/src/cli/scan.rs` | 104, 158, 169, 544, 577, 612 | 6 |
+
+Total: 10 cfg-gate expansions. The non-Linux fallback in `trace/loader.rs:184-190` becomes the unified "feature-off OR non-Linux" fallback (single `cfg(not(all(target_os = "linux", feature = "ebpf-tracing")))`).
+
+## Runtime guard
+
+The `mikebom trace` dispatcher (in `mikebom-cli/src/main.rs` or `mikebom-cli/src/cli/trace_cmd.rs` per the inventory) gets a feature-off arm that returns the FR-003 error message. This is a 5-10 LOC change.
+
+## CI restructure
+
+Three jobs in `.github/workflows/ci.yml`:
+
+1. **`lint-and-test`** (Linux): default features, stable only.
+   - Drops: nightly install, bpf-linker install, `xtask ebpf` step.
+   - Keeps: clippy + test + sbomqs install.
+2. **`lint-and-test-macos`**: unchanged.
+3. **`lint-and-test-ebpf`** (Linux, NEW): clone of pre-020 `lint-and-test`.
+   - Adds `--features ebpf-tracing` to clippy + test.
+   - Keeps nightly + bpf-linker + xtask ebpf.
+
+All three run in parallel (no `needs:` chain). PR is green when all three pass.
+
+## Constitution alignment
+
+- **Principle I (zero C)**: aya is pure Rust per the `data-encoding`-style audit; libc is `cfg(unix)` but only for FFI signatures. No new C deps. ✓
+- **Principle IV (no .unwrap() in production)**: this milestone touches Cargo.toml + cfg gates + one runtime guard arm; no new `.unwrap()` introduced. ✓
+- **Principle VI (three-crate architecture)**: untouched. mikebom-ebpf stays its own crate. ✓
+- **Principle (atomic per-submodule commits, lessons from 018+019)**: this milestone is small enough for a single commit, but split per-concern (Cargo.toml + code gates, then runtime guard, then CI, then docs+pre-pr) keeps each commit independently verifiable.
+
+## Phasing
+
+Five commits in dependency order:
+
+1. **020/cargo-feature**: Add `[features]` to `mikebom-cli/Cargo.toml`; flip aya/aya-log/libc to `optional = true`.
+2. **020/cfg-gates**: Mechanical expansion of 10 cfg gates in `trace/*` + `cli/scan.rs`. After this commit, default `cargo +stable test --workspace` passes (proves feature-off is sound).
+3. **020/runtime-guard**: Add the FR-003 error path in the trace dispatcher + the `tests/feature_gate.rs` integration test.
+4. **020/ci-split**: Restructure `.github/workflows/ci.yml` into three jobs. Update `scripts/pre-pr.sh` for the FR-005 opt-in.
+5. **020/docs**: Update `CLAUDE.md` with the feature-flag guidance.
+
+Per FR-008, each commit's `./scripts/pre-pr.sh` must be clean. Commits 1+2 must land together if commit 1 alone breaks compilation (aya gone but cfg gates still unconditional). Decision in research R3.
+
+## Estimated effort
+
+| Phase | Effort | Notes |
+|---|---|---|
+| 1 (Cargo feature) | 15 min | Mechanical |
+| 2 (cfg gates) | 30 min | 10 sed-able expansions |
+| 3 (runtime guard + test) | 45 min | New integration test scaffolding |
+| 4 (CI split) | 30 min | YAML duplication + path adjustments |
+| 5 (docs) | 15 min | One paragraph in CLAUDE.md |
+| **Total** | **2-3 hr** | One focused half-day. |
+
+## Risks
+
+- **R1**: If `mikebom-common`'s `aya-user` feature transitively requires `aya`, the feature gate must include it. Verified in research.md R2.
+- **R2**: If the `trace` subcommand's clap parsing references types from the gated module (e.g., `LoaderConfig`), parsing breaks even with feature off. The current code keeps `LoaderConfig` un-gated (`mikebom-cli/src/trace/loader.rs:6-14`), but the `ScanArgs` struct in `cli/scan.rs` may need a gate review. Verified in research.md R4.
+- **R3**: Atomic commit ordering — if commit 1 (Cargo.toml) lands without commit 2 (cfg gates), `aya` becomes unavailable but `use aya::*` lines still try to import. Compilation breaks. Resolution: ship 1+2 as a single commit, OR verify pre-PR is clean after commit 1 alone (it won't be, so combine).
+- **R4**: CI YAML duplication — the new `lint-and-test-ebpf` job is ~70% identical to the old `lint-and-test`. Reusable workflows are an option but add YAML complexity. Pragmatic call: duplicate the YAML for now, factor later if a third eBPF-needing job appears.

--- a/specs/020-ebpf-feature-gate/quickstart.md
+++ b/specs/020-ebpf-feature-gate/quickstart.md
@@ -1,0 +1,108 @@
+---
+description: "Quickstart — implementing milestone 020 ebpf-tracing feature gate"
+status: quickstart
+milestone: 020
+---
+
+# Quickstart: ebpf-tracing Feature Gate
+
+This is the implementer's checklist. The full spec lives in `spec.md`; the per-task ladder is in `tasks.md`. Read both before starting.
+
+## Pre-flight
+
+1. Confirm clean tree on `main` post-#44 merge.
+2. Branch: `git checkout -b 020-ebpf-feature-gate` (already done if you're picking this up mid-stream).
+3. Baseline: `./scripts/pre-pr.sh` clean, captures pre-020 timing as comparison reference.
+
+## Implementation order (4 atomic commits)
+
+### Commit 1: `020/feature-gate` (Cargo.toml + cfg gates)
+
+Why combined? Per research R3, splitting them produces an intermediate state that doesn't compile.
+
+1. Read `mikebom-common/Cargo.toml` to resolve research R2 (does `aya-user` require aya?). If yes, expand the umbrella.
+2. Add `[features]` block to `mikebom-cli/Cargo.toml` per data-model.md "feature declaration".
+3. Flip aya/aya-log/libc to `optional = true` per data-model.md "optional-dep transformation".
+4. Mechanically expand 10 cfg gates per data-model.md inventory:
+   - `mikebom-cli/src/trace/loader.rs` — 2 positive + 2 negative
+   - `mikebom-cli/src/trace/processor.rs` — 1 positive
+   - `mikebom-cli/src/trace/pid_tracker.rs` — 1 positive
+   - `mikebom-cli/src/cli/scan.rs` — 6 positive
+5. Verify: `cargo +stable check --workspace --tests` clean (no aya, default features).
+6. Verify: `cargo +stable check --workspace --tests --features ebpf-tracing` clean (Linux only).
+7. `./scripts/pre-pr.sh` clean.
+8. Commit.
+
+### Commit 2: `020/runtime-guard` (FR-003 error + integration test)
+
+1. Add the `#[cfg(not(all(...)))] pub async fn execute` twin in `cli/scan.rs` per research R5 / data-model.md "runtime guard".
+2. Create `mikebom-cli/tests/feature_gate.rs`:
+   - One test: `trace_capture_returns_feature_off_error_in_default_build`.
+   - Spawns `mikebom trace capture --target-pid 1`, asserts non-zero exit + exact FR-003 stderr substring.
+   - Skipped via `#[cfg(feature = "ebpf-tracing")]` so it runs ONLY in default builds.
+3. `./scripts/pre-pr.sh` clean.
+4. Commit.
+
+### Commit 3: `020/ci-split` (.github/workflows/ci.yml + scripts/pre-pr.sh)
+
+1. In `.github/workflows/ci.yml`:
+   - From `lint-and-test`: drop the "Install nightly Rust", "Install bpf-linker", "Build eBPF object" steps. Keep stable + clippy + tests + sbomqs.
+   - Add new job `lint-and-test-ebpf` cloned from pre-020 `lint-and-test` (with all the eBPF prereqs), but pass `--features ebpf-tracing` on clippy + test commands.
+   - Leave `lint-and-test-macos` alone.
+2. In `scripts/pre-pr.sh`:
+   - Default behavior unchanged (no eBPF).
+   - Add `MIKEBOM_PREPR_EBPF=1` opt-in: when set, append `--features ebpf-tracing` to both clippy and test invocations.
+3. `./scripts/pre-pr.sh` clean (default).
+4. `MIKEBOM_PREPR_EBPF=1 ./scripts/pre-pr.sh` clean (only if you're on Linux + have nightly + bpf-linker).
+5. Commit.
+
+### Commit 4: `020/docs` (CLAUDE.md)
+
+1. Add a short paragraph under "Active Technologies" or as a new "Feature flags" subsection:
+
+```markdown
+## Feature flags
+
+- `ebpf-tracing` (off by default): enables `mikebom trace` (Linux + nightly + bpf-linker required).
+  Build the kernel-side object with `cargo run -p xtask -- ebpf`, then test with
+  `cargo +stable test --workspace --features ebpf-tracing`. Local-only verification:
+  `MIKEBOM_PREPR_EBPF=1 ./scripts/pre-pr.sh`.
+```
+
+2. `./scripts/pre-pr.sh` clean.
+3. Commit.
+
+## Common pitfalls (from past milestones)
+
+- **Don't drop the `target.'cfg(target_os = "linux")'` predicate** on the optional deps. Macs running `cargo build --features ebpf-tracing` should get a clean no-op, not a build error from an unbuildable Linux-only crate.
+- **Don't gate `LoaderConfig`**. The struct is a plain-data DTO — its compilation is target/feature-independent. Only the `inner` module that uses aya needs the gate.
+- **Don't gate `mod tests`**. Unit tests under `src/trace/*` that use aya types need the gate; tests that don't, don't. Inspect each module.
+- **Don't put `bpf-linker` install in the default lane just because it's cached**. Cache-hit cost is non-zero (a few seconds), and the cache itself is environmentally costly. The point of the milestone is "default lane never thinks about eBPF".
+- **Don't forget `tests/feature_gate.rs` is gated INVERSELY**: it runs in default builds and verifies the runtime guard. With the feature on, it should be skipped (the guard isn't reachable).
+
+## Verification commands
+
+```bash
+# Default Linux/macOS build (the new normal)
+cargo +stable check --workspace --tests
+cargo +stable clippy --workspace --all-targets -- -D warnings
+cargo +stable test --workspace
+cargo tree -p mikebom -e normal | rg '^aya|^aya-log'  # should be empty
+
+# Feature-on Linux build (CI ebpf lane)
+cargo +stable check --workspace --tests --features ebpf-tracing
+cargo +stable clippy --workspace --all-targets --features ebpf-tracing -- -D warnings
+cargo +stable test --workspace --features ebpf-tracing
+cargo tree -p mikebom -e normal --features ebpf-tracing | rg '^aya|^aya-log'  # should match
+
+# Pre-PR convenience
+./scripts/pre-pr.sh                    # default
+MIKEBOM_PREPR_EBPF=1 ./scripts/pre-pr.sh  # opt-in (Linux only)
+```
+
+## What success looks like
+
+- 4 commits on `020-ebpf-feature-gate`.
+- All 3 CI jobs (lint-and-test, lint-and-test-macos, lint-and-test-ebpf) green on the PR.
+- `lint-and-test` Linux runtime ≤ 2m (vs ~2m30s pre-020); macOS unchanged at ~1m20s; ebpf job ~2m30s.
+- 27 byte-identity goldens regen with zero diff (no behavior drift in non-trace paths).

--- a/specs/020-ebpf-feature-gate/research.md
+++ b/specs/020-ebpf-feature-gate/research.md
@@ -1,0 +1,133 @@
+---
+description: "Research notes — milestone 020 ebpf-tracing feature gate"
+status: research
+milestone: 020
+---
+
+# Research: ebpf-tracing Feature Gate
+
+Pre-implementation investigation. Each finding (R1-R5) supports one or more functional requirements in `spec.md`.
+
+## R1: Why a Cargo feature, not just `cfg(target_os = "linux")` exclusion?
+
+**Question**: macOS already excludes aya/aya-log/libc via the target gate. Why introduce a feature flag at all? Why not "just" make Linux contributors install nightly + bpf-linker?
+
+**Finding**: The contributor-experience cost on Linux is real and load-bearing for CI:
+
+- `cargo +nightly install bpf-linker --locked` runs on every Linux CI invocation (`.github/workflows/ci.yml:67-71`). The conditional `if ! command -v bpf-linker` skips reinstall when cached, but the cache miss on a clean runner is ~30s.
+- `cargo run --package xtask -- ebpf` (`.github/workflows/ci.yml:74`) takes ~30-60s.
+- The nightly toolchain installation step runs unconditionally (`.github/workflows/ci.yml:51-54`).
+
+Combined: ~60-90s per Linux PR for a code path that has not been touched in production work since `b0f31c1` (bootstrap). PRs that touch only `scan_fs/`, `package_db/`, `generate/`, `attestation/`, etc. — i.e., 100% of recent merge traffic — pay this cost for zero gain.
+
+A feature flag lets us:
+1. Drop nightly + bpf-linker from the default Linux CI lane.
+2. Move that cost into a dedicated `lint-and-test-ebpf` lane that only validates the trace path.
+3. Give local Linux dev the same experience as macOS: stable-only, fast.
+
+**Decision**: Feature flag, default off. Constraint per FR-001.
+
+## R2: Does `mikebom-common`'s `aya-user` feature transitively require `aya`?
+
+**Question**: `mikebom-cli/Cargo.toml:24` reads:
+
+```toml
+mikebom-common = { path = "../mikebom-common", features = ["std", "aya-user"] }
+```
+
+If `aya-user` itself requires `aya`, the `ebpf-tracing` feature gate must also include the `mikebom-common/aya-user` activation, otherwise toggling `ebpf-tracing` off won't actually drop aya from the dep graph (it'd still come in via the always-on common-crate feature).
+
+**Finding**: To be confirmed during T001 of tasks.md by reading `mikebom-common/Cargo.toml`. Two outcomes:
+
+- **If `aya-user` requires `aya` directly**: change the line to `features = ["std"], default-features = false`, and the `ebpf-tracing` feature does `mikebom-common = { ... features = ["aya-user"] }` via a `dep:` activation. (Requires `optional = true` on the mikebom-common dep, OR a feature-only re-export.)
+- **If `aya-user` is just a marker / re-exports types defined in mikebom-common itself**: leave the line alone; the umbrella feature only needs to activate the three direct deps.
+
+**Decision**: Defer to T001. Spec FR-001 names the three direct deps as the umbrella's contents; if R2's confirmation reveals `aya-user` is also load-bearing, FR-001 is amended in a follow-up edit before any code lands.
+
+## R3: Atomic commit ordering — can the Cargo.toml change ship without the cfg-gate change?
+
+**Question**: Plan.md commits 1 and 2 are separate. Is commit 1 (`Cargo.toml`: aya → optional) safe to land alone?
+
+**Finding**: No. Once `aya` is `optional = true` and `default = []`, the `use aya::*` lines in `trace/loader.rs:21-22`, `trace/processor.rs:74`, `cli/scan.rs:173`, etc. fail to resolve unless wrapped in `cfg(feature = "ebpf-tracing")`. The compiler error chain on Linux without the feature would be:
+
+```
+error[E0432]: unresolved import `aya`
+  --> mikebom-cli/src/trace/loader.rs:21:9
+```
+
+**Decision**: Combine commits 1 and 2 into a single atomic commit titled `020/cargo-feature+cfg-gates`. This violates plan.md's per-commit-clean discipline only on the *intermediate* state; the combined commit is itself clean. The lesson from milestones 018 + 019 is "atomic per cohort" — Cargo.toml + cfg gates are the same cohort here.
+
+Plan.md updated to four commits:
+
+1. `020/feature-gate`: Cargo.toml + 10 cfg gates + non-Linux fallback unification.
+2. `020/runtime-guard`: trace dispatcher arm + `tests/feature_gate.rs`.
+3. `020/ci-split`: `.github/workflows/ci.yml` restructure + `scripts/pre-pr.sh` opt-in.
+4. `020/docs`: `CLAUDE.md` paragraph.
+
+## R4: Does the `mikebom trace` clap parser depend on feature-gated types?
+
+**Question**: If `ScanArgs` (in `cli/scan.rs`) holds a field of a feature-gated type, clap parsing breaks even when the user just runs `mikebom trace --help`.
+
+**Finding**: Inspecting `mikebom-cli/src/cli/scan.rs:30-97`:
+
+```rust
+pub struct ScanArgs {
+    pub target_pid: Option<u32>,
+    pub libssl_path: Option<PathBuf>,
+    pub ring_buffer_size: u32,
+    pub trace_children: bool,
+    pub ebpf_object: Option<PathBuf>,
+    pub attestation_format: String,
+    pub signing_key: Option<PathBuf>,
+    pub signing_key_passphrase_env: Option<String>,
+    pub keyless: bool,
+    pub fulcio_url: String,
+    pub rekor_url: String,
+    pub no_transparency_log: bool,
+    pub require_signing: bool,
+    #[arg(last = true)]
+    pub command: Vec<String>,
+}
+```
+
+All fields are `std`-typed. No aya types in the struct. Safe to keep the struct + clap derive un-gated.
+
+`build_signing_identity` (line 104) IS gated, but it's an `impl` method, not part of clap parsing. Its gate expansion to `feature = "ebpf-tracing"` is part of the mechanical sweep — but: this method also handles non-trace signing logic (Fulcio keyless), so gating it removes signing identity construction from default builds.
+
+**Decision**: `build_signing_identity` is invoked only from `execute_scan` (the trace path), so feature-gating it is safe. The `sbom verify` path uses a different signing-verify code path entirely. Confirmed by grep: `build_signing_identity` is referenced only in `cli/scan.rs:execute_scan`.
+
+## R5: How does the runtime guard get added without breaking the cfg structure?
+
+**Question**: When the feature is off, `execute_scan` doesn't compile (it uses aya types). How does the dispatcher in `main.rs` route `Commands::Trace` to the FR-003 error message?
+
+**Finding**: Two clean options:
+
+**Option A**: Two `execute` functions in `cli/scan.rs`, distinguished by cfg:
+
+```rust
+#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]
+pub async fn execute(args: ScanArgs) -> anyhow::Result<()> { /* existing impl */ }
+
+#[cfg(not(all(target_os = "linux", feature = "ebpf-tracing")))]
+pub async fn execute(_args: ScanArgs) -> anyhow::Result<()> {
+    anyhow::bail!(
+        "this build was compiled without eBPF support; \
+         rebuild with --features ebpf-tracing on a Linux host \
+         to enable trace capture"
+    )
+}
+```
+
+Dispatcher calls `cli::scan::execute(args).await` unconditionally. The cfg picks the right body.
+
+**Option B**: Gate the `Commands::Trace` variant itself, and feature-off builds emit "unknown subcommand". Worse UX (FR-006 violated).
+
+**Decision**: Option A. The existing `trace/loader.rs:184-190` non-Linux fallback already uses this pattern; we're extending it one level up to the CLI dispatcher.
+
+## R6: Should `xtask ebpf` warn when invoked with feature off?
+
+**Question**: A contributor runs `cargo run -p xtask -- ebpf` with default features. Does it succeed (build the kernel artifact) or fail (warn about feature mismatch)?
+
+**Finding**: `xtask` is a build helper. It doesn't depend on `mikebom-cli` features at all — it just shells out to nightly cargo against `mikebom-ebpf/`. The kernel-side artifact is independent of the user-space feature flag.
+
+**Decision**: No xtask change. A contributor who wants to test the trace path locally runs `cargo run -p xtask -- ebpf` then `cargo +stable test --workspace --features ebpf-tracing`. Two-step, but each step is honest about its job.

--- a/specs/020-ebpf-feature-gate/spec.md
+++ b/specs/020-ebpf-feature-gate/spec.md
@@ -1,0 +1,135 @@
+---
+description: "eBPF code path behind a Cargo feature flag (Tier 6 — contributor-experience cleanup)"
+status: spec
+milestone: 020
+---
+
+# Spec: `ebpf-tracing` Feature Gate
+
+## Background
+
+`mikebom-ebpf` is a separate, nightly-only, `bpfel-unknown-none`-target crate that provides kernel-side trace probes for the experimental `mikebom trace` subcommand. It has been **dormant since bootstrap** (`git log --oneline mikebom-ebpf/` shows two commits ever: `b0f31c1` bootstrap, `17c29a3` Cargo.lock). Despite this, its build cost is paid by every Linux CI run on every PR:
+
+- `cargo +nightly install bpf-linker --locked` — first-run install, ~30s
+- `cargo +nightly build --target=bpfel-unknown-none -Z build-std=core --release` — ~30-60s
+- nightly toolchain installation (always done; `dtolnay/rust-toolchain@nightly` step at `.github/workflows/ci.yml:51-54`)
+
+The user-space deps `aya`, `aya-log`, and `libc` are unconditionally present in the Linux build via `[target.'cfg(target_os = "linux")'.dependencies]` (`mikebom-cli/Cargo.toml:103-106`). On macOS they're already absent — the macOS CI leg is eBPF-clean and runs in ~1m20s vs. Linux's ~2m30s.
+
+This milestone makes eBPF support **opt-in via a Cargo feature flag**. Default builds (Linux + macOS, local + CI) drop nightly + bpf-linker + aya. A separate explicit CI lane (`lint-and-test-ebpf`, Linux only) opts into the feature and validates the trace path. Contributors who never touch `mikebom trace` no longer pay the toolchain tax.
+
+## User Story (US1, P1)
+
+**As a contributor working on non-trace code paths**, I want default workspace builds (`cargo build`, `cargo test --workspace`, `cargo clippy --workspace --all-targets`) to compile and pass without nightly Rust, without bpf-linker, and without aya/aya-log/libc in the dependency graph, so that my local dev loop and our CI default lane reflect only the surface area I'm actually touching.
+
+**Why P1**: This is the only remaining Tier-6 item from the post-019 cleanup roadmap. It materially changes contributor experience (Linux dev no longer needs nightly+bpf-linker for non-trace work; macOS dev path remains the canonical reference experience). Other tier-4 module-split candidates (parity/extractors.rs, builder.rs) can land later without affecting this.
+
+### Independent Test
+
+After implementation:
+
+- `rustup toolchain list` containing only `stable` is sufficient to compile + test the workspace.
+- `cargo +stable clippy --workspace --all-targets -- -D warnings` succeeds without bpf-linker installed.
+- `cargo +stable test --workspace` succeeds without `mikebom-ebpf/target/` existing.
+- `cargo tree -p mikebom -e normal | grep -E '^aya|^aya-log|^libc'` returns empty (only `libc` indirect via other crates is OK).
+- `cargo +stable clippy --workspace --all-targets --features ebpf-tracing -- -D warnings` succeeds when bpf-linker IS installed (CI ebpf lane).
+- `mikebom trace capture --help` invoked from a default build returns a friendly "this build was compiled without eBPF support; rebuild with `--features ebpf-tracing` on a Linux host" message rather than crashing or compiling the subcommand out entirely (per FR-006 — discoverability).
+
+## Acceptance Scenarios
+
+**Scenario 1: Default Linux build, no bpf-linker, non-trace contributor**
+```
+Given: a clean Linux dev box with stable toolchain only, no bpf-linker
+When:  contributor runs `./scripts/pre-pr.sh`
+Then:  clippy + test both pass; xtask ebpf is never invoked; aya/aya-log not in build
+```
+
+**Scenario 2: Default macOS build, unchanged**
+```
+Given: macOS dev box with stable toolchain
+When:  contributor runs `./scripts/pre-pr.sh`
+Then:  identical to milestone-016 behavior — zero warnings, all user-space tests pass,
+       dependency graph identical to pre-020 (macOS already excluded eBPF deps)
+```
+
+**Scenario 3: Opt-in feature build on Linux**
+```
+Given: Linux dev box with stable + nightly + bpf-linker installed,
+       and `cargo run -p xtask -- ebpf` already executed
+When:  contributor runs `cargo +stable test --workspace --features ebpf-tracing`
+Then:  trace::loader::load_and_attach is compiled in; aya/aya-log/libc present in
+       dependency graph; the `trace::loader::tests::*` (if any) execute against the
+       kernel object
+```
+
+**Scenario 4: Default build, user invokes `mikebom trace`**
+```
+Given: a default-features mikebom binary
+When:  user runs `mikebom trace capture --target-pid 123`
+Then:  process exits with a clear error message naming the missing feature and
+       the rebuild command — NOT a panic, NOT a missing-subcommand error
+```
+
+**Scenario 5: CI runtime savings**
+```
+Given: PR touching only mikebom-cli/src/scan_fs/* (no trace code)
+When:  GitHub Actions CI runs
+Then:  `lint-and-test` (linux + macos) jobs do NOT install nightly + bpf-linker;
+       `lint-and-test-ebpf` runs in parallel and is the only job that pays the
+       eBPF cost
+```
+
+## Edge Cases
+
+- **`mikebom trace` discoverability**: Subcommand stays in `--help` output even when feature is off, so users can discover it exists. The runtime guard (FR-006) is what intercepts execution.
+- **Cross-feature regressions**: Feature-on Linux build must be byte-identical to pre-020 Linux build for non-trace code paths (no behavior drift in `sbom scan`, `sbom verify`, `attestation generate`, etc.).
+- **`xtask ebpf` invocation**: Stays exactly as it is. CI just stops calling it on the default lane. Local devs can still `cargo run -p xtask -- ebpf` whenever they want.
+- **`mikebom-ebpf` crate itself**: Untouched. Already `exclude = ["mikebom-ebpf"]` in workspace `Cargo.toml`. The feature flag controls only the user-space loader, not the kernel-side crate's build trigger.
+- **Test wiring**: No integration tests under `mikebom-cli/tests/` reference the trace pipeline today (per pre-spec inventory). Unit tests under `src/trace/*` that use `aya::*` are gated by `#[cfg(target_os = "linux")]` — these gates expand to `#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]`.
+
+## Functional Requirements
+
+- **FR-001**: `mikebom-cli/Cargo.toml` declares a `[features]` block with `default = []` and `ebpf-tracing = ["dep:aya", "dep:aya-log", "dep:libc"]`. The `aya`, `aya-log`, and `libc` entries in `[target.'cfg(target_os = "linux")'.dependencies]` become `optional = true`.
+- **FR-002**: All `#[cfg(target_os = "linux")]` gates in `mikebom-cli/src/trace/*` and `mikebom-cli/src/cli/scan.rs` expand to `#[cfg(all(target_os = "linux", feature = "ebpf-tracing"))]`. The unrelated gates in `scan_fs/os_release.rs:134` and `attestation/builder.rs:109` (host-detection, kernel-version detection) are NOT changed — those stay platform-only.
+- **FR-003**: `mikebom trace` (capture + run) subcommand parsing remains in clap unchanged. When the feature is off, the dispatcher in `mikebom-cli/src/main.rs` (or the trace sub-dispatcher) returns an `anyhow::Error` with the exact text: `"this build was compiled without eBPF support; rebuild with --features ebpf-tracing on a Linux host to enable trace capture"`. No panic, no clap-level "unknown subcommand".
+- **FR-004**: `.github/workflows/ci.yml` is restructured into three jobs:
+  1. `lint-and-test` (Linux): default features, no nightly, no bpf-linker, no `xtask ebpf` step.
+  2. `lint-and-test-macos`: unchanged from pre-020.
+  3. `lint-and-test-ebpf` (Linux, NEW): nightly + bpf-linker + xtask ebpf + clippy/test with `--features ebpf-tracing`.
+- **FR-005**: `./scripts/pre-pr.sh` runs the same two commands as the default `lint-and-test` CI lane (no eBPF). A documented opt-in for contributors who want to verify the eBPF lane: `MIKEBOM_PREPR_EBPF=1 ./scripts/pre-pr.sh` adds `--features ebpf-tracing` to both commands.
+- **FR-006**: The `trace` subcommand's `--help` output remains discoverable in default builds. A short note in `mikebom trace --help` (or `mikebom --help` adjacent to the trace subcommand) names the feature flag, so users can self-serve the rebuild.
+- **FR-007**: `cargo tree -p mikebom -e normal` from a default build does NOT list `aya` or `aya-log` as direct deps. (`libc` is allowed indirect because other workspace deps may pull it in.)
+- **FR-008**: Each commit in the milestone leaves the tree in a state where `./scripts/pre-pr.sh` passes — same per-commit-clean discipline as 018 + 019.
+- **FR-009**: `CLAUDE.md` is updated with one-paragraph guidance on the feature flag in the "Active Technologies" or "Commands" section.
+- **FR-010**: A new `tests/feature_gate.rs` integration test asserts that `mikebom trace` from a default build returns the FR-003 error string and exit code 1 (proves the runtime guard works).
+
+## Key Entities
+
+No new data — this is a build-system + module-gating refactor. The "entity" introduced is the `ebpf-tracing` Cargo feature itself, formally specified in `contracts/feature-flag.md`.
+
+## Success Criteria
+
+- **SC-001**: Default `cargo +stable test --workspace` completes on a stable-only Linux toolchain without bpf-linker installed. (Verification: `rustup toolchain uninstall nightly && which bpf-linker || true && ./scripts/pre-pr.sh`.)
+- **SC-002**: `lint-and-test` Linux CI job runs faster than the pre-020 baseline by ≥ 30s (baseline ~2m30s; target ≤ 2m). Measured via `gh pr checks 44` style timing post-merge.
+- **SC-003**: `lint-and-test-ebpf` Linux CI job is green on the milestone-020 PR — proves the feature-on path still works.
+- **SC-004**: macOS CI job timing is unchanged from milestone 016 baseline (already eBPF-free; this is a regression check, not an improvement).
+- **SC-005**: `cargo tree -p mikebom -e normal --no-default-features` (or `cargo tree -p mikebom -e normal` with default features) shows zero direct entries for `aya` or `aya-log`. Verified via `git diff` of `cargo tree` output before/after.
+- **SC-006**: The 27 byte-identity goldens (CDX + SPDX 2.3 + SPDX 3) regen with zero diff — no behavior change in non-trace code paths.
+
+## Clarifications
+
+- **Default features**: `default = []`, NOT `default = ["ebpf-tracing"]`. Rationale: the whole point of the milestone is to make the default cheap. Linux CI's eBPF lane is the regression gate for the trace path; making it default would defeat the purpose.
+- **Feature name**: `ebpf-tracing`, not `trace` or `ebpf`. Specific enough to communicate intent (kernel-side instrumentation), avoids collision with potential future `trace`-named features (e.g., logging).
+- **Subcommand visibility**: Stays in `--help`. Discoverability matters; the runtime guard explains the rebuild.
+- **xtask**: Untouched. The `cargo run -p xtask -- ebpf` command remains the canonical way to build the kernel-side artifact, just no longer invoked on the default CI lane.
+- **`mikebom-ebpf` crate**: Untouched. Already workspace-excluded.
+
+## Out of Scope
+
+- Splitting `mikebom-ebpf` itself or the kernel-side probes.
+- Adding new trace features.
+- Rewriting `mikebom trace` UX.
+- Replacing aya with another eBPF userland library.
+- Changing the build artifact path or the loader's discovery logic (`mikebom-ebpf/target/...` and fallback).
+- macOS DYLD interposition / EndpointSecurity (deferred to a future milestone, per memory `project_macos_tracing.md`).
+- Any changes to non-eBPF Linux-only code (`os_release.rs:134`, `attestation/builder.rs:109`).

--- a/specs/020-ebpf-feature-gate/tasks.md
+++ b/specs/020-ebpf-feature-gate/tasks.md
@@ -1,0 +1,150 @@
+---
+description: "Task list — milestone 020 ebpf-tracing feature gate"
+---
+
+# Tasks: ebpf-tracing Feature Gate — Design-First
+
+**Input**: Design documents from `/specs/020-ebpf-feature-gate/`
+**Prerequisites**: spec.md (✅), plan.md (✅), research.md (✅), data-model.md (✅), contracts/feature-flag.md (✅), quickstart.md (✅)
+
+**Tests**: One new integration test (`tests/feature_gate.rs`, FR-010) plus the existing 27-golden byte-identity regression surface.
+
+**Organization**: Single user story (US1). Four atomic commits.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable — N/A here, commits are dependency-ordered.
+- **[Story]**: All maps to US1.
+
+## Path Conventions
+
+- Touches `mikebom-cli/Cargo.toml`, `.github/workflows/ci.yml`, `scripts/pre-pr.sh`, `CLAUDE.md`.
+- Touches `mikebom-cli/src/trace/{loader,processor,pid_tracker}.rs` and `mikebom-cli/src/cli/scan.rs` (cfg gates only).
+- Adds `mikebom-cli/tests/feature_gate.rs`.
+- Does NOT touch `mikebom-ebpf/`, `xtask/`, `mikebom-common/` (unless R2 reveals `aya-user` needs to move; documented in T001).
+
+---
+
+## Phase 1: Setup + Resolve R2
+
+**Purpose**: Resolve the open research question on `mikebom-common/aya-user` before any code lands.
+
+- [ ] T001 [US1] Read `mikebom-common/Cargo.toml`. Confirm whether the `aya-user` feature transitively requires `aya`. If yes, plan the umbrella expansion (likely: change `mikebom-cli/Cargo.toml:24` to `features = ["std"]`, add `aya-user` activation under `ebpf-tracing` in the new `[features]` block). If no, no change needed. Record finding in a 2-line comment in T002's commit message.
+- [ ] T002 [US1] Snapshot baseline: `./scripts/pre-pr.sh 2>&1 | tee /tmp/baseline-020.txt | grep -E '^test [a-z_:]+ \.\.\. ok' | sort -u > /tmp/baseline-020-tests.txt`. Used at T013 for SC-002 test-name parity check.
+
+---
+
+## Phase 2: Commit 1 — `020/feature-gate`
+
+**Goal**: Cargo.toml gets `[features]`; aya/aya-log/libc become optional; 12 cfg gates expand to feature-aware form.
+
+**Independent test**: After T006, default `./scripts/pre-pr.sh` is clean and `cargo tree -p mikebom -e normal | rg '^aya'` is empty.
+
+- [ ] T003 [US1] Edit `mikebom-cli/Cargo.toml`:
+  - Add `[features]` block per data-model.md "feature declaration".
+  - Flip aya/aya-log/libc to `optional = true` per data-model.md "optional-dep transformation".
+  - Apply T001's R2 finding (umbrella may need `mikebom-common/aya-user`).
+- [ ] T004 [US1] Mechanical cfg-gate expansion in `mikebom-cli/src/trace/{loader,processor,pid_tracker}.rs` per data-model.md inventory. Expected diff: ~6 lines.
+- [ ] T005 [US1] Mechanical cfg-gate expansion in `mikebom-cli/src/cli/scan.rs` per data-model.md inventory (6 positive gates). Expected diff: ~6 lines.
+- [ ] T006 [US1] Verify default build: `cargo +stable check --workspace --tests` clean. Verify feature-on build (Linux): `cargo +stable check --workspace --tests --features ebpf-tracing` clean. Pre-PR clean.
+- [ ] T007 [US1] Commit: `refactor(020/feature-gate): introduce ebpf-tracing Cargo feature, drop aya from default deps`.
+
+---
+
+## Phase 3: Commit 2 — `020/runtime-guard`
+
+**Goal**: `mikebom trace` returns the FR-003 error in default builds; integration test asserts on it.
+
+**Independent test**: After T010, `cargo +stable test -p mikebom --test feature_gate` passes in default build; same test is skipped (compiled out) under `--features ebpf-tracing`.
+
+- [ ] T008 [US1] Add the inverse-cfg `pub async fn execute` twin to `mikebom-cli/src/cli/scan.rs` per research R5. Exact body lifted from data-model.md "runtime guard".
+- [ ] T009 [US1] Create `mikebom-cli/tests/feature_gate.rs`. Single test gated `#[cfg(not(feature = "ebpf-tracing"))]` that:
+  1. Builds the binary path via `common::bin()` (already exists in `tests/common/mod.rs`).
+  2. Runs `<binary> trace capture --target-pid 1`.
+  3. Asserts: exit code != 0, stderr contains the substring `"compiled without eBPF support"`, AND contains `"--features ebpf-tracing"`.
+- [ ] T010 [US1] Verify: `cargo +stable test --workspace` includes `feature_gate::trace_capture_returns_feature_off_error_in_default_build` and it passes. With `--features ebpf-tracing` it should be filtered out (or absent). Pre-PR clean.
+- [ ] T011 [US1] Commit: `refactor(020/runtime-guard): add feature-off error path for mikebom trace + integration test`.
+
+---
+
+## Phase 4: Commit 3 — `020/ci-split`
+
+**Goal**: CI runs three jobs; default Linux + macOS jobs drop nightly/bpf-linker entirely; new ebpf job validates the feature-on path.
+
+**Independent test**: After push, GitHub Actions UI shows three checks; pre-existing `lint-and-test` shrinks; new `lint-and-test-ebpf` runs in parallel and is green.
+
+- [ ] T012 [US1] Edit `.github/workflows/ci.yml`:
+  - In `lint-and-test`: remove the "Install eBPF build deps" (still keep clang/llvm/libelf for sigstore? — verify; if only eBPF needs them, drop), "Install nightly Rust", "Install bpf-linker", "Build eBPF object" steps. Keep checkout, stable Rust, cache, sbomqs install, Add Go bin to PATH, Clippy, Tests.
+  - Add new job `lint-and-test-ebpf` (Linux), copy of pre-020 `lint-and-test`, but:
+    - Clippy command: `cargo +stable clippy --workspace --all-targets --features ebpf-tracing -- -D warnings`
+    - Tests command: `cargo +stable test --workspace --features ebpf-tracing`
+    - Otherwise identical (nightly install, bpf-linker, xtask ebpf, sbomqs).
+  - `lint-and-test-macos` unchanged.
+- [ ] T013 [US1] Edit `scripts/pre-pr.sh`:
+  - Default behavior unchanged.
+  - When env `MIKEBOM_PREPR_EBPF=1` is set, append `--features ebpf-tracing` to both clippy and test commands. Echo a clear "running ebpf lane" header line.
+- [ ] T014 [US1] Verify locally: `./scripts/pre-pr.sh` clean (default). `MIKEBOM_PREPR_EBPF=1 ./scripts/pre-pr.sh` clean if your environment has nightly + bpf-linker. (Optional locally; CI will catch the feature-on path regardless.)
+- [ ] T015 [US1] Commit: `ci(020/ci-split): three-lane CI — default lint-and-test (linux+macos) + opt-in lint-and-test-ebpf`.
+
+---
+
+## Phase 5: Commit 4 — `020/docs`
+
+**Goal**: CLAUDE.md tells future contributors how the feature flag works.
+
+- [ ] T016 [US1] Edit `CLAUDE.md` per quickstart.md "Commit 4" template. Place the `## Feature flags` section after `## Active Technologies` and before `## Project Structure`.
+- [ ] T017 [US1] Pre-PR clean.
+- [ ] T018 [US1] Commit: `docs(020/docs): document ebpf-tracing feature flag in CLAUDE.md`.
+
+---
+
+## Phase 6: Polish & Verification
+
+**Purpose**: Final-state acceptance proof per spec SC-001 through SC-006.
+
+- [ ] T019 SC-001 verification: From a Linux box (or container), `rustup toolchain uninstall nightly` (skip if can't), confirm `./scripts/pre-pr.sh` clean. (CI's `lint-and-test` job is the canonical proof — this is local belt-and-braces.)
+- [ ] T020 SC-005 verification: `cargo tree -p mikebom -e normal | rg '^aya|^aya-log'` empty (default). `cargo tree -p mikebom -e normal --features ebpf-tracing | rg '^aya'` non-empty (Linux only).
+- [ ] T021 SC-006 verification: `MIKEBOM_UPDATE_CDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test --workspace --tests -- --test-threads=1` produces zero diff in `mikebom-cli/tests/golden/`. (Pre-existing `spdx_determinism::cargo_scan_is_deterministic` flake under load is documented; re-run that single test in isolation to confirm.)
+- [ ] T022 Push branch; observe all three CI jobs green. Capture timing.
+- [ ] T023 SC-002 timing check: `lint-and-test` Linux ≤ 2m (vs ~2m30s baseline). Comment timing in PR description if tight against the budget.
+- [ ] T024 Author the PR description. Per-commit summary (4 commits), feature-flag contract pointer, byte-identity attestation, CI timing comparison.
+
+---
+
+## Dependency Graph
+
+```text
+T001 (R2 confirm) ──→ T002 (baseline snapshot)
+                         │
+                         ↓
+                     T003 → T004 → T005 → T006 → T007  ← Commit 1 (feature-gate)
+                                                  │
+                                                  ↓
+                                              T008 → T009 → T010 → T011  ← Commit 2 (runtime-guard)
+                                                                    │
+                                                                    ↓
+                                                                T012 → T013 → T014 → T015  ← Commit 3 (ci-split)
+                                                                                       │
+                                                                                       ↓
+                                                                                    T016 → T017 → T018  ← Commit 4 (docs)
+                                                                                                   │
+                                                                                                   ↓
+                                                                                              T019 → T020 → T021 → T022 → T023 → T024
+                                                                                                                                  │
+                                                                                                                                  ↓
+                                                                                                                            Polish done
+```
+
+Each commit must leave `./scripts/pre-pr.sh` clean (FR-008). Commits 1-2 are landlocked by code+test pairs. Commits 3-4 are CI/docs only.
+
+## Estimated effort
+
+| Phase | Estimated effort | Notes |
+|---|---|---|
+| Phase 1 (setup + R2) | 15 min | Cargo.toml read + baseline snapshot |
+| Phase 2 (feature-gate commit) | 30 min | Mechanical Cargo.toml + 12 cfg expansions |
+| Phase 3 (runtime-guard commit) | 45 min | New integration test scaffolding is the new wrinkle |
+| Phase 4 (ci-split commit) | 30 min | YAML duplication, careful step pruning |
+| Phase 5 (docs commit) | 15 min | One paragraph |
+| Phase 6 (polish) | 30 min | If CI green on first push |
+| **Total** | **2-3 hr** | One focused half-day. |


### PR DESCRIPTION
## Summary

Tier 6 of the post-#38 cleanup roadmap: puts the user-space eBPF integration behind a Cargo feature flag (`ebpf-tracing`, off by default). Default Linux + macOS CI lanes drop nightly + bpf-linker entirely; a dedicated `lint-and-test-ebpf` lane validates the feature-on path. Local Linux dev no longer needs nightly toolchain for non-trace work — matches the macOS contributor experience.

mikebom-ebpf crate untouched. xtask untouched. `mikebom trace` subcommand stays discoverable via `--help` in default builds; runtime guard returns a friendly rebuild-instruction error when invoked.

## Per-commit chain

| Commit | Cohort | Effect |
|---|---|---|
| `b998118` | docs(020): full 8-file spec set | spec / plan / research / data-model / contracts / quickstart / tasks / checklists (861 LOC of design) |
| `9aaf5ea` | feature-gate (Cargo.toml + 16 cfg gates) | `[features]` block; aya/aya-log/libc → optional; cfg gates expand to `cfg(all(target_os = "linux", feature = "ebpf-tracing"))` |
| `82d80d0` | runtime-guard | feature-off `execute_scan` stub satisfies FR-003 substrings; new `tests/feature_gate.rs` integration test |
| `9fc0a7a` | ci-split | 3-lane CI: default `lint-and-test` (Linux) + `lint-and-test-macos` (unchanged) + new `lint-and-test-ebpf` (--features ebpf-tracing) |
| `7a5f4d3` | docs | CLAUDE.md "Feature flags" section |

## Key design decisions (from research.md)

- **R2**: `mikebom-common`'s `aya-user` feature transitively requires `aya` (`mikebom-common/Cargo.toml:10`), so `mikebom-cli/Cargo.toml:24` drops `aya-user` and the new `ebpf-tracing` umbrella adds it back via `mikebom-common/aya-user`. Without this, the gate would be cosmetic.
- **R3**: Cargo.toml + cfg-gates ship in **one atomic commit** (`9aaf5ea`). Splitting them produces an intermediate state where `use aya::*` lines fail to resolve on Linux.
- **R5**: Runtime guard piggybacks on the existing non-Linux `execute_scan` stub. The cfg expansion (`cfg(not(all(target_os = "linux", feature = "ebpf-tracing")))`) automatically catches both "non-Linux" AND "Linux without feature" — single source of truth.

## Cross-target dep-tree verification (SC-005)

```
$ cargo tree -p mikebom -e normal --target x86_64-unknown-linux-gnu | rg '^aya|^aya-log'
(empty — default features)

$ cargo tree -p mikebom -e normal --target x86_64-unknown-linux-gnu --features ebpf-tracing | rg '^aya'
aya v0.13.1
aya-log v0.2.1
```

## Byte-identity attestation (SC-006)

`MIKEBOM_UPDATE_CDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test --workspace --tests -- --test-threads=1` produces zero diff in `mikebom-cli/tests/golden/`. All 27 byte-identity goldens (CDX + SPDX 2.3 + SPDX 3) confirm no behavior change in non-trace paths.

## CI matrix (post-merge)

| Job | Runner | Toolchain | Features | Pre-020 cost | Post-020 cost |
|---|---|---|---|---|---|
| `lint-and-test` | ubuntu-latest | stable | default | ~2m30s | target ≤ 2m |
| `lint-and-test-macos` | macos-latest | stable | default | ~1m20s | unchanged |
| `lint-and-test-ebpf` (NEW) | ubuntu-latest | stable + nightly | `ebpf-tracing` | n/a | ~2m30s (parity with pre-020 default) |

Three jobs run in parallel; PR is green when all three pass.

## Test plan

- [x] `./scripts/pre-pr.sh` clean locally (default lane)
- [x] `cargo +stable test -p mikebom --test feature_gate` passes (default), 0-tests under `--features ebpf-tracing`
- [x] Cross-target dep-tree verified empty for default Linux build
- [x] 27-golden regen produces zero diff (SC-006)
- [ ] Default `lint-and-test` Linux CI green (target ≤ 2m runtime)
- [ ] `lint-and-test-macos` CI green (regression check, unchanged)
- [ ] `lint-and-test-ebpf` CI green (proves feature-on path still works on Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)