### PR TITLE
fix(test): pin MIKEBOM_FIXED_TIMESTAMP to close latent byte-identity flake

### DIFF
--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -645,7 +645,7 @@ pub async fn execute(
     };
     let output_cfg = OutputConfig {
         mikebom_version: env!("CARGO_PKG_VERSION"),
-        created: chrono::Utc::now(),
+        created: scan_created_timestamp(),
         overrides: plan.overrides.clone(),
     };
 
@@ -744,6 +744,31 @@ pub async fn execute(
 /// Write `bytes` to `path`, creating any missing parent directories.
 ///
 /// Shared by every serializer artifact (CDX today; SPDX + OpenVEX in
+/// Resolve the `created` timestamp for the SBOM output config.
+///
+/// Defaults to `chrono::Utc::now()`. **Test-only override**: when the
+/// `MIKEBOM_FIXED_TIMESTAMP` env var is set to an RFC 3339 string,
+/// that value is used instead — required for tests that compare raw
+/// SBOM bytes across two `mikebom sbom scan` subprocesses (e.g.
+/// `format_dispatch::spdx_3_alias_bytes_are_byte_identical_to_stable_identifier`).
+/// Without the override, the two subprocesses' independent
+/// `Utc::now()` calls can cross a second boundary on slow runners
+/// and produce non-byte-identical output, surfacing as a CI flake
+/// even on docs-only PRs.
+///
+/// Production scans MUST NOT set this env var. An unparseable value
+/// is treated as "unset" — silently fall back to `Utc::now()` rather
+/// than panic, since this is a defensive belt-and-braces helper, not
+/// a hard contract.
+fn scan_created_timestamp() -> chrono::DateTime<chrono::Utc> {
+    if let Ok(s) = std::env::var("MIKEBOM_FIXED_TIMESTAMP") {
+        if let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(&s) {
+            return parsed.with_timezone(&chrono::Utc);
+        }
+    }
+    chrono::Utc::now()
+}
+
 /// later phases). Kept local to this CLI module so the generator crate
 /// has no filesystem dependencies.
 fn write_bytes_to(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {

--- a/mikebom-cli/tests/common/normalize.rs
+++ b/mikebom-cli/tests/common/normalize.rs
@@ -268,6 +268,13 @@ pub fn normalize_spdx3_for_golden(raw: &str, workspace: &Path) -> String {
 /// don't need to exist; the goal is to point cache lookups at empty
 /// paths so the scanner sees no cached metadata regardless of host.
 ///
+/// Also pins `MIKEBOM_FIXED_TIMESTAMP` to a known RFC 3339 value so
+/// SBOM `creationInfo.created` / `metadata.timestamp` is deterministic
+/// across multiple subprocess invocations within the same test. This
+/// closes the latent byte-identity flake where two `mikebom sbom scan`
+/// runs could cross a second boundary on slow CI runners
+/// (`scan_cmd.rs::scan_created_timestamp` reads this env var).
+///
 /// Caller is responsible for ensuring `fake_home` outlives the
 /// Command's execution (typically by holding the source TempDir).
 pub fn apply_fake_home_env(cmd: &mut Command, fake_home: &Path) {
@@ -276,5 +283,6 @@ pub fn apply_fake_home_env(cmd: &mut Command, fake_home: &Path) {
         .env("MAVEN_HOME", fake_home.join("no-maven-home"))
         .env("GOPATH", fake_home.join("no-gopath"))
         .env("GOMODCACHE", fake_home.join("no-gomodcache"))
-        .env("CARGO_HOME", fake_home.join("no-cargo-home"));
+        .env("CARGO_HOME", fake_home.join("no-cargo-home"))
+        .env("MIKEBOM_FIXED_TIMESTAMP", "2026-01-01T00:00:00Z");
 }


### PR DESCRIPTION
## Summary

CI run [`25060658636`](https://github.com/kusari-sandbox/mikebom/actions/runs/25060658636/job/73413409937) on PR #57 surfaced a long-latent timing bug. PR #57 was a docs-only change (README + CHANGELOG); 5+ prior CI runs on the same ebpf lane passed. The failure was content-independent.

## Root cause

`format_dispatch::spdx_3_alias_bytes_are_byte_identical_to_stable_identifier` runs two `mikebom sbom scan` subprocesses (once with `--format spdx-3-json`, once with the alias `spdx-3-json-experimental`) and compares **raw bytes**. The byte-identity contract relied on both subprocesses' independent `Utc::now()` calls landing in the same RFC 3339 second when the SBOM serializer encoded `creationInfo.created`. On the slower ebpf-tracing lane (extra `aya` / `aya-log` deps push link time up), the gap finally crossed a second boundary.

Verified by inspection: `mikebom-cli/src/cli/scan_cmd.rs:648` is the lone `Utc::now()` call in the SBOM emission path. `mikebom-cli/src/generate/spdx/mod.rs:52` confirms the SPDX 3 emitter has no other non-determinism source (documentNamespace is content-hashed; no `Utc::now` / `Uuid::new_v4` in the serialization path). `grep -r MIKEBOM_.*TIMESTAMP` returns empty — no pre-existing env-var override.

## Fix (~30 lines, two files)

1. **`scan_cmd.rs::scan_created_timestamp()` (new helper)** — reads `MIKEBOM_FIXED_TIMESTAMP` (RFC 3339) when set, falls back to `Utc::now()`. Test-only knob — unparseable values silently fall back to `now()` so a malformed value cannot crash production scans. Replaces the bare `Utc::now()` at line 648.

2. **`tests/common/normalize.rs::apply_fake_home_env`** — now also pins `MIKEBOM_FIXED_TIMESTAMP=2026-01-01T00:00:00Z`. Every test that already uses this helper (cdx/spdx/spdx3 regression, cpe_v3_acceptance, format_dispatch, etc.) inherits deterministic timestamps **for free** — no per-test changes needed.

## Why this approach

- **Smallest possible production change** — single function, single env-var read, single line replaced at the call site.
- **Production is unchanged when env unset** — `Utc::now()` fallback. The doc comment makes the test-only intent explicit.
- **Broad reach** — every test in the workspace that already uses `apply_fake_home_env` is now insulated from upstream timestamp variance, not just the one that surfaced the failure.
- **The other byte-identity tests already use `normalize_cdx` / `normalize_spdx2` / `normalize_spdx3`** to STRIP volatile fields, so they're already insulated by a different mechanism. format_dispatch's alias-vs-stable test is the lone case that compares raw bytes — by design, since it tests that two formats produce byte-identical output. Pinning is the right protection there.

## Verification

- `./scripts/pre-pr.sh` clean (workspace-wide).
- The previously-flaky test stress-tested 10x in a row → 10/10 ok.
- Pre-fix this had only failed under specific runner-timing conditions, so we can't exhaustively reproduce it locally; but the timestamp source is the only known non-determinism in the SPDX 3 emit path, so pinning closes the bug by construction.

## Test plan

- [ ] CI default lane (Linux) green
- [ ] CI ebpf lane green ← the lane that flaked
- [ ] CI macOS lane green

Once this lands, PR #57 can rebase atop main and the docs refresh ships clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)