### PR TITLE
feat(031): direct OCI-registry image scan (anonymous-pull MVP, feature-gated)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,6 +2019,7 @@ dependencies = [
  "libc",
  "mikebom-common",
  "object",
+ "oci-client",
  "pem",
  "quick-xml",
  "regex",
@@ -2327,6 +2328,31 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "memchr",
+]
+
+[[package]]
+name = "oci-client"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f5098b86f972ac3484f7c9011bbbbd64aaa7e21d10d2c1a91fefb4ad0ba2ad9"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http 1.4.0",
+ "http-auth",
+ "jwt",
+ "lazy_static",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "unicase",
 ]
 
 [[package]]

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -120,14 +120,21 @@ Walk a directory or extracted container image, produce a CycloneDX SBOM.
 ```bash
 mikebom sbom scan --path ~/.cargo/registry/cache --output cargo.cdx.json
 mikebom sbom scan --image alpine.tar --output alpine.cdx.json
+
+# With --features oci-registry: pull directly from the registry
+# (no `docker save` required)
+cargo install mikebom --features oci-registry
+mikebom sbom scan --image alpine:3.19 --output alpine.cdx.json
+mikebom sbom scan --image gcr.io/distroless/static-debian12:latest \
+    --output distroless.cdx.json
 ```
 
-Exactly one of **`--path <DIR>`** or **`--image <TAR>`** is required.
+Exactly one of **`--path <DIR>`** or **`--image <TAR_OR_REF>`** is required.
 
 | Flag | Default | Purpose |
 |---|---|---|
 | `--path <dir>` | — | Directory to walk recursively. Stream-hashes files with recognised package-artifact suffixes (`.deb`, `.crate`, `.whl`, `.tar.gz`, `.jar`, `.gem`, `.apk`, …). |
-| `--image <tar>` | — | `docker save` tarball. Extracted to a tempdir (OCI whiteouts honoured), then scanned like `--path`. |
+| `--image <tar-or-ref>` | — | Either (a) a `docker save` tarball path on disk, or (b) when built with `--features oci-registry`, an OCI image reference like `alpine:3.19` or `gcr.io/foo/bar@sha256:...`. mikebom auto-detects which based on whether the path exists. Refs are pulled from the registry, layers decompressed, and the resulting tarball is extracted to a tempdir (OCI whiteouts honoured) before being scanned like `--path`. Multi-arch image indexes resolve to `linux/<host-arch>` automatically. Currently anonymous public registries only — auth (Docker keychain + cred helpers) and the `--image-platform <linux/arch>` flag for cross-arch selection are deferred to follow-on milestones (031.x / 031.y). |
 | `--output <[FMT=]PATH>` | per-format default (`mikebom.cdx.json`, `mikebom.spdx.json`, …) | Output path override. Two forms: bare `--output <path>` (applies to the single requested format — rejected with multiple formats) and per-format `--output <fmt>=<path>` (repeatable; each entry retargets one format). The special key `openvex` retargets the OpenVEX sidecar that SPDX emission co-produces when VEX is present — legal only alongside an SPDX format. |
 | `--format <fmt>` | `cyclonedx-json` | See [output formats](#output-formats). Comma-separated list + repeatable flag: `--format cyclonedx-json,spdx-2.3-json` produces both from a single scan. Duplicates dedupe silently. |
 | `--max-file-size <bytes>` | `268435456` (256 MB) | Skip hashing files larger than this |

--- a/mikebom-cli/Cargo.toml
+++ b/mikebom-cli/Cargo.toml
@@ -42,6 +42,30 @@ ebpf-tracing = [
     "mikebom-common/aya-user",
 ]
 
+# Enable direct OCI-registry image scanning. When active, the `--image`
+# CLI flag accepts an OCI image reference (`alpine:3.19`,
+# `gcr.io/foo/bar@sha256:...`, etc.) in addition to the existing
+# docker-save tarball path. The reference is parsed via `oci-client`,
+# the manifest + layer blobs are pulled, gzipped layers are
+# decompressed, and a docker-save-format tarball is written to a
+# tempdir before being routed through the existing extraction path.
+#
+# Requirements when active:
+#   - Network access to the target registry.
+#   - rustls-tls (matches mikebom's existing TLS posture; native-tls
+#     is NOT enabled to keep the dep graph C-free per Principle I).
+#
+# Anonymous public registries only in milestone 031. Auth (Docker
+# keychain + cred helpers) deferred to 031.x; multi-platform flag
+# deferred to 031.y. See
+# `specs/031-oci-registry-image-scan/spec.md` for the full contract.
+#
+# Default builds remain unchanged — the `oci-client` dep and its
+# transitive deps live ONLY in the feature-gated graph.
+oci-registry = [
+    "dep:oci-client",
+]
+
 [dependencies]
 mikebom-common = { path = "../mikebom-common", features = ["std"] }
 
@@ -110,6 +134,14 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+# Milestone 031 — direct OCI-registry image scan. Activated by the
+# `oci-registry` feature only. Pinned with default-features = false +
+# rustls-tls to match mikebom's existing TLS posture (no native-tls,
+# no C deps surfaced via openssl-sys per Principle I). Audited at
+# PR time via `cargo tree -p mikebom --features oci-registry` to
+# verify no `*-sys` transitive deps surface.
+oci-client = { version = "0.12", default-features = false, features = ["rustls-tls"], optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -453,7 +453,7 @@ pub async fn execute(
                         );
                     }
                     tracing::info!(image_ref = %arg_str, "pulling image from registry");
-                    let tempdir = scan_fs::oci_pull::pull_to_tarball(arg_str)?;
+                    let tempdir = scan_fs::oci_pull::pull_to_tarball(arg_str).await?;
                     let tarball = tempdir.path().join("image.tar");
                     _oci_pull_tempdir = Some(tempdir);
                     tarball

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -425,16 +425,54 @@ pub async fn execute(
     // content (the extracted rootfs for --image, or <path>/etc/os-release
     // for a --path root that looks like a rootfs). Explicit
     // `--deb-codename` on the CLI always wins.
+    // Hold any OCI-pull tempdir alive through the `extract` call.
+    // Dropped immediately after `extract` finishes — the tarball
+    // bytes have been read by then and the rootfs lives in its
+    // own tempdir.
+    #[cfg(feature = "oci-registry")]
+    let mut _oci_pull_tempdir: Option<tempfile::TempDir> = None;
+
     let (root_path, target_name, generation_context, auto_codename, _extracted) =
         if let Some(archive) = args.image.as_ref() {
-            if !archive.is_file() {
-                anyhow::bail!(
-                    "--image must point at a docker save tarball: {}",
-                    archive.display()
-                );
-            }
-            tracing::info!(archive = %archive.display(), "extracting docker image");
-            let extracted = scan_fs::docker_image::extract(archive)?;
+            // Milestone 031 — `--image` accepts either a file path
+            // (existing tarball-extract) or an OCI image reference
+            // (new feature-gated registry pull).
+            let archive_path: std::path::PathBuf = if archive.is_file() {
+                archive.clone()
+            } else {
+                #[cfg(feature = "oci-registry")]
+                {
+                    let arg_str = archive.to_str().context(
+                        "--image argument is not valid UTF-8 — required for OCI ref parsing",
+                    )?;
+                    let kind = scan_fs::oci_pull::detect_image_arg_kind(archive);
+                    if kind != scan_fs::oci_pull::ImageArgKind::OciRef {
+                        anyhow::bail!(
+                            "--image argument is neither an existing tarball file nor a parseable OCI image reference: {}",
+                            archive.display()
+                        );
+                    }
+                    tracing::info!(image_ref = %arg_str, "pulling image from registry");
+                    let tempdir = scan_fs::oci_pull::pull_to_tarball(arg_str)?;
+                    let tarball = tempdir.path().join("image.tar");
+                    _oci_pull_tempdir = Some(tempdir);
+                    tarball
+                }
+                #[cfg(not(feature = "oci-registry"))]
+                {
+                    anyhow::bail!(
+                        "--image argument `{}` is not an existing file. \
+                         OCI image references (e.g. `alpine:3.19`) require the \
+                         `oci-registry` Cargo feature to be enabled. Either:\n\
+                         (a) install with `cargo install mikebom --features oci-registry`, or\n\
+                         (b) pre-extract the image with `docker save <ref> -o image.tar` \
+                         and pass `--image image.tar`.",
+                        archive.display()
+                    );
+                }
+            };
+            tracing::info!(archive = %archive_path.display(), "extracting docker image");
+            let extracted = scan_fs::docker_image::extract(&archive_path)?;
             let target = extracted
                 .repo_tag
                 .clone()

--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -11,6 +11,8 @@
 
 pub mod binary;
 pub mod docker_image;
+#[cfg(feature = "oci-registry")]
+pub mod oci_pull;
 pub mod os_release;
 pub mod package_db;
 pub mod walker;

--- a/mikebom-cli/src/scan_fs/oci_pull.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull.rs
@@ -32,7 +32,7 @@ use std::path::Path;
 
 use oci_client::client::{ClientConfig, ImageData};
 use oci_client::manifest::{
-    IMAGE_CONFIG_MEDIA_TYPE, IMAGE_DOCKER_CONFIG_MEDIA_TYPE,
+    ImageIndexEntry, IMAGE_CONFIG_MEDIA_TYPE, IMAGE_DOCKER_CONFIG_MEDIA_TYPE,
     IMAGE_DOCKER_LAYER_GZIP_MEDIA_TYPE, IMAGE_DOCKER_LAYER_TAR_MEDIA_TYPE,
     IMAGE_LAYER_GZIP_MEDIA_TYPE, IMAGE_LAYER_MEDIA_TYPE, IMAGE_MANIFEST_MEDIA_TYPE,
     OCI_IMAGE_MEDIA_TYPE,
@@ -46,10 +46,9 @@ use oci_client::{Client, Reference};
 /// `docker_image::extract` call. The tarball lives at
 /// `<tempdir>/image.tar`.
 ///
-/// `image_ref_label` is the original ref string (e.g.
-/// `alpine:3.19`); it gets recorded as the manifest's
-/// `RepoTags[0]` so the SBOM's subject name carries the
-/// human-readable reference.
+/// `image_ref` is the original ref string (e.g. `alpine:3.19`);
+/// it gets recorded as the manifest's `RepoTags[0]` so the SBOM's
+/// subject name carries the human-readable reference.
 ///
 /// Multi-arch image indexes resolve via oci-client's default
 /// `current_platform_resolver`, which picks the variant matching
@@ -58,18 +57,14 @@ use oci_client::{Client, Reference};
 ///
 /// Anonymous pulls only in milestone 031. Auth handling lives in
 /// the deferred 031.x follow-on.
-pub fn pull_to_tarball(image_ref: &str) -> Result<tempfile::TempDir> {
-    // Async-to-sync bridge: oci-client is tokio-native; mikebom's
-    // CLI scan path is synchronous. Build a current-thread runtime
-    // for the duration of this fn and drop it on exit.
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("building tokio runtime for OCI registry pull")?;
-    runtime.block_on(async { pull_to_tarball_inner(image_ref).await })
-}
-
-async fn pull_to_tarball_inner(image_ref: &str) -> Result<tempfile::TempDir> {
+///
+/// Async by design — mikebom's CLI is already
+/// `#[tokio::main]`-bootstrapped, so callers can `.await` this
+/// directly without bridging. (An earlier draft constructed its
+/// own runtime and panicked with "Cannot start a runtime from
+/// within a runtime" under the existing async-main; making this
+/// async-native sidesteps that.)
+pub async fn pull_to_tarball(image_ref: &str) -> Result<tempfile::TempDir> {
     let reference: Reference = image_ref
         .parse()
         .with_context(|| format!("parsing OCI image reference `{image_ref}`"))?;
@@ -81,10 +76,25 @@ async fn pull_to_tarball_inner(image_ref: &str) -> Result<tempfile::TempDir> {
         "pulling OCI image"
     );
 
+    // Custom platform resolver: always pick `linux/<host-arch>`
+    // regardless of host OS. SBOM scanning of containers is
+    // Linux-bound — even on macOS / Windows hosts we scan Linux
+    // images. oci-client's default `current_platform_resolver`
+    // would look for `darwin/arm64` on macOS, which never matches
+    // a Linux-only image like distroless.
+    let host_arch = host_oci_arch()
+        .context("mapping host architecture to OCI platform name")?;
     let config = ClientConfig {
-        // The current-platform resolver is the default in
-        // ClientConfig::default(); construct via .. to keep
-        // forward-compat if oci-client adds more fields.
+        platform_resolver: Some(Box::new(move |entries: &[ImageIndexEntry]| {
+            entries
+                .iter()
+                .find(|e| {
+                    e.platform.as_ref().is_some_and(|p| {
+                        p.os == "linux" && p.architecture == host_arch
+                    })
+                })
+                .map(|e| e.digest.clone())
+        })),
         ..ClientConfig::default()
     };
     let client = Client::new(config);

--- a/mikebom-cli/src/scan_fs/oci_pull.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull.rs
@@ -26,7 +26,19 @@
 //! `block_on(...)` to bridge — keeping the rest of the CLI path
 //! unchanged. The runtime is dropped on function exit.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+use std::io::{Read, Write};
+use std::path::Path;
+
+use oci_client::client::{ClientConfig, ImageData};
+use oci_client::manifest::{
+    IMAGE_CONFIG_MEDIA_TYPE, IMAGE_DOCKER_CONFIG_MEDIA_TYPE,
+    IMAGE_DOCKER_LAYER_GZIP_MEDIA_TYPE, IMAGE_DOCKER_LAYER_TAR_MEDIA_TYPE,
+    IMAGE_LAYER_GZIP_MEDIA_TYPE, IMAGE_LAYER_MEDIA_TYPE, IMAGE_MANIFEST_MEDIA_TYPE,
+    OCI_IMAGE_MEDIA_TYPE,
+};
+use oci_client::secrets::RegistryAuth;
+use oci_client::{Client, Reference};
 
 /// Pull an OCI image reference and write a docker-save-format
 /// tarball to a tempdir. Returns the TempDir handle so the
@@ -34,25 +46,244 @@ use anyhow::{anyhow, Result};
 /// `docker_image::extract` call. The tarball lives at
 /// `<tempdir>/image.tar`.
 ///
-/// `target_arch` is an OCI platform-arch name (e.g. `amd64`,
-/// `arm64`). Use [`host_oci_arch`] to get the appropriate value
-/// for the current host.
+/// `image_ref_label` is the original ref string (e.g.
+/// `alpine:3.19`); it gets recorded as the manifest's
+/// `RepoTags[0]` so the SBOM's subject name carries the
+/// human-readable reference.
+///
+/// Multi-arch image indexes resolve via oci-client's default
+/// `current_platform_resolver`, which picks the variant matching
+/// `std::env::consts::ARCH/OS`. Cross-arch selection deferred
+/// to milestone 031.y (`--image-platform` flag).
 ///
 /// Anonymous pulls only in milestone 031. Auth handling lives in
 /// the deferred 031.x follow-on.
-#[allow(dead_code)] // wired in commit 2 (031/cli-dispatch-and-pull)
-pub fn pull_to_tarball(
-    _image_ref: &str,
-    _target_arch: &str,
-) -> Result<tempfile::TempDir> {
-    // Filled in commit 2 (031/cli-dispatch-and-pull). This stub
-    // exists in commit 1 so the workspace build matrix passes
-    // for both the feature-on and feature-off cases — and so
-    // dep-audit failures surface independently of any behavior
-    // bugs in the implementation.
-    Err(anyhow!(
-        "oci_pull::pull_to_tarball is not yet implemented (filled in milestone 031 commit 2)"
-    ))
+pub fn pull_to_tarball(image_ref: &str) -> Result<tempfile::TempDir> {
+    // Async-to-sync bridge: oci-client is tokio-native; mikebom's
+    // CLI scan path is synchronous. Build a current-thread runtime
+    // for the duration of this fn and drop it on exit.
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime for OCI registry pull")?;
+    runtime.block_on(async { pull_to_tarball_inner(image_ref).await })
+}
+
+async fn pull_to_tarball_inner(image_ref: &str) -> Result<tempfile::TempDir> {
+    let reference: Reference = image_ref
+        .parse()
+        .with_context(|| format!("parsing OCI image reference `{image_ref}`"))?;
+    tracing::info!(
+        registry = %reference.resolve_registry(),
+        repository = %reference.repository(),
+        tag = ?reference.tag(),
+        digest = ?reference.digest(),
+        "pulling OCI image"
+    );
+
+    let config = ClientConfig {
+        // The current-platform resolver is the default in
+        // ClientConfig::default(); construct via .. to keep
+        // forward-compat if oci-client adds more fields.
+        ..ClientConfig::default()
+    };
+    let client = Client::new(config);
+    let auth = RegistryAuth::Anonymous;
+    // Tell the registry which media types we accept. We accept
+    // both Docker v2 and OCI manifest types, plus tar and gzipped
+    // tar layer types. zstd-compressed layers (a separate OCI
+    // media type) are NOT accepted — registries that prefer
+    // those will return them anyway, in which case
+    // `assert_layers_supported` below catches it with a clear
+    // "not yet supported" error per FR-009.
+    let accepted = vec![
+        IMAGE_MANIFEST_MEDIA_TYPE,
+        OCI_IMAGE_MEDIA_TYPE,
+        IMAGE_LAYER_MEDIA_TYPE,
+        IMAGE_LAYER_GZIP_MEDIA_TYPE,
+        IMAGE_DOCKER_LAYER_TAR_MEDIA_TYPE,
+        IMAGE_DOCKER_LAYER_GZIP_MEDIA_TYPE,
+        IMAGE_CONFIG_MEDIA_TYPE,
+        IMAGE_DOCKER_CONFIG_MEDIA_TYPE,
+    ];
+    let image: ImageData = client
+        .pull(&reference, &auth, accepted)
+        .await
+        .with_context(|| format!("pulling image `{image_ref}`"))?;
+
+    assert_layers_supported(&image)?;
+
+    let tempdir = tempfile::Builder::new()
+        .prefix("mikebom-oci-pull-")
+        .tempdir()
+        .context("creating tempdir for OCI pull tarball")?;
+    let tarball_path = tempdir.path().join("image.tar");
+    assemble_docker_save_tarball(&image, image_ref, &tarball_path)
+        .context("assembling docker-save-format tarball from pulled image")?;
+    Ok(tempdir)
+}
+
+/// Reject layers we can't decompress. zstd is the main risk in
+/// modern OCI images.
+fn assert_layers_supported(image: &ImageData) -> Result<()> {
+    for (idx, layer) in image.layers.iter().enumerate() {
+        match layer.media_type.as_str() {
+            // Plain tar — no decompression needed.
+            IMAGE_LAYER_MEDIA_TYPE | IMAGE_DOCKER_LAYER_TAR_MEDIA_TYPE => {}
+            // Gzipped tar — handled by `flate2::read::GzDecoder`.
+            IMAGE_LAYER_GZIP_MEDIA_TYPE | IMAGE_DOCKER_LAYER_GZIP_MEDIA_TYPE => {}
+            other => {
+                return Err(anyhow!(
+                    "image layer {idx} has unsupported media type `{other}`. \
+                     Milestone 031 supports plain tar and gzipped tar; zstd-compressed \
+                     and other layer types are deferred to a future milestone."
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Build a `docker save`-format tarball at `out_path` from the
+/// pulled image data. The format (per moby's image-spec):
+///
+/// - `manifest.json`: top-level array with one entry containing
+///   `Config`, `RepoTags`, `Layers`.
+/// - `<config-digest>.json`: the image config JSON blob.
+/// - `<layer-digest>/layer.tar`: per-layer plain-tar bytes.
+///
+/// We name layer files by their **uncompressed** tar's SHA-256.
+/// That's what `docker_image::extract` expects: it reads each
+/// `Layers[]` entry as a plain tar file.
+fn assemble_docker_save_tarball(
+    image: &ImageData,
+    image_ref: &str,
+    out_path: &Path,
+) -> Result<()> {
+    let out = std::fs::File::create(out_path)
+        .with_context(|| format!("creating tarball at {}", out_path.display()))?;
+    let mut builder = tar::Builder::new(std::io::BufWriter::new(out));
+
+    // Decompress each layer (if needed) and stage the resulting
+    // tar bytes for inclusion. Note the digest tracked here is the
+    // digest of the UNCOMPRESSED tar — that's what docker save
+    // names the file by, even when the original layer descriptor's
+    // digest was the gzipped form.
+    let mut layer_paths_for_manifest: Vec<String> = Vec::new();
+    let mut staged_layers: Vec<(String, Vec<u8>)> = Vec::new();
+    for layer in &image.layers {
+        let decompressed = decompress_layer(layer)?;
+        let digest = sha256_hex(&decompressed);
+        let layer_path_in_tarball = format!("{digest}/layer.tar");
+        layer_paths_for_manifest.push(layer_path_in_tarball.clone());
+        staged_layers.push((layer_path_in_tarball, decompressed));
+    }
+
+    // Stage the config JSON.
+    let config_digest = sha256_hex(&image.config.data);
+    let config_filename = format!("{config_digest}.json");
+
+    // manifest.json
+    let manifest_json = serde_json::json!([
+        {
+            "Config": config_filename,
+            "RepoTags": [image_ref],
+            "Layers": layer_paths_for_manifest,
+        }
+    ]);
+    let manifest_bytes = serde_json::to_vec(&manifest_json)
+        .context("serializing manifest.json")?;
+    append_tarball_entry(&mut builder, "manifest.json", &manifest_bytes)?;
+
+    // <config-digest>.json — config blob.
+    append_tarball_entry(&mut builder, &config_filename, &image.config.data)?;
+
+    // Per-layer entries.
+    for (layer_path, layer_bytes) in &staged_layers {
+        append_tarball_entry(&mut builder, layer_path, layer_bytes)?;
+    }
+
+    let buf_writer = builder
+        .into_inner()
+        .context("finalizing tarball (tar::Builder::into_inner)")?;
+    let mut file = buf_writer
+        .into_inner()
+        .map_err(|e| anyhow!("BufWriter flush failed: {e}"))?;
+    file.flush().context("flushing tarball file")?;
+    file.sync_all().context("sync_all on tarball file")?;
+    Ok(())
+}
+
+fn append_tarball_entry<W: Write>(
+    builder: &mut tar::Builder<W>,
+    path: &str,
+    bytes: &[u8],
+) -> Result<()> {
+    let mut header = tar::Header::new_gnu();
+    header.set_size(bytes.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder
+        .append_data(&mut header, path, bytes)
+        .with_context(|| format!("appending {path} to tarball"))?;
+    Ok(())
+}
+
+fn decompress_layer(layer: &oci_client::client::ImageLayer) -> Result<Vec<u8>> {
+    match layer.media_type.as_str() {
+        IMAGE_LAYER_MEDIA_TYPE | IMAGE_DOCKER_LAYER_TAR_MEDIA_TYPE => Ok(layer.data.clone()),
+        IMAGE_LAYER_GZIP_MEDIA_TYPE | IMAGE_DOCKER_LAYER_GZIP_MEDIA_TYPE => {
+            let mut decoder = flate2::read::GzDecoder::new(layer.data.as_slice());
+            let mut out = Vec::new();
+            decoder
+                .read_to_end(&mut out)
+                .context("decompressing gzipped layer")?;
+            Ok(out)
+        }
+        other => Err(anyhow!(
+            "unexpected layer media type `{other}` (should have been caught by assert_layers_supported)"
+        )),
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+/// Distinguish a `--image` argument as either a path on disk
+/// (existing tarball-extract path) or an OCI image reference
+/// (the new registry-pull path).
+///
+/// Detection rules (priority order):
+///  1. If a file exists at the given path → treat as tarball.
+///  2. Else if the string parses as `Reference` → treat as ref.
+///  3. Else → return `Invalid` so the caller can surface a clear
+///     "neither a file nor a parseable image ref" error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ImageArgKind {
+    /// Path to a docker-save-format tarball on disk.
+    Path,
+    /// OCI image reference (e.g. `alpine:3.19`).
+    OciRef,
+    /// Neither — error.
+    Invalid,
+}
+
+pub fn detect_image_arg_kind(arg: &Path) -> ImageArgKind {
+    if arg.is_file() {
+        return ImageArgKind::Path;
+    }
+    let s = match arg.to_str() {
+        Some(s) => s,
+        None => return ImageArgKind::Invalid,
+    };
+    match s.parse::<Reference>() {
+        Ok(_) => ImageArgKind::OciRef,
+        Err(_) => ImageArgKind::Invalid,
+    }
 }
 
 /// Map `std::env::consts::ARCH` to an OCI platform-arch name. The
@@ -99,6 +330,149 @@ mod tests {
             ["amd64", "arm64", "arm", "riscv64", "ppc64le", "s390x"].contains(&arch),
             "unexpected OCI arch `{arch}` for std::env::consts::ARCH = {}",
             std::env::consts::ARCH,
+        );
+    }
+
+    #[test]
+    fn detect_image_arg_kind_recognizes_existing_file_as_path() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        // Newly-created tempfile exists on disk → Path.
+        assert_eq!(detect_image_arg_kind(tmp.path()), ImageArgKind::Path);
+    }
+
+    #[test]
+    fn detect_image_arg_kind_recognizes_typical_image_refs() {
+        // Common shapes: `name:tag`, `lib/name:tag`, `host/name:tag`,
+        // `host/path/name@sha256:...`. None of these exist as files.
+        let cases = &[
+            "alpine:3.19",
+            "library/alpine:3.19",
+            "docker.io/library/alpine:3.19",
+            "gcr.io/distroless/static-debian12:latest",
+            "ghcr.io/foo/bar@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        ];
+        for case in cases {
+            let p = Path::new(case);
+            assert_eq!(
+                detect_image_arg_kind(p),
+                ImageArgKind::OciRef,
+                "expected OciRef for `{case}`",
+            );
+        }
+    }
+
+    #[test]
+    fn detect_image_arg_kind_rejects_garbage() {
+        let p = Path::new("");
+        assert_eq!(detect_image_arg_kind(p), ImageArgKind::Invalid);
+    }
+
+    /// Build a synthetic ImageData from hand-crafted fake layers +
+    /// a fake config blob, run `assemble_docker_save_tarball`, and
+    /// assert the resulting tarball is parseable by
+    /// `docker_image::extract` AND yields the expected file in the
+    /// rootfs.
+    #[test]
+    fn assemble_docker_save_tarball_round_trips_via_extract() {
+        use crate::scan_fs::docker_image;
+        use oci_client::client::{Config, ImageLayer};
+
+        // Build a synthetic 2-file tar bytes for a "layer". The
+        // simplest layer: a tar archive containing one file named
+        // `etc/os-release` with a known body.
+        let layer_uncompressed = {
+            let mut builder = tar::Builder::new(Vec::<u8>::new());
+            let body = b"ID=mikebom-test\nVERSION=0\n";
+            let mut header = tar::Header::new_gnu();
+            header.set_path("etc/os-release").unwrap();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append(&header, body.as_ref()).unwrap();
+            builder.into_inner().unwrap()
+        };
+
+        // Gzip-compress the layer to simulate a real registry layer
+        // (gzipped tar is the most common shape).
+        let layer_compressed = {
+            use std::io::Write;
+            let mut encoder = flate2::write::GzEncoder::new(
+                Vec::<u8>::new(),
+                flate2::Compression::default(),
+            );
+            encoder.write_all(&layer_uncompressed).unwrap();
+            encoder.finish().unwrap()
+        };
+
+        // Synthetic config blob (just a small JSON object — extract
+        // doesn't read its contents, only references the filename
+        // via manifest.json's Config field).
+        let config_data = b"{\"architecture\":\"amd64\",\"os\":\"linux\"}".to_vec();
+
+        let image = ImageData {
+            layers: vec![ImageLayer {
+                data: layer_compressed,
+                media_type: IMAGE_LAYER_GZIP_MEDIA_TYPE.to_string(),
+                annotations: None,
+            }],
+            digest: Some("sha256:fake".to_string()),
+            config: Config {
+                data: config_data,
+                media_type: IMAGE_CONFIG_MEDIA_TYPE.to_string(),
+                annotations: None,
+            },
+            manifest: None,
+        };
+
+        // Emit the tarball, then extract it.
+        let tempdir = tempfile::tempdir().unwrap();
+        let tarball = tempdir.path().join("image.tar");
+        assemble_docker_save_tarball(&image, "test/sample:latest", &tarball)
+            .expect("tarball assembly should succeed");
+        assert!(tarball.exists(), "tarball file was not created");
+
+        let extracted = docker_image::extract(&tarball)
+            .expect("extract should accept the assembled tarball");
+
+        // Verify the layer's content reached the rootfs.
+        let os_release = extracted.rootfs.join("etc/os-release");
+        assert!(
+            os_release.exists(),
+            "etc/os-release missing from extracted rootfs"
+        );
+        let body = std::fs::read_to_string(&os_release).unwrap();
+        assert!(
+            body.contains("ID=mikebom-test"),
+            "os-release body unexpected: {body:?}"
+        );
+
+        // RepoTags round-trip — what we passed in should come back.
+        assert_eq!(extracted.repo_tag.as_deref(), Some("test/sample:latest"));
+    }
+
+    #[test]
+    fn assert_layers_supported_rejects_zstd() {
+        use oci_client::client::{Config, ImageLayer};
+
+        let image = ImageData {
+            layers: vec![ImageLayer {
+                data: vec![0u8; 16],
+                media_type: "application/vnd.oci.image.layer.v1.tar+zstd".to_string(),
+                annotations: None,
+            }],
+            digest: None,
+            config: Config {
+                data: Vec::new(),
+                media_type: IMAGE_CONFIG_MEDIA_TYPE.to_string(),
+                annotations: None,
+            },
+            manifest: None,
+        };
+        let err = assert_layers_supported(&image).unwrap_err();
+        assert!(
+            err.to_string().contains("zstd")
+                || err.to_string().contains("unsupported media type"),
+            "expected zstd-related error; got: {err}"
         );
     }
 }

--- a/mikebom-cli/src/scan_fs/oci_pull.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull.rs
@@ -1,0 +1,104 @@
+//! OCI registry image pull (milestone 031).
+//!
+//! This module is gated behind the default-off `oci-registry` Cargo
+//! feature. When enabled, the `--image <ref>` CLI argument accepts
+//! an OCI image reference (e.g. `alpine:3.19`,
+//! `gcr.io/foo/bar@sha256:...`) in addition to the existing
+//! docker-save tarball path. The reference is parsed via
+//! `oci_client::Reference`, the manifest + layer blobs are pulled,
+//! gzipped layers are decompressed, and a docker-save-format
+//! tarball is written to a tempdir before being routed through the
+//! existing `scan_fs::docker_image::extract` path.
+//!
+//! Sub-scope (milestone 031):
+//!   * Anonymous public registries only.
+//!   * Host-arch image selection only (no `--image-platform` flag).
+//!   * Gzipped layers only (zstd → clear "not yet supported" error).
+//!
+//! Deferred:
+//!   * 031.x — authenticated pulls (Docker keychain + cred helpers).
+//!   * 031.y — `--image-platform linux/arch` flag.
+//!   * 031.z — layer caching.
+//!
+//! Async-to-sync bridge: `oci-client` is async/tokio-native;
+//! mikebom's CLI scan path is synchronous. We construct a
+//! `tokio::runtime::Runtime` inside `pull_to_tarball` and use
+//! `block_on(...)` to bridge — keeping the rest of the CLI path
+//! unchanged. The runtime is dropped on function exit.
+
+use anyhow::{anyhow, Result};
+
+/// Pull an OCI image reference and write a docker-save-format
+/// tarball to a tempdir. Returns the TempDir handle so the
+/// caller can keep it alive through the subsequent
+/// `docker_image::extract` call. The tarball lives at
+/// `<tempdir>/image.tar`.
+///
+/// `target_arch` is an OCI platform-arch name (e.g. `amd64`,
+/// `arm64`). Use [`host_oci_arch`] to get the appropriate value
+/// for the current host.
+///
+/// Anonymous pulls only in milestone 031. Auth handling lives in
+/// the deferred 031.x follow-on.
+#[allow(dead_code)] // wired in commit 2 (031/cli-dispatch-and-pull)
+pub fn pull_to_tarball(
+    _image_ref: &str,
+    _target_arch: &str,
+) -> Result<tempfile::TempDir> {
+    // Filled in commit 2 (031/cli-dispatch-and-pull). This stub
+    // exists in commit 1 so the workspace build matrix passes
+    // for both the feature-on and feature-off cases — and so
+    // dep-audit failures surface independently of any behavior
+    // bugs in the implementation.
+    Err(anyhow!(
+        "oci_pull::pull_to_tarball is not yet implemented (filled in milestone 031 commit 2)"
+    ))
+}
+
+/// Map `std::env::consts::ARCH` to an OCI platform-arch name. The
+/// OCI image-spec uses Go's GOARCH naming (`amd64`, `arm64`,
+/// `arm`, `riscv64`, etc.) which differs from Rust's `ARCH`
+/// constant (`x86_64`, `aarch64`, etc.).
+///
+/// Returns an error for unmapped host architectures so the
+/// caller can surface a clear "host arch X not supported, please
+/// use --image-platform <linux/...> when 031.y ships" message.
+#[allow(dead_code)] // wired in commit 2 (031/cli-dispatch-and-pull)
+pub fn host_oci_arch() -> Result<&'static str> {
+    Ok(match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        "arm" => "arm",
+        "riscv64" => "riscv64",
+        "powerpc64" => "ppc64le", // typical OCI naming
+        "s390x" => "s390x",
+        other => {
+            return Err(anyhow!(
+                "host architecture `{other}` not mapped to an OCI platform name; \
+                 milestone 031 supports x86_64/aarch64/arm/riscv64/powerpc64/s390x. \
+                 Cross-arch image pulls (`--image-platform linux/<arch>`) deferred to milestone 031.y."
+            ));
+        }
+    })
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_oci_arch_returns_a_known_value_for_typical_hosts() {
+        // CI runs on x86_64 (Linux) and aarch64 (macOS arm). Both
+        // must map cleanly. Other hosts may be unmapped — we don't
+        // assert a specific value to keep the test cross-platform.
+        let arch = host_oci_arch();
+        assert!(arch.is_ok(), "host_oci_arch failed: {arch:?}");
+        let arch = arch.unwrap();
+        assert!(
+            ["amd64", "arm64", "arm", "riscv64", "ppc64le", "s390x"].contains(&arch),
+            "unexpected OCI arch `{arch}` for std::env::consts::ARCH = {}",
+            std::env::consts::ARCH,
+        );
+    }
+}

--- a/mikebom-cli/tests/no_c_dependencies.rs
+++ b/mikebom-cli/tests/no_c_dependencies.rs
@@ -40,38 +40,60 @@ const BLACKLIST: &[&str] = &[
     "libsqlite3-sys",
     "openssl-sys",
     "c-bindings",
+    // Milestone 031 — when adding the optional `oci-registry` feature
+    // we discovered that newer oci-client versions transitively bring
+    // in `aws-lc-sys` (a `*-sys` crate wrapping the AWS-LC C library)
+    // via newer rustls's switched-default crypto provider. We pinned
+    // `oci-client = "0.12"` to stay on rustls's older ring-based
+    // default. Adding `aws-lc-sys` to the blacklist locks in that
+    // decision: future oci-client version bumps that pull aws-lc
+    // back fail this test at PR time. See
+    // specs/031-oci-registry-image-scan/spec.md FR-005 / SC-005.
+    "aws-lc-sys",
 ];
 
-#[test]
-fn no_c_dependencies_in_tree() {
+fn assert_no_c_deps(extra_args: &[&str], profile_label: &str) {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let output = Command::new("cargo")
-        .arg("tree")
-        .arg("-p")
-        .arg("mikebom")
-        .arg("-e")
-        .arg("normal")
+    let mut cmd = Command::new("cargo");
+    cmd.arg("tree").arg("-p").arg("mikebom").arg("-e").arg("normal");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let output = cmd
         .current_dir(manifest_dir)
         .output()
         .expect("cargo tree should run");
     assert!(
         output.status.success(),
-        "cargo tree failed: stderr={}",
+        "cargo tree {profile_label} failed: stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
     let tree = String::from_utf8_lossy(&output.stdout);
     let matches: Vec<&str> = tree
         .lines()
-        .filter(|line| {
-            BLACKLIST.iter().any(|needle| line.contains(needle))
-        })
+        .filter(|line| BLACKLIST.iter().any(|needle| line.contains(needle)))
         .collect();
     assert!(
         matches.is_empty(),
-        "Principle I violation: C-backed crate found in dep tree:\n{}\n\
+        "Principle I violation in {profile_label} tree: C-backed crate found:\n{}\n\
          Full blacklist: {:?}\n\
          See specs/003-multi-ecosystem-expansion/tasks.md T001 for the rationale.",
         matches.join("\n"),
         BLACKLIST,
     );
+}
+
+#[test]
+fn no_c_dependencies_in_tree() {
+    assert_no_c_deps(&[], "default-profile");
+}
+
+/// Milestone 031 — also audit the feature-on tree so future bumps of
+/// oci-client (or other gated deps) that re-introduce a C-backed
+/// crate fail this test at PR time. The default-profile audit above
+/// would not catch them since the feature-gated deps don't appear
+/// when `cargo tree` is invoked without `--features`.
+#[test]
+fn no_c_dependencies_in_oci_registry_feature_tree() {
+    assert_no_c_deps(&["--features", "oci-registry"], "oci-registry-feature");
 }

--- a/mikebom-cli/tests/oci_registry_smoke.rs
+++ b/mikebom-cli/tests/oci_registry_smoke.rs
@@ -1,0 +1,137 @@
+//! Network-gated end-to-end smoke test for milestone 031.
+//!
+//! This test pulls a real public OCI image from a real registry,
+//! runs it through the full mikebom pipeline (oci_pull →
+//! docker_image::extract → scan → SBOM emission), and verifies the
+//! output is well-formed. It runs ONLY when:
+//!
+//!   1. The crate is built with `--features oci-registry`, AND
+//!   2. The `MIKEBOM_OCI_NETWORK_TESTS=1` env var is set.
+//!
+//! The default Linux + ebpf + macOS CI lanes do NOT set the env
+//! var, so this test is silently skipped on every standard PR. A
+//! follow-on milestone may add a dedicated `lint-and-test-oci-network`
+//! job that flips it on; for milestone 031 it ships as opt-in only.
+//!
+//! To run locally:
+//!
+//! ```sh
+//! MIKEBOM_OCI_NETWORK_TESTS=1 cargo +stable test \
+//!     -p mikebom --features oci-registry --test oci_registry_smoke
+//! ```
+
+#![cfg(feature = "oci-registry")]
+
+use std::process::Command;
+
+fn network_tests_enabled() -> bool {
+    std::env::var("MIKEBOM_OCI_NETWORK_TESTS").ok().as_deref() == Some("1")
+}
+
+#[test]
+fn pulls_alpine_3_19_and_emits_apk_components() {
+    if !network_tests_enabled() {
+        eprintln!(
+            "skipping: set MIKEBOM_OCI_NETWORK_TESTS=1 to run network-gated smoke tests"
+        );
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("alpine.cdx.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_mikebom"))
+        .arg("--offline") // VEX/CD enrichment off; pure registry pull
+        .arg("sbom")
+        .arg("scan")
+        .arg("--image")
+        .arg("alpine:3.19")
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(&out_path)
+        .output()
+        .expect("mikebom should run");
+    assert!(
+        output.status.success(),
+        "mikebom failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let bytes = std::fs::read(&out_path).expect("read alpine.cdx.json");
+    let sbom: serde_json::Value = serde_json::from_slice(&bytes).expect("valid CDX JSON");
+    let components = sbom["components"]
+        .as_array()
+        .expect("CDX components array");
+    // Alpine 3.19 base image has ~15-20 apk packages; we
+    // intentionally don't pin the exact count to avoid breaking
+    // when alpine bumps a minor version. Just assert non-empty
+    // and at least one well-formed apk PURL.
+    assert!(
+        !components.is_empty(),
+        "alpine:3.19 should yield ≥1 component; got 0"
+    );
+    let has_apk_purl = components.iter().any(|c| {
+        c["purl"]
+            .as_str()
+            .is_some_and(|p| p.starts_with("pkg:apk/alpine/"))
+    });
+    assert!(
+        has_apk_purl,
+        "alpine:3.19 should yield at least one pkg:apk/alpine/* PURL; got components: {}",
+        serde_json::to_string_pretty(&components).unwrap_or_default()
+    );
+}
+
+#[test]
+fn pulls_distroless_static_and_emits_well_formed_sbom_with_zero_components() {
+    if !network_tests_enabled() {
+        eprintln!(
+            "skipping: set MIKEBOM_OCI_NETWORK_TESTS=1 to run network-gated smoke tests"
+        );
+        return;
+    }
+
+    // distroless static images intentionally ship with NO package
+    // manager metadata. mikebom should produce a well-formed SBOM
+    // with zero components — that's the correct behavior, not a
+    // bug. Anything else (panic, error, hallucinated components)
+    // is a regression.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("distroless.cdx.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_mikebom"))
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--image")
+        .arg("gcr.io/distroless/static-debian12:latest")
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(&out_path)
+        .output()
+        .expect("mikebom should run");
+    assert!(
+        output.status.success(),
+        "mikebom failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let bytes = std::fs::read(&out_path).expect("read distroless.cdx.json");
+    let sbom: serde_json::Value = serde_json::from_slice(&bytes).expect("valid CDX JSON");
+    // SBOM is well-formed — the fields we care about are present.
+    assert!(sbom["bomFormat"].as_str().is_some(), "missing bomFormat");
+    assert!(
+        sbom["specVersion"].as_str().is_some(),
+        "missing specVersion"
+    );
+    assert!(
+        sbom["serialNumber"].as_str().is_some(),
+        "missing serialNumber"
+    );
+    // Zero components is the correct outcome here.
+    let components = sbom["components"].as_array().map(|c| c.len()).unwrap_or(0);
+    assert_eq!(
+        components, 0,
+        "distroless static image should yield 0 components (it ships no package metadata); got {components}"
+    );
+}

--- a/specs/031-oci-registry-image-scan/checklists/requirements.md
+++ b/specs/031-oci-registry-image-scan/checklists/requirements.md
@@ -1,0 +1,140 @@
+# Spec Quality Checklist: OCI Registry Image Scan
+
+**Checklist for** `/specs/031-oci-registry-image-scan/spec.md`
+
+## Coverage
+
+- [X] Background section explains the UX gap (syft/trivy
+      take refs directly, mikebom takes only tarballs) + cites
+      file:line evidence for the integration seam (`scan_fs/docker_image.rs:70`
+      for extract; `scan_cmd.rs:429` for current --image
+      dispatch; `Cargo.toml:15` for reqwest+rustls).
+- [X] User story has a P-priority (P1 — UX gap) and a "why
+      this priority" justification grounded in real-world
+      adoption friction.
+- [X] Independent Test is concrete (specific build commands +
+      observable end-to-end behavior).
+- [X] Acceptance scenarios use Given/When/Then framing (5
+      scenarios covering anon pull, path-vs-ref dispatch,
+      feature-off error, registry-failure error, and
+      multi-platform).
+- [X] Edge Cases section names corner cases (no-tag default,
+      digest refs, registry hostnames, gzipped layers, layer
+      digest verification, anonymous-only scope, multi-arch
+      host-arch-only, async runtime bridge).
+- [X] Functional Requirements numbered (FR-001 through FR-013).
+- [X] Key Entities — `oci_pull::pull_to_tarball` signature
+      specified inline in FR-002.
+- [X] Success Criteria measurable (SC-001 through SC-008),
+      each with a verification mechanism.
+- [X] Clarifications section captures the 6 scope decisions
+      (default-off feature gate; pull-then-scan vs streaming;
+      anonymous-only deferral; host-arch-only deferral; no
+      caching; async-to-sync bridge).
+- [X] Out of Scope explicitly names every adjacent concern with
+      named follow-on milestones (031.x / 031.y / 031.z) and
+      indefinite-defer items (zstd layers, daemon socket,
+      streaming, signature verification).
+
+## Tighter spec set rationale (4 files vs 8)
+
+- [X] No `research.md` — the dep-choice analysis (`oci-client`
+      rationale + rejected alternatives) lives in plan.md
+      Architecture / Crate choice section. The recon was
+      thorough enough to commit to a crate without a separate
+      research doc.
+- [X] No `data-model.md` — only one new public fn signature +
+      one helper struct kind (an `ImageArgKind` enum), specified
+      inline in FRs.
+- [X] No `contracts/` — the only public-API change is the CLI
+      `--image` flag's expanded shape, fully specified in FR-004.
+- [X] No `quickstart.md` — 4 short files self-explanatory.
+
+This is the **10th use** of the 4-file template (after 021,
+022, 023, 024, 025, 026, 028, 029, 030). Pattern fully
+validated even for milestones with new feature gates and new
+crate deps.
+
+## Independence
+
+- [X] Single user story self-contained.
+- [X] Each per-commit deliverable (3 commits) independently
+      verifiable (per FR-013 each commit's pre-PR passes both
+      build profiles).
+- [X] **Sub-scoping discipline**: anonymous-only / host-arch-only
+      keep this milestone shippable in ~3 days. Auth + multi-arch
+      / caching tracked as 031.x / 031.y / 031.z. Avoids the
+      milestone-grows-under-foot pattern.
+
+## Concreteness
+
+- [X] FRs cite specific file paths and line numbers.
+- [X] FR-001 names the exact Cargo feature name (`oci-registry`)
+      and the exact dep entry shape.
+- [X] FR-002 names the exact public-fn signature.
+- [X] FR-004 specifies the dispatch logic with the four
+      branches enumerated.
+- [X] FR-007/008/009 name the exact error-message shape for
+      the three categories (auth not supported, multi-arch
+      missing match, zstd layers).
+- [X] SC-005 quantifies the dep-audit bar (no `*-sys` / `*-c`
+      transitive deps surface).
+- [X] SC-008 names the verification image
+      (`gcr.io/distroless/static-debian12:latest`) — chosen for
+      stability + small size + permissive license + public
+      anonymous availability.
+
+## Internal consistency
+
+- [X] FR-002 (oci_pull module) + FR-004 (CLI dispatch) + FR-005
+      (TempDir lifetime) + FR-006 (error propagation) flow
+      end-to-end.
+- [X] Deferred items in Out of Scope (031.x auth, 031.y
+      multi-arch flag, 031.z caching) align with FR-007 / FR-008
+      / FR-009's "not yet supported" error messages — users see
+      the same scope boundary in the error path that the spec
+      documents in prose.
+- [X] Edge Case "async runtime bridge" aligns with plan.md's R4
+      and the FR-002 implementation sketch in tasks T010.
+
+## Lessons from milestones 016-030
+
+- [X] FR-013 carries the per-commit-clean discipline,
+      extended to dual-profile (default + feature-on).
+- [X] **Feature-gate precedent**: matches milestone 020's
+      `ebpf-tracing` feature gate. Same shape: opt-in capability,
+      transitive deps gated, default profile stays slim.
+- [X] **Dep-discipline lesson from 029**: 029 was zero-new-deps;
+      this milestone introduces a new dep but with a feature
+      gate. The audit step (T006) preserves Principle I
+      enforcement.
+- [X] **Sub-scope discipline lesson from 026**: 026 explicitly
+      sub-scoped from 7 libraries to easy-4 with the rest as
+      026.x. This milestone applies the same pattern (anon-only
+      / host-arch-only with 031.x and 031.y as named follow-ons).
+- [X] Recon-first: every claim grounded in pre-spec recon at
+      file:line level.
+
+## Pre-implementation
+
+- [X] [PHASE-1] T001 reconnaissance done (2026-04-28).
+- [ ] [PHASE-1] T002 baseline snapshot captured.
+- [ ] [PHASE-2] Commit 1 (feature gate + dep audit + stub) landed.
+- [ ] [PHASE-3] Commit 2 (oci_pull module + CLI dispatch + tests)
+      landed.
+- [ ] [PHASE-4] Commit 3 (smoke test + docs) landed.
+- [ ] [POLISH] SC-001-SC-008 verified.
+- [ ] [POLISH] All 3 standard CI lanes green on default profile.
+- [ ] [POLISH] Manual end-to-end smoke test against
+      `gcr.io/distroless/static-debian12:latest` succeeds.
+
+## Post-merge
+
+- [ ] [QUALITATIVE] Next time someone wants to demo mikebom
+      against a public image, they run
+      `cargo install mikebom --features oci-registry` then
+      `mikebom sbom scan --image alpine:3.19` — same UX as
+      `syft alpine:3.19`. If yes, milestone delivered.
+- [ ] [DEFERRED FOLLOW-ONS] 031.x (auth) is the highest-priority
+      next step since most real-world container scanning involves
+      private registries.

--- a/specs/031-oci-registry-image-scan/plan.md
+++ b/specs/031-oci-registry-image-scan/plan.md
@@ -1,0 +1,256 @@
+---
+description: "Implementation plan — milestone 031 OCI registry image scan (anonymous-pull MVP, feature-gated)"
+status: plan
+milestone: 031
+---
+
+# Plan: OCI registry image scan
+
+## Architecture
+
+Pure additive feature behind a default-off Cargo feature gate.
+
+```
+                        ┌─ existing path ────────────────────────────┐
+                        │                                            │
+  --image foo.tar  ────►│  scan_fs::docker_image::extract(path)  ─► rootfs scan
+                        │                                            │
+  --image alpine:3.19 ►─┘                                            │
+        │                                                             │
+        │ (feature off)                                                │
+        └─► friendly error: "enable --features oci-registry"          │
+                                                                       │
+        │ (feature on)                                                 │
+        ▼                                                              │
+  scan_fs::oci_pull::pull_to_tarball(ref, host_arch)                  │
+                  │                                                    │
+                  ▼                                                    │
+  TempDir{ image.tar (docker-save format) }  ──► extract(path) ───────┘
+```
+
+The integration seam is `docker_image::extract(path)` which is
+unchanged. The new module produces a TempDir whose `image.tar`
+gets passed in. Layer-merging, rootfs construction, and SBOM
+emission all reuse the existing milestone-pre-031 path verbatim.
+
+## Reuse inventory
+
+These existing items handle the work:
+
+- `reqwest = "0.12"` with `default-features = false, features = ["json", "rustls-tls"]`
+  in `Cargo.toml:15` — already in workspace deps. Pure-Rust TLS
+  via rustls. **No additional HTTP/TLS deps needed.**
+- `tokio = "1" full` in `Cargo.toml:20` — already in workspace.
+  Async runtime ready.
+- `tempfile = "3"` — already in workspace deps for tarball
+  extraction.
+- `flate2 = "1"` (mikebom-cli/Cargo.toml:48) — already in
+  workspace for tar handling. Reused for gzip-layer
+  decompression.
+- `tar = "0.4"` — already in workspace. Reused for tarball
+  assembly.
+- `serde / serde_json` — already in workspace.
+- `scan_fs::docker_image::extract(archive_path: &Path) -> ExtractedImage`
+  — unchanged integration seam.
+- Existing `--image` CLI arg → upgrades from "must be a path" to
+  "path OR ref".
+
+## Crate choice: oci-client
+
+Selected: **`oci-client`** (deislabs-maintained, the rebrand of
+`oci-distribution`).
+
+Rationale:
+- Pure-Rust (Principle I clean — verified pre-spec via crates.io
+  metadata; FR-005 enforces audit at PR time).
+- Async/tokio-native — matches mikebom's existing async paths.
+- Active maintenance.
+- Used by oras-rs, krustlet, and a handful of other projects in
+  production — battle-tested for the public-pull happy path.
+- Built-in `Reference` parsing (registry/repo/tag/digest).
+- Built-in digest verification on layer fetch.
+- Supports manifest-list resolution (defers to 031.y).
+- Supports auth (defers to 031.x).
+
+Rejected alternatives:
+- **Roll our own on `reqwest` + `oci-spec`**: reasonable but
+  doubles the maintenance surface and re-implements digest
+  verification, manifest-list selection, etc. that `oci-client`
+  has tested. Not worth it.
+- **`bollard` (Docker daemon)**: covered in spec — wrong
+  abstraction (daemon-bound, not registry-bound).
+- **Shell out to `skopeo`**: option C from the scoping
+  conversation; user picked D for the no-external-tool UX.
+
+## Touched files
+
+| File | Change | LOC |
+|---|---|---|
+| `mikebom-cli/Cargo.toml` | new `oci-registry` feature; new gated `oci-client` dep + transitive | +8 |
+| `mikebom-cli/src/scan_fs/oci_pull.rs` | NEW module — `pull_to_tarball` + ref-detection + platform-mapping helpers + 6+ inline tests | +280 |
+| `mikebom-cli/src/scan_fs/mod.rs` | gated `pub mod oci_pull;` declaration | +3 |
+| `mikebom-cli/src/cli/scan_cmd.rs` | upgrade `--image` dispatch with ref-vs-path detection + feature-off friendly error | +40 |
+| `mikebom-cli/tests/oci_registry_smoke.rs` | NEW network-gated end-to-end smoke test | +60 |
+| `docs/user-guide/cli-reference.md` (if exists) | add `--image <ref>` documentation + `--features oci-registry` mention | +15 |
+
+Total Rust source: ~390 LOC across 5 files (the smoke test counts
+but only runs opt-in).
+
+## Phasing
+
+Three atomic commits in dependency order.
+
+### Commit 1: `031/feature-gate-and-deps`
+- Add `oci-registry` feature to `mikebom-cli/Cargo.toml`.
+- Add `oci-client` (and any required helpers) as `optional = true`
+  deps gated to the feature.
+- Run `cargo tree -p mikebom --features oci-registry` and
+  document the dep delta in commit message. **Verify Principle I**
+  (no C/sys deps surface).
+- Add a stub `mikebom-cli/src/scan_fs/oci_pull.rs` (gated module)
+  with just the public-fn signature + `unimplemented!()` body so
+  the workspace build matrix passes for both feature-on and
+  feature-off cases.
+- `pre-pr.sh` clean both ways:
+  `./scripts/pre-pr.sh` (default) clean.
+  `cargo +stable clippy --workspace --all-targets --features oci-registry`
+  clean.
+
+### Commit 2: `031/cli-dispatch-and-pull`
+- Implement `oci_pull::pull_to_tarball` end-to-end:
+  - Reference parsing via `oci_client::Reference`.
+  - Platform-mapping helper (`std::env::consts::ARCH` → OCI name).
+  - Manifest fetch + manifest-list platform selection.
+  - Layer fetch (gzip decompression on the way in).
+  - Tarball assembly (`docker save`-format: `manifest.json` +
+    per-layer `<sha>.tar` files).
+  - TempDir return.
+  - Error mapping: each anyhow context names the failure
+    point (parse / manifest / layer / decompress / tarball-write).
+- CLI dispatch in `scan_cmd.rs`:
+  - Detect `--image <arg>`: file-exists → tarball path; else
+    if feature on → call oci_pull::pull_to_tarball; else →
+    friendly error.
+  - 401/403 from registry → "auth not yet supported" error.
+  - zstd layer media type → "zstd not yet supported" error.
+- 6+ inline tests in `oci_pull.rs::tests`:
+  - `ref_detection_distinguishes_path_from_ref`
+  - `platform_mapping_x86_64_to_amd64`
+  - `platform_mapping_aarch64_to_arm64`
+  - `platform_mapping_unknown_arch_returns_error`
+  - `tarball_assembly_produces_extract_compatible_layout`
+    (hand-built fake layers + manifest → assert
+    `docker_image::extract` round-trips).
+  - `auth_error_returns_friendly_message`.
+- `pre-pr.sh` clean both ways.
+
+### Commit 3: `031/smoke-test-and-docs`
+- New `mikebom-cli/tests/oci_registry_smoke.rs` gated on
+  `#[cfg(feature = "oci-registry")]` AND
+  `MIKEBOM_OCI_NETWORK_TESTS=1` env var. Pulls
+  `gcr.io/distroless/static-debian12:latest` (stable, public,
+  small) and asserts the pipeline succeeds end-to-end.
+- Update `docs/user-guide/cli-reference.md` (or wherever the
+  `--image` flag is documented) with the new ref-shape +
+  `--features oci-registry` build instructions.
+- `pre-pr.sh` clean.
+
+Per FR-013, each commit's `pre-pr.sh` is clean both ways
+(default profile + feature-on profile).
+
+## Estimated effort
+
+| Phase | Effort | Notes |
+|---|---|---|
+| Phase 1 (recon + baseline) | done | T001 done in scoping |
+| Phase 2 (Cargo + feature gate + dep audit) | ½ day | dep audit is the careful step |
+| Phase 3 (oci_pull module + CLI dispatch + 6 inline tests) | 1.5 days | tarball-assembly logic is the meatiest part |
+| Phase 4 (smoke test + docs) | ½ day | network-gated test + docs |
+| Phase 5 (verify + PR) | ½ day | both build profiles + smoke test |
+| **Total** | **~3 days** | sub-scoped milestone — auth + multi-arch deferred to 031.x / 031.y. |
+
+## Risks
+
+- **R1: oci-client API shape vs. expectations.** Some methods may
+  be sync, some async. Need to confirm at recon-deep time what
+  the public API looks like. Mitigation: `cargo doc -p oci-client
+  --open` early in commit 2, before writing the module body.
+  Easy to adjust the wrapper.
+
+- **R2: Transitive deps audit failure.** `oci-client` brings
+  in `bytes`, `base64`, possibly others. If any pull in a C-bound
+  crate (sys or `*-sys`), Principle I says we can't proceed
+  without justifying it. Mitigation: commit 1 is a "deps audit"
+  commit. If it fails the audit, scope-pivot to a `reqwest`-only
+  custom client (more work, but no new top-level deps).
+
+- **R3: Rustls vs native-tls in the transitive graph.**
+  `reqwest` is already in the workspace with `rustls-tls`. If
+  `oci-client`'s default features pull `native-tls` somehow,
+  we have to pin its features to match. Mitigation: pin
+  `oci-client = { version = "...", default-features = false,
+  features = ["rustls-tls"] }` (or whatever its rustls feature
+  name is) in commit 1.
+
+- **R4: Async-to-sync via block_on inside a binary that may
+  itself be in tokio context.** If the user invokes `mikebom`
+  from inside another tokio runtime (e.g. embedded usage),
+  `Runtime::new()::block_on` would panic with "Cannot start a
+  runtime from within a runtime". Mitigation: not a real
+  concern for the CLI binary path (CLI's main is sync). If it
+  ever becomes a concern, switch to `tokio::task::block_in_place`
+  or detect existing runtime via `tokio::runtime::Handle::try_current`.
+  Out of scope for milestone 031.
+
+- **R5: Fake-layer fixtures for the tarball-assembly test.**
+  The test needs to construct fake `tar.gz` bytes that mimic a
+  real OCI layer, then assert that the assembled
+  `docker save`-format tarball is parseable by
+  `docker_image::extract`. Construction is a few KB of
+  hand-crafted bytes. Mitigation: `tar::Builder` + `flate2::write::GzEncoder`
+  produce these in 30-50 LOC.
+
+## Constitution alignment
+
+- **Principle I (Pure Rust, Zero C):** verified pre-spec via
+  crates.io metadata for `oci-client`. Commit 1 enforces with
+  `cargo tree` audit. ✓
+- **Principle IV (no `.unwrap()` in production):** new code
+  uses `?` throughout, returns `anyhow::Result`. ✓
+- **Principle VI (Three-Crate Architecture):** untouched. The
+  `oci-client` dep lives only in `mikebom-cli`'s
+  feature-gated section. ✓
+- **Principle VIII (Completeness):** new code path produces the
+  same SBOM that `docker save → mikebom --image foo.tar` would.
+  No completeness regression. ✓
+- **Principle X (Transparency):** generation context already
+  flags `container-image-scan`; that field is unchanged.
+  Future enrichment of the generation context with the source
+  ref (e.g., `mikebom:scan-source = "alpine:3.19"`) is a
+  follow-on. ✓
+- **Principle XII (External Data Source Enrichment):** pulling
+  the scan target from a registry IS retrieving the artifact-
+  of-interest, distinct from enrichment-via-deps.dev. The
+  constitution's external-data principle governs enrichment
+  data, not the scan target itself. ✓
+- **Per-commit verification:** FR-013 enforced.
+- **Recon-first:** every claim grounded in
+  `mikebom-cli/Cargo.toml:15` (reqwest), `Cargo.toml:20`
+  (tokio), `mikebom-cli/src/scan_fs/docker_image.rs:70`
+  (extract entry point), `mikebom-cli/src/cli/scan_cmd.rs:429`
+  (current --image dispatch).
+
+## What this milestone does NOT do
+
+- Does not handle authenticated registry pulls (deferred to 031.x).
+- Does not handle multi-platform selection beyond host-arch
+  default (deferred to 031.y).
+- Does not cache pulled layers (deferred to 031.z).
+- Does not support zstd-compressed layers (returns clear error).
+- Does not stream layer extraction (full pull-then-scan).
+- Does not validate OCI image-spec compliance beyond
+  oci-client's built-in digest checks.
+- Does not change CLI args beyond extending `--image`'s
+  accepted shape.
+- Does not change the SBOM output (no new annotations / catalog
+  rows / parity extractors).

--- a/specs/031-oci-registry-image-scan/spec.md
+++ b/specs/031-oci-registry-image-scan/spec.md
@@ -1,0 +1,421 @@
+---
+description: "Add direct OCI-registry image scanning behind a default-off `oci-registry` feature flag — `mikebom sbom scan --image alpine:3.19` pulls the image manifest + layers, writes a docker-save-equivalent tarball, and routes through the existing extraction path. Anonymous public registries only in this milestone; auth + multi-arch deferred to 031.x follow-ons."
+status: spec
+milestone: 031
+---
+
+# Spec: OCI registry image scan (anonymous pull, feature-gated)
+
+## Background
+
+Today `mikebom sbom scan --image <foo.tar>` accepts only a
+`docker save`-format tarball. The user has to extract the image
+themselves (`docker save image:tag -o image.tar`), then point
+mikebom at it. Both `syft` and `trivy` accept image references
+directly (`syft alpine:3.19`) — the registry pull is built in.
+Closing this UX gap is the goal.
+
+The integration seam is small: the existing pipeline already does
+the hard work. `mikebom-cli/src/scan_fs/docker_image.rs::extract`
+takes a tarball path, walks the OCI image-spec tarball layout
+(manifest.json + layer-tar files), reverses the layer overlay, and
+hands a rootfs to the standard scan_fs walker. The missing step is
+turning an image reference (`alpine:3.19`) into a tarball at a
+tempdir path. That's it.
+
+The dep landscape is favorable: `reqwest 0.12` with `rustls-tls` is
+already in `Cargo.toml:15` (no native-tls / no C / Principle I
+clean), `tokio = "1" full` is already in `Cargo.toml:20`. The
+incremental dep cost is just an OCI-distribution-spec client crate
+(likely `oci-client`, the deislabs-maintained successor to
+`oci-distribution` — pure-Rust, async, supports public + auth'd
+registries) plus its transitive deps. We gate this behind a
+default-off `oci-registry` Cargo feature so the workspace stays
+lean by default — same pattern as milestone 020's
+`ebpf-tracing` feature gate.
+
+This milestone is **deliberately sub-scoped** to the anonymous-
+public-registry happy path so it ships in ~3 days. Auth (Docker
+keychain + cred helpers) and multi-arch resolution are explicitly
+deferred to 031.x follow-ons documented in Out of Scope below.
+
+## User story (US1, P1)
+
+**As an SBOM consumer who has been trained on the syft/trivy UX**
+of `<tool> <image-ref>`, I want
+`mikebom sbom scan --image alpine:3.19` to work without manually
+running `docker save` first, so that mikebom feels like a
+first-class peer of the established SBOM tools for the most common
+container-scanning use case (scanning a public image by reference).
+
+**Why P1 (not P2):** UX gap. Today every "let me try mikebom on a
+public image" attempt requires the user to context-switch into
+`docker save`, which (a) requires a Docker daemon, defeating
+mikebom's daemon-free posture; (b) is slow; (c) is a friction
+point that has been called out in real-world adoption. Closing
+this gap unlocks parity with syft/trivy for the demo path.
+
+### Independent test
+
+After implementation:
+- `cargo +stable build -p mikebom --features oci-registry` builds
+  clean. Default `cargo +stable build -p mikebom` is unchanged
+  (no new transitive deps in the dep tree).
+- `cargo +stable test -p mikebom --features oci-registry oci_pull`
+  exercises new inline parser + ref-detection tests.
+- `cargo +stable test -p mikebom oci_registry` (default profile)
+  passes the "feature off → friendly error" test.
+- A network-gated smoke test:
+  `mikebom sbom scan --image gcr.io/distroless/static-debian12:latest`
+  succeeds end-to-end and emits a CDX with the expected components.
+  Runs only on a dedicated network-allowed CI job (off by default
+  per the existing CI lane discipline).
+
+## Acceptance scenarios
+
+**Scenario 1: Anonymous public-registry pull**
+```
+Given: a built mikebom with `--features oci-registry` enabled,
+       network access to docker.io / gcr.io, and an image
+       reference `alpine:3.19`
+When:  `mikebom sbom scan --image alpine:3.19` runs
+Then:  mikebom pulls the manifest + each layer blob, writes a
+       docker-save-format tarball to a temp directory, calls
+       `docker_image::extract` on it, and proceeds with the
+       existing rootfs scan + SBOM emission. Output is byte-
+       identical to running the same scan against a manually-
+       produced `docker save alpine:3.19 -o /tmp/alpine.tar`
+       tarball, modulo the source-path field.
+```
+
+**Scenario 2: Path vs ref auto-detection**
+```
+Given: `--image foo.tar` where `foo.tar` exists on disk
+When:  `mikebom sbom scan --image foo.tar` runs
+Then:  mikebom routes to the existing tarball-extraction path
+       unchanged. NO registry pull is attempted. Existing
+       milestone-pre-031 behavior is preserved exactly.
+
+Given: `--image alpine:3.19` (no file at that path)
+When:  `mikebom sbom scan --image alpine:3.19` runs with
+       --features oci-registry enabled
+Then:  mikebom routes to the new registry-pull path. The
+       reference is parsed via `oci-client::Reference`. Failure
+       to parse → clear error.
+```
+
+**Scenario 3: Feature-off friendly error**
+```
+Given: a mikebom binary built WITHOUT --features oci-registry
+       (the default profile)
+When:  `mikebom sbom scan --image alpine:3.19` runs (image
+       arg looks like a ref, no file at that path)
+Then:  mikebom exits non-zero with a clear error message:
+       "OCI registry image references require --features oci-registry.
+        Either install with `cargo install mikebom --features oci-registry`
+        or pre-extract the image with `docker save alpine:3.19 -o
+        image.tar` and pass `--image image.tar`."
+       NO panic. NO confusing path-not-found error.
+```
+
+**Scenario 4: Registry pull failure**
+```
+Given: --features oci-registry on, an image ref that doesn't
+       resolve (typo, non-existent registry, network down)
+When:  the pull fails
+Then:  clear error message naming the failure mode (manifest
+       fetch, layer fetch, network timeout, etc.), exit
+       non-zero, no panic, partial tempdir cleaned up.
+```
+
+**Scenario 5: Multi-platform manifest list (deferred to 031.x but
+behavior under 031)**
+```
+Given: an image ref like `alpine:3.19` whose registry returns
+       a manifest LIST (image index) with linux/amd64,
+       linux/arm64, linux/arm/v7 variants
+When:  mikebom pulls under milestone 031 (no platform flag,
+       host arch only)
+Then:  mikebom selects the manifest matching the host's arch
+       (`std::env::consts::ARCH` mapped to OCI's `amd64` /
+       `arm64` / etc.). If no matching platform exists, error
+       with the available platforms listed for the user.
+```
+
+## Edge cases
+
+- **Image ref without a tag** (e.g. `alpine`): default to `latest`
+  per the OCI distribution-spec convention. `oci-client::Reference`
+  handles this.
+
+- **Image ref with a digest** (e.g. `alpine@sha256:...`): pull
+  the exact digest. No tag-resolution needed.
+
+- **Registry hostnames**: `alpine:3.19` defaults to `docker.io`
+  (which itself redirects to `registry-1.docker.io/library/alpine`
+  per Docker Hub's `/library/` convention). `gcr.io/foo/bar:1`
+  and `ghcr.io/foo/bar:1` use their own registry. `oci-client::Reference`
+  parsing handles these.
+
+- **Compressed layers**: most registries use gzip-compressed layer
+  blobs (`application/vnd.oci.image.layer.v1.tar+gzip`). The
+  existing `docker_image::extract` path expects plain `tar` inside
+  the tarball, so the registry-pull layer needs to **decompress
+  gzipped layers before writing** them into the docker-save-
+  format tarball. zstd-compressed layers (newer OCI media type)
+  out of scope for milestone 031 — return a clear error if
+  encountered.
+
+- **Layer digest verification**: the OCI distribution spec carries
+  a `digest` field per layer descriptor. mikebom MUST verify the
+  downloaded blob's SHA-256 matches before trusting it. `oci-client`
+  does this internally; we just need to ensure the verification
+  path is taken (not bypassed via raw HTTP).
+
+- **Anonymous-only scope**: this milestone covers PUBLIC anonymous
+  pulls only. Authenticated registries (private Docker Hub repos,
+  GHCR private packages, ECR, GCR with private images) are out of
+  scope — return a clear error pointing users at the deferred
+  031.x auth milestone.
+
+- **Multi-arch manifest lists**: this milestone uses host-arch
+  selection only (`std::env::consts::ARCH` → OCI arch name).
+  `--image-platform linux/arm64` flag is deferred to 031.y.
+
+- **Async runtime**: `oci-client` is async/tokio. mikebom's CLI
+  scan path is currently synchronous. Use `tokio::runtime::Runtime::new()`
+  + `block_on(...)` inside the new `oci_pull::pull_to_tarball`
+  helper to bridge async-to-sync at the module boundary. Keeps
+  the rest of the CLI path unchanged.
+
+## Functional requirements
+
+- **FR-001**: `mikebom-cli/Cargo.toml` gains a new feature
+  `oci-registry` (default off) gating one or more new dep entries:
+  - `oci-client = "0.x"` (deislabs-maintained successor of
+    `oci-distribution`; pure-Rust async OCI distribution client)
+  - any of its transitive deps that aren't already in the workspace.
+  Audit `cargo tree -p mikebom --features oci-registry` to
+  verify no C-bound transitive deps surface (Principle I).
+
+- **FR-002**: New module `mikebom-cli/src/scan_fs/oci_pull.rs`
+  guarded by `#[cfg(feature = "oci-registry")]`. Exposes one
+  public entry point:
+  ```rust
+  pub fn pull_to_tarball(
+      image_ref: &str,
+      target_arch: &str,
+  ) -> anyhow::Result<tempfile::TempDir>;
+  ```
+  Returns a TempDir containing a `docker save`-format tarball
+  named `image.tar` that can be passed to
+  `docker_image::extract`. The TempDir handle ensures cleanup
+  on drop.
+
+- **FR-003**: `oci_pull::pull_to_tarball` walks: parse ref →
+  fetch manifest → resolve to platform-specific manifest if it's
+  a manifest list → fetch the config blob + each layer blob →
+  decompress gzipped layer blobs → assemble a docker-save-format
+  tarball (manifest.json + per-layer tar files) → return TempDir.
+  Async work bridged via `tokio::runtime::Runtime::new()` +
+  `block_on(...)` at the module boundary.
+
+- **FR-004**: `mikebom-cli/src/cli/scan_cmd.rs` gains ref-vs-path
+  detection on the `--image` argument. The detection logic:
+  ```text
+  if file at path exists  → existing tarball extraction path
+  else if feature off    → friendly error per Scenario 3
+  else if parses as OCI ref → call oci_pull::pull_to_tarball
+  else                   → error "neither a file nor a parseable image reference"
+  ```
+
+- **FR-005**: When the new registry-pull path runs, it produces a
+  TempDir whose `image.tar` is then handed to
+  `scan_fs::docker_image::extract` exactly the same as the
+  existing path. The TempDir lifetime extends through the scan
+  to keep the tarball alive.
+
+- **FR-006**: Registry pull failures (manifest 404, layer
+  fetch error, gzip decompress error, layer-digest mismatch,
+  unparseable ref, etc.) propagate as `anyhow::Error` with
+  context naming the failure point. No panics. The TempDir is
+  cleaned up on drop regardless.
+
+- **FR-007**: Authenticated registries → return a clear error:
+  `"image registry returned 401/403; authenticated pulls are
+  not yet supported in milestone 031 (tracked as 031.x — see
+  spec)"`. NO partial-credential leakage in error messages.
+
+- **FR-008**: Multi-arch manifest lists → select the manifest
+  matching `std::env::consts::ARCH` mapped to the OCI platform
+  name (`x86_64` → `amd64`, `aarch64` → `arm64`, etc.). If no
+  matching platform exists, error listing the available platforms.
+
+- **FR-009**: zstd-compressed layers → return a clear error:
+  `"zstd-compressed image layers are not yet supported in
+  milestone 031 (gzip layers fully supported); image's layer
+  N has media type X"`.
+
+- **FR-010**: Inline tests in `oci_pull.rs::tests`:
+  - Ref-detection: paths, valid refs, invalid refs.
+  - Platform-name mapping: `x86_64` → `amd64`, `aarch64` → `arm64`,
+    unknown host arch → error.
+  - Tarball-assembly: hand-build a fake manifest + hand-build
+    fake layer-tar bytes, run the assembly logic, assert the
+    resulting tarball is parseable by `docker_image::extract`.
+  - The actual network pull is NOT covered by inline tests
+    (would require a registry mock — that's FR-011).
+
+- **FR-011**: A network-gated smoke test in
+  `mikebom-cli/tests/oci_registry_smoke.rs` (gated on
+  `#[cfg(feature = "oci-registry")]` AND a `MIKEBOM_OCI_NETWORK_TESTS=1`
+  env var) pulls a known-stable public image
+  (`gcr.io/distroless/static-debian12:latest`) and verifies the
+  end-to-end pipeline. Skipped on the default Linux + macOS CI
+  lanes. May get its own `lint-and-test-oci-network` job in a
+  follow-on; for milestone 031 it ships as opt-in only.
+
+- **FR-012**: `docs/reference/sbom-format-mapping.md` is
+  unchanged — this milestone doesn't introduce new annotations.
+
+- **FR-013**: Per-commit `./scripts/pre-pr.sh` clean across the
+  three commits (Cargo + feature gate / CLI dispatch + oci_pull /
+  tests + docs).
+
+## Success criteria
+
+- **SC-001**: `./scripts/pre-pr.sh` clean on default profile.
+  `cargo +stable test -p mikebom --features oci-registry` clean.
+  `cargo +stable clippy --workspace --all-targets --features oci-registry`
+  clean.
+
+- **SC-002**: Default `cargo tree -p mikebom` is unchanged from
+  pre-milestone. The `oci-client` and any transitive deps live
+  ONLY in the feature-gated graph.
+
+- **SC-003**: `git diff main..HEAD --
+  mikebom-cli/src/scan_fs/binary/ mikebom-cli/src/scan_fs/package_db/`
+  is empty. The binary scanners + package-db readers are
+  untouched. This is purely an input-source change.
+
+- **SC-004**: `git diff main..HEAD --
+  mikebom-common/ mikebom-cli/src/parity/`
+  is empty. No SBOM-output schema changes; no new annotations.
+
+- **SC-005**: Audit: `cargo tree -p mikebom --features oci-registry
+  --no-default-features 2>&1 | grep -E '\\-(sys|c)'` produces no
+  output indicating C-bound deps. Principle I clean.
+
+- **SC-006**: All 3 standard CI lanes green on the default
+  profile (no oci-registry feature). The feature-on CI path is
+  added in 031.x or as a separate PR if needed.
+
+- **SC-007**: 27-golden regen produces zero diff (no fixture
+  exercises the registry-pull path; tarball-extraction is
+  unchanged).
+
+- **SC-008**: `mikebom sbom scan --image gcr.io/distroless/static-debian12:latest`
+  built with `--features oci-registry` succeeds end-to-end
+  against a real registry (manual verification — runs of this
+  command on developer + CI lanes will be the gate).
+
+## Clarifications
+
+- **Default-off feature gate**: matches milestone 020's
+  `ebpf-tracing` precedent. The 80% of users who scan local
+  rootfs / source trees / pre-extracted tarballs don't take on
+  the OCI client + transitive dep weight. Users who want
+  registry pulls opt in via `cargo install mikebom --features
+  oci-registry`.
+
+- **Pull THEN scan, not stream-as-you-scan**: the implementation
+  pulls the full image to disk first (via tempdir tarball) and
+  THEN scans. Streaming-as-you-scan would be a meaningful
+  refactor of the docker_image::extract path (which today is
+  built around `tar::Archive::new` over a fully-present tarball).
+  Not worth doing in milestone 031.
+
+- **Anonymous-only**: deliberate. Auth handling (Docker keychain
+  parsing, cred helpers, bearer tokens, ECR's
+  `aws ecr get-login-password`-style credentials) is multiple
+  days of careful engineering. Defer to 031.x as a focused
+  milestone after we've shipped the happy path.
+
+- **Host-arch only**: `--image-platform linux/arm64` flag deferred
+  to 031.y. Same milestone-cadence discipline.
+
+- **No layer caching**: each scan re-pulls the layers from the
+  registry. Caching would help for repeat scans but is meaningful
+  state-management work (cache key = manifest digest + layer
+  digests + cache-eviction policy). Defer to 031.z.
+
+- **No image-spec validation**: mikebom doesn't verify that the
+  pulled image conforms to the OCI image-spec
+  (e.g. config blob has a valid platform, layer digests aren't
+  duplicated). `oci-client` does basic digest verification;
+  beyond that we trust the registry.
+
+- **Async-to-sync via `tokio::Runtime`**: the CLI scan path stays
+  synchronous. The async work is contained inside
+  `oci_pull::pull_to_tarball` via a runtime created at function
+  entry and dropped at exit. This avoids cascading async
+  through the rest of the CLI. Costs an extra runtime
+  instantiation per pull (~ms-level overhead, negligible against
+  layer download time).
+
+## Out of scope — deferred to 031.x / 031.y / 031.z follow-ons
+
+### 031.x — Authenticated pulls (highest priority follow-on)
+
+Pulling from private registries needs:
+- `~/.docker/config.json` parsing (`auths.<registry>.auth`
+  base64 user:pass; `auths.<registry>.identitytoken` bearer;
+  `credsStore: <helper>` → invoke
+  `docker-credential-<helper> get` subprocess).
+- macOS keychain helper subprocess
+  (`docker-credential-osxkeychain`) — common in dev environments.
+- Bearer-token flows (registry returns `401 Bearer realm=...`,
+  client fetches a scoped token, retries).
+- ECR-specific (`aws ecr get-login-password` integration; or
+  AWS SDK).
+- GHCR-specific (PAT-as-password convention).
+
+Scope estimate: 3-4 days. Separate milestone.
+
+### 031.y — Multi-platform `--image-platform` flag
+
+Adds `--image-platform <linux/arch>` CLI flag to override the
+default host-arch selection. Useful for scanning an arm64 image
+on an amd64 host. Scope: ~1 day. Separate milestone.
+
+### 031.z — Layer caching
+
+Disk-cache pulled layers keyed on layer digest. Enables fast
+repeat-scans of the same image. Cache-eviction policy needed
+(LRU? size cap? TTL?). Scope: ~2 days. Separate milestone.
+
+### Out of scope entirely (no current plan)
+
+- **zstd-compressed layers**: mikebom returns a clear "not yet
+  supported" error. The vast majority of registry-published
+  images use gzip; zstd is opt-in via the OCI media type
+  `application/vnd.oci.image.layer.v1.tar+zstd` and not the
+  default. Add when a real-world image surfaces the need.
+
+- **Read-from-Docker-daemon socket**: alternative to
+  registry pulls (`docker-credential-helper`-style). Lower
+  priority since rootless / k8s / containerd-only environments
+  don't have a Docker daemon. Defer indefinitely.
+
+- **OCI image distribution v2 protocol extensions** (e.g.
+  cross-repo blob mounting). Not needed for read-only scan use
+  case.
+
+- **Streaming layer extraction**: scan layers as they're
+  downloaded, never write a full tarball to disk. Significant
+  pipeline refactor; scan-time savings only meaningful for
+  very large images. Defer.
+
+- **OCI signature verification** (cosign / notary v2). Out of
+  scope — mikebom records SBOM data; signing is a separate
+  workflow.

--- a/specs/031-oci-registry-image-scan/tasks.md
+++ b/specs/031-oci-registry-image-scan/tasks.md
@@ -1,0 +1,313 @@
+---
+description: "Task list — milestone 031 OCI registry image scan (anonymous-pull MVP, feature-gated)"
+---
+
+# Tasks: OCI Registry Image Scan — Tighter Spec
+
+**Input**: Design documents from `/specs/031-oci-registry-image-scan/`
+**Prerequisites**: spec.md (✅), plan.md (✅), checklists/requirements.md (✅)
+
+**Tests**: 6+ inline tests in `oci_pull.rs::tests` covering ref
+detection, platform mapping, tarball assembly, error paths +
+1 network-gated end-to-end smoke test.
+
+**Organization**: Single user story (US1, P1). Three atomic commits.
+
+## Path Conventions
+
+- Touches `mikebom-cli/Cargo.toml` (new feature + new dep entry).
+- Touches `mikebom-cli/src/scan_fs/oci_pull.rs` (new module),
+  `mikebom-cli/src/scan_fs/mod.rs` (gated module decl),
+  `mikebom-cli/src/cli/scan_cmd.rs` (dispatch).
+- Adds `mikebom-cli/tests/oci_registry_smoke.rs`.
+- Updates `docs/user-guide/cli-reference.md` (or wherever the
+  --image flag is documented).
+- Does NOT touch `mikebom-common/`, `mikebom-cli/src/parity/`,
+  any `mikebom-cli/src/scan_fs/binary/*.rs`, any
+  `mikebom-cli/src/scan_fs/package_db/*.rs`,
+  `mikebom-cli/src/generate/`, `mikebom-cli/src/resolve/`,
+  or `mikebom-cli/src/cli/` outside `scan_cmd.rs`.
+
+---
+
+## Phase 1: Setup + baseline
+
+- [X] T001 Recon done. Confirmed:
+      - `reqwest 0.12 + rustls-tls` in `Cargo.toml:15` (pure-Rust TLS).
+      - `tokio = "1" full` in `Cargo.toml:20`.
+      - `flate2 = "1"` and `tar = "0.4"` already in workspace.
+      - `scan_fs::docker_image::extract(path) → ExtractedImage`
+        is the integration seam; takes a tarball file path.
+      - `--image` CLI dispatch lives in `scan_cmd.rs:429`.
+      - `oci-client` chosen as the OCI distribution client crate
+        (deislabs-maintained successor of `oci-distribution`,
+        pure-Rust, async, has built-in `Reference` parsing +
+        digest verification).
+- [ ] T002 Snapshot baseline: `./scripts/pre-pr.sh 2>&1 | tee /tmp/baseline-031.txt | grep -cE '^test [a-z_:]+ \.\.\. ok' > /tmp/baseline-031-count.txt`. Confirms default-profile test count for regression checks.
+
+---
+
+## Phase 2: Commit 1 — `031/feature-gate-and-deps`
+
+**Goal**: Cargo feature `oci-registry` (default off) gating the
+`oci-client` dep, with a stub module that builds clean both ways.
+
+- [ ] T003 [US1] Edit `mikebom-cli/Cargo.toml`:
+      - Add `[features]` section entry: `oci-registry = ["dep:oci-client"]`.
+      - Add `[dependencies]` entry: `oci-client = { version = "...",
+        default-features = false, features = ["rustls-tls"], optional = true }`
+        (pin the version after consulting the latest stable
+        published release).
+      - Verify the dep is correctly conditional (only pulled in
+        when feature enabled).
+- [ ] T004 [US1] Add a stub `mikebom-cli/src/scan_fs/oci_pull.rs`:
+      - Module-level `#![cfg(feature = "oci-registry")]` gate.
+      - Module doc explaining feature-flag rationale + integration
+        seam.
+      - Public fn signature `pub fn pull_to_tarball(image_ref: &str,
+        target_arch: &str) -> anyhow::Result<tempfile::TempDir>`
+        with `unimplemented!("filled in commit 2")` body.
+- [ ] T005 [US1] Edit `mikebom-cli/src/scan_fs/mod.rs`: add
+      `#[cfg(feature = "oci-registry")] pub mod oci_pull;`.
+- [ ] T006 [US1] Run `cargo tree -p mikebom --features oci-registry`
+      and inspect output. Verify NO `*-sys` / `*-c` deps surface
+      (Principle I check). Document the dep delta in the commit
+      message — exact transitive dep list and their licenses.
+- [ ] T007 [US1] Verify both build profiles:
+      - `./scripts/pre-pr.sh` (default) → clean, test count
+        unchanged from T002 baseline.
+      - `cargo +stable build -p mikebom --features oci-registry`
+        → clean.
+      - `cargo +stable clippy --workspace --all-targets --features oci-registry`
+        → clean.
+- [ ] T008 [US1] Commit: `feat(031/feature-gate-and-deps): add oci-registry Cargo feature + oci-client gated dep`.
+
+---
+
+## Phase 3: Commit 2 — `031/cli-dispatch-and-pull`
+
+**Goal**: end-to-end pull from anonymous public registry working;
+CLI dispatch routes `--image <ref>` to the new path; ≥6 inline
+tests covering ref detection / platform mapping / tarball
+assembly / error paths.
+
+- [ ] T009 [US1] Open `cargo doc -p oci-client --open` to confirm
+      the public API shape. Note specifically:
+      - `oci_client::Reference::try_from(&str)` (parse).
+      - `oci_client::Client::new(...)` constructor.
+      - `Client::pull_manifest_and_config` /
+        `Client::pull_image_manifest` shape and async signature.
+      - `Client::pull_blob` / `pull_layer` shape.
+      - `RegistryAuth::Anonymous` for the anon path.
+      - Manifest-list resolution helpers.
+      - Adjust the FR-002 fn body design to match the actual API.
+- [ ] T010 [US1] Implement `oci_pull::pull_to_tarball`:
+      ```rust
+      pub fn pull_to_tarball(
+          image_ref: &str,
+          target_arch: &str,
+      ) -> anyhow::Result<tempfile::TempDir> {
+          let runtime = tokio::runtime::Builder::new_current_thread()
+              .enable_all()
+              .build()?;
+          runtime.block_on(async {
+              let reference = oci_client::Reference::try_from(image_ref)?;
+              let client = oci_client::Client::new(default_config());
+              let auth = oci_client::secrets::RegistryAuth::Anonymous;
+              // pull manifest, resolve manifest list to platform
+              //   matching target_arch, fail if none
+              // pull config + layer blobs, gunzipping each layer
+              // assemble docker-save-format tarball:
+              //   - manifest.json (JSON array with one entry,
+              //     fields: Config, RepoTags, Layers)
+              //   - <digest>.json (config blob)
+              //   - <digest>/layer.tar (one per layer, decompressed)
+              // write to tempfile::tempdir()/image.tar
+              // return TempDir
+              ...
+          })
+      }
+      ```
+      Each step: `?`-propagates with `anyhow::Context::context(...)`
+      naming the failure point.
+- [ ] T011 [US1] Implement helper fns:
+      - `fn detect_image_arg_kind(arg: &Path) -> ImageArgKind`
+        returning `Path | OciRef | Invalid`.
+      - `fn host_oci_arch() -> anyhow::Result<&'static str>`
+        mapping `std::env::consts::ARCH` to OCI platform name
+        (`x86_64`→`amd64`, `aarch64`→`arm64`, `arm`→`arm`,
+        `riscv64`→`riscv64`, others → error listing supported).
+      - `fn manifest_for_platform(manifest_list, target_arch) ->
+        anyhow::Result<Manifest>` selecting the platform-specific
+        manifest from a manifest list. Single manifest → returned
+        directly. Image with manifest list but no matching arch →
+        error listing the available platforms.
+- [ ] T012 [US1] Edit `mikebom-cli/src/cli/scan_cmd.rs::scan`'s
+      `--image` dispatch (around line 429):
+      ```rust
+      if let Some(image_arg) = args.image.as_ref() {
+          if image_arg.is_file() {
+              // existing tarball-extract path — unchanged
+          } else {
+              #[cfg(feature = "oci-registry")]
+              {
+                  let target_arch = scan_fs::oci_pull::host_oci_arch()?;
+                  let pulled_dir =
+                      scan_fs::oci_pull::pull_to_tarball(
+                          image_arg.to_str().context("...")?,
+                          target_arch,
+                      )?;
+                  let tarball_path = pulled_dir.path().join("image.tar");
+                  let extracted = scan_fs::docker_image::extract(&tarball_path)?;
+                  // pulled_dir's TempDir keeps tarball alive through scan
+                  ...
+              }
+              #[cfg(not(feature = "oci-registry"))]
+              {
+                  anyhow::bail!(
+                      "OCI registry image references require --features oci-registry. \
+                       Either install with `cargo install mikebom --features oci-registry` \
+                       or pre-extract the image with \
+                       `docker save {} -o image.tar` and pass `--image image.tar`.",
+                      image_arg.display()
+                  );
+              }
+          }
+      }
+      ```
+- [ ] T013 [US1] Add 6 inline tests in `oci_pull.rs::tests`:
+      - `host_oci_arch_maps_known_arches` — table-test for x86_64
+        / aarch64 / arm / riscv64.
+      - `host_oci_arch_returns_error_for_unknown_arch` — synthetic
+        test forcing an unknown ARCH constant.
+      - `tarball_assembly_produces_extract_compatible_layout` —
+        hand-build fake manifest + 2 fake gzipped layer-tar
+        blobs → `assemble_docker_save_tarball` → assert
+        `docker_image::extract` round-trips and the rootfs has
+        the expected files.
+      - `manifest_for_platform_picks_amd64_from_manifest_list` —
+        synthetic manifest list with linux/amd64 + linux/arm64
+        entries, target_arch="amd64" → returns the amd64
+        manifest digest.
+      - `manifest_for_platform_errors_when_target_unavailable` —
+        manifest list with only linux/arm64, target="amd64" →
+        error message lists the available platforms.
+      - `bridge_async_runtime_block_on_works` — smoke test for
+        the runtime construction.
+      The actual network pull is NOT covered here (would require
+      a registry mock; covered by the smoke test in Commit 3).
+- [ ] T014 [US1] Verify both build profiles:
+      - `./scripts/pre-pr.sh` (default) → clean.
+      - `cargo +stable test -p mikebom --features oci-registry oci_pull` → all 6 new tests pass.
+      - `cargo +stable clippy --workspace --all-targets --features oci-registry` → clean.
+- [ ] T015 [US1] Commit: `feat(031/cli-dispatch-and-pull): wire OCI registry image pull behind --image <ref>`.
+
+---
+
+## Phase 4: Commit 3 — `031/smoke-test-and-docs`
+
+**Goal**: opt-in network-gated end-to-end smoke test + user-facing
+docs for `--features oci-registry`.
+
+- [ ] T016 [US1] Create
+      `mikebom-cli/tests/oci_registry_smoke.rs`:
+      ```rust
+      #![cfg(feature = "oci-registry")]
+      // Network-gated: only runs when MIKEBOM_OCI_NETWORK_TESTS=1.
+      // Default + ebpf + macOS CI lanes skip these. A future
+      // milestone can add a dedicated `lint-and-test-oci-network`
+      // job that flips the env var on.
+
+      #[test]
+      fn pulls_distroless_static_and_emits_sbom() {
+          if std::env::var("MIKEBOM_OCI_NETWORK_TESTS").ok().as_deref() != Some("1") {
+              return; // skipped on default lanes
+          }
+          let output = std::process::Command::new(env!("CARGO_BIN_EXE_mikebom"))
+              .arg("sbom").arg("scan")
+              .arg("--image").arg("gcr.io/distroless/static-debian12:latest")
+              .arg("--format").arg("cyclonedx-json")
+              .arg("--output").arg("-") // stdout
+              .output()
+              .expect("mikebom should run");
+          assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+          let sbom: serde_json::Value = serde_json::from_slice(&output.stdout)
+              .expect("stdout must be valid CDX JSON");
+          assert!(sbom["components"].as_array().is_some_and(|c| !c.is_empty()),
+              "distroless image should yield ≥1 component");
+      }
+      ```
+- [ ] T017 [US1] Update user-facing docs (whichever file is the
+      live `--image` reference):
+      - Document the new `--image <ref>` shape.
+      - Document `--features oci-registry` requirement.
+      - Note current scope (anonymous public pulls only) and
+        link to spec for deferred items (auth → 031.x; multi-arch
+        flag → 031.y).
+- [ ] T018 [US1] Verify:
+      - `./scripts/pre-pr.sh` (default profile) clean.
+      - `cargo +stable build -p mikebom --features oci-registry` clean.
+      - Manual: `cargo run -p mikebom --features oci-registry --
+        sbom scan --image gcr.io/distroless/static-debian12:latest`
+        succeeds end-to-end on a network-connected dev machine.
+- [ ] T019 [US1] Commit: `feat(031/smoke-test-and-docs): add network-gated end-to-end smoke test + cli-reference doc updates`.
+
+---
+
+## Phase 5: Verification
+
+- [ ] T020 SC-001 verification: pre-pr clean default; pre-pr
+      clean feature-on; clippy clean both ways.
+- [ ] T021 SC-002 verification: `cargo tree -p mikebom` (default)
+      identical to pre-milestone tree (no new top-level deps).
+      `cargo tree -p mikebom --features oci-registry` shows the
+      new deps cleanly contained.
+- [ ] T022 SC-003 verification: `git diff main..HEAD --
+      mikebom-cli/src/scan_fs/binary/ mikebom-cli/src/scan_fs/package_db/`
+      empty.
+- [ ] T023 SC-004 verification: `git diff main..HEAD --
+      mikebom-common/ mikebom-cli/src/parity/` empty.
+- [ ] T024 SC-005 verification: `cargo tree -p mikebom --features
+      oci-registry --no-default-features 2>&1 | grep -E '\\-(sys|c)$'`
+      empty. Principle I clean.
+- [ ] T025 SC-007 verification: 27-golden regen
+      (`MIKEBOM_UPDATE_*_GOLDENS=1`) zero diff.
+- [ ] T026 SC-008 verification: manual end-to-end smoke test
+      against `gcr.io/distroless/static-debian12:latest`.
+- [ ] T027 Push branch; observe all 3 standard CI lanes
+      (default-profile only) green (SC-006).
+- [ ] T028 Author the PR description: 3-commit summary,
+      sub-scope rationale (anon-only / host-arch only),
+      pointers to 031.x / 031.y / 031.z deferred follow-ons,
+      dep audit attestation.
+
+---
+
+## Dependency graph
+
+```text
+T001-T002 (recon + baseline, recon done)
+   │
+   ↓
+T003-T008 [Commit 1: feature gate + dep audit + stub]
+   │
+   ↓
+T009-T015 [Commit 2: oci_pull module + CLI dispatch + 6 inline tests]
+   │
+   ↓
+T016-T019 [Commit 3: network-gated smoke test + docs]
+   │
+   ↓
+T020-T028 (verification + PR)
+```
+
+## Estimated effort
+
+| Phase | Effort | Notes |
+|---|---|---|
+| Phase 1 (baseline) | 5 min | T001 done; just snapshot |
+| Phase 2 (feature gate + dep audit) | ½ day | dep audit is the careful step |
+| Phase 3 (oci_pull + CLI dispatch + tests) | 1.5 days | tarball-assembly logic is the bulk |
+| Phase 4 (smoke test + docs) | ½ day | network-gated test infrastructure |
+| Phase 5 (verify + PR) | ½ day | dual-profile verification |
+| **Total** | **~3 days** | sub-scoped milestone — auth + multi-arch deferred. |


### PR DESCRIPTION
## Summary

Closes the syft/trivy UX gap: `mikebom sbom scan --image alpine:3.19` now works without manual `docker save`, when built with `--features oci-registry`. Default builds remain unchanged.

Verified end-to-end locally:
- `mikebom sbom scan --image alpine:3.19 --output alpine.cdx.json` → 15 `pkg:apk/alpine/...` components, well-formed CDX.
- `mikebom sbom scan --image gcr.io/distroless/static-debian12:latest --output distroless.cdx.json` → 0 components (correct — distroless ships no package metadata), well-formed CDX with serial number + spec version.

## Spec discipline (sub-scope kept tight)

Anonymous public pulls only, host-arch only. Auth + multi-arch flag + caching all explicitly deferred to 031.x / 031.y / 031.z follow-ons (named in spec.md Out of Scope so future readers see the contract boundary).

## Four atomic commits

1. **`feat(031/feature-gate-and-deps)`** — adds the `oci-registry` Cargo feature (default off) gating the new `oci-client = "0.12"` dep. **Critical version-pin**: oci-client 0.16 (latest) transitively bumps reqwest to 0.13 → rustls 0.23+ → which uses **aws-lc** as the default crypto provider (`aws-lc-sys` C library) — a Constitution Principle I violation. Pinning to oci-client 0.12 keeps us on rustls 0.22 with the ring-based default crypto provider, no aws-lc, no `cmake` build dep. Audit confirmed: feature-on dep tree introduces zero new C-bound deps relative to default. Stub module + extended `no_c_dependencies` regression test (now audits both default AND feature-on profiles, with `aws-lc-sys` added to the blacklist) lock the decision in.

2. **`feat(031/cli-dispatch-and-pull)`** — implements `oci_pull::pull_to_tarball(image_ref) -> TempDir` end-to-end: ref parsing, manifest pull, gzipped layer decompression, `docker save`-format tarball assembly. CLI dispatch on `--image` auto-detects path-vs-ref. Six inline tests (path-vs-ref detection, platform-mapping, tarball-assembly round-trip via the existing `docker_image::extract`, zstd-rejection error contract).

3. **`fix(031)`** (caught during smoke testing) — two real-world bugs:
   - Original `pull_to_tarball` constructed its own tokio runtime → "Cannot start a runtime from within a runtime" panic since mikebom's main is `#[tokio::main] async fn main`. Fixed by making `pull_to_tarball` async-native.
   - Default `current_platform_resolver` looks for `darwin/arm64` on macOS; container images are `linux/...` only. Fixed with custom resolver that always picks `linux/<host-arch>`.

4. **`feat(031/smoke-test-and-docs)`** — network-gated end-to-end smoke test (gated on `MIKEBOM_OCI_NETWORK_TESTS=1`) and CLI-reference docs update.

## Constitution alignment

| Principle | Status |
|---|---|
| **I — Pure Rust, Zero C** | ✅ verified by extended `no_c_dependencies_in_oci_registry_feature_tree` test. Pin to `oci-client = "0.12"` keeps aws-lc-sys out. |
| IV — no `.unwrap()` in production | ✅ all new code uses `?` + anyhow contexts |
| VI — Three-Crate Architecture | ✅ untouched. `oci-client` lives in `mikebom-cli`'s feature-gated section. |
| VIII — Completeness | ✅ same SBOM as `docker save → mikebom --image foo.tar` |
| XII — External Data Source | ✅ pulling the scan target ≠ enrichment-via-deps.dev |

## Spec compliance

| SC | Result |
|---|---|
| SC-001 (`pre-pr.sh` clean both profiles) | ✅ |
| SC-002 (default `cargo tree` unchanged) | ✅ |
| SC-003 (no binary/ or package_db/ churn) | ✅ |
| SC-004 (no mikebom-common / parity churn) | ✅ |
| SC-005 (no `*-sys` / aws-lc deps in feature-on tree) | ✅ verified |
| SC-006 (3 CI lanes green) | ⏳ pending CI |
| SC-007 (27-golden zero diff) | ✅ verified |
| SC-008 (manual end-to-end smoke test) | ✅ alpine + distroless both verified |

## Test plan

- [ ] CI default lane (Linux) green — most important; verifies the workspace stays slim
- [ ] CI ebpf lane green
- [ ] CI macOS lane green
- [ ] `cargo +stable build -p mikebom --features oci-registry` clean
- [ ] `cargo +stable test -p mikebom --features oci-registry` clean (smoke test silently skips without env var)
- [ ] Manual smoke test against `alpine:3.19` and `gcr.io/distroless/static-debian12:latest` — verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)