### PR TITLE
docs: surface 029 (cargo-auditable extraction) in user-facing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 ## [Unreleased]
 
 ### Added
+- **Milestone 029 — cargo-auditable extraction.** Extracts the
+  zlib-compressed JSON manifest from Rust binaries' `.dep-v0` linker
+  section ([cargo-auditable](https://github.com/rust-secure-code/cargo-auditable)
+  format) and surfaces the full build-time crate dependency closure as
+  per-crate `pkg:cargo/<name>@<version>` components with
+  `evidence-kind = "cargo-auditable"`, `confidence = "high"`,
+  `parent_purl` cross-linking back to the file-level binary, and
+  index-based `dependencies` resolved into `depends` edges. The binary
+  itself gains a `mikebom:detected-cargo-auditable = true` cross-link
+  annotation (Rust analog of milestone 005's `mikebom:detected-go =
+  true`). Cargo wrappers in Debian Trixie+, Fedora 40+, Alpine Edge,
+  and the official Rust container images auto-enable the embedding —
+  so most Rust binaries built in those environments now surface their
+  full statically-linked crate closure without source access. Cross-
+  format: ELF / Mach-O / PE. Optional bag annotations
+  `mikebom:cargo-auditable-source` (non-registry sources) and
+  `mikebom:cargo-auditable-kind` (non-runtime kinds) preserve
+  manifest detail. **Fifth amortization-proof consumer of the
+  milestone-023 `extra_annotations` bag** (after 023/024/025/028 —
+  026 was a coverage-breadth milestone that didn't touch the bag).
+  No new crate dependencies — `flate2` and `serde_json` were already
+  in the workspace. See `specs/029-cargo-auditable-extraction/spec.md`
+  and catalog row C36 in `docs/reference/sbom-format-mapping.md`.
 - **Milestone 026 — curated version-string scanner expansion (easy-4
   cohort).** Extends `version_strings.rs`'s curated scanner from 7 to
   **11 self-identifying native libraries**. Four new detectors with

--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ build a proper CycloneDX with:
   `mikebom:go-vcs-modified` on the main-module entry. Same data
   `go version -m` shows, baked into the SBOM so consumers don't have
   to shell out.
+- **Rust crate-closure provenance** — extracts the full build-time
+  crate dependency closure from the `.dep-v0` linker section that
+  [`cargo auditable build`](https://github.com/rust-secure-code/cargo-auditable)
+  embeds. Each crate becomes a `pkg:cargo/<name>@<version>` component
+  with `evidence-kind = "cargo-auditable"` and `confidence = "high"`
+  (build-time truth — distinct from `embedded-version-string`'s
+  heuristic tier), `parent_purl` cross-linking back to the file-level
+  binary. The binary itself gains a
+  `mikebom:detected-cargo-auditable = true` cross-link annotation
+  (the Rust analog of `mikebom:detected-go = true`). Cargo wrappers
+  shipped with **Debian Trixie+, Fedora 40+, Alpine Edge, and the
+  official Rust container images** auto-enable the embedding, so most
+  Rust binaries built in those environments surface their full crate
+  closure without source access. Cross-format: ELF / Mach-O / PE.
 - **Curated embedded-version-string detection** for **11
   high-CVE-volume native libraries** statically-linked into compiled
   binaries — the heuristic-tier counterpart to source-tree manifest

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -297,7 +297,7 @@ bag amortizes that cost across all future per-binary-metadata
 milestones — a new key is one `entry.extra_annotations.insert(...)`
 call.
 
-**Consumers shipped (4 — pattern fully validated):**
+**Consumers shipped (5 — pattern fully validated):**
 - Milestone 023 — ELF identity (`mikebom:elf-build-id`,
   `mikebom:elf-runpath`, `mikebom:elf-debuglink`) populated in
   `binary/entry.rs::make_file_level_component` →
@@ -319,12 +319,25 @@ call.
   CodeView Type-2 record + IMAGE_FILE_HEADER + IMAGE_OPTIONAL_HEADER
   via `object` 0.36's typed PE accessors in `binary/pe.rs`. PE32 vs
   PE32+ auto-dispatched by `IMAGE_OPTIONAL_HEADER.Magic`.
+- Milestone 029 — cargo-auditable cross-link
+  (`mikebom:detected-cargo-auditable = true`) populated in
+  `binary/entry.rs::build_cargo_auditable_cross_link` when the binary
+  carries a parsed `.dep-v0` manifest. Per-crate
+  `pkg:cargo/<name>@<version>` components flow through a separate
+  `cargo_auditable_packages_to_entries` helper (regular
+  `PackageDbEntry` channel, not the bag), with the cross-link
+  annotation letting consumers find them without scanning every
+  component. Optional bag annotations
+  `mikebom:cargo-auditable-source` and `mikebom:cargo-auditable-kind`
+  emit on the per-crate components when they carry non-default
+  values (non-registry source / non-runtime kind).
 
-The three identity helpers (`build_elf_identity_annotations`,
-`build_macho_identity_annotations`, `build_pe_identity_annotations`)
-are merged by the unified `build_binary_identity_annotations` →
-each format's bag-emission contract stays co-located with its
-source struct fields.
+The four binary-format / runtime helpers
+(`build_elf_identity_annotations`,
+`build_macho_identity_annotations`, `build_pe_identity_annotations`,
+`build_cargo_auditable_cross_link`) are merged by the unified
+`build_binary_identity_annotations` → each format's bag-emission
+contract stays co-located with its source struct fields.
 
 **Spec discipline:** typed fields stay typed. The bag is for NEW
 per-binary metadata; existing fields like `binary_class`,
@@ -333,18 +346,18 @@ inserted (a typed field's `mikebom:*` name and a bag entry with the
 same name), the parity matrix' `holistic_parity` test catches the
 double-emit at PR time.
 
-**Bag amortization receipts:** four consecutive consumers (023, 024,
-025, 028) shipped with **zero diff** in `package_db/`,
+**Bag amortization receipts:** five consecutive consumers (023, 024,
+025, 028, 029) shipped with **zero diff** in `package_db/`,
 `mikebom-common/`, `cli/`, `resolve/`, `generate/`, and unrelated
 binary-format modules. The 30+ `PackageDbEntry`-init sites are
 untouched by per-binary-metadata work.
 
-Future milestones inheriting the bag without schema churn: 026
-version-string library expansion (glibc, musl, GnuTLS, LibreSSL, V8,
-LLVM, OpenJDK), 027 container layer attribution
-(`mikebom:layer-id`), and follow-on work on signature data
-(Authenticode for PE, codesign for Mach-O — both deferred from
-their parent milestones).
+Future milestones inheriting the bag without schema churn: 027
+container layer attribution (`mikebom:layer-id`), the milestone-026.x
+hard-cohort version-string detectors (glibc / musl / V8 — when
+research clears the technical blockers documented in the deferred
+backlog), and follow-on work on signature data (Authenticode for PE,
+codesign for Mach-O — both deferred from their parent milestones).
 
 ## Relevant specs
 
@@ -356,6 +369,7 @@ their parent milestones).
 - `specs/024-macho-binary-identity/` — Mach-O LC_UUID + LC_RPATH + min-OS via the bag (2nd consumer)
 - `specs/025-go-vcs-metadata/` — Go BuildInfo VCS metadata via the bag (3rd consumer)
 - `specs/028-pe-binary-identity/` — PE CodeView pdb-id + machine + subsystem via the bag (4th consumer; binary trifecta complete)
+- `specs/029-cargo-auditable-extraction/` — cargo-auditable `.dep-v0` manifest extraction → per-crate `pkg:cargo` components + cross-link annotation via the bag (5th consumer)
 - `.specify/memory/constitution.md` — 12-principle constitution; notable constraints: no C dependencies, no `.unwrap()` in production, generation context always stamped, packageurl-python conformance
 
 ---


### PR DESCRIPTION
## Summary

Mirrors the docs-refresh pattern from PR #51 (023+025), PR #55 (024+028), and PR #57 (026) for milestone 029, which extracts the cargo-auditable JSON manifest from Rust binaries' `.dep-v0` linker section.

## What changed

- **`README.md`** — new "Rust crate-closure provenance" bullet in the "Why" section, parallel to the existing "Go VCS provenance" entry. Names the source format (`cargo auditable build` → `.dep-v0`), the consumer-facing distros that auto-enable embedding (Debian Trixie+, Fedora 40+, Alpine Edge, Rust container images), the resulting component shape, and the cross-link annotation. Cross-format coverage (ELF / Mach-O / PE) called out explicitly.

- **`CHANGELOG.md`** — new `Added` entry at the top of `[Unreleased]` for milestone 029, matching the structure of existing 023 / 024 / 025 / 026 / 028 entries. Includes the no-new-crate-deps attestation and the 5th-amortization-proof callout (with the explicit note that 026's coverage-breadth milestone didn't touch the bag, so 029 resumes the streak).

- **`docs/design-notes.md`**:
  - "Per-component generic annotation bag" section's consumer list bumps from **4** to **5**.
  - Explains the asymmetry: the cross-link annotation goes through the bag, but per-crate components flow through the regular `PackageDbEntry` channel.
  - Helpers list updates from 3 to 4 (`build_cargo_auditable_cross_link` joins).
  - "Bag amortization receipts" sub-bullet bumps to 5 consecutive consumers.
  - Future-milestones list trimmed: 026 has shipped without touching the bag; replaced with the milestone-026.x hard-cohort research-and-attempt entry.
  - Add 029 spec to "Relevant specs" list.

## Out of scope (kept narrow)

- `docs/ecosystems.md` untouched. Same scoping decision as PR #51 / #55 / #57: cross-format binary-extraction lives in the README, not in per-ecosystem detail. cargo-auditable is technically a Rust-ecosystem signal but it's binary-format-detected, not source-tree-detected, so it belongs alongside the other binary scanners in the README rather than in the cargo-ecosystem section.

## Test plan

- [ ] CI default lane (Linux) green
- [ ] CI ebpf lane green
- [ ] CI macOS lane green
- [ ] `./scripts/pre-pr.sh` clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)