### PR TITLE
docs: surface 026 (curated version-string scanner) in user-facing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 ## [Unreleased]
 
 ### Added
+- **Milestone 026 — curated version-string scanner expansion (easy-4
+  cohort).** Extends `version_strings.rs`'s curated scanner from 7 to
+  **11 self-identifying native libraries**. Four new detectors with
+  clean self-identifying signatures in the binary's read-only string
+  region:
+  - **GnuTLS** (`GnuTLS X.Y.Z`) — common in curl-with-GnuTLS, wget,
+    GnuPG, GNU-stack tools.
+  - **LibreSSL** (`LibreSSL X.Y.Z`) — macOS system tools (system curl
+    was LibreSSL-backed for years), OpenBSD-derived utilities.
+  - **LLVM** (`LLVM version X.Y.Z`) — strict prefix; bare `LLVM ` is
+    too noisy (matches `LLVM ERROR:`, `LLVM IR ...` etc.).
+  - **OpenJDK** — two-scheme parser handling both modern JEP 322
+    (`21.0.1+12`) and legacy Java 8 (`8u362-b09`).
+
+  Each match emits a `pkg:generic/<library>@<version>` component with
+  `mikebom:evidence-kind = "embedded-version-string"` and
+  `mikebom:confidence = "heuristic"`, flowing through the existing
+  `version_match_to_entry` machinery (no downstream wiring change).
+  9 new inline tests cover positive + negative cases per library
+  plus a `libressl_distinct_from_openssl` cross-validation test.
+
+  Three additional libraries from the original wishlist (glibc, musl,
+  V8) are deferred to a 026.x research-and-attempt follow-on because
+  they don't have clean self-identifying strings in `string_region` —
+  glibc's `GLIBC_X.Y` lives in the `.gnu.version_r` ELF section, musl
+  rarely self-identifies in compiled output, and V8's version strings
+  are buried in stack-trace formatting code. Tracked via
+  `TODO(milestone-026.x)` in `version_strings.rs` and the
+  "Deferred backlog" section of `docs/design-notes.md`. See
+  `specs/026-version-string-library-expansion/spec.md`.
+
+  Note: this milestone is **not** a `extra_annotations` bag consumer —
+  it produces new components rather than annotations on existing
+  components. The bag-amortization streak from 023/024/025/028 stays
+  at four; 026 is purely scanner coverage breadth.
 - **Milestone 028 — PE binary identity.** Every Windows-binary scan
   now surfaces three identity signals via `object` 0.36's typed PE
   accessors: `mikebom:pe-pdb-id` (the `<guid-hex-lowercase>:<age>`

--- a/README.md
+++ b/README.md
@@ -90,6 +90,26 @@ build a proper CycloneDX with:
   `mikebom:go-vcs-modified` on the main-module entry. Same data
   `go version -m` shows, baked into the SBOM so consumers don't have
   to shell out.
+- **Curated embedded-version-string detection** for **11
+  high-CVE-volume native libraries** statically-linked into compiled
+  binaries — the heuristic-tier counterpart to source-tree manifest
+  parsing. mikebom walks the binary's read-only string region
+  (`.rodata` / `__TEXT,__cstring` / `.rdata` — never the full image,
+  to bound the false-positive surface) and recognises each library's
+  canonical version banner anchored at a NUL boundary:
+  - **Crypto / TLS:** OpenSSL, BoringSSL, LibreSSL, GnuTLS
+  - **Compression / data:** zlib, SQLite
+  - **Networking:** curl
+  - **Regex:** PCRE, PCRE2
+  - **Compiler / runtime:** LLVM, OpenJDK (handles both modern JEP-322
+    `21.0.1+12` and legacy Java-8 `8u362-b09`)
+
+  Each detection emits a `pkg:generic/<library>@<version>` component
+  with `mikebom:evidence-kind = "embedded-version-string"` and
+  `mikebom:confidence = "heuristic"`, so downstream CVE matchers
+  (Vex / OSV / NVD / Kusari Inspector) have pre-resolved coordinates
+  to query against — no need to know in advance which libraries a
+  binary statically links.
 
 On top of scan-mode, mikebom adds:
 


### PR DESCRIPTION
## Summary

Mirrors the 023+025 (PR #51) and 024+028 (PR #55) docs-refresh pattern for milestone 026, which extended the curated embedded-version-string scanner from 7 to 11 libraries (added GnuTLS / LibreSSL / LLVM / OpenJDK).

Notable: the version-string scanner concept was **never** in user-facing docs — even before 026. The pre-existing 7-library scanner (OpenSSL / BoringSSL / zlib / SQLite / curl / PCRE / PCRE2) shipped as part of milestone 005-era binary-scanning work but the README never introduced it. So this docs PR is a more substantive uplift than a 4-library add: it introduces the whole concept for the first time.

## What changed

- **`README.md`** — new "Curated embedded-version-string detection" bullet in the "Why" section. Lists all 11 libraries grouped by category, describes the NUL-boundary anchor that bounds the false-positive surface, and explains the downstream shape (`pkg:generic/<library>@<version>` components with `evidence-kind = "embedded-version-string"` + `confidence = "heuristic"`). Frames the consumer benefit: pre-resolved coords for CVE matchers.

- **`CHANGELOG.md`** — new `Added` entry at the top of `[Unreleased]` for milestone 026, matching the structure of the existing 023 / 024 / 025 / 028 entries. Includes a deferred-cohort callout (glibc / musl / V8) pointing at the `TODO(milestone-026.x)` block in `version_strings.rs`. Notably calls out that 026 is **not** a `extra_annotations` bag consumer — it produces new components rather than annotations — so future readers don't expect it to extend the 023/024/025/028 bag-amortization streak.

## Out of scope (kept narrow)

- **`docs/design-notes.md`** untouched. PR #56 already updated item #12 in the "Deferred backlog" (library count 7 → 11) and added the new "Curated version-string scanner — hard cohort (milestone 026.x)" subsection. Both are already on main.
- **`docs/ecosystems.md`** untouched. Same scoping decision as PR #51 / #55: binary-format / cross-format scanner content lives in the README, not in the per-ecosystem detail page.

## Test plan

- [ ] CI default lane (Linux) green
- [ ] CI ebpf lane green
- [ ] CI macOS lane green
- [ ] `./scripts/pre-pr.sh` clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)