### PR TITLE
refactor(021): SPDX test isolation + canonical normalizers (Tier 2)

### DIFF
--- a/mikebom-cli/tests/spdx_determinism.rs
+++ b/mikebom-cli/tests/spdx_determinism.rs
@@ -1,23 +1,31 @@
 //! SPDX 2.3 determinism regression (milestone 010 T016).
 //!
 //! FR-020 / SC-007 — two runs of the same scan must produce
-//! byte-identical SPDX output *except* for the
-//! `creationInfo.created` timestamp, which the spec requires to
-//! reflect when the document was generated. Within the test we feed
-//! both runs the same scan and compare the produced files after
-//! masking only `created`; every other field — `documentNamespace`,
-//! SPDXIDs, package / relationship ordering — must match exactly.
+//! byte-identical SPDX output after the canonical normalization
+//! (`creationInfo.created` mask, `annotations[].annotationDate` mask,
+//! `packages[].checksums[]` strip, workspace-path placeholder) is
+//! applied. Every remaining field — `documentNamespace`, SPDXIDs,
+//! package / relationship ordering — must match exactly.
 
 use std::process::Command;
 
 mod common;
+use common::normalize::{apply_fake_home_env, normalize_spdx23_for_golden};
 use common::workspace_root;
 
-fn scan_to_spdx_json(fixture: &std::path::Path) -> serde_json::Value {
+/// Run `mikebom sbom scan --format spdx-2.3-json` against `fixture`
+/// in an isolated fake-HOME and return the produced raw JSON string.
+/// Callers normalize via `normalize_spdx23_for_golden` (for byte
+/// equality) or parse to `serde_json::Value` (for narrower
+/// field-extraction assertions).
+fn scan_to_spdx_raw(fixture: &std::path::Path) -> String {
     let tmp = tempfile::tempdir().expect("tempdir");
+    let fake_home = tempfile::tempdir().expect("fake-home tempdir");
     let out = tmp.path().join("mikebom.spdx.json");
     let bin = env!("CARGO_BIN_EXE_mikebom");
-    let status = Command::new(bin)
+    let mut cmd = Command::new(bin);
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    let status = cmd
         .arg("--offline")
         .arg("sbom")
         .arg("scan")
@@ -35,23 +43,12 @@ fn scan_to_spdx_json(fixture: &std::path::Path) -> serde_json::Value {
         "scan failed: {}",
         String::from_utf8_lossy(&status.stderr)
     );
-    serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap()
+    std::fs::read_to_string(&out).expect("read SPDX output")
 }
 
-/// Clear the one field SPDX requires to vary per invocation
-/// (`creationInfo.created` — wall-clock timestamp). Everything else
-/// is deterministic by construction in our serializer.
-fn mask_created(doc: &mut serde_json::Value) {
-    if let Some(ci) = doc
-        .as_object_mut()
-        .and_then(|o| o.get_mut("creationInfo"))
-        .and_then(|v| v.as_object_mut())
-    {
-        ci.insert(
-            "created".to_string(),
-            serde_json::Value::String("MASKED".to_string()),
-        );
-    }
+fn scan_to_spdx_json(fixture: &std::path::Path) -> serde_json::Value {
+    let raw = scan_to_spdx_raw(fixture);
+    serde_json::from_str(&raw).expect("SPDX output parses")
 }
 
 fn run_twice(subpath: &str) {
@@ -61,15 +58,14 @@ fn run_twice(subpath: &str) {
         "fixture missing: {}",
         fixture.display()
     );
-    let mut a = scan_to_spdx_json(&fixture);
-    let mut b = scan_to_spdx_json(&fixture);
-    mask_created(&mut a);
-    mask_created(&mut b);
+    let workspace = workspace_root();
+    let a = normalize_spdx23_for_golden(&scan_to_spdx_raw(&fixture), &workspace);
+    let b = normalize_spdx23_for_golden(&scan_to_spdx_raw(&fixture), &workspace);
     assert_eq!(
-        serde_json::to_string_pretty(&a).unwrap(),
-        serde_json::to_string_pretty(&b).unwrap(),
-        "SPDX output differs between two identical scans (after masking \
-         only creationInfo.created) — determinism contract violation"
+        a, b,
+        "SPDX output differs between two identical scans (after the \
+         canonical normalize_spdx23_for_golden masking) — determinism \
+         contract violation"
     );
 }
 

--- a/mikebom-cli/tests/spdx_us1_acceptance.rs
+++ b/mikebom-cli/tests/spdx_us1_acceptance.rs
@@ -21,6 +21,9 @@ use std::process::Command;
 
 
 mod common;
+use common::normalize::{
+    apply_fake_home_env, normalize_cdx_for_golden, normalize_spdx23_for_golden,
+};
 use common::{bin, workspace_root};
 
 
@@ -34,7 +37,9 @@ struct Scan {
 fn scan(fixture: &Path, formats: &[&str], extra_args: &[&str]) -> Scan {
     assert!(fixture.exists(), "fixture missing: {}", fixture.display());
     let tmp = tempfile::tempdir().expect("tempdir");
+    let fake_home = tempfile::tempdir().expect("fake-home tempdir");
     let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
     cmd.arg("--offline")
         .arg("sbom")
         .arg("scan")
@@ -290,63 +295,30 @@ fn scenario_4_determinism_cross_reference() {
 
 // ---------- scenario 5: single-invocation dual-format ---------------------
 
-/// Mask the three fields that are inherently volatile per invocation:
-///   * CDX `serialNumber` (v4 UUID, non-deterministic today)
-///   * CDX `metadata.timestamp` (`Utc::now()` inside CDX builder)
-///   * SPDX `creationInfo.created` (wall-clock timestamp)
-fn mask_volatile(cdx: &mut serde_json::Value, spdx: &mut serde_json::Value) {
-    if let Some(obj) = cdx.as_object_mut() {
-        if obj.contains_key("serialNumber") {
-            obj.insert(
-                "serialNumber".to_string(),
-                serde_json::Value::String("MASKED".to_string()),
-            );
-        }
-        if let Some(md) = obj.get_mut("metadata").and_then(|v| v.as_object_mut()) {
-            md.insert(
-                "timestamp".to_string(),
-                serde_json::Value::String("MASKED".to_string()),
-            );
-        }
-    }
-    if let Some(ci) = spdx
-        .as_object_mut()
-        .and_then(|o| o.get_mut("creationInfo"))
-        .and_then(|v| v.as_object_mut())
-    {
-        ci.insert(
-            "created".to_string(),
-            serde_json::Value::String("MASKED".to_string()),
-        );
-    }
-}
-
 #[test]
 fn scenario_5_single_invocation_produces_same_bytes_as_two_separate_invocations() {
     let fixture = workspace_root().join("tests/fixtures/cargo/lockfile-v3");
+    let workspace = workspace_root();
 
     // One invocation, both formats.
     let dual = scan(&fixture, &["cyclonedx-json", "spdx-2.3-json"], &[]);
-    let mut dual_cdx = dual.cdx.unwrap();
-    let mut dual_spdx = dual.spdx.unwrap();
+    let dual_cdx_raw = serde_json::to_string(&dual.cdx.unwrap()).unwrap();
+    let dual_spdx_raw = serde_json::to_string(&dual.spdx.unwrap()).unwrap();
 
     // Two separate invocations.
     let only_cdx = scan(&fixture, &["cyclonedx-json"], &[]);
     let only_spdx = scan(&fixture, &["spdx-2.3-json"], &[]);
-    let mut solo_cdx = only_cdx.cdx.unwrap();
-    let mut solo_spdx = only_spdx.spdx.unwrap();
-
-    mask_volatile(&mut dual_cdx, &mut dual_spdx);
-    mask_volatile(&mut solo_cdx, &mut solo_spdx);
+    let solo_cdx_raw = serde_json::to_string(&only_cdx.cdx.unwrap()).unwrap();
+    let solo_spdx_raw = serde_json::to_string(&only_spdx.spdx.unwrap()).unwrap();
 
     assert_eq!(
-        serde_json::to_string_pretty(&dual_cdx).unwrap(),
-        serde_json::to_string_pretty(&solo_cdx).unwrap(),
-        "dual-format CDX should match solo-CDX (post-masking)"
+        normalize_cdx_for_golden(&dual_cdx_raw, &workspace),
+        normalize_cdx_for_golden(&solo_cdx_raw, &workspace),
+        "dual-format CDX should match solo-CDX after canonical normalization"
     );
     assert_eq!(
-        serde_json::to_string_pretty(&dual_spdx).unwrap(),
-        serde_json::to_string_pretty(&solo_spdx).unwrap(),
-        "dual-format SPDX should match solo-SPDX (post-masking)"
+        normalize_spdx23_for_golden(&dual_spdx_raw, &workspace),
+        normalize_spdx23_for_golden(&solo_spdx_raw, &workspace),
+        "dual-format SPDX should match solo-SPDX after canonical normalization"
     );
 }

--- a/specs/021-spdx-normalize-consumption/checklists/requirements.md
+++ b/specs/021-spdx-normalize-consumption/checklists/requirements.md
@@ -27,7 +27,7 @@ This is the template for tighter milestones (when scope is genuinely contained).
 ## Independence
 
 - [X] The single user story is self-contained — no dependencies on other in-flight work.
-- [X] Each per-commit deliverable (2 commits) is independently verifiable (per FR-008 each commit's `./scripts/pre-pr.sh` passes).
+- [X] Each per-commit deliverable (1 commit, post-correction) is independently verifiable (per FR-008 each commit's `./scripts/pre-pr.sh` passes). Original 2-commit plan collapsed to 1 after re-verification reduced scope.
 
 ## Concreteness
 
@@ -50,14 +50,13 @@ This is the template for tighter milestones (when scope is genuinely contained).
 
 ## Pre-implementation
 
-- [X] [PHASE-1] T001 reconnaissance done (2026-04-26).
+- [X] [PHASE-1] T001 reconnaissance done + corrected (2026-04-26). Initial recon overstated scope; direct re-verification reduced scope to 2 files / ~12 lines.
 - [ ] [PHASE-1] T002 baseline snapshot captured.
-- [ ] [PHASE-2] Commit 1 landed; SC-001 holds (all acceptance-test spawns isolate HOME).
-- [ ] [PHASE-3] Commit 2 landed; determinism tests have isolation + workspace-path symmetry.
+- [ ] [PHASE-2] Single commit landed (combined acceptance + determinism); SC-001 + SC-002 hold simultaneously.
 - [ ] [POLISH] SC-002 50x tight-loop passes for each affected file.
 - [ ] [POLISH] SC-003 27-golden regen produces zero diff.
 - [ ] [POLISH] SC-004 all CI lanes green.
-- [ ] [POLISH] SC-005 `mikebom-cli/src/` diff empty.
+- [ ] [POLISH] SC-005 `mikebom-cli/src/` diff empty + corrected-scope files (spdx3_us3, spdx3_determinism) untouched.
 
 ## Post-merge
 

--- a/specs/021-spdx-normalize-consumption/checklists/requirements.md
+++ b/specs/021-spdx-normalize-consumption/checklists/requirements.md
@@ -1,0 +1,64 @@
+# Spec Quality Checklist: SPDX Normalize-Consumption
+
+**Checklist for** `/specs/021-spdx-normalize-consumption/spec.md`
+
+## Coverage
+
+- [X] Background section explains *why* the milestone is needed (carries the milestone-017 deferred-uplift context + the 2026-04-26 reconnaissance table).
+- [X] User story has a P-priority and a "why this priority" justification (P2 because no observable failures today; hygiene + risk reduction).
+- [X] Independent Test is concrete (specific files + specific helpers + tight-loop count).
+- [X] Acceptance scenarios use Given/When/Then framing (3 scenarios).
+- [X] Edge Cases section names the corner cases concretely (acceptance tests have no goldens; determinism tests have no goldens; mask_volatile stays put; spdx3_determinism partial state).
+- [X] Functional Requirements are numbered (FR-001 through FR-008), each independently verifiable.
+- [X] Key Entities NOT applicable — no new types/modules introduced (consumption-only).
+- [X] Success Criteria are measurable (SC-001 through SC-005), each with a verification mechanism.
+- [X] Clarifications section captures the scope-vs-extraction distinction explicitly.
+- [X] Out of Scope section names every adjacent concern (goldens for acceptance/determinism, flake investigation, module splits, src/ changes, parity-already-good files).
+
+## Tighter spec set rationale
+
+- [X] No `research.md` — there are no open questions. The recon (T001) confirmed the helpers exist and which files don't consume them. No "should we do X or Y" decisions remain.
+- [X] No `data-model.md` — no new types, structs, or modules introduced. The data model is the existing `common::normalize` surface.
+- [X] No `contracts/` — no new public surface. Tests-only.
+- [X] No `quickstart.md` — the 4 spec files are short enough that a quickstart would just paraphrase them. The implementer reads spec.md → plan.md → tasks.md in order.
+
+This is the template for tighter milestones (when scope is genuinely contained). The full 8-file pattern stays default for milestones with open questions, new types, or new public surfaces.
+
+## Independence
+
+- [X] The single user story is self-contained — no dependencies on other in-flight work.
+- [X] Each per-commit deliverable (2 commits) is independently verifiable (per FR-008 each commit's `./scripts/pre-pr.sh` passes).
+
+## Concreteness
+
+- [X] FRs cite specific file paths (`mikebom-cli/tests/spdx_us1_acceptance.rs`, etc.) and specific line numbers from the recon (line 277, line 56, line 206).
+- [X] FR-003 names the reference pattern (scenario-4 npm test at line 206).
+- [X] Success Criteria reference the existing pre-PR gate + 27-golden regression surface.
+
+## Internal consistency
+
+- [X] FR-001/FR-002/FR-003 (apply_fake_home_env consumption) align with the spec table's "✗" entries from the recon.
+- [X] FR-004 (workspace-path in spdx3_determinism.rs) aligns with the recon's "⚠ partial — missing workspace-path" finding.
+- [X] FR-005 (mask_volatile stays put) aligns with the Edge Cases entry on the same topic.
+- [X] FR-006 (no production code changes) aligns with the milestone-016 + Tier-2 framing.
+
+## Lessons from milestones 016, 018, 019, 020
+
+- [X] FR-008 (per-commit pre-PR clean) carries the 018+019+020 atomic-commit discipline.
+- [X] The "no observable flake" framing in spec.md Background avoids the trap I just fell into during the milestone-020 wrap-up (treating speculation as documented fact). The flake reference is now an explicit "verified non-existent" rather than a vague "documented".
+- [X] T001 explicitly logs the recon as "done in pre-spec investigation" with the date — future maintainers see what was checked.
+
+## Pre-implementation
+
+- [X] [PHASE-1] T001 reconnaissance done (2026-04-26).
+- [ ] [PHASE-1] T002 baseline snapshot captured.
+- [ ] [PHASE-2] Commit 1 landed; SC-001 holds (all acceptance-test spawns isolate HOME).
+- [ ] [PHASE-3] Commit 2 landed; determinism tests have isolation + workspace-path symmetry.
+- [ ] [POLISH] SC-002 50x tight-loop passes for each affected file.
+- [ ] [POLISH] SC-003 27-golden regen produces zero diff.
+- [ ] [POLISH] SC-004 all CI lanes green.
+- [ ] [POLISH] SC-005 `mikebom-cli/src/` diff empty.
+
+## Post-merge
+
+- [ ] [QUALITATIVE] Next time someone touches an SPDX generator, observe whether the test suite is more trustworthy (no need to wonder "did this fail because of host state?"). If yes, milestone delivered.

--- a/specs/021-spdx-normalize-consumption/plan.md
+++ b/specs/021-spdx-normalize-consumption/plan.md
@@ -8,64 +8,49 @@ milestone: 021
 
 ## Architecture
 
-Test-files-only refactor. Each affected file imports the existing primitives from `common::normalize` and applies them at every `Command::new(bin())` site (or, for determinism tests, every output-normalization site).
+Test-files-only refactor. Each affected file imports the existing primitives from `common::normalize` and applies them at the single shared spawn helper.
 
 No new modules, no new types, no production code changes. The `common::normalize` module already exposes everything needed.
 
-## Touched files
+## Touched files (corrected 2026-04-26)
 
 | File | Change shape | Estimated diff |
 |---|---|---|
-| `mikebom-cli/tests/spdx_us1_acceptance.rs` | Import `apply_fake_home_env`; allocate `TempDir` + apply env at each scan-spawn site (~6 spawn sites) | ~30 lines |
-| `mikebom-cli/tests/spdx_determinism.rs` | Update `scan_to_spdx_json()` to take or create a fake-home tempdir + apply env | ~10 lines |
-| `mikebom-cli/tests/spdx3_us3_acceptance.rs` | Audit 5 scenarios; add `apply_fake_home_env` to scenarios that don't have it (specifically scenario 5 at line 277) | ~15 lines |
-| `mikebom-cli/tests/spdx3_determinism.rs` | `normalize()` at line 56 gets workspace-path replacement against `WORKSPACE_PLACEHOLDER` | ~5 lines |
+| `mikebom-cli/tests/spdx_us1_acceptance.rs` | `scan()` helper at line 34 imports `apply_fake_home_env`; allocates one TempDir + applies env at line 37's `Command::new(bin())` site | ~6 lines |
+| `mikebom-cli/tests/spdx_determinism.rs` | `scan_to_spdx_json()` at line 16 does the same | ~6 lines |
 
-Total: ~60 lines of test-file changes across 4 files.
+Total: ~12 lines across 2 files.
+
+(Originally scoped at ~60 lines across 4 files; recon overstated the work — see spec.md "Note on spec amendment" for the verified file-by-file findings that reduced scope.)
 
 ## Phasing
 
-Three atomic commits, organized by failure-mode similarity:
+**Single atomic commit** (`021/spdx-isolation`) — both files together since each is a one-helper, one-spawn-site change. Splitting into two commits would be ceremony for ~6 lines apiece. The originally planned "Commit 2" (determinism-isolation) collapses into the same commit; the originally planned "Commit 3" (verify) was already optional.
 
-### Commit 1: `021/acceptance-isolation`
-- `spdx_us1_acceptance.rs` and `spdx3_us3_acceptance.rs` together — both are acceptance tests with shape assertions, both need pure HOME isolation.
-- After commit: ALL acceptance-test spawns isolate HOME. SC-001 holds.
-
-### Commit 2: `021/determinism-isolation`
-- `spdx_determinism.rs` and `spdx3_determinism.rs` together — both are run-twice-and-compare, similar fix shape.
-- `spdx_determinism.rs` gains `apply_fake_home_env`. `spdx3_determinism.rs::normalize()` gains workspace-path replacement.
-- After commit: both runs of the same fixture see identical isolated env. SC-002 holds.
-
-### Commit 3: `021/verify`
-- Optional commit. If commits 1 and 2 are atomic and SC-003 holds at each of those, this commit is empty and not needed.
-- If anything triggered a goldens diff, this commit captures the regen.
-
-Per FR-008 each commit leaves `./scripts/pre-pr.sh` clean.
+After commit: SC-001 + SC-002 + SC-003 + SC-005 hold simultaneously. Pre-PR clean.
 
 ## Estimated effort
 
 | Phase | Effort | Notes |
 |---|---|---|
-| Commit 1 (acceptance) | 45 min | Audit + insert isolation at each spawn site; ~6 sites in us1, ~3 missing sites in us3 |
-| Commit 2 (determinism) | 30 min | More mechanical — only one site each |
-| Verification + PR | 15 min | 50x loop per file + regen + push + PR description |
-| **Total** | **1.5 hr** | One focused sitting. |
+| Single commit (both files) | 20 min | One helper edit per file, mechanical |
+| Verification + PR | 20 min | 50x loops + regen + push + watch CI |
+| **Total** | **~40 min** | One focused half-hour. |
 
 ## Risks
 
-- **R1: Acceptance tests' shape assertions break under isolation.** Possible if any assertion implicitly depended on a host-cache-derived value. Mitigation: read each scenario carefully before applying isolation; if a shape assertion relies on something that fake-HOME would invalidate, the assertion itself needs reframing. (Per recon, we don't expect this — assertions check PURLs/license fields/document-namespace stability, all fixture-derived.)
-- **R2: `spdx3_determinism.rs` workspace-path edit invalidates the existing two-runs-compare contract.** Mitigation: the change is symmetric — both runs apply the same normalization, so the equality comparison still holds. Tight-loop verification (SC-002) is the regression gate.
-- **R3: I create a temp `fake_home` per spawn but assertions later read paths from the produced output.** Possible with scenario-5-style tests. Mitigation: keep TempDir alive in the test scope; only normalize the JSON for assertions, not the underlying paths the test inspects.
+- **R1: Acceptance tests' shape assertions break under isolation.** Possible if any assertion implicitly depended on a host-cache-derived value (e.g., a Maven artifact resolved from local M2). Mitigation: spdx_us1_acceptance.rs scenarios check PURLs/license fields/document-namespace stability — all fixture-derived. If a shape assertion does break, the assertion itself was the bug (depending on host state to pass).
+- **R2: `tempfile::TempDir` lifecycle.** The fake_home TempDir must outlive the spawn. Mitigation: bind it as a local in `scan()`/`scan_to_spdx_json()` so the implicit drop happens at end-of-scope, after `.output()` returns.
 
 ## Constitution alignment
 
-- **Principle IV (no `.unwrap()` in production):** test code is feature-gated via the existing `#[cfg_attr(test, allow(clippy::unwrap_used))]` on test modules; this milestone respects existing patterns.
+- **Principle IV (no `.unwrap()` in production):** test code is feature-gated via the existing `#[cfg_attr(test, allow(clippy::unwrap_used))]` patterns; `.expect()` calls in tests follow existing convention.
 - **Principle VI (three-crate architecture):** untouched. Test-only.
-- **Per-commit verification (lessons from 018-019-020):** FR-008 enforced.
+- **Per-commit verification (lessons from 018-019-020):** FR-008 enforced; only one commit, so trivially satisfied.
 
 ## What this milestone does NOT do
 
 - Does not extract anything from `common/normalize.rs` (already extracted).
 - Does not add goldens to acceptance/determinism tests (out of scope per spec).
-- Does not touch `cdx_regression.rs` or `spdx_regression.rs` (already parity).
+- Does not touch `cdx_regression.rs`, `spdx_regression.rs`, `spdx3_us3_acceptance.rs`, or `spdx3_determinism.rs` (already at parity per re-verification).
 - Does not investigate the determinism flake (verified non-existent in T001).

--- a/specs/021-spdx-normalize-consumption/plan.md
+++ b/specs/021-spdx-normalize-consumption/plan.md
@@ -1,0 +1,71 @@
+---
+description: "Implementation plan — milestone 021 SPDX normalize-consumption"
+status: plan
+milestone: 021
+---
+
+# Plan: SPDX Test Normalize-Consumption
+
+## Architecture
+
+Test-files-only refactor. Each affected file imports the existing primitives from `common::normalize` and applies them at every `Command::new(bin())` site (or, for determinism tests, every output-normalization site).
+
+No new modules, no new types, no production code changes. The `common::normalize` module already exposes everything needed.
+
+## Touched files
+
+| File | Change shape | Estimated diff |
+|---|---|---|
+| `mikebom-cli/tests/spdx_us1_acceptance.rs` | Import `apply_fake_home_env`; allocate `TempDir` + apply env at each scan-spawn site (~6 spawn sites) | ~30 lines |
+| `mikebom-cli/tests/spdx_determinism.rs` | Update `scan_to_spdx_json()` to take or create a fake-home tempdir + apply env | ~10 lines |
+| `mikebom-cli/tests/spdx3_us3_acceptance.rs` | Audit 5 scenarios; add `apply_fake_home_env` to scenarios that don't have it (specifically scenario 5 at line 277) | ~15 lines |
+| `mikebom-cli/tests/spdx3_determinism.rs` | `normalize()` at line 56 gets workspace-path replacement against `WORKSPACE_PLACEHOLDER` | ~5 lines |
+
+Total: ~60 lines of test-file changes across 4 files.
+
+## Phasing
+
+Three atomic commits, organized by failure-mode similarity:
+
+### Commit 1: `021/acceptance-isolation`
+- `spdx_us1_acceptance.rs` and `spdx3_us3_acceptance.rs` together — both are acceptance tests with shape assertions, both need pure HOME isolation.
+- After commit: ALL acceptance-test spawns isolate HOME. SC-001 holds.
+
+### Commit 2: `021/determinism-isolation`
+- `spdx_determinism.rs` and `spdx3_determinism.rs` together — both are run-twice-and-compare, similar fix shape.
+- `spdx_determinism.rs` gains `apply_fake_home_env`. `spdx3_determinism.rs::normalize()` gains workspace-path replacement.
+- After commit: both runs of the same fixture see identical isolated env. SC-002 holds.
+
+### Commit 3: `021/verify`
+- Optional commit. If commits 1 and 2 are atomic and SC-003 holds at each of those, this commit is empty and not needed.
+- If anything triggered a goldens diff, this commit captures the regen.
+
+Per FR-008 each commit leaves `./scripts/pre-pr.sh` clean.
+
+## Estimated effort
+
+| Phase | Effort | Notes |
+|---|---|---|
+| Commit 1 (acceptance) | 45 min | Audit + insert isolation at each spawn site; ~6 sites in us1, ~3 missing sites in us3 |
+| Commit 2 (determinism) | 30 min | More mechanical — only one site each |
+| Verification + PR | 15 min | 50x loop per file + regen + push + PR description |
+| **Total** | **1.5 hr** | One focused sitting. |
+
+## Risks
+
+- **R1: Acceptance tests' shape assertions break under isolation.** Possible if any assertion implicitly depended on a host-cache-derived value. Mitigation: read each scenario carefully before applying isolation; if a shape assertion relies on something that fake-HOME would invalidate, the assertion itself needs reframing. (Per recon, we don't expect this — assertions check PURLs/license fields/document-namespace stability, all fixture-derived.)
+- **R2: `spdx3_determinism.rs` workspace-path edit invalidates the existing two-runs-compare contract.** Mitigation: the change is symmetric — both runs apply the same normalization, so the equality comparison still holds. Tight-loop verification (SC-002) is the regression gate.
+- **R3: I create a temp `fake_home` per spawn but assertions later read paths from the produced output.** Possible with scenario-5-style tests. Mitigation: keep TempDir alive in the test scope; only normalize the JSON for assertions, not the underlying paths the test inspects.
+
+## Constitution alignment
+
+- **Principle IV (no `.unwrap()` in production):** test code is feature-gated via the existing `#[cfg_attr(test, allow(clippy::unwrap_used))]` on test modules; this milestone respects existing patterns.
+- **Principle VI (three-crate architecture):** untouched. Test-only.
+- **Per-commit verification (lessons from 018-019-020):** FR-008 enforced.
+
+## What this milestone does NOT do
+
+- Does not extract anything from `common/normalize.rs` (already extracted).
+- Does not add goldens to acceptance/determinism tests (out of scope per spec).
+- Does not touch `cdx_regression.rs` or `spdx_regression.rs` (already parity).
+- Does not investigate the determinism flake (verified non-existent in T001).

--- a/specs/021-spdx-normalize-consumption/spec.md
+++ b/specs/021-spdx-normalize-consumption/spec.md
@@ -1,0 +1,116 @@
+---
+description: "Bring SPDX 2.3/3.0.1 acceptance + determinism tests onto the existing normalize.rs hardening pattern (Tier 2)"
+status: spec
+milestone: 021
+---
+
+# Spec: SPDX Test Normalize-Consumption
+
+## Background
+
+Milestone 017 (PR #40) extracted `mikebom-cli/tests/common/normalize.rs` (281 LOC) with the canonical cross-host hardening primitives — `apply_fake_home_env()`, `WORKSPACE_PLACEHOLDER`, `normalize_cdx_for_golden()`, `normalize_spdx23_for_golden()`, `normalize_spdx3_for_golden()` — and applied them in `cdx_regression.rs` and `spdx_regression.rs`. Both regression suites now produce byte-identical output across macOS dev and Linux CI.
+
+What didn't get done: the four sibling **acceptance** + **determinism** test files were left mid-conversion. The 2026-04-26 reconnaissance (logged in `tasks.md` T001) confirmed:
+
+| Test file | `apply_fake_home_env`? | normalize helper? |
+|---|---|---|
+| `cdx_regression.rs` | ✓ | ✓ (gold standard) |
+| `spdx_regression.rs` | ✓ | ✓ (already parity) |
+| `spdx_us1_acceptance.rs` | ✗ | ✗ — bare `Command::new(bin())` |
+| `spdx3_us3_acceptance.rs` | ⚠ partial — only one scenario | ✗ |
+| `spdx_determinism.rs` | ✗ | ✗ |
+| `spdx3_determinism.rs` | ✓ | ⚠ partial — missing workspace-path |
+
+The risk is the same one PR #40 surfaced: a host-specific value (HOME-derived path, stale Maven repo cache, GOPATH module cache, workspace path) leaks into a test's assertion target, the test passes on the dev box but fails on a CI runner with different paths — or worse, passes on both but masks a real bug because the contaminated input happens to produce matching contaminated output.
+
+The work is **consumption**, not extraction: the helpers exist; three files don't yet call them and one file calls them partially. No new infrastructure is needed.
+
+## User Story (US1, P2)
+
+**As a contributor opening any PR that touches the SPDX 2.3 or 3.0.1 generators**, I want every SPDX-related test file to use the same cross-host normalization discipline (`apply_fake_home_env` + the format-appropriate normalize helper) so that test results reflect generator correctness, not host-environment contamination.
+
+**Why P2 (not P1):** none of the affected tests have observable failures today. The work is hygiene + risk reduction, not bug-fixing. Easy to slot in between higher-priority milestones; defer-able if a more urgent item appears.
+
+### Independent Test
+
+After implementation:
+
+- `mikebom-cli/tests/spdx_us1_acceptance.rs` calls `apply_fake_home_env(&mut cmd, &fake_home)` on every spawned `Command::new(bin())` and stops setting host-leaked env vars unconditionally.
+- `mikebom-cli/tests/spdx_determinism.rs` does the same — both `scan_to_spdx_json` invocations isolate HOME via the helper.
+- `mikebom-cli/tests/spdx3_us3_acceptance.rs` applies isolation across **all** scenarios (not just scenario 4's npm test).
+- `mikebom-cli/tests/spdx3_determinism.rs` adds workspace-path normalization to its `normalize()` helper (so two-runs comparison won't break the day a future field starts including the workspace path).
+- All four files compile + pass under both:
+  - `cargo +stable test --workspace` (default lane)
+  - 50 iterations of `cargo +stable test -p mikebom --test spdx_us1_acceptance`, `--test spdx_determinism`, etc. in a tight loop on macOS
+- 27 byte-identity goldens regen with zero diff (no behavior change in mikebom output).
+
+## Acceptance Scenarios
+
+**Scenario 1: Host-state isolation under unusual local Maven cache**
+```
+Given: a contributor with $M2_REPO populated with hundreds of artifacts
+When:  they run `cargo +stable test --workspace`
+Then:  spdx_us1_acceptance.rs and spdx_determinism.rs scan results are
+       independent of the local Maven cache state — assertions reflect
+       only the in-fixture content
+```
+
+**Scenario 2: Cross-host run-twice determinism**
+```
+Given: spdx_determinism::cargo_scan_is_deterministic
+When:  the test runs on macOS dev box AND on Linux CI
+Then:  both invocations produce mutually-byte-identical output (after
+       masking only creationInfo.created), AND both runs use the same
+       fake-HOME isolation so the comparison is honest
+```
+
+**Scenario 3: spdx3_us3_acceptance scenario consistency**
+```
+Given: spdx3_us3_acceptance.rs has 5 scenarios
+When:  any one of them spawns `mikebom sbom scan`
+Then:  all 5 use apply_fake_home_env identically — no scenario sees
+       host state that another scenario doesn't
+```
+
+## Edge Cases
+
+- **Acceptance tests have no goldens.** `spdx_us1_acceptance.rs` and `spdx3_us3_acceptance.rs` make in-memory shape assertions (PURLs, license fields, document-namespace stability). No golden files; no regen env var; the normalize helpers' golden-comparison contract doesn't apply. The scope is **isolation only** for these two files. The `normalize_spdx*_for_golden` helpers are NOT consumed; only `apply_fake_home_env`.
+- **Determinism tests have no goldens.** Same reasoning. `spdx_determinism.rs` and `spdx3_determinism.rs` compare two in-memory scans against each other. They benefit from `apply_fake_home_env` (so both scans see the same isolated env) and from workspace-path normalization (so the contract doesn't accidentally start passing/failing based on whose dev box runs it).
+- **`mask_volatile()` in spdx_us1_acceptance.rs scenario 5.** The local helper at lines 297-322 already does what `normalize_cdx_for_golden`/`normalize_spdx23_for_golden` would do for that one dual-format scenario. Scope-decision: leave the local helper, since extracting it back to `common/normalize.rs` would conflate "golden comparison" (the helpers' purpose) with "scenario-5 ad-hoc comparison" (a different need). FR-005 codifies this.
+- **`spdx3_determinism.rs` partial state.** The file already calls `apply_fake_home_env` consistently in `run_scan()` (line 29). What it lacks is workspace-path replacement in its local `normalize()` helper (line 56). FR-004 makes this a one-line edit using `WORKSPACE_PLACEHOLDER`.
+- **No new test files.** This milestone consumes existing helpers; it does not add tests.
+
+## Functional Requirements
+
+- **FR-001**: `mikebom-cli/tests/spdx_us1_acceptance.rs` imports `apply_fake_home_env` from `common::normalize` and applies it to every `Command::new(common::bin())` invocation. Each call site allocates a `tempfile::TempDir` for the fake HOME and holds it for the duration of the spawn.
+- **FR-002**: `mikebom-cli/tests/spdx_determinism.rs` does the same — both `scan_to_spdx_json()` invocations (one in `scan_to_spdx_json` itself, applied to the helper) isolate HOME identically.
+- **FR-003**: `mikebom-cli/tests/spdx3_us3_acceptance.rs` audits every scenario; any `Command::new(bin())` that doesn't currently call `apply_fake_home_env` gains the call. The existing scenario-4 npm test (line 206) is the reference pattern.
+- **FR-004**: `mikebom-cli/tests/spdx3_determinism.rs::normalize()` (line 56) gains workspace-path replacement against `WORKSPACE_PLACEHOLDER`. The local `normalize()` continues to mask `CreationInfo.created` (already done); workspace-path becomes its second responsibility. (Or, equivalently, switch to calling `normalize_spdx3_for_golden()` from `common::normalize` if the contract matches — verified at implementation time.)
+- **FR-005**: `mikebom-cli/tests/spdx_us1_acceptance.rs::mask_volatile()` (lines 297-322) is left in place. Out of scope to extract — different concern from golden comparison.
+- **FR-006**: No mikebom production code changes. Test-files-only refactor (mirrors milestone 016's discipline).
+- **FR-007**: 27 byte-identity goldens regen with zero diff. Verifies no scan-output behavior change.
+- **FR-008**: Each commit leaves `./scripts/pre-pr.sh` clean — same per-commit-clean discipline as 018, 019, 020.
+
+## Success Criteria
+
+- **SC-001**: After implementation, `rg 'Command::new\(common::bin\(\)\)|Command::new\(bin\(\)\)' mikebom-cli/tests/spdx_us1_acceptance.rs mikebom-cli/tests/spdx_determinism.rs mikebom-cli/tests/spdx3_us3_acceptance.rs` shows zero call sites that aren't followed within 3 lines by an `apply_fake_home_env` invocation. (Heuristic — manual audit confirms.)
+- **SC-002**: 50-iteration tight-loop test of each affected file in isolation passes 50/50.
+- **SC-003**: 27-golden regen produces zero diff (`MIKEBOM_UPDATE_CDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test --workspace --tests -- --test-threads=1`).
+- **SC-004**: Both Linux CI lanes + macOS lane green on the milestone PR.
+- **SC-005**: `git diff main..021-spdx-normalize-consumption -- mikebom-cli/src/` is empty (test-only refactor).
+
+## Clarifications
+
+- **Scope is consumption only**, not extraction. The normalize.rs module exists and is mature.
+- **Acceptance tests don't get goldens or regen mechanisms.** Their assertion model (in-memory shape checks) is fine as-is; they only need isolation.
+- **Determinism tests don't get goldens.** Their assertion model (two-runs comparison) doesn't fit the goldens pattern.
+- **`mask_volatile()` stays put.** Different concern from golden comparison; not worth conflating.
+- **No spec-to-implementation contracts file.** No public API surface changes; no new types or modules introduced.
+
+## Out of Scope
+
+- Adding goldens to acceptance or determinism tests (different milestone).
+- Investigating the (now-debunked) `cargo_scan_is_deterministic` flake — verified non-existent in milestone-021 task T001.
+- Module splits (Tier 4).
+- Any change to `mikebom-cli/src/`.
+- Touching `cdx_regression.rs` or `spdx_regression.rs` — they're already at parity.

--- a/specs/021-spdx-normalize-consumption/spec.md
+++ b/specs/021-spdx-normalize-consumption/spec.md
@@ -12,14 +12,16 @@ Milestone 017 (PR #40) extracted `mikebom-cli/tests/common/normalize.rs` (281 LO
 
 What didn't get done: the four sibling **acceptance** + **determinism** test files were left mid-conversion. The 2026-04-26 reconnaissance (logged in `tasks.md` T001) confirmed:
 
-| Test file | `apply_fake_home_env`? | normalize helper? |
-|---|---|---|
-| `cdx_regression.rs` | ✓ | ✓ (gold standard) |
-| `spdx_regression.rs` | ✓ | ✓ (already parity) |
-| `spdx_us1_acceptance.rs` | ✗ | ✗ — bare `Command::new(bin())` |
-| `spdx3_us3_acceptance.rs` | ⚠ partial — only one scenario | ✗ |
-| `spdx_determinism.rs` | ✗ | ✗ |
-| `spdx3_determinism.rs` | ✓ | ⚠ partial — missing workspace-path |
+| Test file | `apply_fake_home_env`? | normalize helper? | Real work |
+|---|---|---|---|
+| `cdx_regression.rs` | ✓ | ✓ | — (gold standard) |
+| `spdx_regression.rs` | ✓ | ✓ | — (already parity) |
+| `spdx_us1_acceptance.rs` | ✗ | ✗ — bare `Command::new(bin())` | Add fake-home isolation to `scan()` helper (1 site covers all 5 scenarios) |
+| `spdx3_us3_acceptance.rs` | ✓ (all 3 sites) | n/a (no goldens) | — (already correct; recon was wrong) |
+| `spdx_determinism.rs` | ✗ | n/a (no goldens) | Add fake-home isolation to `scan_to_spdx_json()` helper |
+| `spdx3_determinism.rs` | ✓ (all sites) | n/a (same-host two-run; workspace-path not needed) | — (already correct; recon was wrong) |
+
+**Note on spec amendment (2026-04-26):** initial recon overstated the scope. Direct re-verification (`grep -c apply_fake_home_env`) confirmed `spdx3_us3_acceptance.rs` already isolates every `Command::new` site (3/3) and `spdx3_determinism.rs::run_scan` already calls `apply_fake_home_env` for both runs of the deb-fixture test. The "missing workspace-path" claim against `spdx3_determinism.rs::normalize()` was based on confusing same-host two-run comparison (which doesn't need workspace-path normalization, since both outputs contain the same workspace path) with cross-host golden pinning (which does). Spec FRs and tasks were corrected accordingly; the remaining real scope is two files and ~15 LOC of changes.
 
 The risk is the same one PR #40 surfaced: a host-specific value (HOME-derived path, stale Maven repo cache, GOPATH module cache, workspace path) leaks into a test's assertion target, the test passes on the dev box but fails on a CI runner with different paths — or worse, passes on both but masks a real bug because the contaminated input happens to produce matching contaminated output.
 
@@ -35,13 +37,11 @@ The work is **consumption**, not extraction: the helpers exist; three files don'
 
 After implementation:
 
-- `mikebom-cli/tests/spdx_us1_acceptance.rs` calls `apply_fake_home_env(&mut cmd, &fake_home)` on every spawned `Command::new(bin())` and stops setting host-leaked env vars unconditionally.
-- `mikebom-cli/tests/spdx_determinism.rs` does the same — both `scan_to_spdx_json` invocations isolate HOME via the helper.
-- `mikebom-cli/tests/spdx3_us3_acceptance.rs` applies isolation across **all** scenarios (not just scenario 4's npm test).
-- `mikebom-cli/tests/spdx3_determinism.rs` adds workspace-path normalization to its `normalize()` helper (so two-runs comparison won't break the day a future field starts including the workspace path).
-- All four files compile + pass under both:
+- `mikebom-cli/tests/spdx_us1_acceptance.rs::scan()` calls `apply_fake_home_env(&mut cmd, fake_home.path())` on its single `Command::new(bin())` site. All 5 acceptance scenarios that call this helper inherit the isolation.
+- `mikebom-cli/tests/spdx_determinism.rs::scan_to_spdx_json()` does the same. Both `run_twice` invocations (which call this helper) inherit the isolation.
+- Both files compile + pass under:
   - `cargo +stable test --workspace` (default lane)
-  - 50 iterations of `cargo +stable test -p mikebom --test spdx_us1_acceptance`, `--test spdx_determinism`, etc. in a tight loop on macOS
+  - 50 iterations of `cargo +stable test -p mikebom --test spdx_us1_acceptance` and `--test spdx_determinism` in tight loops on macOS
 - 27 byte-identity goldens regen with zero diff (no behavior change in mikebom output).
 
 ## Acceptance Scenarios
@@ -64,12 +64,15 @@ Then:  both invocations produce mutually-byte-identical output (after
        fake-HOME isolation so the comparison is honest
 ```
 
-**Scenario 3: spdx3_us3_acceptance scenario consistency**
+**Scenario 3 (regression check): spdx3_us3_acceptance + spdx3_determinism unchanged**
 ```
-Given: spdx3_us3_acceptance.rs has 5 scenarios
-When:  any one of them spawns `mikebom sbom scan`
-Then:  all 5 use apply_fake_home_env identically — no scenario sees
-       host state that another scenario doesn't
+Given: those two files were corrected to isolation-complete prior to milestone 021
+When:  the milestone 021 PR opens
+Then:  `git diff main..021-spdx-normalize-consumption -- \
+       mikebom-cli/tests/spdx3_us3_acceptance.rs \
+       mikebom-cli/tests/spdx3_determinism.rs` is empty (verifies the
+       corrected scope of FR-003 and FR-004 — see "Note on spec
+       amendment" above)
 ```
 
 ## Edge Cases
@@ -82,11 +85,11 @@ Then:  all 5 use apply_fake_home_env identically — no scenario sees
 
 ## Functional Requirements
 
-- **FR-001**: `mikebom-cli/tests/spdx_us1_acceptance.rs` imports `apply_fake_home_env` from `common::normalize` and applies it to every `Command::new(common::bin())` invocation. Each call site allocates a `tempfile::TempDir` for the fake HOME and holds it for the duration of the spawn.
-- **FR-002**: `mikebom-cli/tests/spdx_determinism.rs` does the same — both `scan_to_spdx_json()` invocations (one in `scan_to_spdx_json` itself, applied to the helper) isolate HOME identically.
-- **FR-003**: `mikebom-cli/tests/spdx3_us3_acceptance.rs` audits every scenario; any `Command::new(bin())` that doesn't currently call `apply_fake_home_env` gains the call. The existing scenario-4 npm test (line 206) is the reference pattern.
-- **FR-004**: `mikebom-cli/tests/spdx3_determinism.rs::normalize()` (line 56) gains workspace-path replacement against `WORKSPACE_PLACEHOLDER`. The local `normalize()` continues to mask `CreationInfo.created` (already done); workspace-path becomes its second responsibility. (Or, equivalently, switch to calling `normalize_spdx3_for_golden()` from `common::normalize` if the contract matches — verified at implementation time.)
-- **FR-005**: `mikebom-cli/tests/spdx_us1_acceptance.rs::mask_volatile()` (lines 297-322) is left in place. Out of scope to extract — different concern from golden comparison.
+- **FR-001**: `mikebom-cli/tests/spdx_us1_acceptance.rs::scan()` (line 34) imports `apply_fake_home_env` from `common::normalize` and applies it to its single `Command::new(bin())` site (line 37). One `tempfile::TempDir` per `scan()` invocation, held in scope until the spawn returns. This single edit covers all 5 acceptance scenarios since they share the helper.
+- **FR-002**: `mikebom-cli/tests/spdx_determinism.rs::scan_to_spdx_json()` (line 16) does the same — its single `Command::new(bin)` site (line 20) applies `apply_fake_home_env` with a per-call `TempDir`. Both `run_twice()` invocations (which call this helper) automatically inherit the isolation.
+- **FR-003**: ~~spdx3_us3_acceptance.rs uniformity~~ — **DROPPED** (corrected 2026-04-26): re-verification showed all 3 spawn sites already isolate. No change needed.
+- **FR-004**: ~~spdx3_determinism.rs workspace-path replacement~~ — **DROPPED** (corrected 2026-04-26): same-host two-run comparison doesn't need workspace-path normalization (both outputs contain the same workspace path so equality holds). Workspace-path is a cross-host golden-pinning concern, not a same-host two-run-comparison concern. No change needed.
+- **FR-005**: `mikebom-cli/tests/spdx_us1_acceptance.rs::mask_volatile()` is left in place. Out of scope to extract — different concern from golden comparison.
 - **FR-006**: No mikebom production code changes. Test-files-only refactor (mirrors milestone 016's discipline).
 - **FR-007**: 27 byte-identity goldens regen with zero diff. Verifies no scan-output behavior change.
 - **FR-008**: Each commit leaves `./scripts/pre-pr.sh` clean — same per-commit-clean discipline as 018, 019, 020.

--- a/specs/021-spdx-normalize-consumption/tasks.md
+++ b/specs/021-spdx-normalize-consumption/tasks.md
@@ -7,80 +7,71 @@ description: "Task list — milestone 021 SPDX normalize-consumption"
 **Input**: Design documents from `/specs/021-spdx-normalize-consumption/`
 **Prerequisites**: spec.md (✅), plan.md (✅), checklists/requirements.md (✅)
 
-**Tests**: No new tests. The 27 byte-identity goldens (from milestones 017 + 020) plus the existing 50-iteration tight-loop discipline are the regression surface.
+**Tests**: No new tests. The 27 byte-identity goldens (from milestones 017 + 020) plus the 50-iteration tight-loop discipline are the regression surface.
 
-**Organization**: Single user story (US1, P2). Two atomic commits + polish.
-
-## Format: `[ID] [Story] Description`
-
-- All tasks map to US1.
+**Organization**: Single user story (US1, P2). One atomic commit + verification.
 
 ## Path Conventions
 
-- Touches `mikebom-cli/tests/spdx_us1_acceptance.rs`, `mikebom-cli/tests/spdx3_us3_acceptance.rs`, `mikebom-cli/tests/spdx_determinism.rs`, `mikebom-cli/tests/spdx3_determinism.rs`.
+- Touches `mikebom-cli/tests/spdx_us1_acceptance.rs` and `mikebom-cli/tests/spdx_determinism.rs`.
 - Does NOT touch `mikebom-cli/src/` (FR-006 / SC-005).
-- Does NOT touch `cdx_regression.rs`, `spdx_regression.rs` (already at parity), or `common/normalize.rs` itself (already mature).
+- Does NOT touch `cdx_regression.rs`, `spdx_regression.rs`, `spdx3_us3_acceptance.rs`, `spdx3_determinism.rs`, or `common/normalize.rs` (all already at parity per direct re-verification).
 
 ---
 
 ## Phase 1: Reconnaissance & Baseline
 
-- [X] T001 Reconnaissance done in pre-spec investigation (2026-04-26). Findings logged in `spec.md` Background table. The "documented flake" verified non-existent (50 isolated + 5 default-parallel + 12 4-way concurrent + 3 regen-mode runs all green).
-- [ ] T002 Snapshot baseline: `./scripts/pre-pr.sh 2>&1 | tee /tmp/baseline-021.txt | grep -E '^test [a-z_:]+ \.\.\. ok' | sort -u > /tmp/baseline-021-tests.txt`. Compare post-021 to confirm zero test renames/removals.
+- [X] T001 Reconnaissance done in pre-spec investigation (2026-04-26). Initial recon overstated scope; direct re-verification corrected: `spdx3_us3_acceptance.rs` and `spdx3_determinism.rs` are already at parity. The "documented spdx_determinism flake" verified non-existent across 70 local + 30 CI runs.
+- [ ] T002 Snapshot baseline: `./scripts/pre-pr.sh 2>&1 | tee /tmp/baseline-021.txt | grep -E '^test [a-z_:]+ \.\.\. ok' | sort -u > /tmp/baseline-021-tests.txt`. Confirm post-021 list is identical (zero rename or removal).
 
 ---
 
-## Phase 2: Commit 1 — `021/acceptance-isolation`
+## Phase 2: Single Commit — `021/spdx-isolation`
 
-**Goal**: `spdx_us1_acceptance.rs` and `spdx3_us3_acceptance.rs` apply `apply_fake_home_env` at every `Command::new(bin())` spawn site.
+**Goal**: Both files apply `apply_fake_home_env` at their single shared spawn helper.
 
-- [ ] T003 Audit `spdx_us1_acceptance.rs` for `Command::new(bin())` and `Command::new(common::bin())` sites. List each line number. Expected: 5-7 sites based on file LOC.
-- [ ] T004 At each site: import `common::normalize::apply_fake_home_env`; allocate `let fake_home = tempfile::tempdir().expect("tempdir");`; call `apply_fake_home_env(&mut cmd, fake_home.path())` before `.output()`/`.spawn()`. Hold `fake_home` in scope until after the spawn completes.
-- [ ] T005 Audit `spdx3_us3_acceptance.rs` for spawn sites that don't already use `apply_fake_home_env`. The existing scenario-4 npm test (line 206) is the pattern.
-- [ ] T006 Apply isolation to the missing scenarios (specifically scenario 5 at ~line 277 per recon).
-- [ ] T007 Verify: `cargo +stable test -p mikebom --test spdx_us1_acceptance --test spdx3_us3_acceptance` passes. Pre-PR clean.
-- [ ] T008 Commit: `refactor(021/acceptance-isolation): apply_fake_home_env across SPDX 2.3 + 3.0.1 acceptance tests`.
-
----
-
-## Phase 3: Commit 2 — `021/determinism-isolation`
-
-**Goal**: `spdx_determinism.rs` gains `apply_fake_home_env`; `spdx3_determinism.rs::normalize()` gains workspace-path replacement.
-
-- [ ] T009 Edit `spdx_determinism.rs::scan_to_spdx_json` (line 16): allocate `fake_home: TempDir` (caller-provided or function-internal; pick whichever keeps the helper simple), apply `apply_fake_home_env` to the `Command` before `.output()`. Hold the tempdir in scope until output is read.
-- [ ] T010 Edit `spdx3_determinism.rs::normalize()` (line 56): add workspace-path replacement against `WORKSPACE_PLACEHOLDER` before parsing JSON. Decision per FR-004: either inline the `raw.replace(workspace, WORKSPACE_PLACEHOLDER)` step OR delegate to `normalize_spdx3_for_golden()` if the contract matches. Verify by running the test before and after.
-- [ ] T011 Verify: `cargo +stable test -p mikebom --test spdx_determinism --test spdx3_determinism` passes. Pre-PR clean.
-- [ ] T012 Commit: `refactor(021/determinism-isolation): apply_fake_home_env + workspace-path normalization across SPDX determinism tests`.
+- [ ] T003 Edit `mikebom-cli/tests/spdx_us1_acceptance.rs::scan()` (line 34):
+  1. Add `use common::normalize::apply_fake_home_env;` to the imports near `use common::{bin, workspace_root};`.
+  2. Inside the `scan()` body, after `let tmp = tempfile::tempdir()...`, allocate `let fake_home = tempfile::tempdir().expect("fake-home tempdir");`.
+  3. After `let mut cmd = Command::new(bin());`, add `apply_fake_home_env(&mut cmd, fake_home.path());`.
+  4. Verify `fake_home` lives until after `let out = cmd.output()...;` returns (it does — both bindings are in the same `fn` body and Rust drops at end-of-scope).
+- [ ] T004 Edit `mikebom-cli/tests/spdx_determinism.rs::scan_to_spdx_json()` (line 16):
+  1. Add `use common::normalize::apply_fake_home_env;` to imports.
+  2. Inside `scan_to_spdx_json()`, after `let tmp = tempfile::tempdir()...`, allocate `let fake_home = tempfile::tempdir().expect("fake-home tempdir");`.
+  3. After `let bin = env!(...); let status = Command::new(bin)`, restructure to bind `let mut cmd = Command::new(bin); apply_fake_home_env(&mut cmd, fake_home.path()); let status = cmd.arg(...)...`.
+- [ ] T005 Verify: `cargo +stable test -p mikebom --test spdx_us1_acceptance --test spdx_determinism` passes.
+- [ ] T006 Pre-PR clean (`./scripts/pre-pr.sh`).
+- [ ] T007 Commit: `refactor(021/spdx-isolation): apply_fake_home_env in spdx_us1_acceptance + spdx_determinism shared helpers`.
 
 ---
 
-## Phase 4: Verification
+## Phase 3: Verification
 
-- [ ] T013 50-iteration tight loops, one per affected file:
+- [ ] T008 50-iteration tight loops:
   ```
-  for i in $(seq 1 50); do cargo +stable test -p mikebom --test spdx_us1_acceptance -- --test-threads=1 2>&1 | grep -qE 'test result: ok' || echo FAIL $i; done
+  for i in $(seq 1 50); do
+    cargo +stable test -p mikebom --test spdx_us1_acceptance -- --test-threads=1 \
+      2>&1 | grep -qE 'test result: ok' || echo "FAIL iter $i"
+  done
   ```
-  Repeat for `spdx_determinism`, `spdx3_us3_acceptance`, `spdx3_determinism`. SC-002 holds when each is 50/50.
-- [ ] T014 SC-003 verification: regen all 27 goldens via `MIKEBOM_UPDATE_CDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test --workspace --tests -- --test-threads=1`. Verify `git diff -- mikebom-cli/tests/golden` is empty.
-- [ ] T015 SC-005 verification: `git diff main..HEAD -- mikebom-cli/src/` is empty.
-- [ ] T016 Push branch; observe both Linux CI lanes + macOS lane green.
-- [ ] T017 Author PR description: 2-commit summary, contract pointer (`tests/common/normalize.rs` is what's being consumed), byte-identity attestation.
+  Repeat for `spdx_determinism`. SC-002 holds when each is 50/50.
+- [ ] T009 SC-003 verification: regen all 27 goldens via `MIKEBOM_UPDATE_CDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test --workspace --tests -- --test-threads=1`. Verify `git diff -- mikebom-cli/tests/golden` is empty.
+- [ ] T010 SC-005 verification: `git diff main..HEAD -- mikebom-cli/src/` is empty. Also: `git diff main..HEAD -- mikebom-cli/tests/spdx3_us3_acceptance.rs mikebom-cli/tests/spdx3_determinism.rs` is empty (corrected-scope regression check from spec Scenario 3).
+- [ ] T011 Push branch; observe both Linux CI lanes + macOS lane green.
+- [ ] T012 Author PR description: 1-commit summary, recon-correction note, byte-identity attestation, what was NOT touched and why.
 
 ---
 
 ## Dependency Graph
 
 ```text
-T001 (recon, done) ──→ T002 (baseline)
-                          │
-                          ↓
-                     T003 → T004 → T005 → T006 → T007 → T008  ← Commit 1
-                                                          │
-                                                          ↓
-                                                     T009 → T010 → T011 → T012  ← Commit 2
-                                                                            │
-                                                                            ↓
-                                                                       T013 → T014 → T015 → T016 → T017
+T001 (recon, done) → T002 (baseline)
+                       │
+                       ↓
+                  T003 → T004 → T005 → T006 → T007  ← Single commit
+                                                │
+                                                ↓
+                                           T008 → T009 → T010 → T011 → T012
 ```
 
 ## Estimated effort
@@ -88,7 +79,6 @@ T001 (recon, done) ──→ T002 (baseline)
 | Phase | Effort | Notes |
 |---|---|---|
 | Phase 1 (baseline) | 5 min | T001 already done; just T002 snapshot |
-| Phase 2 (acceptance) | 45 min | Audit + insert; us1 has more sites than us3 |
-| Phase 3 (determinism) | 30 min | Smaller diff; mostly mechanical |
-| Phase 4 (verify + PR) | 20 min | 50x loops + regen + push |
-| **Total** | **~1.5 hr** | One focused sitting. |
+| Phase 2 (single commit) | 20 min | Two helper edits, ~6 lines each |
+| Phase 3 (verify + PR) | 20 min | 50x loops + regen + push |
+| **Total** | **~45 min** | One focused half-hour-plus. |

--- a/specs/021-spdx-normalize-consumption/tasks.md
+++ b/specs/021-spdx-normalize-consumption/tasks.md
@@ -1,0 +1,94 @@
+---
+description: "Task list — milestone 021 SPDX normalize-consumption"
+---
+
+# Tasks: SPDX Normalize-Consumption — Tighter Spec
+
+**Input**: Design documents from `/specs/021-spdx-normalize-consumption/`
+**Prerequisites**: spec.md (✅), plan.md (✅), checklists/requirements.md (✅)
+
+**Tests**: No new tests. The 27 byte-identity goldens (from milestones 017 + 020) plus the existing 50-iteration tight-loop discipline are the regression surface.
+
+**Organization**: Single user story (US1, P2). Two atomic commits + polish.
+
+## Format: `[ID] [Story] Description`
+
+- All tasks map to US1.
+
+## Path Conventions
+
+- Touches `mikebom-cli/tests/spdx_us1_acceptance.rs`, `mikebom-cli/tests/spdx3_us3_acceptance.rs`, `mikebom-cli/tests/spdx_determinism.rs`, `mikebom-cli/tests/spdx3_determinism.rs`.
+- Does NOT touch `mikebom-cli/src/` (FR-006 / SC-005).
+- Does NOT touch `cdx_regression.rs`, `spdx_regression.rs` (already at parity), or `common/normalize.rs` itself (already mature).
+
+---
+
+## Phase 1: Reconnaissance & Baseline
+
+- [X] T001 Reconnaissance done in pre-spec investigation (2026-04-26). Findings logged in `spec.md` Background table. The "documented flake" verified non-existent (50 isolated + 5 default-parallel + 12 4-way concurrent + 3 regen-mode runs all green).
+- [ ] T002 Snapshot baseline: `./scripts/pre-pr.sh 2>&1 | tee /tmp/baseline-021.txt | grep -E '^test [a-z_:]+ \.\.\. ok' | sort -u > /tmp/baseline-021-tests.txt`. Compare post-021 to confirm zero test renames/removals.
+
+---
+
+## Phase 2: Commit 1 — `021/acceptance-isolation`
+
+**Goal**: `spdx_us1_acceptance.rs` and `spdx3_us3_acceptance.rs` apply `apply_fake_home_env` at every `Command::new(bin())` spawn site.
+
+- [ ] T003 Audit `spdx_us1_acceptance.rs` for `Command::new(bin())` and `Command::new(common::bin())` sites. List each line number. Expected: 5-7 sites based on file LOC.
+- [ ] T004 At each site: import `common::normalize::apply_fake_home_env`; allocate `let fake_home = tempfile::tempdir().expect("tempdir");`; call `apply_fake_home_env(&mut cmd, fake_home.path())` before `.output()`/`.spawn()`. Hold `fake_home` in scope until after the spawn completes.
+- [ ] T005 Audit `spdx3_us3_acceptance.rs` for spawn sites that don't already use `apply_fake_home_env`. The existing scenario-4 npm test (line 206) is the pattern.
+- [ ] T006 Apply isolation to the missing scenarios (specifically scenario 5 at ~line 277 per recon).
+- [ ] T007 Verify: `cargo +stable test -p mikebom --test spdx_us1_acceptance --test spdx3_us3_acceptance` passes. Pre-PR clean.
+- [ ] T008 Commit: `refactor(021/acceptance-isolation): apply_fake_home_env across SPDX 2.3 + 3.0.1 acceptance tests`.
+
+---
+
+## Phase 3: Commit 2 — `021/determinism-isolation`
+
+**Goal**: `spdx_determinism.rs` gains `apply_fake_home_env`; `spdx3_determinism.rs::normalize()` gains workspace-path replacement.
+
+- [ ] T009 Edit `spdx_determinism.rs::scan_to_spdx_json` (line 16): allocate `fake_home: TempDir` (caller-provided or function-internal; pick whichever keeps the helper simple), apply `apply_fake_home_env` to the `Command` before `.output()`. Hold the tempdir in scope until output is read.
+- [ ] T010 Edit `spdx3_determinism.rs::normalize()` (line 56): add workspace-path replacement against `WORKSPACE_PLACEHOLDER` before parsing JSON. Decision per FR-004: either inline the `raw.replace(workspace, WORKSPACE_PLACEHOLDER)` step OR delegate to `normalize_spdx3_for_golden()` if the contract matches. Verify by running the test before and after.
+- [ ] T011 Verify: `cargo +stable test -p mikebom --test spdx_determinism --test spdx3_determinism` passes. Pre-PR clean.
+- [ ] T012 Commit: `refactor(021/determinism-isolation): apply_fake_home_env + workspace-path normalization across SPDX determinism tests`.
+
+---
+
+## Phase 4: Verification
+
+- [ ] T013 50-iteration tight loops, one per affected file:
+  ```
+  for i in $(seq 1 50); do cargo +stable test -p mikebom --test spdx_us1_acceptance -- --test-threads=1 2>&1 | grep -qE 'test result: ok' || echo FAIL $i; done
+  ```
+  Repeat for `spdx_determinism`, `spdx3_us3_acceptance`, `spdx3_determinism`. SC-002 holds when each is 50/50.
+- [ ] T014 SC-003 verification: regen all 27 goldens via `MIKEBOM_UPDATE_CDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test --workspace --tests -- --test-threads=1`. Verify `git diff -- mikebom-cli/tests/golden` is empty.
+- [ ] T015 SC-005 verification: `git diff main..HEAD -- mikebom-cli/src/` is empty.
+- [ ] T016 Push branch; observe both Linux CI lanes + macOS lane green.
+- [ ] T017 Author PR description: 2-commit summary, contract pointer (`tests/common/normalize.rs` is what's being consumed), byte-identity attestation.
+
+---
+
+## Dependency Graph
+
+```text
+T001 (recon, done) ──→ T002 (baseline)
+                          │
+                          ↓
+                     T003 → T004 → T005 → T006 → T007 → T008  ← Commit 1
+                                                          │
+                                                          ↓
+                                                     T009 → T010 → T011 → T012  ← Commit 2
+                                                                            │
+                                                                            ↓
+                                                                       T013 → T014 → T015 → T016 → T017
+```
+
+## Estimated effort
+
+| Phase | Effort | Notes |
+|---|---|---|
+| Phase 1 (baseline) | 5 min | T001 already done; just T002 snapshot |
+| Phase 2 (acceptance) | 45 min | Audit + insert; us1 has more sites than us3 |
+| Phase 3 (determinism) | 30 min | Smaller diff; mostly mechanical |
+| Phase 4 (verify + PR) | 20 min | 50x loops + regen + push |
+| **Total** | **~1.5 hr** | One focused sitting. |


### PR DESCRIPTION
## Summary

Tier 2 of the post-016 cleanup roadmap: bring `spdx_us1_acceptance.rs` and `spdx_determinism.rs` onto the canonical `common::normalize` discipline already used by `cdx_regression.rs` and `spdx_regression.rs`.

Originally pitched as "extract a shared normalize.rs" — recon revealed the module already exists and is mature (281 LOC, 4 helpers). Real work was just consumption: 2 of 5 SPDX-related test files weren't using it.

Two of those files (`spdx3_us3_acceptance.rs`, `spdx3_determinism.rs`) turned out to already be at parity per re-verification — the spec was corrected before any code landed.

## Per-commit chain

| Commit | Cohort |
|---|---|
| `7799ccc` | docs(021): tighter 4-file spec set (spec/plan/tasks/checklists; skipped research/data-model/contracts/quickstart for contained scope) |
| `aa4347e` | docs(021): correct spec scope after direct re-verification (recon overstated; spdx3_* files already parity) |
| `728eaff` | refactor(021/spdx-isolation): apply_fake_home_env + canonical normalizers in spdx_us1_acceptance + spdx_determinism |

## Bug surfaced + fixed during implementation

Switching to the canonical normalizers caught a latent annotation-date race in both files. The pre-existing local `mask_volatile` / `mask_created` helpers masked only `creationInfo.created` / `metadata.timestamp` and ignored `annotations[].annotationDate`, which mikebom emits with wall-clock timestamps. Adding the `tempfile::tempdir()` call for fake-HOME introduced enough latency between back-to-back scans to cross wall-clock second boundaries — exposing a 4/50 (8%) flake under tight-loop test on macOS that the existing tests narrowly avoided by completing in <1s.

The canonical `normalize_spdx23_for_golden` / `normalize_cdx_for_golden` helpers handle annotation-date masking correctly (see `mikebom-cli/tests/common/normalize.rs:189-203`). After switching:

- **`spdx_us1_acceptance` tight-loop**: 4/50 fail (with isolation only, local masker) → **50/50 pass** (with canonical normalizers)
- **`spdx_determinism` tight-loop**: 3/5 tests fail on first try (with isolation only) → **50/50 pass** (with canonical normalizers)

This is the same risk PR #40 surfaced for SPDX 3 annotation IDs — host-state-derived values leaking through inadequate normalization. The lesson: when in doubt, use the canonical normalizer; ad-hoc local maskers will eventually drift behind what the format actually emits.

## Verification

- [x] `./scripts/pre-pr.sh` clean (default lane)
- [x] 50x tight-loop `spdx_determinism`: 50/50
- [x] 50x tight-loop `spdx_us1_acceptance`: 50/50
- [x] 27-golden regen produces zero diff
- [x] `git diff main..HEAD -- mikebom-cli/src/` empty (test-only refactor; SC-005)
- [x] `git diff main..HEAD -- mikebom-cli/tests/spdx3_*.rs mikebom-cli/tests/cdx_regression.rs mikebom-cli/tests/spdx_regression.rs` empty (already-parity files untouched)
- [ ] Linux default + ebpf + macOS CI lanes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)