### PR TITLE
docs: surface 023 (ELF identity + bag) + 025 (Go VCS) in user-facing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 ## [Unreleased]
 
 ### Added
+- **Milestone 025 — Go BuildInfo VCS metadata.** Every Go-binary scan
+  now surfaces the source-tree VCS state recorded at build time. The
+  main-module entry (`pkg:golang/<module>@<version>`) gains three new
+  annotations across CDX / SPDX 2.3 / SPDX 3:
+  `mikebom:go-vcs-revision` (commit SHA from `vcs.revision`),
+  `mikebom:go-vcs-time` (RFC 3339 commit timestamp from `vcs.time`),
+  `mikebom:go-vcs-modified` (dirty-tree boolean from `vcs.modified`,
+  preserved as the literal string `"true"` / `"false"` matching Go's
+  wire format). The data was already present in BuildInfo's vers_info
+  blob; pre-025 the parser read only the first line (Go version) and
+  discarded the rest. Dep modules don't carry VCS info — it's a
+  main-module concern. Surfaced via the milestone-023 generic
+  annotation bag, with zero PackageDbEntry-init churn or generate/
+  plumbing changes (the bag's amortization payoff). 4 atomic commits;
+  see `specs/025-go-vcs-metadata/spec.md` and catalog rows C27/C28/C29
+  in `docs/reference/sbom-format-mapping.md`.
+- **Milestone 023 — ELF binary identity + per-component generic
+  annotation bag.** Two cohorts in one milestone. (a) ELF identity:
+  every Linux-binary scan now surfaces `NT_GNU_BUILD_ID` (the
+  canonical Linux binary-identity hash used by `eu-unstrip`,
+  `coredumpctl`, `debuginfod`, `*-dbgsym` packaging), `DT_RPATH` /
+  `DT_RUNPATH` (embedded library search paths the dynamic loader
+  consults — `$ORIGIN` etc. recorded raw), and `.gnu_debuglink`
+  (pointer to the stripped-debug sibling file). Three new annotations
+  on the file-level binary component: `mikebom:elf-build-id`,
+  `mikebom:elf-runpath`, `mikebom:elf-debuglink`. SC-002 is satisfied
+  on Linux CI: `/bin/ls` scan emits a non-empty hex build-id (every
+  modern distro stamps build-ids by default). (b) Per-component
+  annotation bag: `extra_annotations: BTreeMap<String, Value>` on
+  `PackageDbEntry` and `ResolvedComponent` provides a generic per-
+  component annotation channel that future per-binary-metadata
+  milestones (024 Mach-O LC_UUID, 026 version-string library
+  expansion, 027 container layer attribution) can populate without
+  per-field schema migration. Determinism is preserved by `BTreeMap`
+  iteration order. Catalog rows C24/C25/C26.
+
 - **Milestone 010 — SPDX 2.3 output + OpenVEX sidecar + SPDX 3.0.1
   experimental stub.** SPDX 2.3 JSON is now a peer of CycloneDX across
   all 9 supported ecosystems. A single `mikebom sbom scan` invocation

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ build a proper CycloneDX with:
   `packageurl-python` reference implementation (including
   `+` → `%2B` encoding across every ecosystem; `epoch=0` omission
   on RPM; lexicographic qualifier sort).
+- **Compiled-binary identity** for ELF — extracts NT_GNU_BUILD_ID,
+  DT_RPATH/DT_RUNPATH, and `.gnu_debuglink` reference for every Linux
+  binary scanned. Surfaced as `mikebom:elf-build-id` /
+  `mikebom:elf-runpath` / `mikebom:elf-debuglink` annotations across
+  CDX, SPDX 2.3, and SPDX 3 outputs. The build-id is the canonical
+  binary-identity field used by `eu-unstrip`, `coredumpctl`,
+  `debuginfod`, and `*-dbgsym` packaging — making cross-image binary
+  dedup and debug-symbol correlation a direct lookup.
+- **Go VCS provenance** — extracts `vcs.revision` (commit SHA),
+  `vcs.time` (RFC 3339 build timestamp), and `vcs.modified` (dirty-tree
+  flag) from every Go binary's BuildInfo. Surfaced as
+  `mikebom:go-vcs-revision` / `mikebom:go-vcs-time` /
+  `mikebom:go-vcs-modified` on the main-module entry. Same data
+  `go version -m` shows, baked into the SBOM so consumers don't have
+  to shell out.
 
 On top of scan-mode, mikebom adds:
 

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -264,12 +264,58 @@ canonical cross-format contract is
 added anywhere in the scan pipeline breaks the build until it's
 mapped.
 
+## Per-component generic annotation bag (milestone 023)
+
+`PackageDbEntry` and `ResolvedComponent` carry an
+`extra_annotations: BTreeMap<String, serde_json::Value>` field. Each
+entry is emitted at SBOM-generation time as a `mikebom:<key>`
+annotation across all three formats — a CycloneDX `properties[]`
+entry, a SPDX 2.3 `annotations[]` envelope, and a SPDX 3
+graph-element `Annotation`. The emission code in
+`generate/cyclonedx/builder.rs`, `generate/spdx/annotations.rs`, and
+`generate/spdx/v3_annotations.rs` iterates the bag deterministically
+(`BTreeMap`'s sorted-by-key order is what byte-identity goldens
+depend on).
+
+**Why a bag and not typed fields:** `PackageDbEntry` has 30+
+struct-literal init sites and no `Default` impl (`Purl` and
+`SpdxExpression` don't have meaningful defaults), so each new typed
+field forces 30+ manual `field: None,` additions per milestone. The
+bag amortizes that cost across all future per-binary-metadata
+milestones — a new key is one `entry.extra_annotations.insert(...)`
+call.
+
+**First two consumers:**
+- Milestone 023 — ELF identity (`mikebom:elf-build-id`,
+  `mikebom:elf-runpath`, `mikebom:elf-debuglink`) populated in
+  `binary/entry.rs::make_file_level_component`.
+- Milestone 025 — Go BuildInfo VCS metadata
+  (`mikebom:go-vcs-revision`, `mikebom:go-vcs-time`,
+  `mikebom:go-vcs-modified`) populated in
+  `package_db/go_binary.rs::build_vcs_annotations` on the main-module
+  entry.
+
+**Spec discipline:** typed fields stay typed. The bag is for NEW
+per-binary metadata; existing fields like `binary_class`,
+`evidence_kind`, `is_dev` don't migrate. If duplicate keys are
+inserted (a typed field's `mikebom:*` name and a bag entry with the
+same name), the parity matrix' `holistic_parity` test catches the
+double-emit at PR time.
+
+Future per-binary-metadata milestones inheriting the bag without
+schema churn: 024 Mach-O LC_UUID + codesign + min-OS, 026
+version-string library expansion (glibc, musl, GnuTLS, LibreSSL, V8,
+LLVM, OpenJDK), 027 container layer attribution
+(`mikebom:layer-id`), 028 PE Delay-Load + machine-type + subsystem.
+
 ## Relevant specs
 
 - `specs/001-build-trace-pipeline/` — original eBPF build-trace mode
 - `specs/002-python-npm-ecosystem/` — Python + npm ecosystem expansion
 - `specs/003-multi-ecosystem-expansion/` — Go / RPM / Maven / Cargo / Gem + foundational work
 - `specs/010-spdx-output-support/` — SPDX 2.3 + SPDX 3.0.1-experimental + OpenVEX sidecar + dual-format data-placement map
+- `specs/023-elf-binary-identity/` — ELF NT_GNU_BUILD_ID + RPATH/RUNPATH + .gnu_debuglink + per-component annotation bag
+- `specs/025-go-vcs-metadata/` — Go BuildInfo VCS metadata via the bag (first follow-on consumer)
 - `.specify/memory/constitution.md` — 12-principle constitution; notable constraints: no C dependencies, no `.unwrap()` in production, generation context always stamped, packageurl-python conformance
 
 ---

--- a/docs/ecosystems.md
+++ b/docs/ecosystems.md
@@ -221,6 +221,18 @@ list but not module-to-module relationships.
 **Hashes:** the binary itself gets hashed (`ResolutionTechnique::FilePathPattern`
 at 0.70 confidence with file-level evidence); individual modules don't.
 
+**VCS metadata (milestone 025):** when the binary was built with
+`-buildvcs=true` (the Go default since 1.18), three additional
+annotations attach to the main-module entry: `mikebom:go-vcs-revision`
+(commit SHA from `vcs.revision`), `mikebom:go-vcs-time` (RFC 3339
+build timestamp from `vcs.time`), and `mikebom:go-vcs-modified`
+(dirty-tree boolean from `vcs.modified`, preserved as the literal
+`"true"` / `"false"` string per Go's wire format). Surfaced via the
+milestone-023 `extra_annotations` bag — same data `go version -m
+<binary>` shows. Dep entries don't carry VCS metadata; that's a
+main-module concern. Binaries built with `-buildvcs=false` or outside
+a VCS worktree emit no `mikebom:go-vcs-*` annotations.
+
 **Known limitations:**
 - Stripped binaries where BuildInfo extraction fails get
   `mikebom:buildinfo-status = missing` and emit only as a file-level


### PR DESCRIPTION
## Summary

Per user request after merging milestone 025: docs were stale on the user-visible additions from milestones 023 (ELF binary identity + per-component annotation bag) and 025 (Go BuildInfo VCS metadata). Both add new annotations to every CDX/SPDX output for ELF / Go binaries, and contributors and SBOM consumers need to know they exist.

This PR is doc-only — no source changes. Targeted at the docs people actually read first.

## Changes

| File | Change |
|---|---|
| `README.md` | 2 new bullets in the "Why" section: compiled-binary identity (ELF build-id + RPATH/RUNPATH + debuglink) and Go VCS provenance |
| `CHANGELOG.md` | 2 new `Added` entries at top of `[Unreleased]` for 023 + 025 with full annotation lists, source-format references, and bag-amortization rationale |
| `docs/design-notes.md` | New "Per-component generic annotation bag (milestone 023)" section explaining the architectural pattern, plus 023 + 025 added to the Relevant specs list |
| `docs/ecosystems.md` | Extended the golang section with a "VCS metadata (milestone 025)" subsection |

## Out of scope (deferred)

- Backfilling CHANGELOG entries for milestones 011-022 (mostly structural refactors / CI hygiene; not user-visible).
- Per-format binary scanning architecture writeups in `docs/architecture/`.

## Verification

- [x] `./scripts/pre-pr.sh` clean (markdown-only changes)
- [ ] CI green on the docs PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)