### PR TITLE
feat: enable oci-registry Cargo feature by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,23 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
   was never relocated there. New unit + integration tests exercise
   every disposition. See `specs/009-maven-shade-deps/spec.md` FR-002b.
 
+### Changed
+- **`oci-registry` Cargo feature is now on by default.** Direct
+  registry pulls (`mikebom sbom scan --image alpine:3.19`) work
+  out of the box on a stock `cargo install mikebom` — matches
+  syft / trivy UX without requiring `--features oci-registry`.
+  The post-milestone-032 substrate (`oci-spec` types-only +
+  workspace `reqwest 0.12` + mikebom-owned thin HTTP client) is
+  small enough + durable enough that the milestone-031 default-off
+  framing no longer pays for itself. Users embedding mikebom in a
+  context that needs a minimal-deps build can opt out via
+  `cargo install mikebom --no-default-features`; the local
+  `--path <dir>` and `--image <foo.tar>` paths still work in that
+  configuration. The dep-audit guardrail
+  (`no_c_dependencies_in_oci_registry_feature_tree` regression
+  test) continues to enforce zero new C-bound transitive deps in
+  the now-default tree.
+
 ### Removed
 - **`mikebom sbom compare` subcommand** and the `demos/` directory.
   The head-to-head comparison story is now owned by a separate test

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -121,9 +121,8 @@ Walk a directory or extracted container image, produce a CycloneDX SBOM.
 mikebom sbom scan --path ~/.cargo/registry/cache --output cargo.cdx.json
 mikebom sbom scan --image alpine.tar --output alpine.cdx.json
 
-# With --features oci-registry: pull directly from the registry
-# (no `docker save` required)
-cargo install mikebom --features oci-registry
+# Pull directly from the registry — no `docker save` required.
+# `oci-registry` is on by default as of milestone 033.
 mikebom sbom scan --image alpine:3.19 --output alpine.cdx.json
 mikebom sbom scan --image gcr.io/distroless/static-debian12:latest \
     --output distroless.cdx.json
@@ -134,7 +133,7 @@ Exactly one of **`--path <DIR>`** or **`--image <TAR_OR_REF>`** is required.
 | Flag | Default | Purpose |
 |---|---|---|
 | `--path <dir>` | — | Directory to walk recursively. Stream-hashes files with recognised package-artifact suffixes (`.deb`, `.crate`, `.whl`, `.tar.gz`, `.jar`, `.gem`, `.apk`, …). |
-| `--image <tar-or-ref>` | — | Either (a) a `docker save` tarball path on disk, or (b) when built with `--features oci-registry`, an OCI image reference like `alpine:3.19` or `gcr.io/foo/bar@sha256:...`. mikebom auto-detects which based on whether the path exists. Refs are pulled from the registry, layers decompressed, and the resulting tarball is extracted to a tempdir (OCI whiteouts honoured) before being scanned like `--path`. Multi-arch image indexes resolve to `linux/<host-arch>` automatically. Currently anonymous public registries only — auth (Docker keychain + cred helpers) and the `--image-platform <linux/arch>` flag for cross-arch selection are deferred to follow-on milestones (031.x / 031.y). |
+| `--image <tar-or-ref>` | — | Either (a) a `docker save` tarball path on disk, or (b) an OCI image reference like `alpine:3.19` or `gcr.io/foo/bar@sha256:...`. mikebom auto-detects which based on whether the path exists. Refs are pulled from the registry, layers decompressed, and the resulting tarball is extracted to a tempdir (OCI whiteouts honoured) before being scanned like `--path`. Multi-arch image indexes resolve to `linux/<host-arch>` automatically. Currently anonymous public registries only — auth (Docker keychain + cred helpers) and the `--image-platform <linux/arch>` flag for cross-arch selection are deferred to follow-on milestones (031.x / 031.y). Disable the registry-pull capability with `cargo install mikebom --no-default-features` if you want a minimal-deps build for embedded use; tarball-extraction still works. |
 | `--output <[FMT=]PATH>` | per-format default (`mikebom.cdx.json`, `mikebom.spdx.json`, …) | Output path override. Two forms: bare `--output <path>` (applies to the single requested format — rejected with multiple formats) and per-format `--output <fmt>=<path>` (repeatable; each entry retargets one format). The special key `openvex` retargets the OpenVEX sidecar that SPDX emission co-produces when VEX is present — legal only alongside an SPDX format. |
 | `--format <fmt>` | `cyclonedx-json` | See [output formats](#output-formats). Comma-separated list + repeatable flag: `--format cyclonedx-json,spdx-2.3-json` produces both from a single scan. Duplicates dedupe silently. |
 | `--max-file-size <bytes>` | `268435456` (256 MB) | Skip hashing files larger than this |

--- a/mikebom-cli/Cargo.toml
+++ b/mikebom-cli/Cargo.toml
@@ -21,7 +21,11 @@ name = "mikebom"
 path = "src/lib.rs"
 
 [features]
-default = []
+# `oci-registry` is on by default as of milestone 033 — direct
+# registry pulls (`mikebom sbom scan --image alpine:3.19`) are now
+# part of the standard install. Users who want a minimal-deps
+# build can `--no-default-features` to drop the oci-spec dep.
+default = ["oci-registry"]
 
 # Enable user-space eBPF tracing for the `mikebom trace` subcommand.
 # Activates aya/aya-log/libc + the `aya-user` feature on mikebom-common,
@@ -42,33 +46,38 @@ ebpf-tracing = [
     "mikebom-common/aya-user",
 ]
 
-# Enable direct OCI-registry image scanning. When active, the `--image`
-# CLI flag accepts an OCI image reference (`alpine:3.19`,
-# `gcr.io/foo/bar@sha256:...`, etc.) in addition to the existing
-# docker-save tarball path. The reference is parsed by mikebom's
-# own thin parser (scan_fs/oci_pull/reference.rs); the manifest +
-# layer blobs are pulled via mikebom's thin HTTP client
+# Direct OCI-registry image scanning. When active (default as of
+# milestone 033), the `--image` CLI flag accepts an OCI image
+# reference (`alpine:3.19`, `gcr.io/foo/bar@sha256:...`, etc.) in
+# addition to the existing docker-save tarball path. The reference
+# is parsed by mikebom's own thin parser
+# (scan_fs/oci_pull/reference.rs); the manifest + layer blobs are
+# pulled via mikebom's thin HTTP client
 # (scan_fs/oci_pull/registry.rs) on top of workspace reqwest 0.12;
 # manifest types come from oci-spec (pure-Rust types-only crate);
-# gzipped layers are decompressed and a docker-save-format
-# tarball is written to a tempdir before being routed through the
-# existing extraction path.
+# gzipped layers are decompressed and a docker-save-format tarball
+# is written to a tempdir before being routed through the existing
+# extraction path.
 #
 # Requirements when active:
-#   - Network access to the target registry.
+#   - Network access to the target registry — only invoked when
+#     the user explicitly passes `--image <ref>` to a non-existent
+#     path. Default `--path <dir>` and `--image <tar>` flows make
+#     no network calls.
 #   - rustls-tls via reqwest's existing workspace pin (matches
 #     mikebom's TLS posture; native-tls is NOT enabled to keep
 #     the dep graph C-free per Principle I).
 #
-# Anonymous public registries only in milestone 031. Auth (Docker
-# keychain + cred helpers) deferred to 031.x (#66); multi-platform
-# flag deferred to 031.y (#67). See
+# Disable with `--no-default-features` if you need a minimal-deps
+# build (e.g., embedding mikebom in another tool that only scans
+# local trees / pre-extracted tarballs).
+#
+# Anonymous public registries only. Auth (Docker keychain + cred
+# helpers) deferred to 031.x (#66); multi-platform flag deferred to
+# 031.y (#67); layer caching deferred to 031.z (#68). See
 # `specs/031-oci-registry-image-scan/spec.md` for the full contract
 # and `specs/032-oci-spec-migration/spec.md` for the substrate
 # rationale.
-#
-# Default builds remain unchanged — `oci-spec` and its transitive
-# deps live ONLY in the feature-gated graph.
 oci-registry = [
     "dep:oci-spec",
 ]

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -461,12 +461,16 @@ pub async fn execute(
                 #[cfg(not(feature = "oci-registry"))]
                 {
                     anyhow::bail!(
-                        "--image argument `{}` is not an existing file. \
-                         OCI image references (e.g. `alpine:3.19`) require the \
-                         `oci-registry` Cargo feature to be enabled. Either:\n\
-                         (a) install with `cargo install mikebom --features oci-registry`, or\n\
-                         (b) pre-extract the image with `docker save <ref> -o image.tar` \
-                         and pass `--image image.tar`.",
+                        "--image argument `{}` is not an existing file, and this \
+                         build of mikebom was compiled with `--no-default-features` \
+                         (the `oci-registry` Cargo feature is OFF), so OCI image \
+                         references like `alpine:3.19` cannot be pulled from a \
+                         registry. Either:\n\
+                         (a) reinstall with the default feature set: \
+                         `cargo install mikebom`, or\n\
+                         (b) pre-extract the image with \
+                         `docker save <ref> -o image.tar` and pass \
+                         `--image image.tar`.",
                         archive.display()
                     );
                 }

--- a/mikebom-cli/src/scan_fs/oci_pull/mod.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull/mod.rs
@@ -1,9 +1,11 @@
 //! OCI registry image pull (milestone 031, restructured into a
 //! submodule directory by milestone 032).
 //!
-//! This module is gated behind the default-off `oci-registry`
-//! Cargo feature. When enabled, the `--image <ref>` CLI argument
-//! accepts an OCI image reference (e.g. `alpine:3.19`,
+//! This module is gated behind the `oci-registry` Cargo feature
+//! (on by default as of milestone 033; users who want a
+//! minimal-deps build can opt out via `--no-default-features`).
+//! When enabled, the `--image <ref>` CLI argument accepts an OCI
+//! image reference (e.g. `alpine:3.19`,
 //! `gcr.io/foo/bar@sha256:...`) in addition to the existing
 //! docker-save tarball path. The reference is parsed, the manifest
 //! plus layer blobs are pulled, gzipped layers are decompressed,


### PR DESCRIPTION
## Summary

Flips `oci-registry` from default-off to default-on. `mikebom sbom scan --image alpine:3.19` now works out of the box on `cargo install mikebom` — no `--features oci-registry` required. Matches syft / trivy UX directly.

Single-commit PR.

## Why

Milestone 031's default-off framing was justified by (a) the oci-client version-pin trap and (b) the perceived dep weight of the registry-pull surface. Both concerns went away with milestone 032's substrate swap:

- The substrate is now `oci-spec` (types-only, pure-Rust) + workspace `reqwest 0.12` + mikebom-owned thin HTTP client. No version-pin trap.
- Dep cost is small: oci-spec's transitive graph is just `serde / serde_json / thiserror / derive_builder / getset / strum / regex / const_format` — all small, all pure-Rust, most already in mikebom's tree.

Verified: `cargo tree -p mikebom` (default) now shows `oci-spec v0.9.0`. `aws-lc` and `oci-client` confirmed absent.

## Trade-offs accepted

- Default install now compiles oci-spec + its handful of derive-helper crates. Compile-time impact is small but non-zero. Worth the UX win.
- Network capability is in the default scan path, **but only fires when the user explicitly passes `--image <ref>` to a non-existent path**. `--path <dir>` and `--image <foo.tar>` flows make zero network calls. Default-on means "the capability is present if you ask for it", not "we make surprise calls without your knowledge".

## Opt-out path preserved

`cargo install mikebom --no-default-features` for embedded-use contexts that want a minimal-deps build. Tarball extraction (`--image <foo.tar>`) still works in that configuration; only direct-registry refs require the feature.

## Changes

- `mikebom-cli/Cargo.toml`: `default = ["oci-registry"]` + updated feature-comment documenting the opt-out path.
- `mikebom-cli/src/scan_fs/oci_pull/mod.rs` doc-comment: drops "default-off" framing.
- `mikebom-cli/src/cli/scan_cmd.rs` feature-off error: now points at `cargo install mikebom` (default) and explains the user must have explicitly `--no-default-features`-ed if they hit this branch.
- `docs/user-guide/cli-reference.md`: quickstart drops the `--features oci-registry` install line; adds note about `--no-default-features` for minimal-deps embedded use.
- `CHANGELOG.md`: new `Changed` entry under `[Unreleased]`.

## Constitution + dep audit

- `cargo tree -p mikebom | grep oci-spec` → present (was absent pre-PR).
- `cargo tree -p mikebom | grep -iE "oci-client|aws-lc"` → empty (durability guardrail holds).
- `no_c_dependencies_in_oci_registry_feature_tree` regression test continues passing on the now-default tree.

## Test plan

- [ ] CI default lane (Linux) green — workspace now compiles oci-spec on the default profile
- [ ] CI ebpf lane green
- [ ] CI macOS lane green
- [ ] `cargo +stable build -p mikebom --no-default-features` clean (verifies opt-out still works)
- [ ] `cargo +stable test -p mikebom` clean — includes the smoke test (silently skips without `MIKEBOM_OCI_NETWORK_TESTS=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)