### PR TITLE
feat(034): authenticated OCI registry pulls (Docker keychain + cred helpers, closes #66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 ## [Unreleased]
 
 ### Added
+- **Milestone 034 (031.x) — Authenticated OCI registry pulls.**
+  `mikebom sbom scan --image <ref>` now supports private registries
+  via the standard Docker keychain — the same `~/.docker/config.json`
+  (or `$DOCKER_CONFIG/config.json`) that `docker pull` uses. All four
+  documented credential sources resolve in Docker's documented
+  precedence order: per-registry `credHelpers` > registry-wide
+  `credsStore` > direct `auths.<reg>.auth` (base64 user:password) >
+  `auths.<reg>.identitytoken`. Credential helpers are invoked as
+  subprocesses (`docker-credential-<helper> get`) per the published
+  protocol — covers ECR (`docker-credential-ecr-login`), Google
+  Artifact Registry (`docker-credential-gcloud`), macOS keychain,
+  Windows credential store, GNOME Secret Service, and `pass`. When
+  credentials resolve, they're sent as Basic auth on the
+  bearer-token realm GET; the resulting bearer token authorizes the
+  manifest + blob fetches. Anonymous fallback is preserved: no
+  config.json + public image works exactly as it did in milestone
+  031. Credentials never leak to stdout, stderr, `--verbose` output,
+  or `RUST_LOG=debug` traces — `Credential::Debug` redacts both
+  fields and the helper subprocess's stderr is dropped to /dev/null.
+  No new top-level dependencies; the
+  `no_c_dependencies_in_oci_registry_feature_tree` regression test
+  still passes. See `specs/034-authenticated-registry-pulls/spec.md`
+  and the new ["Authenticating to private registries"](docs/user-guide/cli-reference.md#authenticating-to-private-registries)
+  section in the user guide. Closes #66.
 - **Milestone 030 — Mach-O codesign metadata.** Every Mach-O scan
   now extracts three identity-flavored signals from the
   `LC_CODE_SIGNATURE` (cmd `0x1D`) SuperBlob's CodeDirectory blob:

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -133,7 +133,7 @@ Exactly one of **`--path <DIR>`** or **`--image <TAR_OR_REF>`** is required.
 | Flag | Default | Purpose |
 |---|---|---|
 | `--path <dir>` | — | Directory to walk recursively. Stream-hashes files with recognised package-artifact suffixes (`.deb`, `.crate`, `.whl`, `.tar.gz`, `.jar`, `.gem`, `.apk`, …). |
-| `--image <tar-or-ref>` | — | Either (a) a `docker save` tarball path on disk, or (b) an OCI image reference like `alpine:3.19` or `gcr.io/foo/bar@sha256:...`. mikebom auto-detects which based on whether the path exists. Refs are pulled from the registry, layers decompressed, and the resulting tarball is extracted to a tempdir (OCI whiteouts honoured) before being scanned like `--path`. Multi-arch image indexes resolve to `linux/<host-arch>` automatically. Currently anonymous public registries only — auth (Docker keychain + cred helpers) and the `--image-platform <linux/arch>` flag for cross-arch selection are deferred to follow-on milestones (031.x / 031.y). Disable the registry-pull capability with `cargo install mikebom --no-default-features` if you want a minimal-deps build for embedded use; tarball-extraction still works. |
+| `--image <tar-or-ref>` | — | Either (a) a `docker save` tarball path on disk, or (b) an OCI image reference like `alpine:3.19` or `gcr.io/foo/bar@sha256:...`. mikebom auto-detects which based on whether the path exists. Refs are pulled from the registry, layers decompressed, and the resulting tarball is extracted to a tempdir (OCI whiteouts honoured) before being scanned like `--path`. Multi-arch image indexes resolve to `linux/<host-arch>` automatically. Both anonymous and authenticated pulls are supported — for private registries, configure `~/.docker/config.json` (the same keychain `docker pull` uses; see ["Authenticating to private registries"](#authenticating-to-private-registries) below). Cross-arch selection (`--image-platform <linux/arch>`) is deferred to milestone 031.y. Disable the registry-pull capability with `cargo install mikebom --no-default-features` if you want a minimal-deps build for embedded use; tarball-extraction still works. |
 | `--output <[FMT=]PATH>` | per-format default (`mikebom.cdx.json`, `mikebom.spdx.json`, …) | Output path override. Two forms: bare `--output <path>` (applies to the single requested format — rejected with multiple formats) and per-format `--output <fmt>=<path>` (repeatable; each entry retargets one format). The special key `openvex` retargets the OpenVEX sidecar that SPDX emission co-produces when VEX is present — legal only alongside an SPDX format. |
 | `--format <fmt>` | `cyclonedx-json` | See [output formats](#output-formats). Comma-separated list + repeatable flag: `--format cyclonedx-json,spdx-2.3-json` produces both from a single scan. Duplicates dedupe silently. |
 | `--max-file-size <bytes>` | `268435456` (256 MB) | Skip hashing files larger than this |
@@ -167,6 +167,87 @@ Behaviour notes:
   `--include-declared-deps`, and `--include-legacy-rpmdb` flags — they
   can be passed either before or after `scan`. See [global flags](#global-flags)
   and [Configuration](configuration.md).
+
+### Authenticating to private registries
+
+When `--image <ref>` resolves to an OCI image reference (rather than a
+tarball path), mikebom uses the same Docker keychain that `docker pull`
+uses — `~/.docker/config.json` (or `$DOCKER_CONFIG/config.json` if set).
+No mikebom-specific credential file or CLI flag is required.
+
+Credentials resolve in this priority order, matching Docker's:
+
+1. **`credHelpers.<registry>`** — per-registry credential helper override.
+   Used by AWS ECR (`docker-credential-ecr-login`) and Google Artifact
+   Registry (`docker-credential-gcloud`). The helper is invoked as a
+   subprocess: `docker-credential-<helper> get` with the registry
+   hostname on stdin, returning `{Username, Secret, ServerURL}` on stdout.
+2. **`credsStore`** — registry-wide helper (e.g. `osxkeychain`, `wincred`,
+   `secretservice`, `pass`, `desktop`). Same subprocess protocol.
+3. **`auths.<registry>.auth`** — direct credentials, base64-encoded as
+   `user:password`. Written by `docker login` on systems without a
+   keychain.
+4. **`auths.<registry>.identitytoken`** — registry-issued bearer token
+   (Azure ACR, some Hub flows). Sent as the secret with username
+   `<token>`.
+
+Examples — `~/.docker/config.json` shapes that mikebom understands:
+
+```json
+// GHCR with a Personal Access Token (PAT) requires the read:packages scope.
+{
+  "auths": {
+    "ghcr.io": { "auth": "<base64('username:ghp_xxxxxxxxxxxx')>" }
+  }
+}
+```
+
+```json
+// macOS Docker Desktop, credentials in the system keychain.
+{
+  "auths": { "ghcr.io": {} },
+  "credsStore": "desktop"
+}
+```
+
+```json
+// AWS ECR via the standard helper.
+{
+  "credHelpers": {
+    "123456789012.dkr.ecr.us-east-1.amazonaws.com": "ecr-login"
+  }
+}
+```
+
+Behaviour notes:
+
+- **Anonymous fallback.** If no `~/.docker/config.json` exists, or no
+  entry matches the target registry, mikebom falls through to the
+  anonymous bearer-token flow that public images already use. No error
+  is raised.
+- **Helper failure → anonymous fallback.** If a credential helper exits
+  non-zero or emits the documented `"credentials not found"` sentinel,
+  mikebom falls through to anonymous (so `credsStore: desktop` doesn't
+  block unrelated public-image scans). Helper stderr is intentionally
+  *not* captured into mikebom's logs — some helpers print partial
+  credentials there.
+- **No secret leakage.** Credentials are never printed to stdout, stderr,
+  `--verbose` output, or `RUST_LOG=debug` traces; the in-memory
+  `Credential` struct redacts both fields in its `Debug` impl. If you
+  observe a leak, please file an issue.
+- **ECR token TTL.** AWS ECR tokens expire after 12 hours. Since
+  mikebom is a one-shot CLI, this never matters in practice — by the
+  time a token would expire, the scan is long since complete.
+- **GHCR PAT scope.** Private GHCR images require `read:packages` on
+  the PAT. `repo` scope alone is not sufficient.
+
+What's not yet supported (deferred to follow-ons):
+
+- `--registry-auth user:pass@host` CLI flag (file `docker login` first).
+- OAuth refresh-token flows beyond the bearer-token retry.
+- Native AWS SDK integration for ECR (`docker-credential-ecr-login`
+  remains the supported path).
+- Registry mirror configs (`registries.conf`, `mirrors`).
 
 ---
 

--- a/mikebom-cli/Cargo.toml
+++ b/mikebom-cli/Cargo.toml
@@ -72,12 +72,16 @@ ebpf-tracing = [
 # build (e.g., embedding mikebom in another tool that only scans
 # local trees / pre-extracted tarballs).
 #
-# Anonymous public registries only. Auth (Docker keychain + cred
-# helpers) deferred to 031.x (#66); multi-platform flag deferred to
+# Anonymous + authenticated pulls (Docker keychain — milestone 034 /
+# 031.x, #66). Both anonymous and credentialed flows go through the
+# same bearer-token retry path; credentials (when resolved from
+# ~/.docker/config.json / $DOCKER_CONFIG/config.json) are applied as
+# Basic auth on the realm token GET. Multi-platform flag deferred to
 # 031.y (#67); layer caching deferred to 031.z (#68). See
-# `specs/031-oci-registry-image-scan/spec.md` for the full contract
-# and `specs/032-oci-spec-migration/spec.md` for the substrate
-# rationale.
+# `specs/031-oci-registry-image-scan/spec.md` for the original
+# contract, `specs/032-oci-spec-migration/spec.md` for the substrate
+# rationale, and `specs/034-authenticated-registry-pulls/spec.md` for
+# the auth design.
 oci-registry = [
     "dep:oci-spec",
 ]

--- a/mikebom-cli/src/scan_fs/oci_pull/auth.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull/auth.rs
@@ -1,0 +1,547 @@
+//! Docker keychain credential resolution for OCI registry pulls
+//! (milestone 034 / 031.x — closes #66).
+//!
+//! Resolves credentials for a target registry from `~/.docker/config.json`
+//! (or `$DOCKER_CONFIG/config.json`), implementing the standard precedence:
+//!
+//!   1. `credHelpers.<registry>` — per-registry credential helper override.
+//!   2. `credsStore` — registry-wide credential helper.
+//!   3. `auths.<registry>.auth` — base64-encoded `user:password`.
+//!   4. `auths.<registry>.identitytoken` — registry-issued identity token.
+//!
+//! Each helper is invoked as a subprocess (`docker-credential-<name> get`)
+//! per the documented Docker cred-helper API:
+//!   <https://github.com/docker/docker-credential-helpers>
+//!
+//! Secret material is held in `Credential`, whose `Debug` is hand-written
+//! to redact both fields. No `tracing::*!` / `anyhow::Context` /
+//! `eprintln!` macro in this module interpolates a secret value;
+//! commit-3's grep audit verifies this mechanically.
+//!
+//! Sync by design: the cred-helper subprocess completes in ~100ms in
+//! practice (worst case a few seconds for ECR's STS round-trip), and
+//! mikebom is a one-shot CLI. Brief blocking in the tokio runtime is
+//! acceptable here. If this ever needs to become async, switch to
+//! `tokio::process::Command` + `tokio::fs::read`.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use base64::engine::general_purpose::STANDARD as B64_STANDARD;
+use base64::Engine as _;
+use serde::Deserialize;
+
+/// A resolved credential pair, with redacting `Debug` impl.
+///
+/// `secret` may be a password (Basic auth), a PAT, or an identity token
+/// depending on the cred source. Treat it as opaque from the perspective
+/// of credential consumers.
+#[derive(Clone)]
+pub(super) struct Credential {
+    pub(super) username: String,
+    pub(super) secret: String,
+}
+
+impl fmt::Debug for Credential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Credential")
+            .field("username", &"<redacted>")
+            .field("secret", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Parsed `~/.docker/config.json`. All fields default to empty so that
+/// partial / minimal configs (a common shape — `docker login` writes
+/// only what it needs) parse successfully.
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct DockerConfig {
+    #[serde(default)]
+    pub(super) auths: HashMap<String, AuthEntry>,
+    #[serde(rename = "credsStore", default)]
+    pub(super) creds_store: Option<String>,
+    #[serde(rename = "credHelpers", default)]
+    pub(super) cred_helpers: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct AuthEntry {
+    #[serde(default)]
+    pub(super) auth: Option<String>,
+    #[serde(default)]
+    pub(super) identitytoken: Option<String>,
+}
+
+/// Locate and parse the user's Docker config. Returns `None` (NOT an
+/// error) if no config exists or it can't be parsed; this is the
+/// common case for systems that have never run `docker login`, and we
+/// want to fall through to anonymous in that case.
+pub(super) fn load_default_docker_config() -> Option<DockerConfig> {
+    let path = docker_config_path()?;
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!(
+                config_path = %path.display(),
+                error = %e,
+                "could not read Docker config; proceeding without registry credentials"
+            );
+            return None;
+        }
+    };
+    match serde_json::from_slice::<DockerConfig>(&bytes) {
+        Ok(cfg) => Some(cfg),
+        Err(e) => {
+            tracing::warn!(
+                config_path = %path.display(),
+                error = %e,
+                "could not parse Docker config; proceeding without registry credentials"
+            );
+            None
+        }
+    }
+}
+
+fn docker_config_path() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("DOCKER_CONFIG") {
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir).join("config.json"));
+        }
+    }
+    let home = std::env::var("HOME").ok()?;
+    if home.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(home).join(".docker").join("config.json"))
+}
+
+/// Resolve credentials for `registry`, applying the precedence:
+/// `credHelpers` > `credsStore` > `auths.<reg>.auth` >
+/// `auths.<reg>.identitytoken` > `None`.
+pub(super) fn resolve_credentials(
+    cfg: &DockerConfig,
+    registry: &str,
+) -> Option<Credential> {
+    let normalized = normalize_registry_key(registry);
+
+    // 1. Per-registry helper override (covers ECR's typical setup:
+    // `credHelpers: { "<account>.dkr.ecr.<region>.amazonaws.com": "ecr-login" }`).
+    let helper_key = cfg
+        .cred_helpers
+        .keys()
+        .find(|k| normalize_registry_key(k) == normalized);
+    if let Some(key) = helper_key {
+        if let Some(helper) = cfg.cred_helpers.get(key) {
+            if let Some(c) = run_credential_helper(helper, registry) {
+                return Some(c);
+            }
+        }
+    }
+
+    // 2. Registry-wide helper (covers `credsStore: desktop` / `osxkeychain`
+    // / `wincred` / `pass` / `secretservice`).
+    if let Some(helper) = cfg.creds_store.as_deref() {
+        if let Some(c) = run_credential_helper(helper, registry) {
+            return Some(c);
+        }
+    }
+
+    // 3 & 4. Direct auth / identitytoken.
+    let auth_key = cfg
+        .auths
+        .keys()
+        .find(|k| normalize_registry_key(k) == normalized);
+    if let Some(key) = auth_key {
+        if let Some(entry) = cfg.auths.get(key) {
+            if let Some(c) = entry.auth.as_deref().and_then(decode_auth_field) {
+                return Some(c);
+            }
+            if let Some(token) = entry.identitytoken.as_deref() {
+                if !token.is_empty() {
+                    return Some(Credential {
+                        username: "<token>".to_string(),
+                        secret: token.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Decode an `auth` field's `<base64(user:secret)>` form. Empty input
+/// or malformed payloads return `None` (caller treats as
+/// "no credentials available").
+fn decode_auth_field(b64: &str) -> Option<Credential> {
+    let trimmed = b64.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let decoded = B64_STANDARD.decode(trimmed).ok()?;
+    let s = std::str::from_utf8(&decoded).ok()?;
+    let (user, secret) = s.split_once(':')?;
+    if user.is_empty() {
+        return None;
+    }
+    Some(Credential {
+        username: user.to_string(),
+        secret: secret.to_string(),
+    })
+}
+
+/// Normalize a registry-name string for matching keys in `auths` /
+/// `credHelpers`. Strips `http(s)://` schemes, drops any path segment,
+/// lowercases the host, and treats `index.docker.io` as `docker.io`.
+fn normalize_registry_key(s: &str) -> String {
+    let mut t = s.trim().to_ascii_lowercase();
+    for prefix in ["https://", "http://"] {
+        if let Some(stripped) = t.strip_prefix(prefix) {
+            t = stripped.to_string();
+            break;
+        }
+    }
+    if let Some(slash) = t.find('/') {
+        t.truncate(slash);
+    }
+    if t == "index.docker.io" {
+        t = "docker.io".to_string();
+    }
+    t
+}
+
+/// Invoke a Docker credential helper subprocess by its short name
+/// (e.g. `osxkeychain`, `ecr-login`). Resolves to the full program name
+/// `docker-credential-<helper>` and dispatches to
+/// [`run_credential_helper_program`].
+fn run_credential_helper(helper: &str, registry: &str) -> Option<Credential> {
+    let program = format!("docker-credential-{helper}");
+    run_credential_helper_program(&program, registry)
+}
+
+/// Invoke a credential helper by full program path or PATH-resolvable
+/// program name. Returns `None` for "credentials not found" or any
+/// helper failure (spawn / wait / non-zero exit / unparseable JSON).
+///
+/// The helper's stderr is piped to `Stdio::null()` — some helpers
+/// emit partial credentials (or auth-failure details) on stderr, and
+/// we don't want those leaking into mikebom's logs.
+fn run_credential_helper_program(program: &str, registry: &str) -> Option<Credential> {
+    use std::io::Write as _;
+
+    let mut child = match Command::new(program)
+        .arg("get")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                helper = %program,
+                error = %e,
+                "could not invoke credential helper; falling back to anonymous"
+            );
+            return None;
+        }
+    };
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = writeln!(stdin, "{registry}");
+    }
+
+    let output = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::warn!(
+                helper = %program,
+                error = %e,
+                "credential helper subprocess failed; falling back to anonymous"
+            );
+            return None;
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // "credentials not found in native keychain" is the documented sentinel
+    // emitted by helpers when no credentials are cached for the registry.
+    // (osxkeychain, wincred, secretservice, pass all use this string.)
+    if !output.status.success()
+        || stdout.to_ascii_lowercase().contains("credentials not found")
+    {
+        return None;
+    }
+
+    #[derive(Deserialize)]
+    struct HelperOutput {
+        #[serde(rename = "Username")]
+        username: String,
+        #[serde(rename = "Secret")]
+        secret: String,
+    }
+
+    let parsed: HelperOutput = serde_json::from_str(&stdout).ok()?;
+    if parsed.username.is_empty() && parsed.secret.is_empty() {
+        return None;
+    }
+    Some(Credential {
+        username: parsed.username,
+        secret: parsed.secret,
+    })
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credential_debug_redacts_both_fields() {
+        let c = Credential {
+            username: "alice".to_string(),
+            secret: "supersecretpat".to_string(),
+        };
+        let dbg = format!("{c:?}");
+        assert!(!dbg.contains("alice"), "username leaked in Debug: {dbg}");
+        assert!(
+            !dbg.contains("supersecretpat"),
+            "secret leaked in Debug: {dbg}"
+        );
+        assert!(dbg.contains("redacted"));
+    }
+
+    #[test]
+    fn normalize_registry_key_handles_common_forms() {
+        assert_eq!(normalize_registry_key("docker.io"), "docker.io");
+        assert_eq!(normalize_registry_key("index.docker.io"), "docker.io");
+        assert_eq!(
+            normalize_registry_key("https://index.docker.io/v1/"),
+            "docker.io"
+        );
+        assert_eq!(
+            normalize_registry_key("https://index.docker.io/v2/"),
+            "docker.io"
+        );
+        assert_eq!(normalize_registry_key("ghcr.io"), "ghcr.io");
+        assert_eq!(normalize_registry_key("GHCR.IO"), "ghcr.io");
+        assert_eq!(
+            normalize_registry_key("https://gcr.io"),
+            "gcr.io"
+        );
+        assert_eq!(
+            normalize_registry_key("123456789012.dkr.ecr.us-east-1.amazonaws.com"),
+            "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+        );
+    }
+
+    #[test]
+    fn decode_auth_field_decodes_user_password() {
+        // base64("alice:hunter2") = YWxpY2U6aHVudGVyMg==
+        let c = decode_auth_field("YWxpY2U6aHVudGVyMg==").unwrap();
+        assert_eq!(c.username, "alice");
+        assert_eq!(c.secret, "hunter2");
+    }
+
+    #[test]
+    fn decode_auth_field_handles_empty_secret() {
+        // base64("alice:") = YWxpY2U6
+        let c = decode_auth_field("YWxpY2U6").unwrap();
+        assert_eq!(c.username, "alice");
+        assert_eq!(c.secret, "");
+    }
+
+    #[test]
+    fn decode_auth_field_rejects_empty_input() {
+        assert!(decode_auth_field("").is_none());
+        assert!(decode_auth_field("   ").is_none());
+    }
+
+    #[test]
+    fn decode_auth_field_rejects_missing_separator() {
+        // base64("aliceonly") = YWxpY2Vvbmx5
+        assert!(decode_auth_field("YWxpY2Vvbmx5").is_none());
+    }
+
+    #[test]
+    fn decode_auth_field_rejects_empty_username() {
+        // base64(":secret") = OnNlY3JldA==
+        assert!(decode_auth_field("OnNlY3JldA==").is_none());
+    }
+
+    #[test]
+    fn resolve_credentials_returns_auth_field() {
+        // base64("alice:pat") = YWxpY2U6cGF0
+        let json = r#"{
+            "auths": {
+                "ghcr.io": { "auth": "YWxpY2U6cGF0" }
+            }
+        }"#;
+        let cfg: DockerConfig = serde_json::from_str(json).unwrap();
+        let c = resolve_credentials(&cfg, "ghcr.io").unwrap();
+        assert_eq!(c.username, "alice");
+        assert_eq!(c.secret, "pat");
+    }
+
+    #[test]
+    fn resolve_credentials_returns_identitytoken_when_no_auth() {
+        let json = r#"{
+            "auths": {
+                "myregistry.example.com": { "identitytoken": "tok-abc-123" }
+            }
+        }"#;
+        let cfg: DockerConfig = serde_json::from_str(json).unwrap();
+        let c = resolve_credentials(&cfg, "myregistry.example.com").unwrap();
+        assert_eq!(c.username, "<token>");
+        assert_eq!(c.secret, "tok-abc-123");
+    }
+
+    #[test]
+    fn resolve_credentials_normalizes_docker_io_aliases() {
+        // base64("u:p") = dTpw
+        let json = r#"{
+            "auths": {
+                "https://index.docker.io/v1/": { "auth": "dTpw" }
+            }
+        }"#;
+        let cfg: DockerConfig = serde_json::from_str(json).unwrap();
+        // The reference parser hands us "docker.io"; the config key is
+        // the legacy index.docker.io URL. Normalization should bridge them.
+        let c = resolve_credentials(&cfg, "docker.io").unwrap();
+        assert_eq!(c.username, "u");
+        assert_eq!(c.secret, "p");
+    }
+
+    #[test]
+    fn resolve_credentials_returns_none_when_empty_auth_entry_and_no_helper() {
+        // `docker login` writes `{"auths": {"<reg>": {}}}` when credentials
+        // live in a credential store and no creds_store is configured here.
+        // With no helper we should fall through to anonymous.
+        let json = r#"{
+            "auths": {
+                "ghcr.io": {}
+            }
+        }"#;
+        let cfg: DockerConfig = serde_json::from_str(json).unwrap();
+        assert!(resolve_credentials(&cfg, "ghcr.io").is_none());
+    }
+
+    #[test]
+    fn resolve_credentials_returns_none_when_registry_unknown() {
+        let json = r#"{ "auths": { "ghcr.io": { "auth": "dTpw" } } }"#;
+        let cfg: DockerConfig = serde_json::from_str(json).unwrap();
+        assert!(resolve_credentials(&cfg, "gcr.io").is_none());
+    }
+
+    #[test]
+    fn resolve_credentials_skips_empty_auth_string() {
+        // `{"auth": ""}` is the marker `docker logout` writes; ignore it.
+        let json = r#"{
+            "auths": { "ghcr.io": { "auth": "" } }
+        }"#;
+        let cfg: DockerConfig = serde_json::from_str(json).unwrap();
+        assert!(resolve_credentials(&cfg, "ghcr.io").is_none());
+    }
+
+    #[test]
+    fn docker_config_default_parses_minimal_json() {
+        let cfg: DockerConfig = serde_json::from_str("{}").unwrap();
+        assert!(cfg.auths.is_empty());
+        assert!(cfg.creds_store.is_none());
+        assert!(cfg.cred_helpers.is_empty());
+    }
+
+    #[test]
+    fn docker_config_parses_full_shape() {
+        let json = r#"{
+            "auths": {
+                "ghcr.io": { "auth": "dTpw" },
+                "myreg.example.com": { "identitytoken": "t" }
+            },
+            "credsStore": "desktop",
+            "credHelpers": {
+                "123.dkr.ecr.us-east-1.amazonaws.com": "ecr-login"
+            }
+        }"#;
+        let cfg: DockerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.auths.len(), 2);
+        assert_eq!(cfg.creds_store.as_deref(), Some("desktop"));
+        assert_eq!(
+            cfg.cred_helpers
+                .get("123.dkr.ecr.us-east-1.amazonaws.com")
+                .map(String::as_str),
+            Some("ecr-login")
+        );
+    }
+
+    // -------- helper-subprocess tests (unix-only shim script) --------
+
+    #[cfg(unix)]
+    fn write_helper_shim(dir: &std::path::Path, name: &str, body: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let path = dir.join(name);
+        std::fs::write(&path, body).unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_credential_helper_program_parses_helper_stdout() {
+        let tmp = tempfile::tempdir().unwrap();
+        // base64("u:p") = dTpw -> we don't actually invoke that path here;
+        // helpers emit JSON, not base64.
+        let body = r#"#!/bin/sh
+read REG
+cat <<JSON
+{"ServerURL":"$REG","Username":"alice","Secret":"hunter2"}
+JSON
+"#;
+        let prog = write_helper_shim(tmp.path(), "docker-credential-mikebomtest", body);
+        let c = run_credential_helper_program(prog.to_str().unwrap(), "ghcr.io").unwrap();
+        assert_eq!(c.username, "alice");
+        assert_eq!(c.secret, "hunter2");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_credential_helper_program_returns_none_for_credentials_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = r#"#!/bin/sh
+echo "credentials not found in native keychain"
+exit 1
+"#;
+        let prog = write_helper_shim(tmp.path(), "docker-credential-mikebomtest-missing", body);
+        assert!(run_credential_helper_program(prog.to_str().unwrap(), "ghcr.io").is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_credential_helper_program_returns_none_on_nonzero_exit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = r#"#!/bin/sh
+exit 2
+"#;
+        let prog = write_helper_shim(tmp.path(), "docker-credential-mikebomtest-broken", body);
+        assert!(run_credential_helper_program(prog.to_str().unwrap(), "ghcr.io").is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_credential_helper_program_returns_none_for_missing_program() {
+        assert!(
+            run_credential_helper_program(
+                "/nonexistent/path/docker-credential-doesnotexist",
+                "ghcr.io"
+            )
+            .is_none()
+        );
+    }
+}

--- a/mikebom-cli/src/scan_fs/oci_pull/mod.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull/mod.rs
@@ -44,6 +44,10 @@
 //! regression test in `mikebom-cli/tests/no_c_dependencies.rs`
 //! locks the substrate decision in.
 
+// `auth` is wired into `registry` in milestone 034 commit 2; this commit
+// only adds the module and its inline tests so it can land independently.
+#[allow(dead_code)]
+mod auth;
 mod platform;
 mod reference;
 mod registry;

--- a/mikebom-cli/src/scan_fs/oci_pull/mod.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull/mod.rs
@@ -44,9 +44,6 @@
 //! regression test in `mikebom-cli/tests/no_c_dependencies.rs`
 //! locks the substrate decision in.
 
-// `auth` is wired into `registry` in milestone 034 commit 2; this commit
-// only adds the module and its inline tests so it can land independently.
-#[allow(dead_code)]
 mod auth;
 mod platform;
 mod reference;
@@ -87,7 +84,7 @@ pub async fn pull_to_tarball(image_ref: &str) -> Result<tempfile::TempDir> {
 
     let host_arch = host_oci_arch()
         .context("mapping host architecture to OCI platform name")?;
-    let client = RegistryClient::new()?;
+    let client = RegistryClient::new(&reference)?;
 
     // Step 1: fetch the manifest. If it's an image index
     // (manifest list), resolve the platform-specific manifest and

--- a/mikebom-cli/src/scan_fs/oci_pull/registry.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull/registry.rs
@@ -1,17 +1,16 @@
-//! Thin OCI distribution-spec HTTP client (milestone 032).
+//! Thin OCI distribution-spec HTTP client (milestone 032; auth in 034).
 //!
 //! Replaces the milestone-031 `oci-client::Client` integration. Built
 //! on the workspace's `reqwest 0.12 + rustls-tls (ring)` (no new
 //! HTTP/TLS deps) and `oci-spec 0.9` (types-only).
 //!
-//! Anonymous-only scope: when a registry returns 401 with
+//! Auth: when a registry returns 401 with
 //! `WWW-Authenticate: Bearer realm="...",service="...",scope="..."`
-//! we fetch a token from the realm UNAUTHENTICATED and retry. This
-//! covers Docker Hub's "anonymous-but-token-required" handshake +
+//! we fetch a token from the realm. Credentials (when available from
+//! the Docker keychain — see `super::auth`) are sent as Basic auth on
+//! the realm GET. Without credentials the realm GET is anonymous,
+//! covering Docker Hub's "anonymous-but-token-required" handshake +
 //! direct-anonymous registries (gcr.io, ghcr.io public, etc.).
-//! Authenticated registries (private repos) are explicitly out of
-//! scope here — milestone 031.x (#66) covers Docker keychain +
-//! cred helpers.
 //!
 //! Endpoints (per OCI distribution-spec v1):
 //!   - `GET /v2/<repo>/manifests/<reference>` — manifest or index
@@ -22,6 +21,7 @@ use sha2::Digest as _;
 
 use oci_spec::image::{ImageIndex, ImageManifest};
 
+use super::auth::Credential;
 use super::reference::ImageReference;
 
 /// Manifest media types we accept (sent on the `Accept` header
@@ -50,15 +50,33 @@ pub(super) enum ManifestOrIndex {
 /// Thin async HTTP client over the OCI distribution-spec.
 pub(super) struct RegistryClient {
     http: reqwest::Client,
+    /// Resolved credentials for the target registry (milestone 034).
+    /// `None` means anonymous-pull mode. Credentials are bound at
+    /// construction time and applied as Basic auth on the bearer-
+    /// token realm fetch in [`Self::fetch_bearer_token`].
+    credentials: Option<Credential>,
 }
 
 impl RegistryClient {
-    pub(super) fn new() -> Result<Self> {
+    /// Build a client for `reference`, resolving Docker-keychain
+    /// credentials for the target registry from
+    /// `~/.docker/config.json` (or `$DOCKER_CONFIG/config.json`) at
+    /// construction time. Missing config / no entry for this registry
+    /// → anonymous mode.
+    pub(super) fn new(reference: &ImageReference) -> Result<Self> {
         let http = reqwest::Client::builder()
             .user_agent(concat!("mikebom/", env!("CARGO_PKG_VERSION")))
             .build()
             .context("building reqwest::Client for OCI registry")?;
-        Ok(Self { http })
+        let credentials = super::auth::load_default_docker_config()
+            .and_then(|cfg| super::auth::resolve_credentials(&cfg, &reference.registry));
+        if credentials.is_some() {
+            tracing::debug!(
+                registry = %reference.registry,
+                "resolved registry credentials from Docker keychain"
+            );
+        }
+        Ok(Self { http, credentials })
     }
 
     /// Fetch the manifest for `reference`. Returns either a
@@ -145,24 +163,34 @@ impl RegistryClient {
             if retry.status().is_success() {
                 return ResponseBody::from_response(retry).await;
             }
+            if self.credentials.is_some() {
+                bail!(
+                    "registry authentication failed for GET {url} \
+                     (got {} after bearer-token retry). Verify credentials \
+                     in ~/.docker/config.json or your credential helper.",
+                    retry.status()
+                );
+            }
             bail!(
-                "registry returned {} for GET {url} after bearer-token retry. \
-                 Authenticated registries are not yet supported in milestone 031 \
-                 (tracked as 031.x — see issue #66).",
+                "registry returned {} for GET {url} after anonymous \
+                 bearer-token retry. For private registries, configure \
+                 ~/.docker/config.json (`auth` or `identitytoken` field) \
+                 or a credential helper.",
                 retry.status()
             );
         }
         // 403 / 404 / 5xx etc.
-        bail!(
-            "registry returned {status} for GET {url}. \
-             Authenticated registries are not yet supported in milestone 031 \
-             (tracked as 031.x — see issue #66)."
-        );
+        bail!("registry returned {status} for GET {url}.");
     }
 
-    /// Anonymous bearer-token fetch from the realm. Used when
-    /// the registry's 401 response includes a `Bearer
-    /// realm="...",service="...",scope="..."` challenge.
+    /// Bearer-token fetch from the realm. Used when the registry's
+    /// 401 response includes a
+    /// `Bearer realm="...",service="...",scope="..."` challenge.
+    ///
+    /// When [`Self::credentials`] is `Some`, sends `Basic <b64(user:secret)>`
+    /// on the realm GET; the realm validates and returns a bearer
+    /// token scoped per the credentials. When `None`, the request is
+    /// anonymous (covers the public-Hub / public-GHCR / gcr.io flow).
     async fn fetch_bearer_token(&self, challenge: &BearerChallenge) -> Result<String> {
         let mut req = self.http.get(&challenge.realm);
         if let Some(service) = challenge.service.as_deref() {
@@ -170,6 +198,9 @@ impl RegistryClient {
         }
         if let Some(scope) = challenge.scope.as_deref() {
             req = req.query(&[("scope", scope)]);
+        }
+        if let Some(c) = self.credentials.as_ref() {
+            req = req.basic_auth(&c.username, Some(&c.secret));
         }
         let resp = req
             .send()
@@ -511,6 +542,133 @@ mod tests {
         assert_eq!(
             url,
             "https://registry-1.docker.io/v2/library/alpine/blobs/sha256:abc123"
+        );
+    }
+
+    /// End-to-end auth wire-up test (milestone 034 commit 2): when a
+    /// `RegistryClient` carries a `Credential`, the bearer-token realm
+    /// fetch sends `Authorization: Basic <b64(user:secret)>`. We spin
+    /// up a tokio TCP listener that speaks one HTTP request and
+    /// inspect the Authorization header on the wire — no mock-server
+    /// crate dependency.
+    #[tokio::test]
+    async fn fetch_bearer_token_sends_basic_auth_when_credential_present() {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            // Read until end-of-headers (\r\n\r\n). GETs have no body,
+            // so we don't need Content-Length parsing.
+            let mut buf = vec![0u8; 4096];
+            let mut total = 0;
+            while total < buf.len() {
+                let n = stream.read(&mut buf[total..]).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                total += n;
+                if buf[..total].windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let request = String::from_utf8_lossy(&buf[..total]).into_owned();
+            let body = r#"{"token":"the-bearer-token"}"#;
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(resp.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+            request
+        });
+
+        // Construct RegistryClient with explicit credentials (bypassing
+        // the Docker-keychain lookup — we don't want this test to
+        // depend on the developer's actual ~/.docker/config.json).
+        let client = RegistryClient {
+            http: reqwest::Client::new(),
+            credentials: Some(Credential {
+                username: "alice".to_string(),
+                secret: "hunter2".to_string(),
+            }),
+        };
+        let challenge = BearerChallenge {
+            realm: format!("http://{addr}/token"),
+            service: Some("test".to_string()),
+            scope: Some("repository:foo/bar:pull".to_string()),
+        };
+
+        let token = client.fetch_bearer_token(&challenge).await.unwrap();
+        assert_eq!(token, "the-bearer-token");
+
+        let request = server.await.unwrap();
+        // base64("alice:hunter2") = YWxpY2U6aHVudGVyMg==
+        assert!(
+            request.contains("Authorization: Basic YWxpY2U6aHVudGVyMg==")
+                || request.contains("authorization: Basic YWxpY2U6aHVudGVyMg=="),
+            "realm GET should carry Basic auth header; got request:\n{request}"
+        );
+    }
+
+    /// Counterpart: anonymous mode (no credentials) sends NO
+    /// Authorization header on the realm GET. Guards against future
+    /// regressions where a default-credential leak could pin auth on
+    /// for everyone.
+    #[tokio::test]
+    async fn fetch_bearer_token_sends_no_auth_when_credential_absent() {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let mut total = 0;
+            while total < buf.len() {
+                let n = stream.read(&mut buf[total..]).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                total += n;
+                if buf[..total].windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let request = String::from_utf8_lossy(&buf[..total]).into_owned();
+            let body = r#"{"token":"anon-token"}"#;
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(resp.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+            request
+        });
+
+        let client = RegistryClient {
+            http: reqwest::Client::new(),
+            credentials: None,
+        };
+        let challenge = BearerChallenge {
+            realm: format!("http://{addr}/token"),
+            service: None,
+            scope: None,
+        };
+
+        let token = client.fetch_bearer_token(&challenge).await.unwrap();
+        assert_eq!(token, "anon-token");
+
+        let request = server.await.unwrap();
+        let has_auth = request
+            .lines()
+            .any(|l| l.to_ascii_lowercase().starts_with("authorization:"));
+        assert!(
+            !has_auth,
+            "anonymous realm GET must not carry Authorization header; got request:\n{request}"
         );
     }
 }

--- a/mikebom-cli/tests/oci_registry_smoke.rs
+++ b/mikebom-cli/tests/oci_registry_smoke.rs
@@ -1,22 +1,36 @@
-//! Network-gated end-to-end smoke test for milestone 031.
+//! Network-gated end-to-end smoke tests for the OCI registry-pull
+//! pipeline (milestones 031 anonymous + 034 authenticated).
 //!
-//! This test pulls a real public OCI image from a real registry,
-//! runs it through the full mikebom pipeline (oci_pull →
-//! docker_image::extract → scan → SBOM emission), and verifies the
-//! output is well-formed. It runs ONLY when:
+//! These tests pull real OCI images from real registries, run them
+//! through the full mikebom pipeline (oci_pull →
+//! docker_image::extract → scan → SBOM emission), and verify the
+//! output is well-formed. They run ONLY when:
 //!
 //!   1. The crate is built with `--features oci-registry`, AND
 //!   2. The `MIKEBOM_OCI_NETWORK_TESTS=1` env var is set.
 //!
 //! The default Linux + ebpf + macOS CI lanes do NOT set the env
-//! var, so this test is silently skipped on every standard PR. A
-//! follow-on milestone may add a dedicated `lint-and-test-oci-network`
-//! job that flips it on; for milestone 031 it ships as opt-in only.
+//! var, so these tests are silently skipped on every standard PR.
+//! A follow-on milestone may add a dedicated
+//! `lint-and-test-oci-network` job that flips it on; for now they
+//! ship as opt-in only.
+//!
+//! The authenticated smoke test additionally requires
+//! `MIKEBOM_OCI_AUTH_TESTS=1` and the env var
+//! `MIKEBOM_OCI_AUTH_PRIVATE_IMAGE_REF` pointing at a private image
+//! you already have credentials for in `~/.docker/config.json`.
+//! Documented in PR descriptions for manual verification.
 //!
 //! To run locally:
 //!
 //! ```sh
 //! MIKEBOM_OCI_NETWORK_TESTS=1 cargo +stable test \
+//!     -p mikebom --features oci-registry --test oci_registry_smoke
+//!
+//! MIKEBOM_OCI_NETWORK_TESTS=1 \
+//! MIKEBOM_OCI_AUTH_TESTS=1 \
+//! MIKEBOM_OCI_AUTH_PRIVATE_IMAGE_REF=ghcr.io/<you>/<priv>:tag \
+//!     cargo +stable test \
 //!     -p mikebom --features oci-registry --test oci_registry_smoke
 //! ```
 
@@ -26,6 +40,10 @@ use std::process::Command;
 
 fn network_tests_enabled() -> bool {
     std::env::var("MIKEBOM_OCI_NETWORK_TESTS").ok().as_deref() == Some("1")
+}
+
+fn auth_tests_enabled() -> bool {
+    std::env::var("MIKEBOM_OCI_AUTH_TESTS").ok().as_deref() == Some("1")
 }
 
 #[test]
@@ -134,4 +152,102 @@ fn pulls_distroless_static_and_emits_well_formed_sbom_with_zero_components() {
         components, 0,
         "distroless static image should yield 0 components (it ships no package metadata); got {components}"
     );
+}
+
+/// Authenticated end-to-end smoke test (milestone 034 / 031.x).
+///
+/// Pulls a private image from the registry using credentials
+/// resolved from `~/.docker/config.json`. The image reference is
+/// passed via `MIKEBOM_OCI_AUTH_PRIVATE_IMAGE_REF` so that this
+/// test doesn't bake in any specific user's private repo.
+///
+/// Skipped silently unless BOTH gate env vars are set:
+///   - `MIKEBOM_OCI_NETWORK_TESTS=1`
+///   - `MIKEBOM_OCI_AUTH_TESTS=1`
+///
+/// Verifies the scan succeeds AND that no credential bytes leak to
+/// stdout / stderr. The `auth` field's base64 string is what we'd
+/// most readily detect in a regression — if it ever shows up in
+/// program output, fail loudly.
+#[test]
+fn pulls_private_image_via_docker_keychain() {
+    if !network_tests_enabled() || !auth_tests_enabled() {
+        eprintln!(
+            "skipping: set MIKEBOM_OCI_NETWORK_TESTS=1 and \
+             MIKEBOM_OCI_AUTH_TESTS=1 to run the authenticated smoke test"
+        );
+        return;
+    }
+
+    let image_ref = match std::env::var("MIKEBOM_OCI_AUTH_PRIVATE_IMAGE_REF") {
+        Ok(r) if !r.is_empty() => r,
+        _ => {
+            eprintln!(
+                "skipping: MIKEBOM_OCI_AUTH_PRIVATE_IMAGE_REF must point at a \
+                 private image you have credentials for in ~/.docker/config.json"
+            );
+            return;
+        }
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("private.cdx.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_mikebom"))
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--image")
+        .arg(&image_ref)
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(&out_path)
+        .env("RUST_LOG", "debug")
+        .output()
+        .expect("mikebom should run");
+    assert!(
+        output.status.success(),
+        "mikebom failed for {image_ref}:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // Best-effort secret-leak guard. If the user's config.json puts a
+    // credential value in `auths.<reg>.auth`, we can read it back here
+    // and confirm it doesn't appear in mikebom's output. This is a
+    // sanity check, not a security guarantee — credential helpers
+    // store the secret outside config.json so we can't guard them.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if let Some(home) = std::env::var_os("HOME") {
+        let cfg_path = std::path::PathBuf::from(home).join(".docker/config.json");
+        if let Ok(cfg_bytes) = std::fs::read(&cfg_path) {
+            if let Ok(cfg_json) = serde_json::from_slice::<serde_json::Value>(&cfg_bytes) {
+                if let Some(auths) = cfg_json.get("auths").and_then(|v| v.as_object()) {
+                    for (_reg, entry) in auths {
+                        for field in ["auth", "identitytoken"] {
+                            if let Some(secret) = entry.get(field).and_then(|v| v.as_str()) {
+                                if !secret.is_empty() {
+                                    assert!(
+                                        !stdout.contains(secret),
+                                        "credential `{field}` value leaked to stdout"
+                                    );
+                                    assert!(
+                                        !stderr.contains(secret),
+                                        "credential `{field}` value leaked to stderr"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // SBOM is well-formed.
+    let bytes = std::fs::read(&out_path).expect("read private.cdx.json");
+    let sbom: serde_json::Value = serde_json::from_slice(&bytes).expect("valid CDX JSON");
+    assert!(sbom["bomFormat"].as_str().is_some(), "missing bomFormat");
+    assert!(sbom["specVersion"].as_str().is_some(), "missing specVersion");
 }

--- a/specs/034-authenticated-registry-pulls/checklists/requirements.md
+++ b/specs/034-authenticated-registry-pulls/checklists/requirements.md
@@ -1,0 +1,98 @@
+# Spec Quality Checklist: Authenticated OCI Registry Pulls (031.x)
+
+**Checklist for** `/specs/034-authenticated-registry-pulls/spec.md`
+
+## Coverage
+
+- [X] Background section names what's missing today (anonymous-only) and
+      cites the file:line auth seam (`registry.rs::fetch_with_bearer_retry`
+      line 107, `fetch_bearer_token` line 166).
+- [X] User story has a P-priority (P1) and a "why this priority"
+      justification (highest-value follow-on; closes the workflow gap that
+      forces `docker pull && docker save`).
+- [X] Independent Test is concrete (specific commands + observable
+      outcomes + secret-leak audit).
+- [X] Acceptance scenarios use Given/When/Then framing (5 scenarios, each
+      naming a different cred source).
+- [X] Edge Cases section names the corner cases (identitytoken, helper
+      failure, helper stdin contract, registry name normalization, Debug
+      impl, empty auth field, ECR).
+- [X] Functional Requirements numbered (FR-001 through FR-008), each with
+      a concrete file path and signature.
+- [X] Key Entities — `DockerConfig`, `Credential`, `AuthEntry` introduced
+      with field-level detail in the FRs.
+- [X] Success Criteria measurable (SC-001 through SC-007), each with an
+      explicit verification command.
+- [X] Clarifications section captures the 4 scope decisions (bearer+creds
+      vs Basic-direct, no new base64 dep, no `dirs` crate, helper timeout).
+- [X] Out of Scope names every adjacent concern (push, mirror configs,
+      OAuth refresh, native ECR SDK, --registry-auth flag, 031.y, 031.z).
+
+## Tighter spec set rationale (4 files vs 8)
+
+- [X] No `research.md` — recon answered every architectural question; no
+      open "should we do X or Y" decisions.
+- [X] No `data-model.md` — FR-001 fully specifies the new types inline.
+- [X] No `contracts/` — public surface unchanged; FR-008 / SC-003 enforce.
+- [X] No `quickstart.md` — 4 short files self-explanatory.
+
+This is the fourth use of the 4-file template (after 021, 022, 023). The
+pattern is stable for genuinely contained milestones.
+
+## Independence
+
+- [X] Single user story self-contained.
+- [X] Each per-commit deliverable independently verifiable (per FR / SC
+      mapping each commit's `./scripts/pre-pr.sh` passes).
+
+## Concreteness
+
+- [X] FRs cite specific file paths and exported items.
+- [X] FR-001 names the exact struct + function signatures.
+- [X] FR-003 / FR-004 name the exact registry.rs surgery points.
+- [X] SC-004 quantifies the LOC ceiling (500 for auth.rs).
+- [X] SC-005 / SC-006 name the verification commands verbatim.
+
+## Internal consistency
+
+- [X] FR-001 (auth.rs surface) aligns with FR-003 (registry.rs uses it)
+      aligns with FR-004 (basic_auth on realm fetch).
+- [X] FR-006 (no secret leak) aligns with SC-006 (grep audit) and the
+      `Credential::Debug` redaction in FR-001.
+- [X] Edge Case "helper exit code != 0" aligns with FR-002's "fall through
+      to anonymous; no helper stderr captured".
+- [X] FR-007 (no_c_dependencies regression test) aligns with the milestone
+      032 substrate inheritance — guardrail still active.
+
+## Lessons from milestones 016-033
+
+- [X] FR-008 carries the per-commit-clean discipline.
+- [X] R3 in plan.md (`#[cfg(unix)]` shim test) anticipates Windows-CI
+      behavior for the cred-helper subprocess test.
+- [X] The auth-on-bearer-token-fetch design reuses the existing
+      `fetch_bearer_token` shape from milestone 032 — no new abstractions.
+- [X] Recon-first: every claim in the spec backed by file:line refs from
+      the just-read registry.rs.
+- [X] Secret-handling discipline (FR-006 + SC-006) follows Constitution
+      Principle X transparency BUT explicitly excludes secrets — codifying
+      the lesson that "transparency does not extend to credentials".
+
+## Pre-implementation
+
+- [X] [PHASE-1] T001 reconnaissance done (2026-04-26).
+- [ ] [PHASE-1] T002 baseline snapshot captured.
+- [ ] [PHASE-2] Commit 1 (auth module) landed.
+- [ ] [PHASE-3] Commit 2 (wire-up) landed.
+- [ ] [PHASE-4] Commit 3 (docs + smoke) landed.
+- [ ] [POLISH] SC-001-SC-007 verified.
+- [ ] [POLISH] All 3 CI lanes green.
+
+## Post-merge
+
+- [ ] [QUALITATIVE] Next time someone tries `mikebom sbom scan --image
+      ghcr.io/<priv>/<repo>:tag` with a working `~/.docker/config.json`,
+      the scan succeeds without a "private registries not yet supported"
+      hint. If yes, milestone delivered.
+- [ ] [FOLLOW-ON] Re-evaluate whether 031.y `--image-platform` (#67) or
+      031.z layer caching (#68) is the next priority, or if a different
+      surface area (e.g., #64 dpkg `status.d/`) jumps ahead.

--- a/specs/034-authenticated-registry-pulls/plan.md
+++ b/specs/034-authenticated-registry-pulls/plan.md
@@ -1,0 +1,183 @@
+---
+description: "Implementation plan — milestone 034 authenticated OCI registry pulls"
+status: plan
+milestone: 034
+---
+
+# Plan: Authenticated OCI registry pulls
+
+## Architecture
+
+A new `auth.rs` sibling to `registry.rs` resolves credentials for a target
+registry, returning `Option<Credential>`. `RegistryClient::new()` calls into
+it once per scan. `fetch_bearer_token` then either sends a Basic-auth header
+on the realm GET (credentials present) or sends it unauthenticated
+(anonymous, today's behavior).
+
+No public API change. No new top-level dep. Lives entirely behind the
+existing `oci-registry` Cargo feature.
+
+```
+┌──────────────┐
+│ mod.rs       │ pull_to_tarball()
+└──────┬───────┘
+       │ creates
+       ▼
+┌──────────────┐    auth.rs::load_default_docker_config()
+│ RegistryClient◄───┐ auth.rs::resolve_credentials()
+└──────┬───────┘    │   → cred-helper subprocess
+       │            │   → DockerConfig.auths[reg].auth (b64-decoded)
+       │            │   → DockerConfig.auths[reg].identitytoken
+       │ uses
+       ▼
+┌──────────────────────────┐
+│ fetch_with_bearer_retry  │
+│   GET → 401              │
+│   parse Bearer challenge │
+│   ┌───────────────────┐  │
+│   │ fetch_bearer_token│ ◄── credentials → Basic auth on realm GET
+│   └───────────────────┘  │
+│   retry GET with Bearer  │
+└──────────────────────────┘
+```
+
+## Reuse inventory
+
+These existing items handle the work; no new infrastructure required:
+
+- **`base64::engine::general_purpose::STANDARD`** — already a direct dep
+  (Cargo.toml line 95). Decodes the `auth` field's `<base64(user:pass)>`.
+- **`reqwest::RequestBuilder::basic_auth(user, Some(secret))`** — built-in
+  on the workspace's `reqwest 0.12`. Sends `Authorization: Basic ...`.
+- **`serde_json`** — workspace dep, parses config.json.
+- **`std::process::Command`** — stdlib, drives the cred-helper subprocess.
+  Stdin is the registry hostname; stdout is JSON with Username/Secret/ServerURL.
+- **`std::env::var("HOME")` / `std::env::var("DOCKER_CONFIG")`** — stdlib
+  path resolution. No `dirs` crate needed.
+- **Existing `parse_bearer_challenge`, `fetch_bearer_token` shape in
+  registry.rs** — surgical edit to add an optional Basic-auth header on
+  the realm GET. ~5 LOC change.
+- **Existing `oci_pull` test scaffolding + `MIKEBOM_OCI_NETWORK_TESTS=1`
+  gate in `oci_registry_smoke.rs`** — extends with
+  `MIKEBOM_OCI_AUTH_TESTS=1` for the auth path.
+
+## Touched files
+
+| File | Change | LOC |
+|---|---|---|
+| `mikebom-cli/src/scan_fs/oci_pull/auth.rs` | NEW — Docker config parser, cred-helper subprocess, Credential type | +400 |
+| `mikebom-cli/src/scan_fs/oci_pull/mod.rs` | declare new module | +1 |
+| `mikebom-cli/src/scan_fs/oci_pull/registry.rs` | thread Credential into fetch_bearer_token; update 401 message | +40 |
+| `mikebom-cli/tests/oci_registry_smoke.rs` | gated auth smoke test | +50 |
+| `docs/user-guide/cli-reference.md` | `--image` auth section | +30 |
+| `CHANGELOG.md` | unreleased entry | +5 |
+| `mikebom-cli/Cargo.toml` | comment update on `oci-registry` feature | +3 |
+
+Total: ~530 LOC across 7 files. Bulk is `auth.rs` (with inline tests).
+
+## Phasing
+
+Three atomic commits; each `./scripts/pre-pr.sh`-clean.
+
+### Commit 1: `034/auth-module`
+- New `auth.rs` with: DockerConfig serde structs, registry name
+  normalization, `load_default_docker_config`, `resolve_credentials`,
+  `run_credential_helper` subprocess, `Credential` type with hand-written
+  redacting `Debug`.
+- Inline tests (10+): config.json variants (auth-only, identitytoken,
+  credsStore, credHelpers, empty auths fallback), registry normalization
+  (docker.io ↔ index.docker.io), Credential::Debug redaction, helper
+  subprocess against a tempdir-deployed shim shell script.
+- `#[allow(dead_code)]` on the public-to-supermodule items since they're
+  not called yet — lifted in commit 2.
+- mod.rs gains `mod auth;`.
+
+### Commit 2: `034/wire-auth-into-registry`
+- `RegistryClient::new()` accepts a `&ImageReference` and resolves
+  credentials lazily.
+- `fetch_bearer_token` takes `Option<&Credential>`, applies Basic auth
+  when present.
+- Update mod.rs's `pull_to_tarball` to pass the reference into
+  `RegistryClient::new`.
+- Update the 401-after-retry error message per FR-005.
+- Remove `#[allow(dead_code)]` from `auth.rs`.
+- Inline integration test: spin up a tiny reqwest mock that returns 401 +
+  bearer challenge, then 200 on the retry; assert the realm-GET
+  Authorization header decodes to the expected user:secret.
+
+### Commit 3: `034/docs-and-smoke`
+- `docs/user-guide/cli-reference.md` gains an "Authenticating to private
+  registries" subsection under `--image`.
+- `CHANGELOG.md` gets an unreleased entry.
+- `mikebom-cli/Cargo.toml`'s `oci-registry` feature comment is updated
+  ("anonymous + Docker-keychain auth").
+- `tests/oci_registry_smoke.rs` gains a `#[ignore]`'d gated test that
+  exercises a private GHCR pull when `MIKEBOM_OCI_AUTH_TESTS=1`.
+- Final `./scripts/pre-pr.sh` audit + grep audit per SC-006.
+
+## Estimated effort
+
+| Phase | Effort | Notes |
+|---|---|---|
+| Commit 1 (auth module) | 6 hr | DockerConfig schema spelunking + subprocess shim test is the careful step |
+| Commit 2 (wire-up) | 3 hr | Integration test with mock reqwest server |
+| Commit 3 (docs + smoke) | 2 hr | Mostly text |
+| Verification + PR | 1 hr | Goldens regen check + CI watch |
+| **Total** | **~12 hr** | One+ focused day. |
+
+## Risks
+
+- **R1: Cred-helper protocol drift.** The Docker cred-helper API is
+  documented at github.com/docker/docker-credential-helpers but isn't
+  versioned formally. Mitigation: align with the
+  [Docker source](https://github.com/docker/cli/blob/master/cli/config/credentials/native_store.go) —
+  stdin = registry, stdout = JSON {Username, Secret, ServerURL}, exit
+  non-zero or `"credentials not found"` on stdout = no creds. This shape
+  has been stable since 2016.
+
+- **R2: `~/.docker/config.json` schema drift.** Same mitigation: cite the
+  Docker `cliconfig.ConfigFile` Go type as the canonical schema. Use serde
+  `#[serde(default)]` everywhere so missing fields don't fail parsing.
+
+- **R3: Test subprocess on Windows.** Cred helpers are platform-specific
+  (`docker-credential-osxkeychain`, `docker-credential-wincred`). Inline
+  test ships a shell-script shim, which won't run on Windows. Mitigation:
+  `#[cfg(unix)]` the shim test; the parsing tests stay portable.
+
+- **R4: Secret leak via `?`-operator + anyhow context.** `anyhow!("...
+  {credential:?} ...")` would leak. Mitigation: hand-written Debug for
+  `Credential` redacts the secret unconditionally; no `tracing::*!` or
+  `anyhow::Context` may take a `Credential` by reference (lint
+  enforced via grep audit per SC-006).
+
+- **R5: GHCR's `package read` PAT scope.** GHCR requires `read:packages`
+  scope on the PAT for private images. Mitigation: documented in
+  cli-reference.md's auth section. Out-of-scope for code: that's a user
+  config issue, not a mikebom bug.
+
+- **R6: ECR token TTL (12h).** AWS ECR tokens expire. mikebom is a
+  one-shot CLI — by the time the token expires, the scan has long since
+  completed. No retry-on-401 logic needed beyond the existing single
+  retry. Documented in the auth section's "ECR notes" callout.
+
+## Constitution alignment
+
+- **Principle I (zero C in deps):** No new top-level deps. `base64`,
+  `serde_json`, `reqwest`, and stdlib `std::process` are all already in
+  the tree. `no_c_dependencies_in_oci_registry_feature_tree` regression
+  test still passes (verified at end of commit 3). ✓
+- **Principle IV (no `.unwrap()` in production):** New `auth.rs` returns
+  `Option`/`Result` everywhere. No panics. Inline tests use the standard
+  `cfg_attr(test, allow(clippy::unwrap_used))` envelope. ✓
+- **Principle VI (three-crate architecture):** Untouched. ✓
+- **Per-commit verification (lessons from 018-022):** FR-008 enforced.
+
+## What this milestone does NOT do
+
+- Does not change CLI args, output flags, or any user-facing surface
+  beyond "private images now scan when config.json is configured."
+- Does not introduce a `--registry-auth` flag.
+- Does not add OAuth refresh-token flows.
+- Does not implement native AWS SDK / ECR client (cred helper handles it).
+- Does not touch the milestone-031 anonymous-pull path's behavior — it
+  remains the fallback when no credentials match.

--- a/specs/034-authenticated-registry-pulls/spec.md
+++ b/specs/034-authenticated-registry-pulls/spec.md
@@ -1,0 +1,244 @@
+---
+description: "Authenticated OCI registry pulls — Docker keychain (config.json + cred helpers) + bearer-token flow with credentials"
+status: spec
+milestone: 034
+closes: "#66"
+---
+
+# Spec: Authenticated OCI registry pulls (031.x)
+
+## Background
+
+Milestone 031 (#63) shipped anonymous-only OCI image scanning. Milestone 032
+(#65) replaced the `oci-client` substrate with a thin custom HTTP client over
+`oci-spec` types + workspace `reqwest`. Milestone 033 (#70) flipped
+`oci-registry` on by default.
+
+`mikebom-cli/src/scan_fs/oci_pull/registry.rs` today has a single auth seam:
+`fetch_with_bearer_retry` issues an unauthenticated GET, on 401 parses
+`WWW-Authenticate: Bearer realm/service/scope`, fetches a token from the realm
+**unauthenticated**, and retries with `Authorization: Bearer <token>`. The 401
+error path emits "Authenticated registries are not yet supported in milestone
+031 (tracked as 031.x — see issue #66)".
+
+Real-world container scanning is dominated by private registries (private
+GHCR packages, private Hub repos, ECR, internal/self-hosted registries).
+Anonymous-only is a meaningful but minority use case. Closing this gap brings
+mikebom to feature-parity with `syft <ref>` / `trivy image <ref>` for the most
+common adoption path.
+
+## User story (US1, P1)
+
+**As an SBOM consumer scanning a container image stored in a private
+registry**, I want `mikebom sbom scan --image <private-ref>` to authenticate
+using the same `~/.docker/config.json` (and credential helpers) that
+`docker pull` already uses, so that I can scan private images without
+embedding credentials in mikebom-specific config.
+
+**Why P1**: this is the highest-value follow-on to milestone 031. Users with
+private registries currently have to `docker pull && docker save` as a
+two-step workaround; that loses the "single-command image scan" UX that 031
+established for public images.
+
+### Independent test
+
+After implementation, the following work end-to-end (CI-gated by
+`MIKEBOM_OCI_NETWORK_TESTS=1` + `MIKEBOM_OCI_AUTH_TESTS=1` for the auth path):
+
+- `mikebom sbom scan --image ghcr.io/<private-org>/<private-image>:latest`
+  succeeds when `~/.docker/config.json` contains a valid PAT for `ghcr.io`.
+- `mikebom sbom scan --image <hub-priv>/<repo>:tag` succeeds when
+  `~/.docker/config.json` declares either a direct `auth` field or
+  `credsStore: desktop` (or a per-registry `credHelpers` entry).
+- `RUST_LOG=debug mikebom sbom scan --image <ref>` does NOT leak the secret
+  in any log line.
+- `mikebom sbom scan --image <ref>` without auth (no config.json + public
+  image) continues to work exactly as today.
+
+## Acceptance scenarios
+
+**Scenario 1: Direct `auth` field in `~/.docker/config.json`**
+```
+Given: ~/.docker/config.json contains
+       { "auths": { "ghcr.io": { "auth": "<base64(user:pat)>" } } }
+When:  mikebom sbom scan --image ghcr.io/private/repo:tag
+Then:  the bearer-token fetch to ghcr.io's realm sends Basic auth using the
+       decoded user:pat; the resulting bearer token authorizes the manifest
+       fetch; scan completes; SBOM contains components.
+```
+
+**Scenario 2: `credHelpers` per-registry override**
+```
+Given: ~/.docker/config.json contains
+       { "credHelpers": { "<reg>": "<helper>" } }
+       and `docker-credential-<helper>` exists on PATH and returns
+       {"Username": "...", "Secret": "...", "ServerURL": "<reg>"} on stdin
+       "<reg>".
+When:  mikebom sbom scan --image <reg>/...
+Then:  mikebom invokes the helper subprocess, parses Username+Secret, uses
+       them as Basic auth on the bearer-token realm fetch; scan completes.
+```
+
+**Scenario 3: `credsStore` registry-wide helper**
+```
+Given: ~/.docker/config.json contains
+       { "auths": { "<reg>": {} }, "credsStore": "<helper>" }
+       (the empty auths entry is the standard "credentials live in the helper"
+       marker that `docker login` writes when credsStore is configured.)
+When:  mikebom sbom scan --image <reg>/...
+Then:  mikebom invokes `docker-credential-<helper> get` with stdin "<reg>";
+       same outcome as Scenario 2.
+```
+
+**Scenario 4: No credentials → graceful anonymous fallback**
+```
+Given: no ~/.docker/config.json (or no entry for the target registry)
+When:  mikebom sbom scan --image <public-ref>
+Then:  scan behaves identically to milestone 031 — anonymous bearer-token
+       handshake. No auth error.
+```
+
+**Scenario 5: Wrong credentials → clear error, no secret leak**
+```
+Given: ~/.docker/config.json contains an invalid PAT for <reg>
+When:  mikebom sbom scan --image <reg>/private/...
+Then:  mikebom reports "registry authentication failed for <reg> (401)".
+       The PAT is NOT included in stdout, stderr, or any log line at any
+       --verbose / RUST_LOG level.
+```
+
+## Edge cases
+
+- **`identitytoken` field**: some registries (notably Azure ACR and some Hub
+  flows) use `identitytoken` instead of `auth`. When present, send it as
+  `Authorization: Bearer <identitytoken>` directly to the realm token
+  endpoint (or as the bearer for the manifest GET, depending on registry).
+  For 034, treat `identitytoken` as a synonym for "Basic-auth via
+  username=`<token>`, password=empty, then bearer-token retry"; this is what
+  `oras` does and matches Hub's documented flow.
+- **Helper exit code != 0**: cred helper failure → fall through to anonymous
+  (don't hard-fail; the user might still have public access). Log a single
+  `tracing::warn!` line that names the helper but NOT its stderr (helper
+  stderr can leak partial creds in some implementations).
+- **Helper stdin contract**: per the
+  [Docker cred-helper API](https://github.com/docker/docker-credential-helpers),
+  stdin is the registry hostname (no scheme, no path). For `docker.io` we
+  send `https://index.docker.io/v1/` (the legacy realm Docker uses for Hub).
+- **registry name normalization**: config.json keys can be `https://...`,
+  `http://...`, bare hostname, or with a path. Normalize to bare hostname
+  for matching, and treat `index.docker.io` / `https://index.docker.io/v1/`
+  / `docker.io` as equivalent.
+- **Secret material in `Debug` impl**: the `Credential` struct must NOT
+  derive `Debug` for its secret field (or must redact it). Inline tests
+  assert that `format!("{:?}", credential)` does not contain the secret.
+- **Empty `auth` field**: some `docker login` flows write `{"auth": ""}` as
+  a marker. Treat empty `auth` the same as a missing `auths` entry → fall
+  through to credsStore / anonymous.
+- **ECR**: the `docker-credential-ecr-login` helper handles AWS SigV4 and
+  STS; mikebom invokes it the same way as any other helper. Native AWS SDK
+  integration is explicitly out of scope (deferred).
+
+## Functional requirements
+
+- **FR-001**: `mikebom-cli/src/scan_fs/oci_pull/auth.rs` is a new module
+  behind the `oci-registry` Cargo feature, exporting (crate-private):
+  - `pub(super) struct DockerConfig` — parsed `~/.docker/config.json`.
+  - `pub(super) struct Credential { username: String, secret: String }`
+    where `Debug` is hand-implemented to redact the secret.
+  - `pub(super) fn load_default_docker_config() -> Option<DockerConfig>`
+    reading `$HOME/.docker/config.json` (or `$DOCKER_CONFIG/config.json` if
+    set). Missing/unreadable file → returns `None`, NOT an error.
+  - `pub(super) fn resolve_credentials(cfg: &DockerConfig, registry: &str)
+    -> Option<Credential>` — implements the precedence:
+    `credHelpers` (per-registry) > `credsStore` (registry-wide) >
+    `auths.<reg>.auth` direct credentials > `auths.<reg>.identitytoken` >
+    None.
+
+- **FR-002**: `mikebom-cli/src/scan_fs/oci_pull/auth.rs::run_credential_helper`
+  invokes `docker-credential-<helper>` as a subprocess with the registry
+  hostname on stdin, parses `{Username, Secret, ServerURL}` JSON from
+  stdout. On non-zero exit OR stdout containing "credentials not found"
+  (helper convention for "no credentials cached"), returns `None`. No
+  helper stderr is captured into mikebom's logs.
+
+- **FR-003**: `mikebom-cli/src/scan_fs/oci_pull/registry.rs::RegistryClient`
+  gains an optional `credentials: Option<Credential>` field, populated in
+  `RegistryClient::new(reference)` by calling
+  `auth::load_default_docker_config()` + `auth::resolve_credentials(&cfg,
+  &reference.registry)`.
+
+- **FR-004**: `registry.rs::fetch_bearer_token` adds `Basic <b64(user:secret)>`
+  to the realm token-fetch request when credentials are available.
+  Anonymous fetch is preserved when credentials are absent.
+
+- **FR-005**: `registry.rs::fetch_with_bearer_retry` updates the 401-after-
+  retry error message: when credentials WERE used and the retry still
+  returned 401, emit "registry authentication failed for <registry> (401).
+  Verify credentials in ~/.docker/config.json or your credential helper."
+  When credentials were NOT used, preserve a hint pointing to milestone
+  034's auth modes (config.json + cred helpers).
+
+- **FR-006**: NO secrets appear in any `tracing::*` macro invocation, any
+  `anyhow::Context` chain, any `eprintln!`, or any `Debug` formatting.
+  Inline tests assert this for `Credential::Debug` and for the auth-failure
+  error message.
+
+- **FR-007**: `mikebom-cli/tests/no_c_dependencies.rs::no_c_dependencies_in_oci_registry_feature_tree`
+  continues to pass — no new C-bound deps introduced. Uses only existing
+  `base64`, `serde_json`, `reqwest`, `std::process` workspace surface.
+
+- **FR-008**: All existing `oci_pull` tests pass unchanged. New inline tests
+  in `auth.rs` cover: config.json parsing for all 4 cred sources, registry
+  name normalization, `Credential::Debug` redaction, helper subprocess via
+  a synthetic `docker-credential-mikebomtest` shim built for the test, and
+  empty-auth fall-through.
+
+## Success criteria
+
+- **SC-001**: `./scripts/pre-pr.sh` clean (default lane).
+- **SC-002**: `MIKEBOM_OCI_NETWORK_TESTS=1 MIKEBOM_OCI_AUTH_TESTS=1
+  cargo +stable test -p mikebom --test oci_registry_smoke
+  -- --include-ignored` passes when `~/.docker/config.json` is configured
+  for the target registry. (Smoke test is `#[ignore]`'d in CI; documented in
+  the PR description for manual verification.)
+- **SC-003**: `git diff main..HEAD -- mikebom-cli/src/cli/ mikebom-cli/src/generate/` is empty —
+  no CLI / generator changes.
+- **SC-004**: `wc -l mikebom-cli/src/scan_fs/oci_pull/auth.rs` ≤ 500.
+- **SC-005**: Adding the `034` work introduces zero new top-level deps in
+  `mikebom-cli/Cargo.toml`. (`base64`, `serde_json`, `reqwest`, and
+  `std::process::Command` already cover everything.)
+- **SC-006**: Grep audit: `rg 'tracing::|anyhow::|eprintln!' mikebom-cli/src/scan_fs/oci_pull/auth.rs`
+  shows zero formatters that interpolate `secret` / `password` / `token`
+  field values. (Mechanical guard against accidental leaks; FR-006 is the
+  semantic guarantee.)
+- **SC-007**: All 3 CI lanes green on the milestone PR.
+
+## Clarifications
+
+- **Why bearer-token + credentials (not Basic-auth-direct)**: All major
+  registries (Hub, GHCR, GCR, ECR, ACR, Quay) use bearer tokens for the
+  manifest/blob endpoints; credentials authorize the *token* fetch, not the
+  manifest fetch. Direct Basic auth on manifest GETs works only for
+  self-hosted Distribution registries with `Basic` realms — niche enough
+  that we defer to a follow-on if it ever comes up.
+- **Why the existing `base64` dep is enough**: `base64::engine::general_purpose::STANDARD`
+  decodes `auth` fields; `URL_SAFE` is not needed (Docker uses standard
+  base64 with padding). No new crate.
+- **Why no `dirs` crate**: `std::env::var("HOME")` covers Linux/macOS;
+  `DOCKER_CONFIG` env override (already standard) handles the Windows /
+  alternative-config case. Adding `dirs` for one path lookup is overkill.
+- **Helper-subprocess timeout**: 5 seconds. Cred helpers normally complete
+  in <100ms; 5s is generous enough for ECR's STS round-trip on a slow
+  network without making mikebom hang indefinitely.
+
+## Out of scope
+
+- Push (mikebom is read-only).
+- Registry mirror configs (`registries.conf` / `mirrors`).
+- OAuth refresh-token flows (separate from the bearer-token-with-creds path
+  this milestone covers).
+- Native AWS SDK integration for ECR (the standard cred helper covers it).
+- `--registry-auth user:pass@host` CLI flag (deferred — start with
+  config.json since that's where users' creds already live).
+- 031.y `--image-platform` (#67) and 031.z layer caching (#68) remain
+  separate follow-ons.

--- a/specs/034-authenticated-registry-pulls/tasks.md
+++ b/specs/034-authenticated-registry-pulls/tasks.md
@@ -1,0 +1,134 @@
+---
+description: "Task list — milestone 034 authenticated OCI registry pulls"
+---
+
+# Tasks: Authenticated OCI registry pulls — Tighter Spec
+
+**Input**: Design documents from `/specs/034-authenticated-registry-pulls/`
+**Prerequisites**: spec.md (✅), plan.md (✅), checklists/requirements.md (✅)
+
+**Tests**: ~10 inline tests in `auth.rs` + a mock-server integration test in `registry.rs` + a gated network smoke test in `tests/oci_registry_smoke.rs`. The existing 31-fixture byte-identity goldens are untouched (no SBOM-shape changes).
+
+**Organization**: Single user story (US1, P1). Three atomic commits.
+
+## Path Conventions
+
+- Adds `mikebom-cli/src/scan_fs/oci_pull/auth.rs` (new module, ~400 LOC).
+- Touches `mikebom-cli/src/scan_fs/oci_pull/{mod,registry}.rs` (additive).
+- Touches `mikebom-cli/tests/oci_registry_smoke.rs` (additive — new gated test).
+- Touches `docs/user-guide/cli-reference.md` (additive — new auth subsection).
+- Touches `mikebom-cli/Cargo.toml` (comment update only on `oci-registry` feature).
+- Touches `CHANGELOG.md` (one new entry).
+- Does NOT touch any other module, CLI command, parity extractor, or test.
+
+---
+
+## Phase 1: Setup + baseline
+
+- [X] T001 Recon done in this session (2026-04-26): registry.rs's auth seam is `fetch_with_bearer_retry` (line 107) calling `fetch_bearer_token` (line 166); both currently anonymous-only. 401-after-retry error message points users at issue #66 — that hint will be updated in commit 2.
+- [ ] T002 Snapshot baseline: `./scripts/pre-pr.sh 2>&1 | tee /tmp/baseline-034.txt | grep -E '^test [a-z_:]+ \.\.\. ok' | sort -u > /tmp/baseline-034-tests.txt`. Confirm post-034 test list shows additions only.
+
+---
+
+## Phase 2: Commit 1 — `034/auth-module`
+
+**Goal**: New `auth.rs` with config.json parsing, cred-helper subprocess, redacting Credential type. No call sites yet.
+
+- [ ] T003 [US1] Create `mikebom-cli/src/scan_fs/oci_pull/auth.rs`. Header doc-comment names the milestone, links to the Docker cred-helper API doc, and notes the redaction discipline.
+- [ ] T004 [US1] Add `Credential { username: String, secret: String }` with hand-written `Debug` (`Credential { username: "<redacted>", secret: "<redacted>" }`). Inline test asserts `format!("{:?}", c)` does not contain the secret.
+- [ ] T005 [US1] Add `DockerConfig` serde struct: `auths: HashMap<String, AuthEntry>`, `creds_store: Option<String>` (rename `credsStore`), `cred_helpers: HashMap<String, String>` (rename `credHelpers`). All fields `#[serde(default)]`. `AuthEntry { auth: Option<String>, identitytoken: Option<String> }`.
+- [ ] T006 [US1] Add `fn load_default_docker_config() -> Option<DockerConfig>`: prefer `$DOCKER_CONFIG/config.json`, fall back to `$HOME/.docker/config.json`. Missing/unreadable file → None (NOT error). Malformed JSON → None + `tracing::warn!` (no path content beyond the path itself).
+- [ ] T007 [US1] Add `fn normalize_registry_key(s: &str) -> String`: strip `https://` / `http://` schemes, strip `/v1/` / `/v2/` paths, lowercase the host, treat `index.docker.io` and `docker.io` as the same. Inline tests for the 4 forms (`docker.io`, `index.docker.io`, `https://index.docker.io/v1/`, `https://index.docker.io/v2/`).
+- [ ] T008 [US1] Add `fn resolve_credentials(cfg: &DockerConfig, registry: &str) -> Option<Credential>` implementing the precedence per FR-001:
+  1. `credHelpers.<reg>` → run helper subprocess.
+  2. `credsStore` → run helper subprocess (any registry).
+  3. `auths.<reg>.auth` → base64-decode → split on `:` → username, secret.
+  4. `auths.<reg>.identitytoken` → return `Credential { username: "<token>", secret: "" }` (Hub-style identity-token flow).
+- [ ] T009 [US1] Add `fn run_credential_helper(helper: &str, registry: &str) -> Option<Credential>`: `Command::new("docker-credential-{helper}").args(["get"]).stdin(piped).stdout(piped).stderr(null).spawn()`, write registry hostname + newline to stdin, wait with 5s timeout. On non-zero exit OR stdout containing `"credentials not found"` → None. Otherwise parse `{Username, Secret, ServerURL}` JSON and return `Credential`.
+- [ ] T010 [US1] Inline test for T008's auth-only flow: synthetic config.json with `auths.<reg>.auth = b64("user:pat")` → expect `Credential { username: "user", secret: "pat" }`.
+- [ ] T011 [US1] Inline test for T008's identitytoken flow: synthetic config.json with `auths.<reg>.identitytoken = "tok"` → expect Credential populated.
+- [ ] T012 [US1] Inline test for T008's empty-auths fall-through: `auths.<reg> = {}` + no credsStore → None.
+- [ ] T013 [US1] [unix-only `#[cfg(unix)]`] Inline test for T009's helper subprocess: write a `docker-credential-mikebomtest` shell script to a tempdir, prepend tempdir to `PATH`, configure DockerConfig with `credHelpers.<reg> = "mikebomtest"`, assert resolve_credentials returns the script's hard-coded Credential.
+- [ ] T014 [US1] [unix-only] Inline test for T009's "credentials not found" fall-through: shim script that prints "credentials not found" on stdout and exits 1 → resolve_credentials returns None (NOT error).
+- [ ] T015 [US1] Edit `mikebom-cli/src/scan_fs/oci_pull/mod.rs` to add `mod auth;`.
+- [ ] T016 [US1] Add `#[allow(dead_code)]` on the new pub(super) items (will be lifted in commit 2).
+- [ ] T017 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T018 [US1] Commit: `feat(034/auth-module): add Docker keychain credential resolver (config.json + cred helpers)`.
+
+---
+
+## Phase 3: Commit 2 — `034/wire-auth-into-registry`
+
+**Goal**: `RegistryClient` resolves credentials at construction; `fetch_bearer_token` applies Basic auth on the realm GET when credentials are available.
+
+- [ ] T019 [US1] Edit `RegistryClient::new` signature: take `reference: &ImageReference`, store `credentials: Option<Credential>` populated by calling `auth::load_default_docker_config()` + `auth::resolve_credentials(&cfg, &reference.registry)`.
+- [ ] T020 [US1] Edit `mod.rs::pull_to_tarball`: pass `&reference` to `RegistryClient::new`.
+- [ ] T021 [US1] Edit `fetch_bearer_token` to take `creds: Option<&Credential>` (or thread through `self.credentials`). When present, call `req.basic_auth(&c.username, Some(&c.secret))` on the realm GET request.
+- [ ] T022 [US1] Update the 401-after-retry error message in `fetch_with_bearer_retry` per FR-005:
+  - Credentials were used: "registry authentication failed for `<registry>` (401). Verify credentials in ~/.docker/config.json or your credential helper."
+  - Credentials were absent: existing wording, but updated to point at milestone 034: "Authenticated registries: configure ~/.docker/config.json (auth/identitytoken) or a credential helper. See `mikebom sbom scan --help`."
+- [ ] T023 [US1] Remove `#[allow(dead_code)]` from `auth.rs` items now that they're called.
+- [ ] T024 [US1] Inline integration test in `registry.rs` (test module): use a hyper-tiny mock returning 401 + `WWW-Authenticate: Bearer realm="http://127.0.0.1:<port>/token",service="<reg>"`, expect mikebom's GET to the token endpoint with `Authorization: Basic <b64(user:pat)>`. Use `tokio::net::TcpListener` directly to avoid adding a mock-server crate.
+- [ ] T025 [US1] Verify: `cargo +stable test -p mikebom --test oci_registry` (or whatever covers the inline registry tests) is green.
+- [ ] T026 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T027 [US1] Commit: `feat(034/wire-auth-into-registry): apply Docker-keychain credentials on the bearer-token realm fetch`.
+
+---
+
+## Phase 4: Commit 3 — `034/docs-and-smoke`
+
+**Goal**: User-facing docs, CHANGELOG, smoke test, Cargo.toml feature comment refresh.
+
+- [ ] T028 [US1] Edit `docs/user-guide/cli-reference.md`: add "Authenticating to private registries" subsection under `--image`, covering: Docker config.json layout (auth / identitytoken), credHelpers per-registry, credsStore registry-wide, ECR helper note (≥12h tokens — OK for one-shot scans), GHCR `read:packages` PAT scope reminder.
+- [ ] T029 [US1] Edit `CHANGELOG.md`: add unreleased entry — "OCI registry image scan now supports private registries via the standard Docker keychain (~/.docker/config.json + credential helpers). Closes #66."
+- [ ] T030 [US1] Edit `mikebom-cli/Cargo.toml`: update the `oci-registry` feature comment from "Anonymous public registries only…" to "Anonymous + Docker-keychain authenticated pulls (config.json + credential helpers)."
+- [ ] T031 [US1] Edit `mikebom-cli/tests/oci_registry_smoke.rs`: add `#[ignore]` test gated on `MIKEBOM_OCI_NETWORK_TESTS=1` AND `MIKEBOM_OCI_AUTH_TESTS=1`. Pulls a private image whose ref is set via `MIKEBOM_OCI_AUTH_PRIVATE_IMAGE_REF` env var. Documented in PR description as user-side verification.
+- [ ] T032 [US1] Verify: `MIKEBOM_OCI_NETWORK_TESTS=1 cargo +stable test -p mikebom --test oci_registry_smoke -- --ignored` works for the AUTHENTICATED smoke test if the environment is set up; existing anonymous smoke tests still pass.
+- [ ] T033 [US1] Grep audit per SC-006: `rg 'tracing::|anyhow::|eprintln!' mikebom-cli/src/scan_fs/oci_pull/auth.rs` — manual review that none of the formatters interpolate `secret` / `password` / `token` field values. (Empty findings or only safe formatters.)
+- [ ] T034 [US1] Verify: `cargo +stable test -p mikebom --test no_c_dependencies` — both regression tests still pass.
+- [ ] T035 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T036 [US1] Commit: `feat(034/docs-and-smoke): user-guide auth section + CHANGELOG + gated private-registry smoke test`.
+
+---
+
+## Phase 5: Verification + PR
+
+- [ ] T037 SC-001: `./scripts/pre-pr.sh` clean.
+- [ ] T038 SC-003: `git diff main..HEAD -- mikebom-cli/src/cli/ mikebom-cli/src/generate/` empty.
+- [ ] T039 SC-004: `wc -l mikebom-cli/src/scan_fs/oci_pull/auth.rs` ≤ 500.
+- [ ] T040 SC-005: `git diff main..HEAD -- mikebom-cli/Cargo.toml mikebom-common/Cargo.toml mikebom-ebpf/Cargo.toml Cargo.toml | grep -E '^\+[a-z][a-z0-9_-]+ = '` — should show ZERO new dep lines (only feature-comment changes).
+- [ ] T041 SC-006: re-run grep audit from T033 + manual eyeball of auth.rs's tracing/anyhow surface.
+- [ ] T042 27-golden regen: `MIKEBOM_UPDATE_*_GOLDENS=1 ./scripts/pre-pr.sh` — expected: ZERO diff (no SBOM-shape changes from this milestone).
+- [ ] T043 Push branch; observe all 3 CI lanes green (SC-007).
+- [ ] T044 Author the PR description: 3-commit summary, recon-context pointer to spec.md, scope reminder ("anonymous fallback preserved"), test instructions for the gated auth smoke test.
+
+---
+
+## Dependency graph
+
+```text
+T001 (recon, done) → T002 (baseline)
+                       │
+                       ↓
+              T003-T018 [Commit 1: auth.rs + inline tests, dead-code allowed]
+                       │
+                       ↓
+              T019-T027 [Commit 2: wire-up + mock-server test]
+                       │
+                       ↓
+              T028-T036 [Commit 3: docs + smoke + Cargo.toml]
+                       │
+                       ↓
+              T037-T044 (verify + PR)
+```
+
+## Estimated effort
+
+| Phase | Effort | Notes |
+|---|---|---|
+| Phase 1 (baseline) | 5 min | T001 done; just snapshot |
+| Phase 2 (auth module) | 6 hr | DockerConfig schema + subprocess shim test is the careful step |
+| Phase 3 (wire-up) | 3 hr | Mock-server inline test |
+| Phase 4 (docs + smoke) | 2 hr | Mostly text |
+| Phase 5 (verify + PR) | 1 hr | Goldens + CI watch |
+| **Total** | **~12 hr** | One+ focused day. |


### PR DESCRIPTION
## Summary

- New `oci_pull::auth` module resolves credentials for the target registry from `~/.docker/config.json` (or `\$DOCKER_CONFIG/config.json`) at construction time, applying the standard Docker precedence: `credHelpers` > `credsStore` > `auths.<reg>.auth` > `auths.<reg>.identitytoken`.
- `RegistryClient` now applies `Authorization: Basic <b64(user:secret)>` on the bearer-token realm GET when credentials are present; anonymous fallback (today's milestone-031 path) is preserved when credentials are absent or fail.
- No new top-level deps; `no_c_dependencies_in_oci_registry_feature_tree` regression still passes. Closes #66.

## Commits (4)

1. **`spec(034)`** — 4-file tighter spec set (`spec.md`, `plan.md`, `tasks.md`, `checklists/requirements.md`).
2. **`feat(034/auth-module)`** — `auth.rs` with DockerConfig parser, cred-helper subprocess invocation, redacting `Credential` type. 19 inline tests. Lands behind `#[allow(dead_code)]` since callers come in commit 2.
3. **`feat(034/wire-auth-into-registry)`** — Threads credentials through `fetch_bearer_token`. Updates the 401-after-retry error message to distinguish credentialed vs anonymous failure modes. 2 new mock-server inline tests using `tokio::net::TcpListener` directly (no mock-server crate added) to verify on-the-wire `Authorization` header presence/absence.
4. **`feat(034/docs-and-smoke)`** — User guide adds an "Authenticating to private registries" subsection, CHANGELOG entry, Cargo.toml feature-comment refresh, and a gated `pulls_private_image_via_docker_keychain` smoke test in `oci_registry_smoke.rs`.

## Secret-handling discipline

- `Credential::Debug` is hand-written to redact both `username` and `secret` fields (inline test asserts).
- All 4 `tracing::warn!` invocations in `auth.rs` interpolate only `path` + IO error / `helper` name + IO error — never secret material. Verified by grep audit (per spec SC-006).
- Helper subprocess stderr is piped to `Stdio::null()` because some helpers print partial credentials there.
- The new gated smoke test reads `auth`/`identitytoken` values out of the developer's actual `~/.docker/config.json` and asserts they don't appear in mikebom's stdout/stderr (best-effort regression guard).

## Verification

- ✅ \`./scripts/pre-pr.sh\` clean on this branch (clippy --workspace --all-targets + cargo test --workspace; binary tests went 1100 → 1121, accounting for the 21 new auth+wire-up tests).
- ✅ \`cargo +stable test -p mikebom --test no_c_dependencies\` — both regression tests still pass; no new C-bound deps.
- ✅ Smoke tests skip cleanly without env (no behavioural change in default CI lanes).
- ⚠️ \`auth.rs\` is 547 LOC vs the 500-LOC spec budget. The variance is the test surface (19 inline tests was richer than the plan estimated); production code is ~245 LOC. No quality concern.

## Test plan

- [ ] CI green on all 3 lanes (Linux default + Linux ebpf + macOS).
- [ ] Manual verification on a private registry the reviewer has access to:
      \`\`\`bash
      MIKEBOM_OCI_NETWORK_TESTS=1 MIKEBOM_OCI_AUTH_TESTS=1 \\
      MIKEBOM_OCI_AUTH_PRIVATE_IMAGE_REF=ghcr.io/<you>/<priv>:tag \\
        cargo +stable test -p mikebom --test oci_registry_smoke
      \`\`\`
      Expected: \`pulls_private_image_via_docker_keychain ... ok\`. Skipped silently otherwise.
- [ ] No regression on existing public-image scans (e.g. \`mikebom sbom scan --image alpine:3.19\`).

## Out of scope (separate follow-ons)

- 031.y \`--image-platform <linux/arch>\` flag (#67).
- 031.z layer caching (#68).
- \`--registry-auth user:pass@host\` CLI flag.
- OAuth refresh-token flows beyond bearer-token retry.
- Native AWS SDK / ECR client (the standard `docker-credential-ecr-login` helper covers ECR via the same keychain path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)