### PR TITLE
docs: surface 030 (Mach-O codesign metadata) in user-facing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 ## [Unreleased]
 
 ### Added
+- **Milestone 030 — Mach-O codesign metadata.** Every Mach-O scan
+  now extracts three identity-flavored signals from the
+  `LC_CODE_SIGNATURE` (cmd `0x1D`) SuperBlob's CodeDirectory blob:
+  `mikebom:macho-codesign-identifier` (e.g. `com.apple.ls` —
+  universal across Apple-signed binaries),
+  `mikebom:macho-codesign-flags` (JSON array decoded from
+  `CodeDirectory.flags` — `hardened-runtime`, `library-validation`,
+  `adhoc`, etc.; unrecognized bits emit as `unknown-0x<hex>`), and
+  `mikebom:macho-codesign-team-id` (10-char Apple Team ID for
+  developer-signed binaries; absent for Apple-system signatures
+  whose `TeamIdentifier=not set` and for ad-hoc signatures). This
+  is what `codesign -dvv` reads. Fat / universal binaries report
+  from the first slice (matching milestone 024's convention).
+  **Sixth amortization-proof consumer of the milestone-023
+  `extra_annotations` bag** (after 023/024/025/028/029 — 026 was
+  a coverage-breadth milestone that didn't touch the bag). No new
+  crate dependencies. CMS PKCS#7 cert-chain decoding (which would
+  extract the leaf-cert subject CN, signing time, intermediate
+  cert hashes — requires ASN.1 DER parsing) and entitlements XML
+  extraction explicitly deferred to a follow-on milestone (likely
+  unified with PE Authenticode, which has the same DER-parsing
+  requirement). See `specs/030-macho-codesign-metadata/spec.md`
+  and catalog rows C37/C38/C39 in
+  `docs/reference/sbom-format-mapping.md`.
 - **Milestone 029 — cargo-auditable extraction.** Extracts the
   zlib-compressed JSON manifest from Rust binaries' `.dep-v0` linker
   section ([cargo-auditable](https://github.com/rust-secure-code/cargo-auditable)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ build a proper CycloneDX with:
     `xcrun symbolicatecrash`, the macOS crash reporter, and every
     `*.dSYM` bundle key on for symbol matching. Fat / universal
     binaries report from the first slice.
+
+    Plus codesign metadata from the `LC_CODE_SIGNATURE` SuperBlob's
+    CodeDirectory: `mikebom:macho-codesign-identifier` (e.g.
+    `com.apple.ls`), `mikebom:macho-codesign-flags` (decoded names
+    from the flags bitfield — `hardened-runtime`,
+    `library-validation`, `adhoc`, etc.), and
+    `mikebom:macho-codesign-team-id` (10-char Apple Team ID for
+    developer-signed binaries). This is what `codesign -dvv` reads.
   - **PE (Windows):** CodeView pdb-id (`<guid>:<age>` from
     `IMAGE_DIRECTORY_ENTRY_DEBUG`), machine type
     (`IMAGE_FILE_HEADER.Machine`), and subsystem
@@ -80,9 +88,10 @@ build a proper CycloneDX with:
     what Microsoft Symbol Server, Mozilla / Chromium symbol stores,
     WinDbg, and drmingw use to locate matching `.pdb` files.
 
-  All nine annotations emit symmetrically across CDX, SPDX 2.3, and
-  SPDX 3, making cross-image binary dedup and debug-symbol
-  correlation a direct lookup regardless of OS.
+  All twelve annotations emit symmetrically across CDX, SPDX 2.3,
+  and SPDX 3, making cross-image binary dedup, debug-symbol
+  correlation, and signing-identity provenance a direct lookup
+  regardless of OS.
 - **Go VCS provenance** — extracts `vcs.revision` (commit SHA),
   `vcs.time` (RFC 3339 build timestamp), and `vcs.modified` (dirty-tree
   flag) from every Go binary's BuildInfo. Surfaced as

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -297,7 +297,7 @@ bag amortizes that cost across all future per-binary-metadata
 milestones — a new key is one `entry.extra_annotations.insert(...)`
 call.
 
-**Consumers shipped (5 — pattern fully validated):**
+**Consumers shipped (6 — pattern fully validated):**
 - Milestone 023 — ELF identity (`mikebom:elf-build-id`,
   `mikebom:elf-runpath`, `mikebom:elf-debuglink`) populated in
   `binary/entry.rs::make_file_level_component` →
@@ -331,13 +331,27 @@ call.
   `mikebom:cargo-auditable-source` and `mikebom:cargo-auditable-kind`
   emit on the per-crate components when they carry non-default
   values (non-registry source / non-runtime kind).
+- Milestone 030 — Mach-O codesign metadata
+  (`mikebom:macho-codesign-identifier`,
+  `mikebom:macho-codesign-flags`, `mikebom:macho-codesign-team-id`)
+  added to the existing `build_macho_identity_annotations` helper.
+  Reads `LC_CODE_SIGNATURE` (cmd `0x1D`) → big-endian SuperBlob
+  (`0xfade0cc0`) → CodeDirectory blob (`0xfade0c02`) via byte-level
+  parsing. Identifier is universal; flags decoded from
+  `CodeDirectory.flags` u32 bitfield (sorted JSON array, unknown
+  bits emit as `unknown-0x<hex>`); team-id only present on
+  CodeDirectory v2.0.5+ for developer-signed binaries (system
+  binaries have `TeamIdentifier=not set`). Same first-slice
+  convention as 024 for fat binaries.
 
 The four binary-format / runtime helpers
 (`build_elf_identity_annotations`,
 `build_macho_identity_annotations`, `build_pe_identity_annotations`,
 `build_cargo_auditable_cross_link`) are merged by the unified
 `build_binary_identity_annotations` → each format's bag-emission
-contract stays co-located with its source struct fields.
+contract stays co-located with its source struct fields. The
+Mach-O helper now owns six fields (the original three identity
+signals from 024 + the three codesign signals from 030).
 
 **Spec discipline:** typed fields stay typed. The bag is for NEW
 per-binary metadata; existing fields like `binary_class`,
@@ -346,8 +360,8 @@ inserted (a typed field's `mikebom:*` name and a bag entry with the
 same name), the parity matrix' `holistic_parity` test catches the
 double-emit at PR time.
 
-**Bag amortization receipts:** five consecutive consumers (023, 024,
-025, 028, 029) shipped with **zero diff** in `package_db/`,
+**Bag amortization receipts:** six consecutive consumers (023, 024,
+025, 028, 029, 030) shipped with **zero diff** in `package_db/`,
 `mikebom-common/`, `cli/`, `resolve/`, `generate/`, and unrelated
 binary-format modules. The 30+ `PackageDbEntry`-init sites are
 untouched by per-binary-metadata work.
@@ -356,8 +370,12 @@ Future milestones inheriting the bag without schema churn: 027
 container layer attribution (`mikebom:layer-id`), the milestone-026.x
 hard-cohort version-string detectors (glibc / musl / V8 — when
 research clears the technical blockers documented in the deferred
-backlog), and follow-on work on signature data (Authenticode for PE,
-codesign for Mach-O — both deferred from their parent milestones).
+backlog), Mach-O entitlements XML extraction (CSMAGIC_EMBEDDED_ENTITLEMENTS,
+deferred from 030), CMS PKCS#7 cert-chain decoding (the leaf-cert
+subject CN, signing time — likely unified with PE Authenticode
+since both need ASN.1 DER parsing), PE DllCharacteristics security
+flags (deferred from 028), and PE Authenticode signing detection
+(deferred from 028 for the dep-cost reason mentioned above).
 
 ## Relevant specs
 
@@ -370,6 +388,7 @@ codesign for Mach-O — both deferred from their parent milestones).
 - `specs/025-go-vcs-metadata/` — Go BuildInfo VCS metadata via the bag (3rd consumer)
 - `specs/028-pe-binary-identity/` — PE CodeView pdb-id + machine + subsystem via the bag (4th consumer; binary trifecta complete)
 - `specs/029-cargo-auditable-extraction/` — cargo-auditable `.dep-v0` manifest extraction → per-crate `pkg:cargo` components + cross-link annotation via the bag (5th consumer)
+- `specs/030-macho-codesign-metadata/` — Mach-O codesign identifier + flags + team-ID via the bag (6th consumer)
 - `.specify/memory/constitution.md` — 12-principle constitution; notable constraints: no C dependencies, no `.unwrap()` in production, generation context always stamped, packageurl-python conformance
 
 ---


### PR DESCRIPTION
## Summary

Mirrors the docs-refresh pattern from PR #51 (023+025), PR #55 (024+028), PR #57 (026), and PR #60 (029) for milestone 030, which extracts Mach-O codesign identifier + flags + team-ID from the `LC_CODE_SIGNATURE` SuperBlob's CodeDirectory.

## What changed

- **`README.md`** — extends the existing Mach-O bullet in the "Compiled-binary identity" section to enumerate the three new codesign annotations alongside the UUID/RPATH/min-OS triple. The summary bumps from "All nine annotations" to "All twelve annotations" and adds "signing-identity provenance" to the consumer-benefit framing.

- **`CHANGELOG.md`** — new `Added` entry at the top of `[Unreleased]` for milestone 030, matching the structure of existing entries. Names the source format (LC_CODE_SIGNATURE → SuperBlob → CodeDirectory), the three signals' universality characteristics (identifier universal; flags + team-id present on developer-signed binaries; absent for Apple-system + ad-hoc), and the deferral of CMS PKCS#7 cert chain decoding + entitlements XML extraction (both queued for a unified follow-on with PE Authenticode since they share the ASN.1 DER parsing requirement).

- **`docs/design-notes.md`**:
  - "Per-component generic annotation bag" consumer list bumps from **5** to **6**.
  - 030 entry documents the byte-level SuperBlob walk + CodeDirectory blob lookup + the team-id CD-version gate (≥ 0x20200) + the system-binary `TeamIdentifier=not set` behavior surfaced during implementation.
  - "Bag amortization receipts" bumps to 6 consecutive consumers.
  - Future-milestones list extended with Mach-O entitlements XML + CMS PKCS#7 cert chain decoding (deferred from 030) and PE DllCharacteristics + Authenticode (deferred from 028).
  - Add 030 spec to "Relevant specs" list.

## Out of scope (kept narrow)

- `docs/ecosystems.md` untouched. Same scoping decision as PR #51 / #55 / #57 / #60: cross-format binary-extraction lives in the README, not in per-ecosystem detail.

## Test plan

- [ ] CI default lane (Linux) green
- [ ] CI ebpf lane green
- [ ] CI macOS lane green
- [ ] `./scripts/pre-pr.sh` clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)