### PR TITLE
docs: surface 024 (Mach-O) + 028 (PE) binary identity in user-facing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 ## [Unreleased]
 
 ### Added
+- **Milestone 028 — PE binary identity.** Every Windows-binary scan
+  now surfaces three identity signals via `object` 0.36's typed PE
+  accessors: `mikebom:pe-pdb-id` (the `<guid-hex-lowercase>:<age>`
+  pair from the CodeView Type-2 record in `IMAGE_DIRECTORY_ENTRY_DEBUG`
+  — the canonical PE binary identity used by Microsoft Symbol Server,
+  Mozilla / Chromium symbol stores, WinDbg, drmingw; analog of
+  Linux's NT_GNU_BUILD_ID and macOS's LC_UUID), `mikebom:pe-machine`
+  (lowercase `IMAGE_FILE_HEADER.Machine` — `amd64` / `i386` /
+  `arm64` / `armnt` / `ia64` / `riscv32` / `riscv64` / `unknown`),
+  and `mikebom:pe-subsystem` (lowercase
+  `IMAGE_OPTIONAL_HEADER.Subsystem` — `console` / `windows-gui` /
+  `efi-application` / `native` / etc., with `WINDOWS_CUI` rendering
+  as `console` per Microsoft toolchain idiom). PE32 vs PE32+
+  bit-width is auto-dispatched by reading
+  `IMAGE_OPTIONAL_HEADER.Magic` (`0x10B` vs `0x20B`). With ELF (023)
+  and Mach-O (024) already shipping, this completes the binary-
+  identity trifecta — every compiled binary mikebom scans now
+  carries cross-platform identity in the SBOM. Surfaced via the
+  milestone-023 generic annotation bag — the **fourth** amortization-
+  proof consumer, with zero churn in `package_db/`, `mikebom-common/`,
+  `cli/`, `resolve/`, `generate/`, `elf.rs`, or `macho.rs`. See
+  `specs/028-pe-binary-identity/spec.md` and catalog rows
+  C33/C34/C35 in `docs/reference/sbom-format-mapping.md`.
+- **Milestone 024 — Mach-O binary identity.** Every macOS-binary
+  scan now surfaces three identity signals from byte-level Mach-O
+  load-command parsing: `mikebom:macho-uuid` (16-byte LC_UUID
+  hex-encoded lowercase — the macOS analog of NT_GNU_BUILD_ID; used
+  by `dwarfdump`, `xcrun symbolicatecrash`, the macOS crash reporter,
+  and every `*.dSYM` bundle for symbol matching),
+  `mikebom:macho-rpath` (LC_RPATH paths in declaration order, dedup'd
+  — `@executable_path` / `@loader_path` / `@rpath` recorded raw,
+  runtime-context-dependent expansion deferred to consumers), and
+  `mikebom:macho-min-os` (`<platform>:<version>` shape — e.g.
+  `macos:14.0`, `ios:17.5` — preferring `LC_BUILD_VERSION`, falling
+  back to `LC_VERSION_MIN_MACOSX` / `LC_VERSION_MIN_IPHONEOS` /
+  `LC_VERSION_MIN_TVOS` / `LC_VERSION_MIN_WATCHOS`). Fat / universal
+  Mach-O binaries report from the FIRST slice's bytes (per-slice
+  arch-divergence is uncommon in practice; consumers needing it can
+  fall back to `otool -l <slice>`). SC-002 verified on the macOS CI
+  lane: `/bin/ls` scan emits a non-empty 32-lowercase-hex
+  `mikebom:macho-uuid` and a non-empty `<platform>:<version>`
+  `mikebom:macho-min-os` — both universal on every supported macOS
+  version. Surfaced via the milestone-023 generic annotation bag,
+  with zero PackageDbEntry-init churn (the bag's amortization
+  payoff). 3 atomic commits; see `specs/024-macho-binary-identity/spec.md`
+  and catalog rows C30/C31/C32 in `docs/reference/sbom-format-mapping.md`.
 - **Milestone 025 — Go BuildInfo VCS metadata.** Every Go-binary scan
   now surfaces the source-tree VCS state recorded at build time. The
   main-module entry (`pkg:golang/<module>@<version>`) gains three new

--- a/README.md
+++ b/README.md
@@ -57,14 +57,32 @@ build a proper CycloneDX with:
   `packageurl-python` reference implementation (including
   `+` → `%2B` encoding across every ecosystem; `epoch=0` omission
   on RPM; lexicographic qualifier sort).
-- **Compiled-binary identity** for ELF — extracts NT_GNU_BUILD_ID,
-  DT_RPATH/DT_RUNPATH, and `.gnu_debuglink` reference for every Linux
-  binary scanned. Surfaced as `mikebom:elf-build-id` /
-  `mikebom:elf-runpath` / `mikebom:elf-debuglink` annotations across
-  CDX, SPDX 2.3, and SPDX 3 outputs. The build-id is the canonical
-  binary-identity field used by `eu-unstrip`, `coredumpctl`,
-  `debuginfod`, and `*-dbgsym` packaging — making cross-image binary
-  dedup and debug-symbol correlation a direct lookup.
+- **Compiled-binary identity across Linux, macOS, and Windows** —
+  every binary mikebom scans carries a cross-platform identity in
+  the SBOM:
+  - **ELF (Linux):** `NT_GNU_BUILD_ID`, `DT_RPATH` / `DT_RUNPATH`,
+    `.gnu_debuglink` → `mikebom:elf-build-id` /
+    `mikebom:elf-runpath` / `mikebom:elf-debuglink`. The build-id is
+    the canonical Linux binary-identity field used by `eu-unstrip`,
+    `coredumpctl`, `debuginfod`, and `*-dbgsym` packaging.
+  - **Mach-O (macOS / iOS):** `LC_UUID`, `LC_RPATH`, and minimum-OS
+    version (`LC_BUILD_VERSION` or `LC_VERSION_MIN_*`) →
+    `mikebom:macho-uuid` / `mikebom:macho-rpath` /
+    `mikebom:macho-min-os`. The UUID is what `dwarfdump`,
+    `xcrun symbolicatecrash`, the macOS crash reporter, and every
+    `*.dSYM` bundle key on for symbol matching. Fat / universal
+    binaries report from the first slice.
+  - **PE (Windows):** CodeView pdb-id (`<guid>:<age>` from
+    `IMAGE_DIRECTORY_ENTRY_DEBUG`), machine type
+    (`IMAGE_FILE_HEADER.Machine`), and subsystem
+    (`IMAGE_OPTIONAL_HEADER.Subsystem`) → `mikebom:pe-pdb-id` /
+    `mikebom:pe-machine` / `mikebom:pe-subsystem`. The pdb-id is
+    what Microsoft Symbol Server, Mozilla / Chromium symbol stores,
+    WinDbg, and drmingw use to locate matching `.pdb` files.
+
+  All nine annotations emit symmetrically across CDX, SPDX 2.3, and
+  SPDX 3, making cross-image binary dedup and debug-symbol
+  correlation a direct lookup regardless of OS.
 - **Go VCS provenance** — extracts `vcs.revision` (commit SHA),
   `vcs.time` (RFC 3339 build timestamp), and `vcs.modified` (dirty-tree
   flag) from every Go binary's BuildInfo. Surfaced as

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -285,15 +285,34 @@ bag amortizes that cost across all future per-binary-metadata
 milestones — a new key is one `entry.extra_annotations.insert(...)`
 call.
 
-**First two consumers:**
+**Consumers shipped (4 — pattern fully validated):**
 - Milestone 023 — ELF identity (`mikebom:elf-build-id`,
   `mikebom:elf-runpath`, `mikebom:elf-debuglink`) populated in
-  `binary/entry.rs::make_file_level_component`.
+  `binary/entry.rs::make_file_level_component` →
+  `build_elf_identity_annotations`.
+- Milestone 024 — Mach-O identity (`mikebom:macho-uuid`,
+  `mikebom:macho-rpath`, `mikebom:macho-min-os`) populated in
+  `binary/entry.rs::build_macho_identity_annotations`. Reads LC_UUID
+  / LC_RPATH / LC_BUILD_VERSION (or LC_VERSION_MIN_*) via byte-level
+  load-command parsing in `binary/macho.rs`. Fat / universal
+  binaries report from the first slice's bytes.
 - Milestone 025 — Go BuildInfo VCS metadata
   (`mikebom:go-vcs-revision`, `mikebom:go-vcs-time`,
   `mikebom:go-vcs-modified`) populated in
   `package_db/go_binary.rs::build_vcs_annotations` on the main-module
-  entry.
+  entry only (deps don't carry VCS info).
+- Milestone 028 — PE identity (`mikebom:pe-pdb-id`,
+  `mikebom:pe-machine`, `mikebom:pe-subsystem`) populated in
+  `binary/entry.rs::build_pe_identity_annotations`. Reads the
+  CodeView Type-2 record + IMAGE_FILE_HEADER + IMAGE_OPTIONAL_HEADER
+  via `object` 0.36's typed PE accessors in `binary/pe.rs`. PE32 vs
+  PE32+ auto-dispatched by `IMAGE_OPTIONAL_HEADER.Magic`.
+
+The three identity helpers (`build_elf_identity_annotations`,
+`build_macho_identity_annotations`, `build_pe_identity_annotations`)
+are merged by the unified `build_binary_identity_annotations` →
+each format's bag-emission contract stays co-located with its
+source struct fields.
 
 **Spec discipline:** typed fields stay typed. The bag is for NEW
 per-binary metadata; existing fields like `binary_class`,
@@ -302,11 +321,18 @@ inserted (a typed field's `mikebom:*` name and a bag entry with the
 same name), the parity matrix' `holistic_parity` test catches the
 double-emit at PR time.
 
-Future per-binary-metadata milestones inheriting the bag without
-schema churn: 024 Mach-O LC_UUID + codesign + min-OS, 026
+**Bag amortization receipts:** four consecutive consumers (023, 024,
+025, 028) shipped with **zero diff** in `package_db/`,
+`mikebom-common/`, `cli/`, `resolve/`, `generate/`, and unrelated
+binary-format modules. The 30+ `PackageDbEntry`-init sites are
+untouched by per-binary-metadata work.
+
+Future milestones inheriting the bag without schema churn: 026
 version-string library expansion (glibc, musl, GnuTLS, LibreSSL, V8,
 LLVM, OpenJDK), 027 container layer attribution
-(`mikebom:layer-id`), 028 PE Delay-Load + machine-type + subsystem.
+(`mikebom:layer-id`), and follow-on work on signature data
+(Authenticode for PE, codesign for Mach-O — both deferred from
+their parent milestones).
 
 ## Relevant specs
 
@@ -315,7 +341,9 @@ LLVM, OpenJDK), 027 container layer attribution
 - `specs/003-multi-ecosystem-expansion/` — Go / RPM / Maven / Cargo / Gem + foundational work
 - `specs/010-spdx-output-support/` — SPDX 2.3 + SPDX 3.0.1-experimental + OpenVEX sidecar + dual-format data-placement map
 - `specs/023-elf-binary-identity/` — ELF NT_GNU_BUILD_ID + RPATH/RUNPATH + .gnu_debuglink + per-component annotation bag
-- `specs/025-go-vcs-metadata/` — Go BuildInfo VCS metadata via the bag (first follow-on consumer)
+- `specs/024-macho-binary-identity/` — Mach-O LC_UUID + LC_RPATH + min-OS via the bag (2nd consumer)
+- `specs/025-go-vcs-metadata/` — Go BuildInfo VCS metadata via the bag (3rd consumer)
+- `specs/028-pe-binary-identity/` — PE CodeView pdb-id + machine + subsystem via the bag (4th consumer; binary trifecta complete)
 - `.specify/memory/constitution.md` — 12-principle constitution; notable constraints: no C dependencies, no `.unwrap()` in production, generation context always stamped, packageurl-python conformance
 
 ---


### PR DESCRIPTION
## Summary

Mirrors the 023+025 docs pattern (PR #51) for the two milestones that have landed since. Now that the binary-identity trifecta is complete (ELF / Mach-O / PE) and the milestone-023 `extra_annotations` bag has 4 consecutive amortization-proof consumers (023, 024, 025, 028), the user-facing docs need to catch up.

## What changed

- **`README.md`** — replace the ELF-only "Compiled-binary identity" bullet in the "Why" section with a unified "Compiled-binary identity across Linux, macOS, and Windows" sub-section enumerating all 9 annotations (3 per format) and the canonical-identity rationale per platform (eu-unstrip / dwarfdump / Microsoft Symbol Server). Consumer-facing — answers "what does mikebom record for this binary?" without forcing a CHANGELOG dive.

- **`CHANGELOG.md`** — two new `Added` entries at the top of `[Unreleased]`:
  - **Milestone 028 — PE binary identity** (CodeView pdb-id + machine + subsystem; trifecta-completion callout)
  - **Milestone 024 — Mach-O binary identity** (LC_UUID + LC_RPATH + min-OS; macOS-CI-anchor SC-002 callout for `/bin/ls`)

  Both entries match the structure of the existing 023 + 025 entries: data fields, source format, spec directory, catalog row IDs (C30-C32 for 024; C33-C35 for 028), and the bag-amortization receipts.

- **`docs/design-notes.md`** — bump the "Per-component generic annotation bag (milestone 023)" section's consumer list from **2** (023 + 025) to **4** (023 + 024 + 025 + 028), with each consumer's source helper named. New "Bag amortization receipts" sub-bullet captures the zero-diff attestation across `package_db/`, `mikebom-common/`, `cli/`, `resolve/`, `generate/`, and unrelated binary-format modules. Shift 024 + 028 from the "future milestones inheriting the bag" line to the "shipped" list. Add 024 + 028 specs to the Relevant specs list.

## Out of scope (kept narrow)

- `docs/ecosystems.md` untouched. Same scoping decision as PR #51: binary-format identity is cross-format / not ecosystem-specific, so the README is the right place for the trifecta callout, not the per-ecosystem detail page.
- Backfilling milestone 011-022 + 026 + 027 entries in the CHANGELOG. Same out-of-scope decision PR #51 made; would be its own milestone.

## Test plan

- [ ] CI default lane (Linux) green
- [ ] CI ebpf lane green
- [ ] CI macOS lane green
- [ ] `./scripts/pre-pr.sh` clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)