### PR TITLE
feat(039): per-file evidence for apk components — apk reaches deb parity (closes #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 ## [Unreleased]
 
 ### Added
+- **Milestone 039 — Per-file evidence for apk components
+  (alpine + chainguard apko + Wolfi).** Closes the asymmetry
+  surfaced during milestone 038's recon (#75): apk-based images
+  now produce per-file `evidence.occurrences[]` blocks at the
+  same quality as deb-based images. Implementation mirrors the
+  dpkg deep-hash path: a new `apk::read_file_lists` extracts
+  per-package paths from the `F:` (directory) and `R:` (regular
+  file) lines that the apk installed-db carries inline; a new
+  `hash_apk_package_files` walks those paths, opens each file,
+  and SHA-256s the content (same 256 MB cap as the dpkg path).
+  A parallel `--no-deep-hash` fast path
+  (`hash_apk_db_only`) hashes the package's stanza bytes
+  in-place. Verified end-to-end:
+  `alpine:3.19` produces 79 file occurrences across 15
+  components (was 0); `cgr.dev/chainguard/static:latest`
+  produces 1217 occurrences across 3 components (was 0). 27
+  byte-identity goldens regen with zero diff (those goldens use
+  `--no-deep-hash` so they're insulated from the deep-hash path
+  by design). Apk-side `additionalContext` carries SHA-256 only;
+  the apk-provided SHA-1 (`Z:` lines) is a future extension. No
+  new top-level dependencies. Closes #75. See
+  `specs/039-apk-deep-hash/spec.md`.
 - **Milestone 038 — Per-file evidence for distroless /
   Bazel-built minimal-image deb scans.** Closes the deferred
   milestone-037 item: distroless deb images

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -179,10 +179,15 @@ Behaviour notes:
   per-file MD5s. Stanza files in this layout legitimately omit the
   `Status:` field (no dpkg daemon manages install state in the image);
   mikebom treats the file's existence as the installation marker.
-  Apk-based minimal images (chainguard apko / Wolfi) get correct
-  component metadata today; per-file evidence for apk components is
-  tracked separately in
-  [#75](https://github.com/kusari-sandbox/mikebom/issues/75).
+- **Apk per-file evidence** (alpine / chainguard apko / Wolfi):
+  per-file `evidence.occurrences[]` is populated for apk-based images
+  too — including both full-fat `alpine:*` scans and minimal apko-built
+  images like `cgr.dev/chainguard/*`. mikebom reads the per-package
+  file list inline from each stanza's `F:` (directory) and `R:`
+  (regular file) lines in `/lib/apk/db/installed`, walks the rootfs,
+  and emits SHA-256 per file. apk-side `additionalContext` carries
+  SHA-256 only (no MD5 cross-ref, as apk doesn't ship one; the
+  apk-provided SHA-1 from `Z:` lines is a future extension).
 
 ### Authenticating to private registries
 

--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -360,6 +360,15 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
             );
         }
 
+        // Milestone 039: build the apk per-package file-list map
+        // once per scan. apk's installed-db carries file ownership
+        // inline (F:/R: lines); we extract it here so the per-entry
+        // loop can do per-package deep-hashing without re-parsing
+        // the database. Returns an empty map for non-apk images
+        // (file-not-found short-circuits cheaply) — the unconditional
+        // call is fine.
+        let apk_file_lists = package_db::apk::read_file_lists(root);
+
         for entry in &db_entries {
             let purl_str = entry.purl.as_str().to_string();
             let ecosystem = entry.purl.ecosystem().to_string();
@@ -368,6 +377,10 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
             // db at varying quality (apk-license extraction is its own
             // follow-up). Detect the dpkg case via the source_path.
             let is_dpkg = entry.source_path.contains("dpkg/status");
+            // Milestone 039: apk per-file deep-hashing — same shape
+            // as the dpkg path. Detected via the standard apk
+            // installed-db source_path.
+            let is_apk = entry.source_path.contains("apk/db/installed");
             // dpkg licenses live out-of-band in /usr/share/doc/<pkg>/
             // copyright; other sources (e.g. Python dist-info METADATA)
             // embed them directly on the entry.
@@ -383,6 +396,9 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
             // capturing the dpkg-recorded MD5 per file for cross-ref.
             // The fast path SHA-256s the dpkg `.md5sums` file content
             // as a per-package fingerprint with no per-file occurrences.
+            //
+            // Milestone 039: apk gets the parallel treatment via
+            // hash_apk_package_files (deep) / hash_apk_db_only (fast).
             let (occurrences, mut component_hashes) = if is_dpkg {
                 if deep_hash {
                     let (occs, root_hash) = package_db::file_hashes::hash_package_files(
@@ -397,6 +413,19 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
                         &entry.name,
                         entry.arch.as_deref(),
                     );
+                    (Vec::new(), h.into_iter().collect::<Vec<_>>())
+                }
+            } else if is_apk {
+                if deep_hash {
+                    let files: &[String] = apk_file_lists
+                        .get(&entry.name)
+                        .map(|v| v.as_slice())
+                        .unwrap_or(&[]);
+                    let (occs, root_hash) =
+                        package_db::file_hashes::hash_apk_package_files(root, files);
+                    (occs, root_hash.into_iter().collect::<Vec<_>>())
+                } else {
+                    let h = package_db::file_hashes::hash_apk_db_only(root, &entry.name);
                     (Vec::new(), h.into_iter().collect::<Vec<_>>())
                 }
             } else {

--- a/mikebom-cli/src/scan_fs/package_db/apk.rs
+++ b/mikebom-cli/src/scan_fs/package_db/apk.rs
@@ -100,6 +100,67 @@ pub fn collect_claimed_paths(
     }
 }
 
+/// Walk `<rootfs>/lib/apk/db/installed` once and build a per-package
+/// file-list map. Used by milestone 039's deep-hash path: the apk
+/// stanza format encodes file ownership inline via interleaved
+/// `F:<dir>` (directory) and `R:<basename>` (regular file) lines —
+/// no companion files like dpkg's `info/<pkg>.list`.
+///
+/// Returns a map keyed on package name with each value being the
+/// rootfs-relative file paths the package's stanza claims. Returns
+/// an empty map when the file is absent (typical for Debian/Ubuntu
+/// rootfs) or unreadable; never errors.
+///
+/// Stanza boundaries (blank lines) reset the current package and
+/// directory tracking. Files declared without a current `F:` (which
+/// shouldn't happen in well-formed databases) are silently skipped
+/// to match the `collect_claimed_paths` posture.
+#[allow(dead_code)] // wired up in milestone 039 commit 3 (`hash-and-wire`).
+pub fn read_file_lists(
+    rootfs: &Path,
+) -> std::collections::HashMap<String, Vec<String>> {
+    let path = rootfs.join(APK_INSTALLED_PATH);
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return std::collections::HashMap::new();
+    };
+    let mut out: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    let mut current_pkg: Option<String> = None;
+    let mut current_dir: Option<String> = None;
+    for line in text.lines() {
+        if line.is_empty() {
+            current_pkg = None;
+            current_dir = None;
+            continue;
+        }
+        if line.len() < 2 || line.as_bytes()[1] != b':' {
+            continue;
+        }
+        match line.as_bytes()[0] {
+            b'P' => {
+                current_pkg = Some(line[2..].to_string());
+                current_dir = None;
+            }
+            b'F' => {
+                current_dir = Some(line[2..].to_string());
+            }
+            b'R' => {
+                let basename = &line[2..];
+                if let (Some(pkg), Some(dir)) = (&current_pkg, &current_dir) {
+                    let rel = if dir.is_empty() {
+                        basename.to_string()
+                    } else {
+                        format!("{dir}/{basename}")
+                    };
+                    out.entry(pkg.clone()).or_default().push(rel);
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
 fn parse(text: &str, source_path: &str, distro_version: Option<&str>) -> Vec<PackageDbEntry> {
     let mut out = Vec::new();
     for stanza in text.split("\n\n") {
@@ -442,5 +503,102 @@ D:so:libc.musl-aarch64.so.1
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].name, "zlib");
         assert!(out[0].source_path.ends_with("/lib/apk/db/installed"));
+    }
+
+    // ---- Milestone 039: per-package file-list extraction ----------------
+
+    /// Helper: write a synthetic apk installed-db at the rootfs-
+    /// relative path used in production.
+    fn write_installed_db(rootfs: &std::path::Path, body: &str) {
+        let p = rootfs.join(APK_INSTALLED_PATH);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, body).unwrap();
+    }
+
+    #[test]
+    fn read_file_lists_extracts_per_package_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        // Two packages, each owning two files. apk stanza format:
+        // P: package, V: version, F: directory, R: basename.
+        write_installed_db(
+            dir.path(),
+            "P:foo\n\
+             V:1.0\n\
+             F:usr/bin\n\
+             R:foo\n\
+             F:etc\n\
+             R:foo.conf\n\
+             \n\
+             P:bar\n\
+             V:2.0\n\
+             F:usr/lib\n\
+             R:libbar.so.1\n\
+             R:libbar.so\n",
+        );
+        let map = read_file_lists(dir.path());
+        assert_eq!(map.len(), 2);
+
+        let foo = map.get("foo").expect("foo entry");
+        assert_eq!(foo.len(), 2);
+        assert!(foo.contains(&"usr/bin/foo".to_string()));
+        assert!(foo.contains(&"etc/foo.conf".to_string()));
+
+        let bar = map.get("bar").expect("bar entry");
+        assert_eq!(bar.len(), 2);
+        assert!(bar.contains(&"usr/lib/libbar.so.1".to_string()));
+        assert!(bar.contains(&"usr/lib/libbar.so".to_string()));
+    }
+
+    #[test]
+    fn read_file_lists_handles_empty_dir_for_root_level_files() {
+        // Some packages (e.g. baselayout-data) have F: with empty
+        // value followed by R: lines for files at the rootfs root.
+        let dir = tempfile::tempdir().unwrap();
+        write_installed_db(
+            dir.path(),
+            "P:baselayout-data\n\
+             V:0.1\n\
+             F:\n\
+             R:.profile\n",
+        );
+        let map = read_file_lists(dir.path());
+        let entries = map.get("baselayout-data").expect("entry");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0], ".profile");
+    }
+
+    #[test]
+    fn read_file_lists_returns_empty_when_db_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        // No installed-db file at all.
+        let map = read_file_lists(dir.path());
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn read_file_lists_resets_state_on_blank_line_between_stanzas() {
+        // If state-reset is broken, baz's R: would attribute to foo
+        // because no F: was seen for baz before blank-line boundary.
+        let dir = tempfile::tempdir().unwrap();
+        write_installed_db(
+            dir.path(),
+            "P:foo\n\
+             V:1.0\n\
+             F:usr/bin\n\
+             R:foo\n\
+             \n\
+             P:baz\n\
+             V:1.0\n\
+             R:orphan\n",
+        );
+        let map = read_file_lists(dir.path());
+        // foo should have its 1 file. baz has no F: before R:, so the
+        // R: line is silently dropped — same posture as
+        // `collect_claimed_paths`.
+        assert_eq!(map.get("foo").map(|v| v.len()), Some(1));
+        assert!(
+            !map.contains_key("baz") || map.get("baz").is_none_or(|v| v.is_empty()),
+            "orphan R: without preceding F: should be skipped"
+        );
     }
 }

--- a/mikebom-cli/src/scan_fs/package_db/apk.rs
+++ b/mikebom-cli/src/scan_fs/package_db/apk.rs
@@ -115,7 +115,6 @@ pub fn collect_claimed_paths(
 /// directory tracking. Files declared without a current `F:` (which
 /// shouldn't happen in well-formed databases) are silently skipped
 /// to match the `collect_claimed_paths` posture.
-#[allow(dead_code)] // wired up in milestone 039 commit 3 (`hash-and-wire`).
 pub fn read_file_lists(
     rootfs: &Path,
 ) -> std::collections::HashMap<String, Vec<String>> {

--- a/mikebom-cli/src/scan_fs/package_db/file_hashes.rs
+++ b/mikebom-cli/src/scan_fs/package_db/file_hashes.rs
@@ -217,6 +217,152 @@ fn read_info_file_bytes(
     None
 }
 
+// ---- Milestone 039: apk per-file deep-hashing -------------------------
+
+/// Deep-hash every file the apk installed-db claims `pkg_name` owns.
+/// Returns the per-file occurrences and a component-level Merkle
+/// root over them — matching the shape produced by
+/// [`hash_package_files`] for dpkg components, so downstream emitters
+/// don't have to discriminate.
+///
+/// `files` is the rootfs-relative path list extracted by
+/// [`super::apk::read_file_lists`] for this package. apk paths come
+/// in unprefixed (`usr/bin/foo`); we resolve to absolute form
+/// (`/usr/bin/foo`) for `FileOccurrence.location` to match the
+/// legacy convention used by the dpkg path.
+///
+/// Files that disappear between install and scan time are silently
+/// skipped (rare; would typically indicate config files removed
+/// during image build). Oversized files (> [`MAX_PER_FILE_BYTES`])
+/// are skipped with a debug log.
+///
+/// Unlike the dpkg path, no MD5 cross-reference is emitted —
+/// apk's analogous `Z:` line carries SHA-1, which is OUT OF SCOPE
+/// for this milestone (could be added later via a follow-on).
+pub fn hash_apk_package_files(
+    rootfs: &Path,
+    files: &[String],
+) -> (Vec<FileOccurrence>, Option<ContentHash>) {
+    let mut occurrences: Vec<FileOccurrence> = Vec::new();
+    for rel in files {
+        let rel = rel.trim_start_matches('/');
+        if rel.is_empty() {
+            continue;
+        }
+        let abs = rootfs.join(rel);
+        let Ok(meta) = abs.symlink_metadata() else {
+            continue;
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        if meta.len() > MAX_PER_FILE_BYTES {
+            tracing::debug!(
+                path = %abs.display(),
+                size = meta.len(),
+                "skipping oversized file in apk deep hash"
+            );
+            continue;
+        }
+        let sha256 = match sha256_file_hex(&abs, MAX_PER_FILE_BYTES) {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::debug!(path = %abs.display(), error = %e, "could not hash apk file");
+                continue;
+            }
+        };
+        // Store the absolute deployed-filesystem path (matches the
+        // legacy convention used on the dpkg side — keeps SBOM
+        // consumers from having to detect ecosystem-specific
+        // location prefixes).
+        occurrences.push(FileOccurrence {
+            location: format!("/{rel}"),
+            sha256,
+            md5_legacy: None,
+        });
+    }
+
+    let root = compute_merkle_root(&occurrences);
+    (occurrences, root)
+}
+
+/// `--no-deep-hash` fast path for apk. SHA-256s the bytes of the
+/// package's stanza extracted from `<rootfs>/lib/apk/db/installed`.
+/// Returns `None` if the installed-db is absent OR the package
+/// isn't found within it. Mirrors the role
+/// [`hash_md5sums_only`] plays for dpkg.
+///
+/// The stanza-extraction is a small embedded scan: walk the file,
+/// detect the `P:<pkg_name>` line, accumulate bytes until the
+/// next blank-line stanza boundary.
+pub fn hash_apk_db_only(rootfs: &Path, pkg_name: &str) -> Option<ContentHash> {
+    let path = rootfs.join("lib/apk/db/installed");
+    let bytes = std::fs::read(&path).ok()?;
+    let stanza = extract_apk_stanza(&bytes, pkg_name)?;
+    let hex = sha256_hex(stanza);
+    ContentHash::sha256(&hex).ok()
+}
+
+/// Find the first stanza in `db_bytes` whose `P:` line names
+/// `pkg_name`, and return that stanza's bytes (a contiguous slice).
+/// Stanzas are separated by `\n\n`; the package-name line is the
+/// authoritative identifier (the apk `P:` field). Linear scan.
+fn extract_apk_stanza<'a>(
+    db_bytes: &'a [u8],
+    pkg_name: &str,
+) -> Option<&'a [u8]> {
+    let needle = format!("P:{pkg_name}\n");
+    let needle_bytes = needle.as_bytes();
+    let mut start = 0usize;
+    while start < db_bytes.len() {
+        let stanza_end = find_blank_line(db_bytes, start);
+        let stanza_slice = &db_bytes[start..stanza_end];
+        if window_starts_with_or_contains_line(stanza_slice, needle_bytes) {
+            return Some(stanza_slice);
+        }
+        // Advance past the blank-line boundary (or to EOF).
+        if stanza_end >= db_bytes.len() {
+            return None;
+        }
+        start = stanza_end + 2; // skip "\n\n"
+    }
+    None
+}
+
+/// Return the byte offset of the next blank line ("\n\n") at or
+/// after `from`, or `db_bytes.len()` if there's no blank line
+/// (last stanza in the file).
+fn find_blank_line(db_bytes: &[u8], from: usize) -> usize {
+    let mut i = from;
+    while i + 1 < db_bytes.len() {
+        if db_bytes[i] == b'\n' && db_bytes[i + 1] == b'\n' {
+            return i;
+        }
+        i += 1;
+    }
+    db_bytes.len()
+}
+
+/// Whether `stanza` contains a line exactly equal to `needle_line`.
+/// `needle_line` ends with `\n`; the match must be at the start of
+/// the stanza or immediately after a `\n` boundary, and consume
+/// the trailing newline.
+fn window_starts_with_or_contains_line(stanza: &[u8], needle_line: &[u8]) -> bool {
+    if stanza.starts_with(needle_line) {
+        return true;
+    }
+    let mut i = 0usize;
+    while i + needle_line.len() <= stanza.len() {
+        if stanza[i] == b'\n' && stanza[i + 1..].starts_with(needle_line) {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+// ----------------------------------------------------------------------
+
 /// Read `<pkg>[:<arch>].md5sums` into a `path -> md5` map. Lines are
 /// `<32-hex-md5>  <relative-path>` (two spaces between the two fields,
 /// per dpkg convention). Missing file → empty map.
@@ -622,5 +768,108 @@ mod tests {
         // Stable across calls (deterministic over the same input bytes).
         let h2 = hash_md5sums_only(dir.path(), "tzdata", None).expect("again");
         assert_eq!(h.value.as_str(), h2.value.as_str());
+    }
+
+    // ---- Milestone 039: apk per-file deep-hashing -----------------------
+
+    fn write_apk_db(rootfs: &std::path::Path, body: &str) {
+        let p = rootfs.join("lib/apk/db/installed");
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(&p, body).unwrap();
+    }
+
+    /// Helper: build a tempdir-rooted fake apk rootfs with the given
+    /// files actually present on disk.
+    fn place_files(rootfs: &std::path::Path, files: &[(&str, &[u8])]) {
+        for (rel, content) in files {
+            let abs = rootfs.join(rel.trim_start_matches('/'));
+            fs::create_dir_all(abs.parent().unwrap()).unwrap();
+            fs::write(&abs, content).unwrap();
+        }
+    }
+
+    #[test]
+    fn hash_apk_package_files_round_trips_files() {
+        let dir = tempfile::tempdir().unwrap();
+        place_files(
+            dir.path(),
+            &[("usr/bin/foo", b"foo-bytes"), ("etc/foo.conf", b"conf=1\n")],
+        );
+        let files = vec!["usr/bin/foo".to_string(), "etc/foo.conf".to_string()];
+        let (occs, root) = hash_apk_package_files(dir.path(), &files);
+        assert_eq!(occs.len(), 2);
+        assert!(root.is_some(), "must produce a per-component Merkle root");
+        for o in &occs {
+            assert_eq!(o.sha256.len(), 64);
+            assert!(
+                o.location.starts_with('/'),
+                "apk occurrence locations must be absolute, got `{}`",
+                o.location
+            );
+            assert!(
+                o.md5_legacy.is_none(),
+                "apk path emits no MD5 cross-ref (Z: lines out of scope)"
+            );
+        }
+    }
+
+    #[test]
+    fn hash_apk_package_files_skips_absent_files() {
+        let dir = tempfile::tempdir().unwrap();
+        place_files(dir.path(), &[("usr/bin/exists", b"on-disk")]);
+        // Only one of the two listed files actually exists on disk.
+        let files = vec!["usr/bin/exists".to_string(), "usr/bin/missing".to_string()];
+        let (occs, root) = hash_apk_package_files(dir.path(), &files);
+        assert_eq!(occs.len(), 1, "absent file must be skipped");
+        assert_eq!(occs[0].location, "/usr/bin/exists");
+        assert!(root.is_some());
+    }
+
+    #[test]
+    fn hash_apk_package_files_returns_empty_for_empty_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let (occs, root) = hash_apk_package_files(dir.path(), &[]);
+        assert!(occs.is_empty());
+        assert!(root.is_none());
+    }
+
+    #[test]
+    fn hash_apk_db_only_finds_named_stanza() {
+        let dir = tempfile::tempdir().unwrap();
+        write_apk_db(
+            dir.path(),
+            "P:foo\n\
+             V:1.0\n\
+             A:x86_64\n\
+             \n\
+             P:bar\n\
+             V:2.0\n\
+             A:x86_64\n",
+        );
+        let h_foo = hash_apk_db_only(dir.path(), "foo")
+            .expect("foo stanza should resolve");
+        let h_bar = hash_apk_db_only(dir.path(), "bar")
+            .expect("bar stanza should resolve");
+        assert_ne!(
+            h_foo.value.as_str(),
+            h_bar.value.as_str(),
+            "different stanzas must hash differently"
+        );
+        // Stable across calls.
+        let h_foo2 = hash_apk_db_only(dir.path(), "foo").expect("again");
+        assert_eq!(h_foo.value.as_str(), h_foo2.value.as_str());
+    }
+
+    #[test]
+    fn hash_apk_db_only_returns_none_for_missing_package() {
+        let dir = tempfile::tempdir().unwrap();
+        write_apk_db(dir.path(), "P:foo\nV:1.0\n");
+        assert!(hash_apk_db_only(dir.path(), "ghost").is_none());
+    }
+
+    #[test]
+    fn hash_apk_db_only_returns_none_when_db_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(hash_apk_db_only(dir.path(), "foo").is_none());
     }
 }

--- a/mikebom-cli/tests/oci_registry_smoke.rs
+++ b/mikebom-cli/tests/oci_registry_smoke.rs
@@ -98,6 +98,43 @@ fn pulls_alpine_3_19_and_emits_apk_components() {
         "alpine:3.19 should yield at least one pkg:apk/alpine/* PURL; got components: {}",
         serde_json::to_string_pretty(&components).unwrap_or_default()
     );
+
+    // Milestone 039: per-file evidence MUST be populated for apk
+    // components (mirrors the milestone-038 deb assertion). Pre-039
+    // this was always 0 because file_hashes.rs was dpkg-only.
+    let mut total_occurrences = 0usize;
+    let mut sha256_seen = false;
+    for c in components {
+        let occs = c["evidence"]["occurrences"]
+            .as_array()
+            .map(|a| a.as_slice())
+            .unwrap_or(&[]);
+        total_occurrences += occs.len();
+        for o in occs {
+            let Some(ctx_str) = o["additionalContext"].as_str() else {
+                continue;
+            };
+            let Ok(ctx) = serde_json::from_str::<serde_json::Value>(ctx_str) else {
+                continue;
+            };
+            if let Some(s) = ctx["sha256"].as_str() {
+                if s.len() == 64 && s.chars().all(|c| c.is_ascii_hexdigit()) {
+                    sha256_seen = true;
+                }
+            }
+        }
+    }
+    assert!(
+        total_occurrences > 0,
+        "milestone 039 (apk per-file evidence) should populate \
+         evidence.occurrences[]; got 0 across {} components — has \
+         hash_apk_package_files regressed?",
+        components.len()
+    );
+    assert!(
+        sha256_seen,
+        "at least one apk occurrence should carry a 64-hex SHA-256 in additionalContext; got none"
+    );
 }
 
 #[test]

--- a/specs/039-apk-deep-hash/checklists/requirements.md
+++ b/specs/039-apk-deep-hash/checklists/requirements.md
@@ -1,0 +1,52 @@
+# Specification Quality Checklist: Per-File Evidence for apk Components
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Validation Notes
+
+- This is a **symmetry milestone**: it brings the apk path to
+  feature parity with the deb path that landed in milestones
+  037 + 038. The spec is intentionally narrow — single user
+  story, no recon-driven branching, no schema changes.
+- No `[NEEDS CLARIFICATION]` markers — milestone 038's recon
+  already established that alpine + apko share the standard apk
+  DB layout, and the dpkg path provides the exact pattern to
+  mirror.
+- SC-001/-002/-003/-005 are quantitatively measurable. SC-002
+  involves a hand-verification step against `apk info -L` that's
+  routine post-merge.
+- Out-of-scope explicitly excludes the `Z:` line SHA-1 cross-ref
+  (the apk-provided checksum), keeping the milestone's surface
+  small enough to ship in a single PR.
+
+## Notes
+
+- Items marked incomplete require spec updates before
+  `/speckit.clarify` or `/speckit.plan`. All items currently pass.

--- a/specs/039-apk-deep-hash/plan.md
+++ b/specs/039-apk-deep-hash/plan.md
@@ -1,0 +1,98 @@
+# Implementation Plan: Per-File Evidence for apk Components
+
+**Branch**: `039-apk-deep-hash` | **Date**: 2026-04-29 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Mirror milestone 038's deb deep-hash path for apk. The apk
+installed-db already encodes the per-file paths inline via `F:`
+(directory) and `R:` (regular file basename) lines under each
+package's stanza, so no companion-file or layout discovery is
+needed — just a one-pass extraction during the same db read,
+and a `hash_apk_package_files` hashing loop that mirrors the
+existing dpkg one.
+
+**Technical approach**: extract a per-package file-list map once
+in `apk.rs`, pass it into a new `hash_apk_package_files` in
+`file_hashes.rs`, and add an `is_apk` branch to the existing
+deep-hash dispatcher in `scan_fs/mod.rs`. ~250 LOC total.
+
+## Technical Context
+
+**Language**: Rust stable (workspace toolchain unchanged from 038).
+**Primary Dependencies**: existing only — `sha2`, stdlib `std::fs` /
+`std::io`, `tempfile` (dev). No new top-level deps.
+**Project Type**: CLI / library (Rust three-crate workspace —
+Constitution Principle VI preserved).
+**Performance**: per-file SHA-256 is IO-bound; cap inherited from
+dpkg path (256 MB / file). Apk packages are typically smaller than
+deb packages so deep-hash cost should be slightly lower.
+**Constraints**: Constitution Principles I, IV, VI (all already
+satisfied; no new surface).
+
+## Constitution Check
+
+| Principle | Status |
+|---|---|
+| I. Pure Rust, Zero C | ✅ no new deps |
+| IV. Type-Driven Correctness | ✅ Option/Result throughout; reuses existing newtypes |
+| V. Specification Compliance | ✅ no SBOM schema changes; reuses CycloneDX evidence shape |
+| VI. Three-Crate Architecture | ✅ touches `mikebom-cli` only |
+| VIII. Completeness | ✅ closes a known false-negative |
+| IX. Accuracy | ✅ file content hashes are observed-bytes truth |
+
+**No constitution violations.**
+
+## Touched files
+
+| File | Change | LOC |
+|---|---|---|
+| `mikebom-cli/src/scan_fs/package_db/apk.rs` | + `read_file_lists(rootfs) -> HashMap<String, Vec<String>>`; inline tests | +90 |
+| `mikebom-cli/src/scan_fs/package_db/file_hashes.rs` | + `hash_apk_package_files(rootfs, &[String])`; + `hash_apk_db_only(rootfs, pkg)`; inline tests | +120 |
+| `mikebom-cli/src/scan_fs/mod.rs` | + `is_apk` branch parallel to `is_dpkg` | +30 |
+| `mikebom-cli/tests/oci_registry_smoke.rs` | extend alpine smoke to assert per-file evidence > 0 | +15 |
+| `docs/user-guide/cli-reference.md` | minimal-image-coverage paragraph adjusted | +5 |
+| `CHANGELOG.md` | unreleased entry | +5 |
+
+Total ~265 LOC across 6 files.
+
+## Phasing
+
+Three commits.
+
+1. **`spec(039)`** — spec set (this file + spec.md + checklists).
+2. **`feat(039/extract-file-lists)`** — `apk.rs::read_file_lists`
+   + inline tests. Behind `#[allow(dead_code)]` until commit 3.
+3. **`feat(039/hash-and-wire)`** — `hash_apk_package_files` in
+   `file_hashes.rs` + `is_apk` branch in `scan_fs/mod.rs` + smoke
+   test extension. Removes the dead-code allow.
+4. **`docs(039)`** — user-guide + CHANGELOG.
+
+## Estimated effort
+
+| Phase | Effort |
+|---|---|
+| Spec set | 30 min |
+| Commit 2 (file-list extract) | 1.5 hr |
+| Commit 3 (hash + wire) | 2 hr |
+| Commit 4 (docs) | 30 min |
+| Verify + PR | 30 min |
+| **Total** | **~5 hr** |
+
+## Risks
+
+- **R1**: apk's `R:` line format edge cases. Most are basenames
+  under the current `F:`-declared directory, but some packages
+  (e.g. baselayout-data) carry empty `F:` for root-level files.
+  The existing `collect_claimed_paths` handles this correctly
+  (line 81 — `if dir.is_empty() ...`); reuse that logic.
+- **R2**: golden drift. Existing 27 byte-identity goldens cover
+  alpine fixtures. If any of those alpine-fixture goldens contain
+  apk components, this milestone WILL change them (adding per-file
+  evidence). Need to regen and verify the change is additive only.
+
+## What this milestone does NOT do
+
+- Does not add the apk-provided SHA-1 cross-reference (Z: lines).
+- Does not change PURL, schema, or fast-hash flag semantics.
+- Does not touch rpm or any other ecosystem.

--- a/specs/039-apk-deep-hash/spec.md
+++ b/specs/039-apk-deep-hash/spec.md
@@ -1,0 +1,193 @@
+# Feature Specification: Per-File Evidence for apk Components
+
+**Feature Branch**: `039-apk-deep-hash`
+**Created**: 2026-04-29
+**Status**: Draft
+**Input**: User description: "apk per-file deep-hashing for alpine and chainguard apko (mirror dpkg file_hashes.rs)"
+
+## User Scenarios & Testing *(mandatory)*
+
+Milestone 038 surfaced an unintentional asymmetry: deb-based image
+scans produce per-file `evidence.occurrences[]` blocks (paths +
+SHA-256 + MD5 cross-ref), while apk-based image scans — both
+full-fat `alpine:3.19` and minimal chainguard apko / Wolfi — emit
+zero per-file evidence. The asymmetry is a coverage gap, not a
+design choice: mikebom's `file_hashes.rs` was implemented for the
+dpkg layout and never extended to apk.
+
+This milestone closes the gap. After it ships, an SBOM consumer
+scanning any apk-based image gets the same evidence quality they
+already get for any deb-based image: per-file paths, content
+hashes, and a component-level Merkle root.
+
+### User Story 1 - Per-file evidence for any apk-based image (Priority: P1)
+
+An SBOM consumer scans an apk-based image (alpine, chainguard
+apko, Wolfi-derived, etc.) and expects each apk component in the
+output to carry a populated `evidence.occurrences[]` block with
+per-file paths and SHA-256 hashes — at the same evidence quality
+already produced for deb components.
+
+**Why this priority**: this is a single-story milestone closing a
+specific symmetry gap discovered during milestone 038. There's no
+broader UX or schema change; just bringing the apk path up to
+parity with the deb path.
+
+**Independent Test**: Run `mikebom sbom scan --image alpine:3.19
+--output alpine.cdx.json` and verify the SBOM has populated per-
+component `evidence.occurrences[]` for every apk component —
+specifically that the total file-occurrence count across all
+components is non-zero (today: 0). Each occurrence carries a 64-
+hex SHA-256 in the established CycloneDX evidence shape.
+
+**Acceptance Scenarios**:
+
+1. **Given** an apk-based image (alpine, chainguard apko, or
+   Wolfi-derived), **When** the user runs an SBOM scan with default
+   flags, **Then** every apk component in the output carries a
+   non-empty per-file evidence block with file paths and content
+   hashes.
+2. **Given** an apk-based image, **When** the user passes the
+   existing `--no-deep-hash` flag, **Then** each component carries
+   a package-level identity hash but the per-file evidence block
+   is empty — matching the existing fast-path behavior for deb
+   components.
+3. **Given** an apk-based image where some files listed in the
+   installed-db are absent from the rootfs (rare; would indicate a
+   broken image), **When** the user runs a scan, **Then** the scan
+   completes successfully, the absent files are silently skipped,
+   and the remaining files are hashed normally.
+4. **Given** a deb-based image (legacy single-file dpkg or
+   minimal-image status.d/), **When** the user runs a scan,
+   **Then** the resulting SBOM is byte-identical to milestone
+   038's output — no regression on dpkg coverage.
+
+---
+
+### Edge Cases
+
+- **Files listed in the apk db but absent from the rootfs**: the
+  image build process may have removed config files or runtime-
+  created paths. The evidence block silently skips absent files,
+  matching the dpkg posture.
+- **Files listed in the apk db but oversized**: same per-file hash
+  cap as the dpkg path applies. Oversized files are skipped with
+  a debug log.
+- **Symlinks listed in the apk db**: follow the symlink and hash
+  the target only if the target is inside the rootfs; out-of-
+  rootfs symlinks are skipped (matches dpkg posture).
+- **Directory entries in the apk db**: apk's `F:` lines name
+  directories; these are not hashable content and are skipped.
+  Only `R:` lines (regular files) produce occurrences.
+- **Stanza fields in arbitrary order**: apk's `F:`/`R:` interleave
+  with metadata fields and reset on blank-line stanza boundaries.
+  The file-list extractor MUST track stanza boundaries correctly
+  so each package's file list is associated with the right
+  package name.
+- **Wolfi / apko-built images**: same standard apk DB layout as
+  alpine. No variant code required.
+- **`--no-package-db`**: when set, the apk reader is skipped
+  entirely. The new per-file evidence path is also skipped (no
+  metadata = no path list to hash). Same as the dpkg path's
+  behavior.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When mikebom scans an apk-based image, each emitted
+  apk component MUST carry a per-file evidence block populated
+  from the apk installed-db's `R:` (regular file) entries under
+  the component's stanza.
+
+- **FR-002**: The per-file evidence block MUST carry the same
+  fields, in the same shape, that the existing deb-component
+  evidence block carries — file path inside the rootfs and SHA-256
+  of the file content. Downstream emitters (CycloneDX, SPDX 2.3,
+  SPDX 3) MUST serialize them identically regardless of whether
+  the component is deb or apk.
+
+- **FR-003**: When the user passes `--no-deep-hash`, the per-file
+  evidence block MUST be empty for apk components — matching the
+  existing fast-path behavior for deb components. The package-
+  level identity hash MUST still resolve.
+
+- **FR-004**: Components with no `R:` entries in their stanza
+  (rare; would indicate a content-less metadata-only package)
+  MUST still appear in the SBOM with package-level identity, but
+  with an empty per-file evidence block. The scan MUST NOT fail.
+
+- **FR-005**: Existing deb-image scans (legacy dpkg or status.d/)
+  MUST be byte-identical to milestone 038's output. The
+  byte-identity goldens MUST regen with zero diff.
+
+- **FR-006**: No new top-level Cargo dependencies. The work reuses
+  `sha2` (already in the dep tree for the dpkg path) and stdlib
+  primitives. The `no_c_dependencies_in_tree` regression test
+  MUST continue to pass.
+
+### Key Entities
+
+- **apk file-list map**: a per-scan map keyed on package name
+  whose values are the rootfs-relative file paths the package's
+  stanza claims. Built once per scan by walking the apk
+  installed-db; consumed by the per-component hashing loop.
+- **Per-file evidence block**: identical to the existing deb-side
+  shape — one `FileOccurrence` per file, carrying the rootfs path
+  + SHA-256.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A scan of `alpine:3.19` produces an SBOM whose apk
+  components each carry a non-empty per-file evidence block —
+  measurable as `total file occurrences across all components > 0`
+  (today: 0).
+
+- **SC-002**: For at least one well-understood apk image
+  (`alpine:3.19`), the per-file evidence count for each package
+  matches what `apk info -L <pkg>` reports on a live alpine
+  system — measurable as a hand-verified count parity for at
+  least one package.
+
+- **SC-003**: A scan of any deb-based image (e.g. `debian:bookworm-
+  slim`, `gcr.io/distroless/static-debian12:latest`) produces an
+  SBOM byte-identical to milestone 038's output — measurable as
+  the existing 27 byte-identity goldens regenning with zero diff.
+
+- **SC-004**: Scanning a chainguard apko / Wolfi image produces
+  per-file evidence in the same shape — measurable as `mikebom
+  sbom scan --image cgr.dev/chainguard/static:latest` having a
+  non-zero per-component occurrences count, where pre-039 it was
+  zero.
+
+- **SC-005**: The fast-hash path (`--no-deep-hash`) produces the
+  same package-level component identities as the deep-hash path,
+  with empty per-file evidence — measurable as set equality on
+  component identity hashes across the two flag values, AND
+  occurrences count = 0 under fast-hash for all apk components.
+
+## Assumptions
+
+- The apk installed-db format used by alpine and apko/wolfi
+  is the same: a single `/lib/apk/db/installed` file with
+  blank-line-separated stanzas, `F:` for directories, `R:` for
+  regular file basenames within the current `F:` directory.
+  Milestone 038's recon confirmed this for chainguard apko.
+- Per-file SHA-1 cross-reference (the `Z:` checksum line that
+  follows each `R:`) is OUT OF SCOPE for this milestone. The
+  dpkg path stores an MD5 cross-ref; the apk path emits SHA-256
+  only for now. A `Z:`-cross-ref pass can be added in a
+  follow-on if real demand surfaces.
+- The existing per-file hash cap and edge-case behavior (absent /
+  oversized / symlink) carry through unchanged from the dpkg path.
+
+## Out of scope
+
+- Apk-provided per-file SHA-1 cross-reference (`Z:` lines).
+- rpm per-file deep-hashing (separate concern; pre-existing
+  deferred item).
+- Any change to SBOM output schema or the fast-hash flag
+  semantics.
+- Manifest caching / registry-side optimizations — orthogonal.

--- a/specs/039-apk-deep-hash/tasks.md
+++ b/specs/039-apk-deep-hash/tasks.md
@@ -1,0 +1,71 @@
+---
+description: "Task list — milestone 039 apk per-file deep-hash"
+---
+
+# Tasks: Per-File Evidence for apk Components
+
+**Input**: spec.md ✅, plan.md ✅, checklists/requirements.md ✅.
+
+**Tests**: included — inline coverage for the new helpers, plus a
+smoke-test assertion update.
+
+**Organization**: Single user story (US1, P1).
+
+## Format: `[ID] [P?] [Story] Description`
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Snapshot baseline by running `./scripts/pre-pr.sh` from the repo root and confirming clean before any changes
+- [ ] T002 Confirm milestone 038's distroless smoke test still passes via `MIKEBOM_OCI_NETWORK_TESTS=1 cargo +stable test --manifest-path /Users/mlieberman/Projects/mikebom/Cargo.toml -p mikebom --test oci_registry_smoke pulls_distroless_static_and_emits_dpkg_status_d_components`
+
+---
+
+## Phase 2: Commit `feat(039/extract-file-lists)`
+
+- [ ] T003 [US1] Add `pub fn read_file_lists(rootfs: &Path) -> std::collections::HashMap<String, Vec<String>>` to `mikebom-cli/src/scan_fs/package_db/apk.rs`. Walks `<rootfs>/lib/apk/db/installed` once, tracking the current package via `P:` and current directory via `F:`, and accumulating each `R:` line as a rootfs-relative path under the current package. Blank-line-separated stanzas reset state.
+- [ ] T004 [US1] Add inline test `read_file_lists_extracts_per_package_paths` in `apk.rs::tests`: synthetic installed-db with 2 packages, each owning 2 files; assert the returned map has 2 entries with the right paths.
+- [ ] T005 [US1] Add inline test `read_file_lists_handles_empty_dir_for_root_level_files` in `apk.rs::tests`: stanza with `F:` (empty value) followed by `R:` lines; assert the resulting paths have no leading directory.
+- [ ] T006 [US1] Add inline test `read_file_lists_returns_empty_when_db_absent` in `apk.rs::tests`: tempdir with no `/lib/apk/db/installed`; assert empty map, no error.
+- [ ] T007 [US1] Mark the new fn with `#[allow(dead_code)]` since callers come in commit 3.
+- [ ] T008 [US1] Run `cargo +stable test -p mikebom --bin mikebom scan_fs::package_db::apk` and confirm new tests pass alongside existing.
+- [ ] T009 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T010 [US1] Commit: `feat(039/extract-file-lists): apk per-package file-list extraction from installed-db F:/R: stanzas`.
+
+---
+
+## Phase 3: Commit `feat(039/hash-and-wire)`
+
+- [ ] T011 [US1] Add `pub fn hash_apk_package_files(rootfs: &Path, files: &[String]) -> (Vec<FileOccurrence>, Option<ContentHash>)` in `file_hashes.rs`. Mirrors `hash_package_files` shape: walks each rootfs-relative path, opens, SHA-256s the content (cap inherited via `MAX_PER_FILE_BYTES`), accumulates occurrences. Computes Merkle root over occurrences. Skips absent / oversized files silently. No `md5_legacy` field — apk's analogous `Z:` cross-ref is out of scope.
+- [ ] T012 [US1] Add `pub fn hash_apk_db_only(rootfs: &Path, pkg_name: &str) -> Option<ContentHash>` for the `--no-deep-hash` fast path. SHA-256s the bytes of the package's stanza extracted from the installed-db (we can't hash a per-package companion file because apk doesn't ship one). Returns `None` if the package isn't found.
+- [ ] T013 [US1] Inline test `hash_apk_package_files_round_trips_files` in `file_hashes.rs::tests`: synthetic rootfs with 2 files; pass them as the file-list; assert 2 occurrences with valid 64-hex SHA-256.
+- [ ] T014 [US1] Inline test `hash_apk_package_files_skips_absent_files` in `file_hashes.rs::tests`: file-list claims 2 files, only 1 exists on disk; assert 1 occurrence.
+- [ ] T015 [US1] Inline test `hash_apk_package_files_returns_empty_for_empty_input` in `file_hashes.rs::tests`: empty file-list; assert empty Vec + None root.
+- [ ] T016 [US1] Edit `mikebom-cli/src/scan_fs/mod.rs` (line 370 area): add an `is_apk` detector mirroring `is_dpkg`. In the deep-hash dispatcher, add an apk branch:
+  - Deep mode: look up the file list from the per-scan map, call `hash_apk_package_files`.
+  - Fast mode: call `hash_apk_db_only`.
+  - The per-scan apk file-list map is built once via `apk::read_file_lists` before the per-entry loop.
+- [ ] T017 [US1] Remove `#[allow(dead_code)]` from `apk::read_file_lists` now that it's wired up.
+- [ ] T018 [US1] Edit `mikebom-cli/tests/oci_registry_smoke.rs`'s `pulls_alpine_3_19_and_emits_apk_components`: add a milestone-039 assertion that total per-component occurrences > 0 AND at least one occurrence carries a 64-hex SHA-256 in the established CDX evidence shape.
+- [ ] T019 [US1] Run `MIKEBOM_OCI_NETWORK_TESTS=1 cargo +stable test --manifest-path /Users/mlieberman/Projects/mikebom/Cargo.toml -p mikebom --test oci_registry_smoke pulls_alpine_3_19_and_emits_apk_components` and confirm passing.
+- [ ] T020 [US1] Run goldens regen: `MIKEBOM_UPDATE_*_GOLDENS=1 cargo +stable test -p mikebom --test '*'`. Existing alpine-fixture goldens MAY change additively (new `evidence.occurrences[]`); verify the change is additive only via `git diff`. Other goldens (deb-fixture, non-apk-fixture) must show zero diff.
+- [ ] T021 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T022 [US1] Commit: `feat(039/hash-and-wire): per-file evidence for apk components — apk reaches deb parity`.
+
+---
+
+## Phase 4: Commit `docs(039)`
+
+- [ ] T023 Update `docs/user-guide/cli-reference.md` Behaviour notes paragraph: apk components now produce per-file evidence in the same shape as deb components (remove the "tracked as #75" qualifier).
+- [ ] T024 Add CHANGELOG Unreleased entry: milestone 039 closes #75 — apk per-file evidence at deb parity for alpine + chainguard apko + Wolfi.
+- [ ] T025 `./scripts/pre-pr.sh` clean.
+- [ ] T026 Commit: `docs(039): apk per-file evidence — user-guide + CHANGELOG`.
+
+---
+
+## Phase 5: PR + verification
+
+- [ ] T027 Push branch.
+- [ ] T028 Open PR closing #75. PR body lists pre/post numbers (alpine + chainguard) + zero-non-apk-golden-drift confirmation.
+- [ ] T029 Verify all 3 CI lanes green (Linux default + Linux ebpf + macOS).


### PR DESCRIPTION
## Summary

- Closes the milestone-038 asymmetry: apk-based images now produce per-file \`evidence.occurrences[]\` at the same quality as deb-based images.
- Concrete impact:
  - \`alpine:3.19\`: **0 → 79 file occurrences** across 15 components.
  - \`cgr.dev/chainguard/static:latest\` (Wolfi): **0 → 1217 occurrences** across 3 components (tzdata's 1202 timezone files dominate).
- Closes #75.

## Commits (4)

1. **\`spec(039)\`** — slim 4-file spec set (spec / plan / tasks / checklists).
2. **\`feat(039/extract-file-lists)\`** — new \`apk::read_file_lists(rootfs) -> HashMap<String, Vec<String>>\` walks the apk installed-db once and builds a per-package file-list map from F:/R: stanzas. 4 inline tests.
3. **\`feat(039/hash-and-wire)\`** — new \`hash_apk_package_files\` (deep) + \`hash_apk_db_only\` (fast-path) in \`file_hashes.rs\`; new \`is_apk\` branch in the \`scan_fs/mod.rs\` deep-hash dispatcher. 6 inline tests.
4. **\`docs(039)\`** — user-guide Behaviour-notes paragraph + CHANGELOG.

## Behavior

| Image | Pre-039 occurrences | Post-039 occurrences |
|---|---|---|
| \`alpine:3.19\` | 0 | 79 (across 15 components) |
| \`cgr.dev/chainguard/static:latest\` | 0 | 1217 (across 3 components) |
| \`debian:bookworm-slim\` (deb) | unchanged | unchanged (zero golden drift) |
| \`gcr.io/distroless/static-debian12\` (deb) | unchanged | unchanged (zero golden drift) |

## Implementation

- The apk installed-db carries file ownership inline (\`F:<dir>\` + \`R:<basename>\` per stanza), unlike dpkg's separate \`info/<pkg>.list\` companion files. So the path-list extraction is a single DB-walk pass: \`apk::read_file_lists(rootfs)\` is called once before the per-entry loop in \`scan_fs/mod.rs\`.
- \`hash_apk_package_files\` mirrors \`hash_package_files\`'s shape so downstream emitters (CycloneDX, SPDX 2.3, SPDX 3) don't have to discriminate. Locations are absolute-prefixed for legacy parity.
- The fast-path \`hash_apk_db_only\` SHA-256s the bytes of the package's stanza extracted from the installed-db (no companion file to hash, unlike dpkg's \`.md5sums\`).
- No MD5 cross-reference on the apk side. apk's analogous \`Z:\` line carries SHA-1; integrating it would require either a schema extension on \`FileOccurrence\` or piggybacking on the existing \`additionalContext\` map. Out of scope for this milestone — call out for a follow-on if real demand surfaces.

## Verification

- ✅ \`./scripts/pre-pr.sh\` clean.
- ✅ Binary tests went 1158 → 1168 (4 new apk.rs file-list tests + 6 new file_hashes.rs apk tests).
- ✅ \`MIKEBOM_OCI_NETWORK_TESTS=1 cargo +stable test --test oci_registry_smoke pulls_alpine_3_19_and_emits_apk_components\` passes against a real registry pull, including the new milestone-039 occurrences-non-empty assertion.
- ✅ Goldens regen produces zero diff (the existing 27 byte-identity goldens are generated with \`--no-deep-hash\` per \`cdx_regression.rs:78\`, which always emits empty \`evidence.occurrences[]\` regardless of layout — per FR-003 this is the contract).
- ✅ No new top-level deps. \`no_c_dependencies_in_tree\` regression still green.
- ✅ \`git diff main..HEAD -- mikebom-cli/src/parity/ mikebom-cli/src/generate/ mikebom-cli/src/resolve/\` empty.

## Test plan

- [ ] CI green on all 3 lanes.
- [ ] Manual verification:
      \`\`\`bash
      mikebom sbom scan --image alpine:3.19 --output /tmp/alpine.cdx.json
      jq '[.components[].evidence.occurrences | length // 0] | add' /tmp/alpine.cdx.json
      # expected: > 0 (was 0 pre-039)

      mikebom sbom scan --image cgr.dev/chainguard/static:latest --output /tmp/chainguard.cdx.json
      jq '[.components[].evidence.occurrences | length // 0] | add' /tmp/chainguard.cdx.json
      # expected: > 0 (was 0 pre-039)
      \`\`\`
- [ ] No regression on deb: \`mikebom sbom scan --image debian:bookworm-slim\` and \`mikebom sbom scan --image gcr.io/distroless/static-debian12:latest\` produce SBOMs identical to milestone 038's output.
- [ ] Fast-path: \`--no-deep-hash\` produces empty per-file evidence for apk components (FR-003).

## Out of scope (future)

- Apk-provided per-file SHA-1 cross-reference (\`Z:\` lines) in \`additionalContext\` — could be added later if real demand surfaces.
- rpm per-file deep-hashing (separate concern; pre-existing deferred item in \`binary/predicates.rs\`).
- Schema-level \`hashes\` array on \`FileOccurrence\` (would unify dpkg's MD5 + apk's SHA-1 cross-refs but requires a schema extension across all three downstream emitters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)