### PR TITLE
feat(036): on-disk cache for OCI image blobs (031.z, closes #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 ## [Unreleased]
 
 ### Added
+- **Milestone 036 (031.z) — On-disk cache for pulled OCI image blobs.**
+  Repeat-scans of the same image now skip the network fetch and
+  read from a SHA-256-content-addressed cache on disk, completing
+  in seconds rather than tens of seconds for non-trivial images.
+  The cache lives at `$MIKEBOM_OCI_CACHE_DIR` →
+  `$XDG_CACHE_HOME/mikebom/oci-layers` →
+  `$HOME/Library/Caches/mikebom/oci-layers` (macOS) →
+  `$HOME/.cache/mikebom/oci-layers` (fallback). Default size cap
+  10 GB with mtime-based LRU eviction; configurable via
+  `--oci-cache-size <bytes>` or `MIKEBOM_OCI_CACHE_SIZE=<bytes>`.
+  Disable with `--no-oci-cache` or `MIKEBOM_OCI_CACHE=0`. Every
+  cache read re-verifies SHA-256 against the digest, so silent
+  corruption is detected and recovered (drop entry + re-fetch).
+  Atomic-rename writes (tempfile + persist) keep concurrent scans
+  safe. Best-effort posture: any IO failure (read-only fs, missing
+  $HOME) falls through to network-only behavior; scans complete
+  either way. Manifests are NOT cached (floating tags like
+  `:latest` need to re-fetch). No new dependencies. Closes #68.
+  See `specs/036-oci-layer-cache/spec.md` and the new
+  ["OCI layer caching"](docs/user-guide/cli-reference.md#oci-layer-caching)
+  section in the user guide.
 - **Milestone 035 (031.y) — `--image-platform` CLI flag for cross-arch
   image scans.** New `mikebom sbom scan --image <ref>
   --image-platform linux/<arch>[/<variant>]` selects a specific

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -135,6 +135,8 @@ Exactly one of **`--path <DIR>`** or **`--image <TAR_OR_REF>`** is required.
 | `--path <dir>` | — | Directory to walk recursively. Stream-hashes files with recognised package-artifact suffixes (`.deb`, `.crate`, `.whl`, `.tar.gz`, `.jar`, `.gem`, `.apk`, …). |
 | `--image <tar-or-ref>` | — | Either (a) a `docker save` tarball path on disk, or (b) an OCI image reference like `alpine:3.19` or `gcr.io/foo/bar@sha256:...`. mikebom auto-detects which based on whether the path exists. Refs are pulled from the registry, layers decompressed, and the resulting tarball is extracted to a tempdir (OCI whiteouts honoured) before being scanned like `--path`. Multi-arch image indexes resolve to `linux/<host-arch>` by default — pass `--image-platform <linux/ARCH[/VARIANT]>` to pick a different platform from a multi-arch index. Both anonymous and authenticated pulls are supported — for private registries, configure `~/.docker/config.json` (the same keychain `docker pull` uses; see ["Authenticating to private registries"](#authenticating-to-private-registries) below). Disable the registry-pull capability with `cargo install mikebom --no-default-features` if you want a minimal-deps build for embedded use; tarball-extraction still works. |
 | `--image-platform <linux/ARCH[/VARIANT]>` | host-arch | Override the platform that's resolved from a multi-arch image index. Only meaningful with a registry `--image <ref>` — for tarballs the platform is fixed by what `docker save` already wrote (passed alongside a tarball, the flag errors). Only `linux` is supported as the OS — mikebom's package-database readers (dpkg / apk / rpm) are linux-rootfs-shaped, so non-Linux containers aren't a meaningful scan target. Common values: `linux/amd64`, `linux/arm64`, `linux/arm/v7`, `linux/386`, `linux/ppc64le`, `linux/s390x`. Use case: a macOS arm64 dev machine scanning a `linux/amd64` image deployed to AWS, or Linux x86_64 CI scanning an `arm64` image deployed to Graviton. When the index doesn't contain a matching entry, the error lists the available platforms. |
+| `--no-oci-cache` | off | Disable the on-disk OCI blob cache for registry pulls. Equivalent to `MIKEBOM_OCI_CACHE=0`. When set, every blob is fetched from the registry on every scan; existing cache files on disk are not touched. Use case: CI lanes that want pure one-shot semantics, or debugging a registry-side regression. See ["OCI layer caching"](#oci-layer-caching) below. |
+| `--oci-cache-size <BYTES>` | 10 GB | Cap (in bytes) for the on-disk OCI blob cache. When the cache exceeds this size after an insert, oldest-mtime entries are evicted until the total drops below the cap. Equivalent env var: `MIKEBOM_OCI_CACHE_SIZE=<bytes>`. See ["OCI layer caching"](#oci-layer-caching) below. |
 | `--output <[FMT=]PATH>` | per-format default (`mikebom.cdx.json`, `mikebom.spdx.json`, …) | Output path override. Two forms: bare `--output <path>` (applies to the single requested format — rejected with multiple formats) and per-format `--output <fmt>=<path>` (repeatable; each entry retargets one format). The special key `openvex` retargets the OpenVEX sidecar that SPDX emission co-produces when VEX is present — legal only alongside an SPDX format. |
 | `--format <fmt>` | `cyclonedx-json` | See [output formats](#output-formats). Comma-separated list + repeatable flag: `--format cyclonedx-json,spdx-2.3-json` produces both from a single scan. Duplicates dedupe silently. |
 | `--max-file-size <bytes>` | `268435456` (256 MB) | Skip hashing files larger than this |
@@ -249,6 +251,58 @@ What's not yet supported (deferred to follow-ons):
 - Native AWS SDK integration for ECR (`docker-credential-ecr-login`
   remains the supported path).
 - Registry mirror configs (`registries.conf`, `mirrors`).
+
+### OCI layer caching
+
+OCI distribution-spec blobs (image config + each layer) are
+content-addressed by SHA-256, so caching them on disk is correct by
+construction: a cache hit on a digest is identical-bytes to a fresh
+network fetch of that digest. mikebom caches every blob it pulls,
+keyed on digest; subsequent scans of the same image reuse the
+cached bytes and complete in seconds rather than tens of seconds.
+The image's manifest is intentionally NOT cached — a floating tag
+like `:latest` should re-fetch the manifest every time so updates
+are detected, after which any new layer digests will naturally
+cache-miss.
+
+**Cache location** (priority order):
+
+1. `$MIKEBOM_OCI_CACHE_DIR` (when set non-empty).
+2. `$XDG_CACHE_HOME/mikebom/oci-layers` (Linux convention).
+3. `$HOME/Library/Caches/mikebom/oci-layers` (macOS).
+4. `$HOME/.cache/mikebom/oci-layers` (fallback).
+
+**Layout**: `<cache-dir>/sha256/<64-hex>` per blob.
+
+**Eviction**: the cache enforces a default 10 GB cap. When an
+insert pushes the total over, oldest-mtime entries are removed
+until the total is back under the cap. Override the cap with
+`--oci-cache-size <bytes>` or `MIKEBOM_OCI_CACHE_SIZE=<bytes>`.
+
+**Disabling**: pass `--no-oci-cache` (or set
+`MIKEBOM_OCI_CACHE=0`) to skip the cache entirely for one
+invocation. Existing cache files on disk are untouched.
+
+**Clearing**: `rm -rf "$XDG_CACHE_HOME/mikebom/oci-layers"` (or
+the macOS / fallback equivalent). mikebom doesn't ship a
+`--clear-oci-cache` command; the directory is the canonical handle.
+
+**Safety properties**:
+
+- Every cache read re-verifies the on-disk SHA-256 against the
+  filename. Corrupted entries (truncated, bit-flipped) are
+  detected, deleted, and re-fetched from the network.
+- Cache writes go through `tempfile + atomic rename` (intra-fs
+  rename, atomic on every POSIX-ish filesystem). Concurrent scans
+  of the same image don't corrupt the final blob — both writers
+  produce identical bytes (same digest = same content) and the
+  rename atomically swaps in one of them.
+- A read-only cache directory or any other IO failure is
+  non-fatal: mikebom logs a warning and falls through to network-
+  only behavior. The scan completes either way.
+- Path-traversal is impossible: only `sha256:<64-hex>` digests
+  resolve to a path; anything else (including `sha256:..`)
+  fails the hex grammar check at lookup time.
 
 ---
 

--- a/mikebom-cli/Cargo.toml
+++ b/mikebom-cli/Cargo.toml
@@ -76,12 +76,17 @@ ebpf-tracing = [
 # 031.x, #66). Both anonymous and credentialed flows go through the
 # same bearer-token retry path; credentials (when resolved from
 # ~/.docker/config.json / $DOCKER_CONFIG/config.json) are applied as
-# Basic auth on the realm token GET. Multi-platform flag deferred to
-# 031.y (#67); layer caching deferred to 031.z (#68). See
+# Basic auth on the realm token GET. Cross-arch image-index
+# resolution via `--image-platform <linux/arch[/variant]>`
+# (milestone 035 / 031.y, #67). On-disk SHA-256-content-addressed
+# blob cache with LRU eviction (milestone 036 / 031.z, #68) —
+# disable with `--no-oci-cache` / `MIKEBOM_OCI_CACHE=0`. See
 # `specs/031-oci-registry-image-scan/spec.md` for the original
 # contract, `specs/032-oci-spec-migration/spec.md` for the substrate
-# rationale, and `specs/034-authenticated-registry-pulls/spec.md` for
-# the auth design.
+# rationale, `specs/034-authenticated-registry-pulls/spec.md` for
+# the auth design, `specs/035-image-platform-flag/spec.md` for the
+# cross-arch design, and `specs/036-oci-layer-cache/spec.md` for the
+# cache design.
 oci-registry = [
     "dep:oci-spec",
 ]

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -76,6 +76,28 @@ pub struct ScanArgs {
     #[arg(long, requires = "image", value_name = "linux/ARCH[/VARIANT]")]
     pub image_platform: Option<String>,
 
+    /// Disable the OCI blob cache for registry pulls. Equivalent to
+    /// `MIKEBOM_OCI_CACHE=0`. When set, every blob (config + layer)
+    /// is fetched from the registry on every scan, even if mikebom
+    /// has already cached the same digest from a previous pull.
+    /// Cache files on disk are untouched.
+    ///
+    /// Use case: CI lanes that want pure one-shot semantics, or
+    /// debugging a registry-side regression.
+    #[arg(long)]
+    pub no_oci_cache: bool,
+    /// Cap (in bytes) for the on-disk OCI blob cache. When the cache
+    /// exceeds this size, oldest-mtime entries are evicted until the
+    /// total drops below the cap. Default: 10 GB. Equivalent env
+    /// var: `MIKEBOM_OCI_CACHE_SIZE=<bytes>`.
+    ///
+    /// Cache location is resolved from (in priority order):
+    /// `$MIKEBOM_OCI_CACHE_DIR`, `$XDG_CACHE_HOME/mikebom/oci-layers`,
+    /// `$HOME/Library/Caches/mikebom/oci-layers` on macOS, otherwise
+    /// `$HOME/.cache/mikebom/oci-layers`.
+    #[arg(long, value_name = "BYTES")]
+    pub oci_cache_size: Option<u64>,
+
     /// Output path override. Two forms are accepted:
     ///
     /// * Bare `--output <path>` — applies to the single requested
@@ -486,9 +508,29 @@ pub async fn execute(
                         );
                     }
                     tracing::info!(image_ref = %arg_str, "pulling image from registry");
+                    // Resolve the layer-cache size cap. `--no-oci-cache`
+                    // (or `MIKEBOM_OCI_CACHE=0`) disables; otherwise
+                    // `--oci-cache-size` overrides
+                    // `MIKEBOM_OCI_CACHE_SIZE` overrides the 10-GB
+                    // default. None disables the cache entirely.
+                    let cache_disabled = args.no_oci_cache
+                        || std::env::var("MIKEBOM_OCI_CACHE").as_deref() == Ok("0");
+                    let cache_size_cap = if cache_disabled {
+                        None
+                    } else {
+                        let env_size = std::env::var("MIKEBOM_OCI_CACHE_SIZE")
+                            .ok()
+                            .and_then(|s| s.parse::<u64>().ok());
+                        Some(
+                            args.oci_cache_size
+                                .or(env_size)
+                                .unwrap_or(10 * 1024 * 1024 * 1024),
+                        )
+                    };
                     let tempdir = scan_fs::oci_pull::pull_to_tarball(
                         arg_str,
                         args.image_platform.as_deref(),
+                        cache_size_cap,
                     )
                     .await?;
                     let tarball = tempdir.path().join("image.tar");

--- a/mikebom-cli/src/scan_fs/oci_pull/cache.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull/cache.rs
@@ -45,6 +45,20 @@ pub(super) struct Cache {
 }
 
 impl Cache {
+    /// Construct a Cache rooted at an explicit directory. Used by
+    /// tests in sibling modules (e.g. `registry::tests`) that need
+    /// to bypass the env-var resolution chain. Production code goes
+    /// through [`Self::open`].
+    #[cfg(test)]
+    pub(super) fn open_for_test(dir: &std::path::Path, size_cap: u64) -> Self {
+        std::fs::create_dir_all(dir.join("sha256"))
+            .expect("test cache dir should be creatable");
+        Self {
+            dir: dir.to_path_buf(),
+            size_cap,
+        }
+    }
+
     /// Build a cache rooted at the resolved cache directory. Returns
     /// `None` if the directory can't be located, created, or written
     /// to — in which case the caller falls through to no-cache mode.

--- a/mikebom-cli/src/scan_fs/oci_pull/cache.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull/cache.rs
@@ -1,0 +1,469 @@
+//! Disk cache for OCI blobs (config + layers) keyed on SHA-256
+//! digest (milestone 036 / 031.z — closes #68).
+//!
+//! OCI distribution-spec blobs are content-addressed: every blob
+//! fetched from `/v2/<repo>/blobs/sha256:<hex>` has a hash that
+//! matches its content. Caching is therefore correct-by-construction
+//! — a cache hit on a digest is always identical to a fresh network
+//! fetch of that digest. We re-verify the on-disk hash on every
+//! cache read to catch silent corruption (truncation, bit-flip,
+//! filesystem damage); on mismatch we delete the entry and fall
+//! through to the network.
+//!
+//! Manifests are intentionally NOT cached: a floating tag like
+//! `:latest` should re-fetch the manifest every time so updates are
+//! detected. Once the manifest resolves to layer digests, those
+//! digests are immutable and cacheable.
+//!
+//! Layout: `<cache_dir>/sha256/<64-hex>` per blob. Atomic writes
+//! via `tempfile::NamedTempFile` + `persist` (intra-fs rename).
+//! LRU eviction keyed on file mtime.
+//!
+//! Cache-dir resolution priority:
+//!   1. `$MIKEBOM_OCI_CACHE_DIR`
+//!   2. `$XDG_CACHE_HOME/mikebom/oci-layers`
+//!   3. macOS: `$HOME/Library/Caches/mikebom/oci-layers`
+//!   4. fallback: `$HOME/.cache/mikebom/oci-layers`
+//!
+//! The cache is "best-effort": any IO failure on open/get/insert
+//! falls through to anonymous behavior (cache-miss-style) rather
+//! than failing the scan. The user's scan runs to completion; the
+//! cache is purely an optimization.
+
+use std::fs::{self, File};
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use anyhow::{Context, Result};
+use sha2::Digest as _;
+
+/// SHA-256-content-addressed disk cache for OCI blobs.
+pub(super) struct Cache {
+    dir: PathBuf,
+    size_cap: u64,
+}
+
+impl Cache {
+    /// Build a cache rooted at the resolved cache directory. Returns
+    /// `None` if the directory can't be located, created, or written
+    /// to — in which case the caller falls through to no-cache mode.
+    pub(super) fn open(size_cap: u64) -> Option<Self> {
+        let dir = resolve_cache_dir()?;
+        let blob_dir = dir.join("sha256");
+        if let Err(e) = fs::create_dir_all(&blob_dir) {
+            tracing::warn!(
+                cache_dir = %dir.display(),
+                error = %e,
+                "could not create OCI cache directory; cache disabled"
+            );
+            return None;
+        }
+        // Probe-write to verify the directory is writable. A read-only
+        // mount or permission-denied path discovers itself here rather
+        // than on the first real cache write.
+        let probe = dir.join(".mikebom-cache-probe");
+        match File::create(&probe).and_then(|mut f| f.write_all(b"ok")) {
+            Ok(_) => {
+                let _ = fs::remove_file(&probe);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    cache_dir = %dir.display(),
+                    error = %e,
+                    "OCI cache directory is not writable; cache disabled"
+                );
+                return None;
+            }
+        }
+        Some(Self { dir, size_cap })
+    }
+
+    /// Read a cached blob if present. Verifies SHA-256 on read; on
+    /// mismatch, deletes the corrupted entry and returns `None`.
+    /// Touches the file's mtime so LRU eviction reflects actual use.
+    pub(super) fn get(&self, digest: &str) -> Option<Vec<u8>> {
+        let path = self.path_for(digest)?;
+        let bytes = match fs::read(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) => {
+                tracing::warn!(
+                    digest = %digest,
+                    error = %e,
+                    "could not read OCI cache entry; falling through to network"
+                );
+                return None;
+            }
+        };
+        let expected_hex = digest.strip_prefix("sha256:")?;
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(&bytes);
+        let actual_hex = format!("{:x}", hasher.finalize());
+        if !actual_hex.eq_ignore_ascii_case(expected_hex) {
+            tracing::warn!(
+                digest = %digest,
+                "OCI cache entry corrupted (sha256 mismatch); evicting and re-fetching"
+            );
+            let _ = fs::remove_file(&path);
+            return None;
+        }
+        // Update mtime for LRU. Best-effort; if the FS doesn't
+        // support it, the eviction order is just slightly off.
+        if let Ok(file) = File::open(&path) {
+            let _ = file.set_modified(SystemTime::now());
+        }
+        tracing::debug!(digest = %digest, bytes = bytes.len(), "OCI blob cache hit");
+        Some(bytes)
+    }
+
+    /// Insert a blob into the cache. Atomic rename via tempfile.
+    /// Triggers eviction if the post-insert total exceeds the cap.
+    /// Caller has already verified the bytes match the digest, so
+    /// we don't re-hash here.
+    pub(super) fn insert(&self, digest: &str, bytes: &[u8]) -> Result<()> {
+        let Some(path) = self.path_for(digest) else {
+            // Non-sha256 digest — silently no-op. The blob is still
+            // returned to the caller; we just don't cache it.
+            return Ok(());
+        };
+        let blob_dir = path
+            .parent()
+            .expect("path_for always returns <dir>/sha256/<hex>");
+        // tempfile-in-same-dir guarantees rename(2) is intra-fs and
+        // atomic. Without this, a tempdir on a different mount would
+        // fail with EXDEV on persist().
+        let mut tmp = tempfile::NamedTempFile::new_in(blob_dir)
+            .with_context(|| format!("creating tempfile in {}", blob_dir.display()))?;
+        tmp.write_all(bytes)
+            .with_context(|| format!("writing tempfile for {digest}"))?;
+        tmp.flush().context("flushing tempfile")?;
+        tmp.persist(&path).map_err(|e| {
+            // PersistError carries the underlying io::Error.
+            anyhow::anyhow!(
+                "atomic-rename to {} failed: {}",
+                path.display(),
+                e.error
+            )
+        })?;
+        // Eviction is best-effort: failures here just mean the cache
+        // grows past the cap until the next successful insert. Don't
+        // propagate.
+        if let Err(e) = self.evict_to_cap() {
+            tracing::warn!(
+                cache_dir = %self.dir.display(),
+                error = %e,
+                "OCI cache eviction failed; cap may be exceeded until next insert"
+            );
+        }
+        Ok(())
+    }
+
+    /// Compute the on-disk path for a digest. Returns `None` for any
+    /// non-`sha256:<64-hex>` value — this is both a digest-format
+    /// check and a path-traversal guard (rejects `..`, `/`, etc.
+    /// that wouldn't pass the hex grammar).
+    fn path_for(&self, digest: &str) -> Option<PathBuf> {
+        let hex = digest.strip_prefix("sha256:")?;
+        if hex.len() != 64 {
+            return None;
+        }
+        if !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return None;
+        }
+        Some(self.dir.join("sha256").join(hex.to_ascii_lowercase()))
+    }
+
+    /// Walk `<dir>/sha256/`, sum file sizes, and remove
+    /// oldest-mtime entries until the total is at or below the cap.
+    fn evict_to_cap(&self) -> Result<()> {
+        let blob_dir = self.dir.join("sha256");
+        // Collect (path, mtime, size) triples.
+        let mut entries: Vec<(PathBuf, SystemTime, u64)> = Vec::new();
+        let read_dir = match fs::read_dir(&blob_dir) {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "reading cache dir {}: {e}",
+                    blob_dir.display()
+                ));
+            }
+        };
+        for entry in read_dir.flatten() {
+            let metadata = match entry.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if !metadata.is_file() {
+                continue;
+            }
+            let mtime = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+            entries.push((entry.path(), mtime, metadata.len()));
+        }
+        let total: u64 = entries.iter().map(|(_, _, sz)| *sz).sum();
+        if total <= self.size_cap {
+            return Ok(());
+        }
+        // Oldest first.
+        entries.sort_by_key(|(_, mtime, _)| *mtime);
+        let mut current = total;
+        for (path, _, size) in &entries {
+            if current <= self.size_cap {
+                break;
+            }
+            // Treat "already gone" as success — a concurrent eviction
+            // beat us to this file, which is fine.
+            match fs::remove_file(path) {
+                Ok(_) => {
+                    tracing::debug!(path = %path.display(), bytes = *size, "evicted OCI cache entry");
+                    current = current.saturating_sub(*size);
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    current = current.saturating_sub(*size);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %e,
+                        "could not evict OCI cache entry"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Resolve the OCI blob cache directory per the FR-002 priority
+/// chain. Returns `None` only if `$HOME` is unset and no override
+/// env var is set — in that case the cache is disabled.
+pub(super) fn resolve_cache_dir() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("MIKEBOM_OCI_CACHE_DIR") {
+        if !p.is_empty() {
+            return Some(PathBuf::from(p));
+        }
+    }
+    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
+        if !xdg.is_empty() {
+            return Some(PathBuf::from(xdg).join("mikebom").join("oci-layers"));
+        }
+    }
+    let home = std::env::var("HOME").ok()?;
+    if home.is_empty() {
+        return None;
+    }
+    let base = if cfg!(target_os = "macos") {
+        PathBuf::from(&home).join("Library").join("Caches")
+    } else {
+        PathBuf::from(&home).join(".cache")
+    };
+    Some(base.join("mikebom").join("oci-layers"))
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// Tests that mutate process-wide env vars (`MIKEBOM_OCI_CACHE_DIR`,
+    /// `XDG_CACHE_HOME`, `HOME`) must hold this lock — cargo runs
+    /// tests in parallel by default and concurrent env-mutation
+    /// produces flaky failures.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Build a Cache directly on a tempdir, bypassing the
+    /// resolve_cache_dir env-var lookup. Exists for test isolation
+    /// — production code goes through `Cache::open`.
+    fn cache_in(dir: &Path, size_cap: u64) -> Cache {
+        fs::create_dir_all(dir.join("sha256")).unwrap();
+        Cache {
+            dir: dir.to_path_buf(),
+            size_cap,
+        }
+    }
+
+    fn sha256_of(bytes: &[u8]) -> String {
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(bytes);
+        format!("sha256:{:x}", hasher.finalize())
+    }
+
+    #[test]
+    fn cold_cache_get_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = cache_in(tmp.path(), 1 << 30);
+        let digest = sha256_of(b"hello");
+        assert!(cache.get(&digest).is_none());
+    }
+
+    #[test]
+    fn insert_then_get_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = cache_in(tmp.path(), 1 << 30);
+        let bytes = b"hello world".to_vec();
+        let digest = sha256_of(&bytes);
+        cache.insert(&digest, &bytes).unwrap();
+        let got = cache.get(&digest).unwrap();
+        assert_eq!(got, bytes);
+    }
+
+    #[test]
+    fn get_with_corrupt_file_returns_none_and_evicts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = cache_in(tmp.path(), 1 << 30);
+        let bytes = b"hello".to_vec();
+        let digest = sha256_of(&bytes);
+        cache.insert(&digest, &bytes).unwrap();
+        // Corrupt the on-disk bytes.
+        let path = cache.path_for(&digest).unwrap();
+        fs::write(&path, b"corrupted").unwrap();
+        assert!(cache.get(&digest).is_none());
+        // The file should have been evicted.
+        assert!(!path.exists(), "corrupt entry should be removed");
+    }
+
+    #[test]
+    fn get_with_non_sha256_digest_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = cache_in(tmp.path(), 1 << 30);
+        assert!(cache.get("sha512:0000000000000000000000000000000000000000000000000000000000000000").is_none());
+        assert!(cache.get("not-a-digest").is_none());
+        assert!(cache.get("sha256:tooshort").is_none());
+        // Wrong length but valid hex.
+        assert!(cache.get("sha256:abcdef").is_none());
+    }
+
+    #[test]
+    fn insert_with_non_sha256_digest_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = cache_in(tmp.path(), 1 << 30);
+        // Should succeed (Ok(())) without writing anything to disk.
+        cache.insert("sha512:00", b"bytes").unwrap();
+        cache.insert("not-a-digest", b"bytes").unwrap();
+        // No files in the sha256 subdir.
+        let count = fs::read_dir(tmp.path().join("sha256"))
+            .unwrap()
+            .count();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn path_for_rejects_path_traversal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = cache_in(tmp.path(), 1 << 30);
+        // Hex grammar check rejects `..`, `/`, etc.
+        assert!(cache
+            .path_for("sha256:../../../etc/passwd")
+            .is_none());
+        assert!(cache.path_for("sha256:/etc/passwd").is_none());
+    }
+
+    #[test]
+    fn eviction_removes_oldest_when_over_cap() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Cap = 600 bytes. Insert three 250-byte blobs in sequence.
+        // After the third, total = 750; oldest must be evicted.
+        let cache = cache_in(tmp.path(), 600);
+
+        let bytes_a = vec![b'a'; 250];
+        let bytes_b = vec![b'b'; 250];
+        let bytes_c = vec![b'c'; 250];
+        let digest_a = sha256_of(&bytes_a);
+        let digest_b = sha256_of(&bytes_b);
+        let digest_c = sha256_of(&bytes_c);
+
+        cache.insert(&digest_a, &bytes_a).unwrap();
+        // Sleep enough that mtimes are distinguishable on filesystems
+        // with 1-second mtime resolution (ext4-default, APFS).
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        cache.insert(&digest_b, &bytes_b).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        cache.insert(&digest_c, &bytes_c).unwrap();
+
+        // a was inserted first → oldest mtime → evicted.
+        assert!(cache.get(&digest_a).is_none(), "oldest should be evicted");
+        assert!(cache.get(&digest_b).is_some(), "newer should remain");
+        assert!(cache.get(&digest_c).is_some(), "newest should remain");
+    }
+
+    #[test]
+    fn concurrent_inserts_do_not_corrupt_final_file() {
+        // 8 threads each insert the same blob 40 times. Final file
+        // must be intact (correct size, hash matches).
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = cache_in(tmp.path(), 1 << 30);
+        let bytes = vec![b'x'; 4096];
+        let digest = sha256_of(&bytes);
+
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                let bytes = bytes.clone();
+                let digest = digest.clone();
+                let cache_ref = &cache;
+                scope.spawn(move || {
+                    for _ in 0..40 {
+                        cache_ref.insert(&digest, &bytes).unwrap();
+                    }
+                });
+            }
+        });
+
+        let got = cache.get(&digest).unwrap();
+        assert_eq!(got, bytes, "concurrent writes should not corrupt the final blob");
+    }
+
+    #[test]
+    fn open_returns_some_for_writable_dir() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let saved = std::env::var("MIKEBOM_OCI_CACHE_DIR").ok();
+        std::env::set_var("MIKEBOM_OCI_CACHE_DIR", tmp.path());
+        let cache = Cache::open(1 << 30);
+        if let Some(v) = saved {
+            std::env::set_var("MIKEBOM_OCI_CACHE_DIR", v);
+        } else {
+            std::env::remove_var("MIKEBOM_OCI_CACHE_DIR");
+        }
+        assert!(cache.is_some());
+    }
+
+    #[test]
+    fn open_returns_none_when_dir_is_unresolvable() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let saved_override = std::env::var("MIKEBOM_OCI_CACHE_DIR").ok();
+        let saved_xdg = std::env::var("XDG_CACHE_HOME").ok();
+        let saved_home = std::env::var("HOME").ok();
+        std::env::remove_var("MIKEBOM_OCI_CACHE_DIR");
+        std::env::remove_var("XDG_CACHE_HOME");
+        std::env::remove_var("HOME");
+        let result = resolve_cache_dir();
+        if let Some(v) = saved_override {
+            std::env::set_var("MIKEBOM_OCI_CACHE_DIR", v);
+        }
+        if let Some(v) = saved_xdg {
+            std::env::set_var("XDG_CACHE_HOME", v);
+        }
+        if let Some(v) = saved_home {
+            std::env::set_var("HOME", v);
+        }
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn resolve_cache_dir_uses_override_first() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let saved = std::env::var("MIKEBOM_OCI_CACHE_DIR").ok();
+        std::env::set_var("MIKEBOM_OCI_CACHE_DIR", "/custom/cache/path");
+        let resolved = resolve_cache_dir().unwrap();
+        if let Some(v) = saved {
+            std::env::set_var("MIKEBOM_OCI_CACHE_DIR", v);
+        } else {
+            std::env::remove_var("MIKEBOM_OCI_CACHE_DIR");
+        }
+        assert_eq!(resolved, PathBuf::from("/custom/cache/path"));
+    }
+}

--- a/mikebom-cli/src/scan_fs/oci_pull/mod.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull/mod.rs
@@ -45,6 +45,11 @@
 //! locks the substrate decision in.
 
 mod auth;
+// `cache` is wired into `registry` in milestone 036 commit 2; this
+// commit only adds the module + inline tests so it can land
+// independently.
+#[allow(dead_code)]
+mod cache;
 mod platform;
 mod reference;
 mod registry;

--- a/mikebom-cli/src/scan_fs/oci_pull/mod.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull/mod.rs
@@ -77,11 +77,17 @@ use tarball::PulledLayer;
 /// Authenticated pulls (milestone 034 / #66): credentials are
 /// resolved from the Docker keychain inside `RegistryClient::new`.
 ///
+/// Layer caching (milestone 036 / #68): when
+/// `cache_size_cap` is `Some(bytes)`, blobs are cached on disk
+/// keyed on their SHA-256 digest. `None` disables caching for
+/// this pull (every blob is fetched from the network).
+///
 /// Async by design — mikebom's CLI is `#[tokio::main]`-bootstrapped,
 /// so callers `.await` this directly without bridging.
 pub async fn pull_to_tarball(
     image_ref: &str,
     image_platform: Option<&str>,
+    cache_size_cap: Option<u64>,
 ) -> Result<tempfile::TempDir> {
     let mut reference = reference::parse_reference(image_ref)
         .with_context(|| format!("parsing OCI image reference `{image_ref}`"))?;
@@ -113,7 +119,12 @@ pub async fn pull_to_tarball(
         "pulling OCI image"
     );
 
-    let client = RegistryClient::new(&reference)?;
+    // Open the layer cache when a cap is configured. Cache::open
+    // is best-effort: any IO failure (read-only fs, missing $HOME,
+    // etc.) returns None and we fall through to no-cache mode. The
+    // user's scan completes either way.
+    let cache_handle = cache_size_cap.and_then(cache::Cache::open);
+    let client = RegistryClient::new(&reference, cache_handle)?;
 
     // Step 1: fetch the manifest. If it's an image index
     // (manifest list), resolve the platform-specific manifest and

--- a/mikebom-cli/src/scan_fs/oci_pull/registry.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull/registry.rs
@@ -22,6 +22,7 @@ use sha2::Digest as _;
 use oci_spec::image::{ImageIndex, ImageManifest};
 
 use super::auth::Credential;
+use super::cache::Cache;
 use super::reference::ImageReference;
 
 /// Manifest media types we accept (sent on the `Accept` header
@@ -55,6 +56,11 @@ pub(super) struct RegistryClient {
     /// construction time and applied as Basic auth on the bearer-
     /// token realm fetch in [`Self::fetch_bearer_token`].
     credentials: Option<Credential>,
+    /// Optional disk cache for blob fetches (milestone 036). `None`
+    /// means no caching: every blob is fetched from the network.
+    /// When set, [`Self::fetch_blob`] consults the cache first and
+    /// inserts on miss.
+    cache: Option<Cache>,
 }
 
 impl RegistryClient {
@@ -63,7 +69,10 @@ impl RegistryClient {
     /// `~/.docker/config.json` (or `$DOCKER_CONFIG/config.json`) at
     /// construction time. Missing config / no entry for this registry
     /// → anonymous mode.
-    pub(super) fn new(reference: &ImageReference) -> Result<Self> {
+    ///
+    /// `cache` is the optional disk cache for blob bodies; `None`
+    /// disables caching.
+    pub(super) fn new(reference: &ImageReference, cache: Option<Cache>) -> Result<Self> {
         let http = reqwest::Client::builder()
             .user_agent(concat!("mikebom/", env!("CARGO_PKG_VERSION")))
             .build()
@@ -76,7 +85,11 @@ impl RegistryClient {
                 "resolved registry credentials from Docker keychain"
             );
         }
-        Ok(Self { http, credentials })
+        Ok(Self {
+            http,
+            credentials,
+            cache,
+        })
     }
 
     /// Fetch the manifest for `reference`. Returns either a
@@ -106,16 +119,36 @@ impl RegistryClient {
     /// Fetch a blob (config or layer) and verify its SHA-256
     /// matches the declared `digest`. The digest is the
     /// `<algorithm>:<hex>` form straight from the descriptor.
+    ///
+    /// When [`Self::cache`] is `Some`, the cache is consulted before
+    /// any network call; on hit the cached bytes (already SHA-256
+    /// verified by [`Cache::get`]) are returned. On miss the
+    /// network bytes are verified, inserted into the cache (errors
+    /// logged but non-fatal), and returned.
     pub(super) async fn fetch_blob(
         &self,
         reference: &ImageReference,
         digest: &str,
     ) -> Result<Vec<u8>> {
+        if let Some(cache) = self.cache.as_ref() {
+            if let Some(bytes) = cache.get(digest) {
+                return Ok(bytes);
+            }
+        }
         let url = blob_url(reference, digest);
         // Blob endpoint accepts any media type; we send `*/*`.
         let body = self.fetch_with_bearer_retry(&url, &["*/*"]).await?;
         verify_sha256(&body.bytes, digest)
             .with_context(|| format!("verifying blob {digest} from {url}"))?;
+        if let Some(cache) = self.cache.as_ref() {
+            if let Err(e) = cache.insert(digest, &body.bytes) {
+                tracing::warn!(
+                    %digest,
+                    error = %e,
+                    "OCI blob cache insert failed; scan continues without caching this blob"
+                );
+            }
+        }
         Ok(body.bytes)
     }
 
@@ -594,6 +627,7 @@ mod tests {
                 username: "alice".to_string(),
                 secret: "hunter2".to_string(),
             }),
+            cache: None,
         };
         let challenge = BearerChallenge {
             realm: format!("http://{addr}/token"),
@@ -652,6 +686,7 @@ mod tests {
         let client = RegistryClient {
             http: reqwest::Client::new(),
             credentials: None,
+            cache: None,
         };
         let challenge = BearerChallenge {
             realm: format!("http://{addr}/token"),
@@ -669,6 +704,47 @@ mod tests {
         assert!(
             !has_auth,
             "anonymous realm GET must not carry Authorization header; got request:\n{request}"
+        );
+    }
+
+    /// End-to-end cache wire-up test (milestone 036 commit 2): when
+    /// a `RegistryClient` carries a populated `Cache`, a subsequent
+    /// `fetch_blob` for the same digest reads from disk without a
+    /// network call. We verify "no network call" by pointing the
+    /// reference at an unreachable host — if the cache misses, the
+    /// fetch errors out on connect.
+    #[tokio::test]
+    async fn fetch_blob_returns_cached_bytes_without_network() {
+        use sha2::Digest as _;
+
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("sha256")).unwrap();
+        let cache = super::super::cache::Cache::open_for_test(tmp.path(), 1 << 30);
+
+        let bytes = b"hello cached world".to_vec();
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(&bytes);
+        let digest = format!("sha256:{:x}", hasher.finalize());
+        cache.insert(&digest, &bytes).unwrap();
+
+        // Reference points at a nonexistent host; if the cache misses
+        // the fetch will fail on connect.
+        let reference = super::super::reference::parse_reference(
+            "registry.invalid.mikebom-test.example/foo/bar:tag",
+        )
+        .unwrap();
+
+        let client = RegistryClient {
+            http: reqwest::Client::new(),
+            credentials: None,
+            cache: Some(cache),
+        };
+
+        let got = client.fetch_blob(&reference, &digest).await.unwrap();
+        assert_eq!(
+            got, bytes,
+            "cache hit should return the previously-inserted bytes \
+             without making a network call"
         );
     }
 }

--- a/mikebom-cli/tests/oci_registry_smoke.rs
+++ b/mikebom-cli/tests/oci_registry_smoke.rs
@@ -154,6 +154,99 @@ fn pulls_distroless_static_and_emits_well_formed_sbom_with_zero_components() {
     );
 }
 
+/// Warm-cache speedup smoke test (milestone 036 / 031.z).
+///
+/// Pulls alpine:3.19 twice into a fresh tempdir-backed cache; the
+/// second pull reads every blob from disk and produces a
+/// byte-identical SBOM. Skipped silently unless
+/// `MIKEBOM_OCI_NETWORK_TESTS=1`.
+#[test]
+fn repeat_pull_uses_cache_for_warm_layers() {
+    if !network_tests_enabled() {
+        eprintln!(
+            "skipping: set MIKEBOM_OCI_NETWORK_TESTS=1 to run network-gated smoke tests"
+        );
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cache_dir = tmp.path().join("cache");
+    std::fs::create_dir_all(&cache_dir).expect("create cache_dir");
+    let out_path_1 = tmp.path().join("alpine1.cdx.json");
+    let out_path_2 = tmp.path().join("alpine2.cdx.json");
+
+    let invoke = |out: &std::path::Path| -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_mikebom"))
+            .arg("--offline")
+            .arg("sbom")
+            .arg("scan")
+            .arg("--image")
+            .arg("alpine:3.19")
+            .arg("--format")
+            .arg("cyclonedx-json")
+            .arg("--output")
+            .arg(out)
+            .env("MIKEBOM_OCI_CACHE_DIR", &cache_dir)
+            .output()
+            .expect("mikebom should run")
+    };
+
+    // First pull: cache is empty → network fetches, writes cache.
+    let out1 = invoke(&out_path_1);
+    assert!(
+        out1.status.success(),
+        "first mikebom pull failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&out1.stdout),
+        String::from_utf8_lossy(&out1.stderr),
+    );
+
+    // After the first pull, the cache directory should contain
+    // some `sha256/<hex>` files. Verify by counting them — at
+    // least one (config + layers) must be present.
+    let blob_dir = cache_dir.join("sha256");
+    let blob_count = std::fs::read_dir(&blob_dir)
+        .map(|rd| rd.flatten().count())
+        .unwrap_or(0);
+    assert!(
+        blob_count >= 2,
+        "first pull should have populated the cache; got {blob_count} blobs in {}",
+        blob_dir.display()
+    );
+
+    // Second pull: same image, same cache → blobs read from disk.
+    let out2 = invoke(&out_path_2);
+    assert!(
+        out2.status.success(),
+        "second mikebom pull failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&out2.stdout),
+        String::from_utf8_lossy(&out2.stderr),
+    );
+
+    // SBOMs from both runs should be byte-identical (same image,
+    // same scan logic; cache hit/miss doesn't change the output).
+    // Strip the timestamp + serialNumber + workspace path before
+    // comparing so we're robust to per-run wall-clock and uuid
+    // variation (the standard cross-host normalization the existing
+    // 27-fixture goldens use).
+    let canonical = |bytes: &[u8]| -> serde_json::Value {
+        let mut v: serde_json::Value =
+            serde_json::from_slice(bytes).expect("valid CDX JSON");
+        if let Some(metadata) = v.get_mut("metadata").and_then(|m| m.as_object_mut()) {
+            metadata.remove("timestamp");
+        }
+        if let Some(o) = v.as_object_mut() {
+            o.remove("serialNumber");
+        }
+        v
+    };
+    let v1 = canonical(&std::fs::read(&out_path_1).expect("read 1"));
+    let v2 = canonical(&std::fs::read(&out_path_2).expect("read 2"));
+    assert_eq!(
+        v1, v2,
+        "warm-cache pull should produce a canonical-identical SBOM to the cold-cache pull"
+    );
+}
+
 /// Cross-arch end-to-end smoke test (milestone 035 / 031.y).
 ///
 /// Pulls alpine:3.19 with `--image-platform` set to a non-host arch

--- a/specs/036-oci-layer-cache/checklists/requirements.md
+++ b/specs/036-oci-layer-cache/checklists/requirements.md
@@ -1,0 +1,87 @@
+# Spec Quality Checklist: OCI layer cache (031.z)
+
+**Checklist for** `/specs/036-oci-layer-cache/spec.md`
+
+## Coverage
+
+- [X] Background cites the file:line seam (`registry.rs:91-102`
+      `fetch_blob`).
+- [X] User story has P-priority (P1 — workflow-critical for
+      iterative scans on bigger images).
+- [X] Independent Test is concrete (specific commands + observable
+      timing + cache-hit log assertion).
+- [X] 6 acceptance scenarios cover cold→warm, corruption recovery,
+      `--no-oci-cache`, eviction, dir override, concurrent-write
+      stress.
+- [X] Edge Cases name read-only-FS, mid-write-disk-full, non-sha256
+      digests, eviction-of-active-files, symlink-safety.
+- [X] FR-001 through FR-009 numbered, each with file paths +
+      signatures.
+- [X] SC-001 through SC-007 measurable with explicit verification
+      commands.
+- [X] Out of Scope names every adjacent concern (manifest cache,
+      distributed cache, --clear-oci-cache, pre-warm).
+
+## Tighter spec set rationale
+
+- [X] No `research.md` — recon answered every architectural
+      question; the `fetch_blob` seam is well-understood from the
+      034/035 work.
+- [X] No `data-model.md` — `Cache { dir, size_cap }` is fully
+      specified inline in FR-001.
+- [X] No `contracts/` — public surface unchanged beyond two new
+      CLI flags + a parameter on `pull_to_tarball`.
+- [X] No `quickstart.md` — 4 short files self-explanatory.
+
+This is the sixth use of the 4-file template (after 021, 022, 023,
+034, 035). Pattern stable.
+
+## Concreteness
+
+- [X] FRs cite specific file paths and exported items.
+- [X] FR-002 names the exact env-var precedence chain.
+- [X] FR-006 names the env-var fallbacks for both flags.
+- [X] SC-005 quantifies LOC ceiling (500).
+
+## Internal consistency
+
+- [X] FR-001 (Cache surface) aligns with FR-005 (RegistryClient
+      uses it) aligns with FR-007 (pull_to_tarball threads it).
+- [X] FR-003 (digest validation) aligns with Edge Case "non-sha256"
+      handling.
+- [X] FR-008 (no new deps) aligns with SC-006 (Cargo.toml diff
+      empty).
+- [X] R2 (NamedTempFile cross-FS) aligns with FR-001's "atomic
+      rename" claim — mitigation is `NamedTempFile::new_in(&dir)`.
+
+## Lessons from 016-035
+
+- [X] Per-commit-clean discipline carried through (FR-009).
+- [X] The cache wraps `fetch_blob`'s existing verify_sha256 — same
+      pattern as auth.rs wrapped fetch_bearer_token. Reuse over
+      reinvention.
+- [X] Mock-server test using tokio TCP listener directly (no new
+      crate) — same playbook as the 034 wire-up tests.
+- [X] Smoke test gating aligns with 031/034/035 conventions
+      (`MIKEBOM_OCI_NETWORK_TESTS=1`).
+- [X] Recon-first: every claim backed by file:line refs from the
+      just-read registry.rs / mod.rs / scan_cmd.rs.
+
+## Pre-implementation
+
+- [X] [PHASE-1] T001 reconnaissance done.
+- [ ] [PHASE-1] T002 baseline snapshot.
+- [ ] [PHASE-2] Commit 1 (cache module) landed.
+- [ ] [PHASE-3] Commit 2 (wire-cache) landed.
+- [ ] [PHASE-4] Commit 3 (docs + smoke) landed.
+- [ ] [POLISH] SC-001-SC-007 verified.
+- [ ] [POLISH] All 3 CI lanes green.
+
+## Post-merge
+
+- [ ] [QUALITATIVE] Iterate on a non-trivial image
+      (`ubuntu:24.04`). Second scan should be visibly faster than
+      the first. If yes, milestone delivered.
+- [ ] [FOLLOW-ON] OCI follow-on queue is now exhausted (031.x #66,
+      031.y #67, 031.z #68 all closed). Next: #64 (dpkg
+      `status.d/` for distroless) or a new architectural surface.

--- a/specs/036-oci-layer-cache/plan.md
+++ b/specs/036-oci-layer-cache/plan.md
@@ -1,0 +1,158 @@
+---
+description: "Implementation plan — milestone 036 OCI layer cache"
+status: plan
+milestone: 036
+---
+
+# Plan: OCI layer cache
+
+## Architecture
+
+```
+┌─────────────────┐
+│ scan_cmd::scan  │ resolves no_oci_cache + oci_cache_size from
+└────────┬────────┘ args/env, calls cache::open(...)
+         │
+         ▼
+┌─────────────────┐
+│ pull_to_tarball │ takes Option<&Cache> arg, threads to
+└────────┬────────┘ RegistryClient::new
+         │
+         ▼
+┌─────────────────────┐
+│ RegistryClient.cache│ Option<Cache> field, parallel to
+└────────┬────────────┘ existing `credentials: Option<Credential>`
+         │
+         ▼
+┌─────────────────────┐
+│ fetch_blob          │ try cache.get(digest) → return cached
+│                     │ on cache miss → network fetch → cache.insert
+└─────────────────────┘ (if cache is Some)
+```
+
+A new `cache.rs` sibling to `auth.rs` and `registry.rs` owns the
+disk surface: dir resolution, atomic-rename writes, SHA-256 verify
+on read with corruption fallback, mtime-based LRU eviction.
+
+No public API change. No new top-level dep. Lives entirely behind
+the existing `oci-registry` Cargo feature.
+
+## Reuse inventory
+
+- **`tempfile::NamedTempFile`** — workspace dep. Atomic rename via
+  `persist()`.
+- **`sha2::Sha256` + the existing `verify_sha256` shape in
+  registry.rs** — the same verification primitive already in use;
+  cache reuses it.
+- **`std::env::var`, `std::fs`, `std::time::SystemTime`,
+  `std::path::PathBuf`** — stdlib; no `dirs` crate.
+- **Existing `tracing::warn!` posture from auth.rs** — same
+  redaction discipline (cache paths and IO errors are not
+  secrets, but the warning style is the same).
+- **`#[cfg(target_os = "macos")]` switching** — already used
+  elsewhere; cache uses it for `~/Library/Caches` vs `~/.cache`.
+
+## Touched files
+
+| File | Change | LOC |
+|---|---|---|
+| `mikebom-cli/src/scan_fs/oci_pull/cache.rs` | NEW — Cache struct, dir resolution, get/insert, eviction | +400 |
+| `mikebom-cli/src/scan_fs/oci_pull/mod.rs` | declare module; thread cache through pull_to_tarball | +25 |
+| `mikebom-cli/src/scan_fs/oci_pull/registry.rs` | RegistryClient.cache field + fetch_blob lookup/insert | +40 |
+| `mikebom-cli/src/cli/scan_cmd.rs` | --no-oci-cache + --oci-cache-size; resolve env vars; build Cache | +60 |
+| `mikebom-cli/tests/oci_registry_smoke.rs` | gated repeat-scan smoke test (cache-hit verification via fixture mock) | +60 |
+| `docs/user-guide/cli-reference.md` | flag rows + cache section | +40 |
+| `CHANGELOG.md` | unreleased entry | +5 |
+
+Total ~630 LOC across 7 files. Bulk in `cache.rs` (with inline
+tests).
+
+## Phasing
+
+Three atomic commits, each `./scripts/pre-pr.sh`-clean.
+
+### Commit 1: `036/cache-module`
+- New `cache.rs` with Cache + open + get + insert + eviction.
+- Inline tests (10+) covering: cold/warm get, mtime-LRU eviction
+  order, corruption recovery, sha512 rejection, missing-dir
+  handling, tempfile cleanup on insert failure.
+- Concurrent-write stress test using `std::thread::scope` (10
+  threads × 100 inserts to same digest set; verify final files
+  intact).
+- mod.rs declares `mod cache;` with `#[allow(dead_code)]`
+  (lifted in commit 2).
+
+### Commit 2: `036/wire-cache`
+- `RegistryClient` accepts `cache: Option<Cache>`.
+- `fetch_blob` consults cache first, inserts on miss.
+- `pull_to_tarball` takes `cache: Option<&Cache>` and forwards.
+- ScanArgs gains `--no-oci-cache` + `--oci-cache-size` (with env
+  fallbacks); scan_cmd builds the Cache.
+- Inline integration test in registry.rs uses tokio TCP listener
+  to count blob fetches, asserts second-fetch is zero-network.
+- Remove `#[allow(dead_code)]`.
+
+### Commit 3: `036/docs-and-smoke`
+- cli-reference.md: new flag rows + "OCI layer caching" subsection.
+- CHANGELOG entry.
+- Cargo.toml feature comment refresh.
+- Gated network smoke test for the warm-cache speedup.
+
+## Estimated effort
+
+| Phase | Effort | Notes |
+|---|---|---|
+| Commit 1 | 6 hr | Eviction + concurrent-write tests are the careful parts |
+| Commit 2 | 4 hr | Mock-server test for hit-counting |
+| Commit 3 | 2 hr | Mostly text |
+| Verification + PR | 1 hr | CI fast (<5 min) |
+| **Total** | **~13 hr** | Slightly under the 2-day issue estimate. |
+
+## Risks
+
+- **R1: mtime resolution on filesystems.** ext4 / APFS update mtime
+  per second by default; that's coarse but adequate for LRU
+  ordering of cache reads. tmpfs and some network filesystems may
+  have lower resolution. If two reads happen in the same second,
+  eviction order is filesystem-dependent — acceptable for an LRU
+  approximation.
+- **R2: NamedTempFile + persist on cross-FS rename.** `persist()`
+  uses `rename(2)` which is atomic only within the same
+  filesystem. If `$HOME` is one mount and `/tmp` is another (the
+  default tempfile dir), the rename could fail with EXDEV.
+  Mitigation: create the tempfile inside the cache dir itself
+  (`NamedTempFile::new_in(&cache_dir)`) so the rename is always
+  intra-fs.
+- **R3: Concurrent eviction races.** Two processes inserting blobs
+  simultaneously, each running eviction at end-of-insert, could
+  both choose the same victim and one would unlink-fail. Mitigate
+  by treating "file not found" on unlink as success during
+  eviction. The eventual-correct-size invariant is what matters.
+- **R4: Cache-dir resolution falsely returns Some on a path that
+  doesn't exist.** Mitigated by `open()` calling `create_dir_all`
+  and verifying writability via a probe-write to a `.mikebom-cache-probe`
+  file (deleted immediately after the probe). Failure → return
+  None; cache is inert.
+- **R5: SHA-256 verify on every read.** ~30 ms per 30 MB blob on
+  modern hardware. Doubles a warm-cache pull's cost vs the
+  zero-verify alternative. Justified: silent corruption is the
+  opposite of the safety property a content-addressed cache
+  should provide. (Future: opt-in `--oci-cache-skip-verify` if
+  benchmarks show it matters.)
+
+## Constitution alignment
+
+- **Principle I (zero C):** No new deps. ✓
+- **Principle IV (no `.unwrap()` in production):** `cache.rs`
+  returns `Option`/`Result` throughout. Tests use the standard
+  `cfg_attr(test, allow(clippy::unwrap_used))` envelope. ✓
+- **Principle VI (three-crate architecture):** Untouched. ✓
+- **Per-commit verification:** FR-009.
+
+## What this milestone does NOT do
+
+- Does not introduce a `--clear-oci-cache` CLI command.
+- Does not cache the manifest.
+- Does not implement a distributed / shared-volume cache.
+- Does not change SBOM output bytes — the same image bytes produce
+  the same SBOM regardless of cache hit/miss.

--- a/specs/036-oci-layer-cache/spec.md
+++ b/specs/036-oci-layer-cache/spec.md
@@ -1,0 +1,264 @@
+---
+description: "Disk cache for pulled OCI image blobs (layers + config) keyed on SHA-256 digest, with LRU eviction"
+status: spec
+milestone: 036
+closes: "#68"
+---
+
+# Spec: OCI layer cache (031.z)
+
+## Background
+
+Milestones 031-035 ship a complete registry-pull pipeline: parse-ref →
+fetch-manifest → resolve-platform → fetch-blobs → assemble-tarball.
+Every `mikebom sbom scan --image <ref>` re-pulls every blob from the
+registry, even when the user just ran the same scan 30 seconds ago.
+For `alpine:3.19` (~3 MB) that's negligible; for `ubuntu:24.04`
+(~28 MB) it's annoying; for an 800 MB ML/CUDA image it's a real
+workflow tax.
+
+OCI blobs are content-addressed by their SHA-256 digest, so caching
+them is straightforward: blob digest matches → safe to read from
+disk without re-verifying upstream. The manifest itself is NOT
+cached — a tag like `:latest` floats over time, and re-fetching the
+manifest is what detects the float (after which the new layer
+digests would naturally cache-miss).
+
+`mikebom-cli/src/scan_fs/oci_pull/registry.rs::fetch_blob` is the
+seam. It already does `verify_sha256` on the network bytes; the same
+verification on cached bytes (with corruption fallback to network)
+gives us safety-by-construction.
+
+## User story (US1, P1)
+
+**As a developer iteratively scanning the same container image** —
+e.g. while debugging an SBOM-format issue — **I want repeated
+`mikebom sbom scan --image <ref>` invocations to skip the network
+fetch for already-pulled blobs**, so iteration is fast.
+
+**Why P1**: this is workflow-critical for any non-trivial image.
+The 031-035 work made registry pulls a one-step UX; without caching,
+the cost of using that UX iteratively is prohibitive on bigger
+images.
+
+### Independent test
+
+After implementation:
+- Run `mikebom sbom scan --image ubuntu:24.04 --output ubuntu1.cdx.json`.
+- Time the second invocation: `mikebom sbom scan --image ubuntu:24.04 --output ubuntu2.cdx.json`.
+- Second invocation completes in ~1-3 s (vs ~10-20 s for first), with
+  `RUST_LOG=debug` showing `cache hit` lines for each blob.
+- `--no-oci-cache` makes the second invocation as slow as the first.
+- The two output SBOMs are byte-identical (same image bytes ⇒ same
+  scan output).
+
+## Acceptance scenarios
+
+**Scenario 1: Cold cache → warm cache speedup**
+```
+Given: ~/.cache/mikebom/oci-layers/ does not exist
+When:  mikebom sbom scan --image alpine:3.19 (twice in a row)
+Then:  the first invocation fetches from network and writes the cache;
+       the second invocation reads from cache (`cache hit` debug logs
+       on every blob) and produces a byte-identical SBOM.
+```
+
+**Scenario 2: Cache-hit corruption recovery**
+```
+Given: a cache file at <cache>/sha256/<digest> whose bytes have been
+       corrupted (truncated, bit-flipped)
+When:  mikebom scans an image that references <digest>
+Then:  mikebom detects the SHA-256 mismatch, drops the cache entry,
+       falls through to a network fetch, and produces a correct SBOM.
+       A `tracing::warn!` records the corruption.
+```
+
+**Scenario 3: `--no-oci-cache` opts out**
+```
+Given: a populated cache
+When:  mikebom sbom scan --image alpine:3.19 --no-oci-cache
+Then:  every blob is fetched from network (no cache reads, no cache
+       writes). The cache files on disk are untouched.
+```
+
+**Scenario 4: Eviction on size-cap**
+```
+Given: the cache has accumulated 11 GB of blobs and the cap is 10 GB
+When:  any new blob is written to the cache
+Then:  the oldest-mtime files are deleted until the total drops below
+       the cap. Files in active use by the current scan are not
+       evicted.
+```
+
+**Scenario 5: `MIKEBOM_OCI_CACHE_DIR` override**
+```
+Given: MIKEBOM_OCI_CACHE_DIR=/tmp/mikebom-test-cache is exported
+When:  mikebom sbom scan --image alpine:3.19
+Then:  cache files land at /tmp/mikebom-test-cache/sha256/<digest>,
+       not under $XDG_CACHE_HOME or $HOME/.cache.
+```
+
+**Scenario 6: Concurrent scans → no corruption**
+```
+Given: two `mikebom sbom scan --image alpine:3.19` processes start at
+       the same moment with an empty cache
+When:  both complete
+Then:  both produce correct SBOMs; the cache files on disk are
+       intact (no zero-byte / truncated files left by interleaved
+       writes). Scenario verifies via stress-test (loop in inline
+       test).
+```
+
+## Edge cases
+
+- **Cache dir on a read-only filesystem.** Don't crash. Fall through
+  to network fetch on every blob; log a single `tracing::warn!` at
+  startup naming the dir + IO error.
+- **Cache dir creation fails (e.g. permission denied).** Same as
+  above — log + fall through.
+- **Insufficient disk space mid-write.** Tempfile-with-rename: the
+  partial write goes to a `.tmp.<pid>` file in the cache dir; on
+  write failure we delete the tempfile and fall through. The
+  in-place final-name file is never touched mid-write, so a
+  concurrent reader never sees a partial blob.
+- **SHA-256 of a non-`sha256:` digest.** `verify_sha256` already
+  rejects non-sha256 algorithms; the cache reuses that.
+  Future-proofing for sha512 is out of scope (no registry uses it
+  in practice today).
+- **Eviction on an actively-being-read file.** Unix's `rename`/
+  `unlink` semantics mean an open fd survives the directory-entry
+  removal — readers complete safely. Eviction does NOT need a
+  process-wide lock.
+- **Symlink in cache dir.** Cache file paths are
+  `<cache>/sha256/<hex>`; `<hex>` is sanitized (only `[0-9a-f]+`
+  passes verify_sha256's check). No path-traversal surface.
+
+## Functional requirements
+
+- **FR-001**: New module `mikebom-cli/src/scan_fs/oci_pull/cache.rs`
+  exports (crate-private):
+  - `pub(super) struct Cache { dir: PathBuf, size_cap: u64 }`.
+  - `pub(super) fn open(size_cap: u64) -> Result<Option<Cache>>` —
+    resolves the cache dir, creates it if absent, returns `None` on
+    any IO failure (cache becomes inert; non-fatal).
+  - `pub(super) fn get(&self, digest: &str) -> Option<Vec<u8>>` —
+    reads `<dir>/sha256/<hex>`, verifies SHA-256, returns bytes on
+    success. Updates the file's mtime for LRU. On corruption,
+    deletes the entry and returns `None`.
+  - `pub(super) fn insert(&self, digest: &str, bytes: &[u8]) -> Result<()>` —
+    writes via tempfile + atomic rename. Triggers eviction if total
+    cache size exceeds `size_cap`.
+
+- **FR-002**: `cache.rs::resolve_cache_dir() -> Option<PathBuf>` —
+  resolves the cache directory in priority order:
+  1. `$MIKEBOM_OCI_CACHE_DIR` (if set non-empty).
+  2. `$XDG_CACHE_HOME/mikebom/oci-layers` (Linux convention).
+  3. macOS: `$HOME/Library/Caches/mikebom/oci-layers`.
+  4. fallback: `$HOME/.cache/mikebom/oci-layers`.
+  Returns `None` if `$HOME` is also unset and no override env var.
+
+- **FR-003**: Digest validation in `cache.rs`. Only `sha256:<64-hex>`
+  digests are cacheable. Anything else (`sha512:`, malformed) →
+  `get` returns `None`, `insert` returns `Ok(())` no-op (caller
+  already ran `verify_sha256` on the network bytes, so a
+  non-cacheable digest just falls through to anonymous network).
+
+- **FR-004**: LRU eviction. After every successful `insert`, if the
+  total size of all `<dir>/sha256/*` files exceeds `size_cap`, walk
+  the directory entries sorted by mtime ascending, `remove_file`
+  until the total drops below the cap. Log evictions at
+  `tracing::debug!`.
+
+- **FR-005**: `mikebom-cli/src/scan_fs/oci_pull/registry.rs::RegistryClient`
+  gains `cache: Option<Cache>` (parallel to the existing
+  `credentials: Option<Credential>`). `RegistryClient::new` accepts
+  a `cache: Option<Cache>` parameter (constructed by the caller).
+  `fetch_blob` consults the cache: hit → return cached bytes (still
+  verified); miss → network fetch → cache insert (if cache is
+  Some) → return.
+
+- **FR-006**: `mikebom-cli/src/cli/scan_cmd.rs::ScanArgs` gains:
+  - `pub no_oci_cache: bool` with `#[arg(long)]`. Env-var fallback:
+    `MIKEBOM_OCI_CACHE=0` is equivalent to `--no-oci-cache`.
+  - `pub oci_cache_size: Option<u64>` with `#[arg(long, value_name =
+    "BYTES")]`. Default when unset: 10 GB
+    (`10 * 1024 * 1024 * 1024`). Env-var fallback:
+    `MIKEBOM_OCI_CACHE_SIZE=<bytes>`.
+
+- **FR-007**: `mikebom-cli/src/scan_fs/oci_pull/mod.rs::pull_to_tarball`
+  signature gains a `cache: Option<&Cache>` parameter (or threads
+  via a builder). The `RegistryClient::new` call passes it through.
+
+- **FR-008**: No new top-level deps. Uses `tempfile` (already a dep),
+  `std::fs`, `std::time::SystemTime` for mtime, `std::env::var`.
+  `dirs` is intentionally NOT added — env-var fallback chain is ~30
+  LOC and avoids the new crate.
+
+- **FR-009**: All existing oci_pull tests pass unchanged. New inline
+  tests in `cache.rs` cover: cold-cache hit/miss, corruption
+  recovery, eviction order, digest-format rejection, dir-creation
+  failure (read-only fs simulation via tempdir), concurrent-write
+  stress (10 threads × 100 inserts).
+
+## Success criteria
+
+- **SC-001**: `./scripts/pre-pr.sh` clean.
+- **SC-002**: `git diff main..HEAD -- mikebom-cli/src/parity/
+  mikebom-cli/src/generate/ mikebom-cli/src/resolve/` empty.
+- **SC-003**: 27-golden regen produces zero diff.
+- **SC-004**: `MIKEBOM_OCI_NETWORK_TESTS=1 cargo +stable test -p
+  mikebom --test oci_registry_smoke pulls_alpine_3_19_and_emits_apk_components`
+  on a freshly-cleared cache: first run does N network blob
+  fetches; second run does 0 (asserted via a counter in the
+  hyper-tiny test server, not the real registry — separate inline
+  test).
+- **SC-005**: `wc -l mikebom-cli/src/scan_fs/oci_pull/cache.rs` ≤
+  500 (production + tests).
+- **SC-006**: `git diff main..HEAD -- mikebom-cli/Cargo.toml
+  mikebom-common/Cargo.toml mikebom-ebpf/Cargo.toml Cargo.toml |
+  grep -E '^\+[a-z][a-z0-9_-]+ = '` empty (no new top-level deps).
+- **SC-007**: All 3 CI lanes green.
+
+## Clarifications
+
+- **Why cache all blobs, not just layers?** Config blobs are tiny
+  (a few KB each) but cost zero to cache. Treating "blob" uniformly
+  in the cache simplifies the seam. The issue text says "layer
+  cache" but in OCI distribution-spec parlance, both config and
+  layers are blobs fetched via the same `/v2/<repo>/blobs/<digest>`
+  endpoint.
+- **Why no `dirs` crate?** Constitution Principle VI prefers reusing
+  existing deps over adding new ones. The cache-dir resolution is
+  ~30 LOC of env-var chain + `cfg!(target_os)` switching — well
+  within "build it ourselves" range. Same posture as the milestone
+  034 `auth.rs` rejection of `dirs` for `~/.docker/config.json`.
+- **Why mtime-based LRU instead of an index file?** Index files are
+  a synchronization headache (lock-free concurrent updates require
+  an extra abstraction). Filesystem mtime is universal, atomic on
+  every POSIX-ish system, and updated for free on read by
+  `File::open`-with-`O_NOATIME`-not-set. Eviction walks the
+  directory once at end-of-insert; for a cache with hundreds of
+  entries this is microseconds.
+- **Why not cache the manifest?** A floating tag (`:latest`,
+  `:edge`) MUST be re-fetched to detect updates. Caching the
+  manifest would mask updates. The manifest fetch is also tiny
+  (~few KB) so cache-savings would be negligible.
+- **Why default 10 GB?** Big enough to fit a few mid-sized images
+  (Ubuntu, Debian, Node.js) without rewriting; small enough that a
+  laptop user's `~/.cache` doesn't balloon unexpectedly. Override
+  via `--oci-cache-size` or `MIKEBOM_OCI_CACHE_SIZE`.
+
+## Out of scope
+
+- **Manifest caching.** See Clarifications.
+- **Distributed cache** (multiple machines sharing a directory) —
+  the current design uses local rename atomicity which doesn't
+  generalize across NFS / Amazon EFS in all cases. Real-world
+  shared caches are an integration concern, not a mikebom feature.
+- **Compression in the cache.** Layers are already gzipped on the
+  wire; we cache them as fetched. No re-compression.
+- **`--clear-oci-cache` CLI command.** Users can `rm -rf` the
+  directory; adding a CLI knob for it inflates surface area for
+  marginal benefit.
+- **Pre-warm / cache-fill commands.** Defer if real demand surfaces.
+- **`#64 dpkg status.d/`** is the next non-OCI-queue item.

--- a/specs/036-oci-layer-cache/tasks.md
+++ b/specs/036-oci-layer-cache/tasks.md
@@ -1,0 +1,110 @@
+---
+description: "Task list — milestone 036 OCI layer cache"
+---
+
+# Tasks: OCI layer cache
+
+**Input**: spec.md (✅), plan.md (✅), checklists/requirements.md (✅).
+
+**Tests**: ~12 inline tests in `cache.rs` (hit/miss/corruption/
+eviction/concurrent-write); 1 mock-server integration test in
+`registry.rs` (zero-network on warm cache); 1 gated network smoke
+test for the warm-cache speedup.
+
+**Organization**: Single user story (US1, P1). Three atomic commits.
+
+## Path conventions
+
+- Adds `mikebom-cli/src/scan_fs/oci_pull/cache.rs` (new module).
+- Touches `mikebom-cli/src/scan_fs/oci_pull/{mod,registry}.rs`.
+- Touches `mikebom-cli/src/cli/scan_cmd.rs` (additive — 2 new
+  flags + cache construction).
+- Touches `mikebom-cli/tests/oci_registry_smoke.rs` (additive).
+- Touches `docs/user-guide/cli-reference.md` and `CHANGELOG.md`.
+- Does NOT touch parity/, generate/, resolve/, attestation/, or
+  any other CLI command.
+
+---
+
+## Phase 1: Setup + baseline
+
+- [X] T001 Recon done in this session: `fetch_blob` at
+      `registry.rs:91-102` is the auth/cache seam — both auth
+      (already wired in 034) and cache (this milestone) wrap the
+      same fetch. The cache wraps OUTSIDE the network fetch (try
+      cache → fall through to network → insert).
+- [ ] T002 Snapshot baseline: `./scripts/pre-pr.sh 2>&1 | tee
+      /tmp/baseline-036.txt | grep -E '^test [a-z_:]+ \.\.\. ok' |
+      sort -u > /tmp/baseline-036-tests.txt`.
+
+---
+
+## Phase 2: Commit 1 — `036/cache-module`
+
+**Goal**: New `cache.rs` with full disk-cache semantics + inline
+tests. No call sites yet.
+
+- [ ] T003 [US1] Create `mikebom-cli/src/scan_fs/oci_pull/cache.rs`. Header doc-comment names the milestone, links the OCI distribution-spec blob endpoint, and explains the SHA-256-content-addressed safety story.
+- [ ] T004 [US1] Add `pub(super) struct Cache { dir: PathBuf, size_cap: u64 }`.
+- [ ] T005 [US1] Add `fn resolve_cache_dir() -> Option<PathBuf>` per FR-002. Inline test covers each env-var path.
+- [ ] T006 [US1] Add `pub(super) fn open(size_cap: u64) -> Option<Cache>`. Resolves dir, `create_dir_all`, probe-writes to `.mikebom-cache-probe` to verify writability. Inline test for missing-HOME → None and read-only-dir → None.
+- [ ] T007 [US1] Add `pub(super) fn get(&self, digest: &str) -> Option<Vec<u8>>`. Validates digest format (must be `sha256:<64-hex>`); reads file; verifies SHA-256; touches mtime via `filetime::set_file_mtime` — wait, that's a new dep. Use `std::fs::File::open` then immediately drop and re-open with `OpenOptions::new().write(true).open(&path)` followed by no-op write of zero bytes? No — simpler: just leave mtime untouched on read (atime carries the LRU). Actually atime is unreliable due to `noatime` mount option. Pragmatic: just call `std::fs::File::set_modified(SystemTime::now())` on the open file — stable since Rust 1.75. Fallback if that's not available: rewrite a sentinel (skip — too complex). Use `set_modified`.
+- [ ] T008 [US1] Add `pub(super) fn insert(&self, digest: &str, bytes: &[u8]) -> Result<()>`. Validates digest; creates `<dir>/sha256/`; writes via `tempfile::NamedTempFile::new_in(&dir)` + `persist()`. Triggers eviction post-insert.
+- [ ] T009 [US1] Add `fn evict_to_cap(&self) -> Result<()>`. Walks `<dir>/sha256/`, sums file sizes, sorts by mtime ascending, removes oldest until under `size_cap`. Uses `read_dir` + `metadata.modified()` + `metadata.len()`.
+- [ ] T010 [US1] Add `fn verify_sha256_file(path: &Path, expected_hex: &str) -> bool` — read all bytes, hash, compare. (Mirrors registry.rs's `verify_sha256` but on-disk.)
+- [ ] T011 [US1] Inline test: cold cache miss → returns None.
+- [ ] T012 [US1] Inline test: insert + get round-trips bytes.
+- [ ] T013 [US1] Inline test: get with corrupted file → returns None AND deletes the file.
+- [ ] T014 [US1] Inline test: get with non-sha256 digest → returns None (no panic).
+- [ ] T015 [US1] Inline test: insert with non-sha256 digest → no-op, no error.
+- [ ] T016 [US1] Inline test: eviction with size_cap=1KB and three 500B entries inserted in order → after the third insert, the oldest is evicted.
+- [ ] T017 [US1] Inline test: concurrent inserts (10 threads × 50 same-digest writes) → final file is correct + intact.
+- [ ] T018 [US1] Inline test: probe-write fails on read-only tempdir → `open` returns None.
+- [ ] T019 [US1] Inline test: missing $HOME + missing override env → `resolve_cache_dir` returns None.
+- [ ] T020 [US1] Edit `mod.rs` to add `#[allow(dead_code)] mod cache;`.
+- [ ] T021 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T022 [US1] Commit: `feat(036/cache-module): add SHA-256-content-addressed disk cache for OCI blobs`.
+
+---
+
+## Phase 3: Commit 2 — `036/wire-cache`
+
+**Goal**: Cache is consulted by `fetch_blob`; CLI flags + env-var
+fallbacks build the Cache; mock-server test verifies zero-network
+on warm cache.
+
+- [ ] T023 [US1] Edit `registry.rs::RegistryClient`: add `cache: Option<Cache>` field. Update `RegistryClient::new` signature to take `cache: Option<Cache>` and store it.
+- [ ] T024 [US1] Edit `registry.rs::fetch_blob`: before the network fetch, consult `self.cache.as_ref().and_then(|c| c.get(digest))`. On hit, return immediately (verify_sha256 already ran inside cache.get). On miss, do the existing fetch, then `if let Some(c) = self.cache.as_ref() { let _ = c.insert(digest, &bytes); }` (insert errors logged but non-fatal).
+- [ ] T025 [US1] Edit `mod.rs::pull_to_tarball` signature: gain `cache: Option<&Cache>` (or `Option<Cache>` — pick what's ergonomic). Pass through to `RegistryClient::new`.
+- [ ] T026 [US1] Edit `scan_cmd.rs::ScanArgs`: add `pub no_oci_cache: bool` and `pub oci_cache_size: Option<u64>` with the doc-comments and clap attributes per FR-006.
+- [ ] T027 [US1] Edit `scan_cmd.rs` (the OciRef branch): build the cache. Logic: if `args.no_oci_cache || env("MIKEBOM_OCI_CACHE") == Some("0")` → None. Else compute size = `args.oci_cache_size.or_else(|| env("MIKEBOM_OCI_CACHE_SIZE").parse().ok()).unwrap_or(10 GB)`; call `cache::open(size)`. Pass into `pull_to_tarball`.
+- [ ] T028 [US1] Remove `#[allow(dead_code)]` from `mod.rs`'s `mod cache;`.
+- [ ] T029 [US1] Add inline integration test in `registry.rs`: tokio TCP listener with a connection-counter; first `fetch_blob` round-trip uses it; second `fetch_blob` for same digest uses 0 connections (cache hit). Construct `RegistryClient` via field-init with explicit `cache: Some(Cache { dir: tempdir, size_cap: 1<<30 })`.
+- [ ] T030 [US1] `cargo +stable test -p mikebom --bin mikebom scan_fs::oci_pull` green; binary test count went up by inline-test count.
+- [ ] T031 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T032 [US1] Commit: `feat(036/wire-cache): consult disk cache in fetch_blob; --no-oci-cache + --oci-cache-size flags`.
+
+---
+
+## Phase 4: Commit 3 — `036/docs-and-smoke`
+
+**Goal**: User-facing docs, CHANGELOG, gated smoke test.
+
+- [ ] T033 [US1] Edit `docs/user-guide/cli-reference.md`: add `--no-oci-cache` and `--oci-cache-size` flag rows; add an "OCI layer caching" subsection covering: cache location precedence (MIKEBOM_OCI_CACHE_DIR > XDG_CACHE_HOME > macOS Caches > ~/.cache), default size cap, how to clear (rm -rf), env-var equivalents.
+- [ ] T034 [US1] Edit `CHANGELOG.md`: unreleased entry — disk cache for OCI blobs (closes #68).
+- [ ] T035 [US1] Edit `mikebom-cli/Cargo.toml`'s `oci-registry` feature comment to mention caching.
+- [ ] T036 [US1] Edit `mikebom-cli/tests/oci_registry_smoke.rs`: add `repeat_pull_uses_cache_and_skips_network` gated test. Pre-clears `MIKEBOM_OCI_CACHE_DIR=<tempdir>`; pulls alpine:3.19 twice; asserts second pull's tracing log contains `cache hit` lines (or asserts wall-clock duration on second is <50% of first).
+- [ ] T037 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T038 [US1] Commit: `feat(036/docs-and-smoke): document --no-oci-cache + --oci-cache-size + gated warm-cache smoke test`.
+
+---
+
+## Phase 5: Verification + PR
+
+- [ ] T039 SC-001: `./scripts/pre-pr.sh` clean.
+- [ ] T040 SC-002: `git diff main..HEAD -- mikebom-cli/src/parity/ mikebom-cli/src/generate/ mikebom-cli/src/resolve/` empty.
+- [ ] T041 SC-003: `MIKEBOM_UPDATE_*_GOLDENS=1 ./scripts/pre-pr.sh` produces zero diff.
+- [ ] T042 SC-005: `wc -l mikebom-cli/src/scan_fs/oci_pull/cache.rs` ≤ 500.
+- [ ] T043 SC-006: `git diff main..HEAD -- mikebom-cli/Cargo.toml ... | grep -E '^\+[a-z]'` empty.
+- [ ] T044 Push branch; observe all 3 CI lanes green (SC-007).
+- [ ] T045 Open PR closing #68.


### PR DESCRIPTION
## Summary

- New SHA-256-content-addressed disk cache for OCI blobs (config + layers). Repeat scans of the same image read from disk and skip the network — meaningful speedup on non-trivial images.
- Closes the OCI follow-on queue: 031.x (#66), 031.y (#67), and 031.z (#68) are now all merged. The \`oci-registry\` feature ships a complete pull-cache-extract pipeline.
- Closes #68.

## Commits (4)

1. **\`spec(036)\`** — 4-file tighter spec set.
2. **\`feat(036/cache-module)\`** — \`cache.rs\` with \`Cache::open\` / \`get\` / \`insert\`, env-var-driven dir resolution, atomic-rename writes, mtime-based LRU eviction, SHA-256 verify on read with corruption recovery. 11 inline tests including an 8-thread × 40-write concurrent-insert stress test.
3. **\`feat(036/wire-cache)\`** — \`RegistryClient.cache: Option<Cache>\`; \`fetch_blob\` consults it before the network. New \`--no-oci-cache\` + \`--oci-cache-size <BYTES>\` flags with env fallbacks (\`MIKEBOM_OCI_CACHE=0\`, \`MIKEBOM_OCI_CACHE_SIZE=<bytes>\`). New inline integration test \`fetch_blob_returns_cached_bytes_without_network\` (cache hit returns correct bytes against an unreachable host — proves no network call is attempted).
4. **\`feat(036/docs-and-smoke)\`** — User-guide "OCI layer caching" subsection, CHANGELOG entry, Cargo.toml feature comment refresh, gated end-to-end smoke test (two scans of \`alpine:3.19\` against a tempdir cache; second produces a canonical-identical SBOM).

## Behavior

- **Cache location** (priority): \`\$MIKEBOM_OCI_CACHE_DIR\` → \`\$XDG_CACHE_HOME/mikebom/oci-layers\` → \`\$HOME/Library/Caches/mikebom/oci-layers\` (macOS) → \`\$HOME/.cache/mikebom/oci-layers\`.
- **Layout**: \`<dir>/sha256/<64-hex>\` per blob.
- **Eviction**: 10 GB default cap, mtime-LRU. Configurable.
- **Disable**: \`--no-oci-cache\` or \`MIKEBOM_OCI_CACHE=0\`.
- **Manifests are not cached** — floating tags like \`:latest\` need to re-fetch the manifest to detect updates; once it resolves to layer digests, those are immutable and cacheable.

## Safety properties

- SHA-256 verify on every read; corrupted bytes → drop entry, re-fetch.
- Tempfile-in-same-dir + \`persist()\` for intra-fs atomic rename. Concurrent scans of the same image don't corrupt the final file.
- Path-traversal impossible: only \`sha256:<64-hex>\` digests resolve to a path; \`sha256:..\` etc. fail the hex grammar check.
- Best-effort: read-only fs, missing \$HOME, parse failures all fall through to network-only behavior. Scans complete either way.

## Verification

- ✅ \`./scripts/pre-pr.sh\` clean.
- ✅ Binary tests went 1134 → 1146 (12 new: 11 cache.rs + 1 cache wire-up integration). Bin tests now 1146 total.
- ✅ \`MIKEBOM_UPDATE_*_GOLDENS=1 ./scripts/pre-pr.sh\` produces zero diff. Cache is a runtime knob.
- ✅ \`cache.rs\` is 483 LOC vs the 500-LOC spec budget.
- ✅ \`git diff main..HEAD -- Cargo.toml ...\` shows zero new top-level deps.
- ✅ No parity / generate / resolve diff.

## Test plan

- [ ] CI green on all 3 lanes.
- [ ] Manual warm-cache verification:
      \`\`\`bash
      MIKEBOM_OCI_NETWORK_TESTS=1 cargo +stable test \\
          -p mikebom --test oci_registry_smoke repeat_pull_uses_cache_for_warm_layers
      \`\`\`
- [ ] Manual disable-path:
      \`\`\`bash
      mikebom sbom scan --image alpine:3.19 --no-oci-cache --output a.cdx.json
      mikebom sbom scan --image alpine:3.19 --no-oci-cache --output b.cdx.json
      \`\`\`
      Both should make full network fetches; \`\$XDG_CACHE_HOME/mikebom/oci-layers/sha256/\` should not gain new files.
- [ ] Manual env override:
      \`\`\`bash
      MIKEBOM_OCI_CACHE_DIR=/tmp/test-cache mikebom sbom scan --image alpine:3.19 -o /tmp/a.cdx.json
      ls /tmp/test-cache/sha256/
      \`\`\`

## Out of scope (future)

- \`--clear-oci-cache\` CLI command — \`rm -rf\` is the canonical handle.
- Pre-warm / cache-fill commands.
- Manifest caching (intentional — floating tags need to re-fetch).
- Distributed / shared-volume cache.

## OCI follow-on status

After this merges, all three sub-scope items from milestone 031 are closed:
- ✅ #66 — 031.x authenticated registry pulls (PR #71)
- ✅ #67 — 031.y \`--image-platform\` flag (PR #72)
- ✅ #68 — 031.z layer caching (this PR)

Next non-OCI items in the queue: #64 (dpkg \`status.d/\` for distroless / chainguard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)