### PR TITLE
feat(040): package-db follow-ons — comment cleanup + apk SHA-1 cross-ref + rpm per-file deep-hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 ## [Unreleased]
 
 ### Added
+- **Milestone 040 — Package-DB follow-ons (trifecta).** Three
+  sequenced follow-on items closing coverage and hygiene gaps
+  after milestones 037 / 038 / 039:
+  - **US1 (housekeeping)**: dropped a stale "deferred to
+    milestone 031.y" framing in `oci_pull/mod.rs::host_oci_arch`
+    that named `--image-platform` as deferred. The flag shipped
+    in milestone 035 (PR #72); the error message now positively
+    references it with an example invocation.
+  - **US2 (apk SHA-1 cross-ref)**: extends milestone 039's apk
+    per-file evidence with the apk-provided SHA-1 from each `Z:`
+    line in `/lib/apk/db/installed`. Surfaced as `sha1` in the
+    per-occurrence `additionalContext` JSON-string alongside the
+    mikebom-computed `sha256`. Mirrors deb's `md5` cross-ref
+    contract from milestone 037. New `ApkFileEntry` struct in
+    apk.rs, new optional `apk_sha1: Option<String>` field on
+    `mikebom_common::resolution::FileOccurrence` (additive,
+    `#[serde(default, skip_serializing_if = "Option::is_none")]`).
+    Verified end-to-end against `alpine:3.19`.
+  - **US3 (rpm per-file deep-hash)**: completes the OS-package
+    per-file-evidence trilogy. rpm-based images (fedora,
+    almalinux, rocky, centos:stream, redhat/*) now produce
+    populated `evidence.occurrences[]` blocks at parity with
+    deb (037/038) and apk (039). New
+    `rpm::read_file_lists(rootfs)` exposes the per-package
+    file-list map decoded from the rpmdb HeaderBlob's
+    `BASENAMES` / `DIRNAMES` / `DIRINDEXES` triple via the
+    existing `iter_rpmdb` helper; new `hash_rpm_package_files`
+    + `hash_rpm_db_only` mirror the apk pattern; new `is_rpm`
+    branch in `scan_fs/mod.rs::read_all`. Verified end-to-end:
+    `fedora:40` produces 147 components with 6966 total file
+    occurrences (was 0). Per the milestone-040 Q1
+    clarification, rpm FILEDIGESTS cross-ref is OUT of scope
+    and deferred to a separate follow-on milestone — rpm-side
+    `additionalContext` carries SHA-256 only.
+  - No new top-level Cargo dependencies. 27 byte-identity
+    goldens regen with zero diff (the goldens use
+    `--no-deep-hash` so they're insulated from the deep-hash
+    path by design).
+  - See `specs/040-pkg-db-followups/spec.md`.
 - **Milestone 039 — Per-file evidence for apk components
   (alpine + chainguard apko + Wolfi).** Closes the asymmetry
   surfaced during milestone 038's recon (#75): apk-based images

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,9 +89,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 040-pkg-db-followups: Added [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
 - 038-minimal-image-deep-hash: Added Rust stable (workspace toolchain inherited + existing only — `sha2` (per-file SHA-256,
 - 016-remaining-clippy-cleanup: Added Rust stable (workspace toolchain inherited from milestones 001–015; no nightly required for this user-space-only work). + existing only — `cargo +stable clippy` (lint engine), `dtolnay/rust-toolchain@stable` (already used in CI), `Swatinem/rust-cache@v2` (already used). **No new crates.**
-- 013-format-parity-enforcement: Added Rust stable (workspace toolchain inherited from milestones 001–012; no nightly). + existing only — `serde`/`serde_json` (format output parsing), `regex` (catalog-row parsing — already in the dependency closure), `tempfile`, `tracing`, `anyhow`. `clap` for the new `parity-check` subcommand (already used for `scan`). **No new crates.**
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -185,9 +185,18 @@ Behaviour notes:
   images like `cgr.dev/chainguard/*`. mikebom reads the per-package
   file list inline from each stanza's `F:` (directory) and `R:`
   (regular file) lines in `/lib/apk/db/installed`, walks the rootfs,
-  and emits SHA-256 per file. apk-side `additionalContext` carries
-  SHA-256 only (no MD5 cross-ref, as apk doesn't ship one; the
-  apk-provided SHA-1 from `Z:` lines is a future extension).
+  and emits SHA-256 per file. As of milestone 040, the apk-provided
+  per-file SHA-1 from each `Z:` line is also surfaced as a
+  cross-reference checksum in `additionalContext` alongside the
+  mikebom-computed SHA-256, mirroring the way deb's `additionalContext`
+  carries `md5` from dpkg's `.md5sums`.
+- **Rpm per-file evidence** (fedora / almalinux / rocky / centos:stream
+  / redhat/*): same shape as deb and apk. mikebom decodes each
+  package's `BASENAMES` / `DIRNAMES` / `DIRINDEXES` triple from the
+  rpmdb HeaderBlob, walks the rootfs, and emits SHA-256 per file.
+  rpm-side `additionalContext` carries SHA-256 only — the rpm-provided
+  FILEDIGESTS cross-ref is a future extension. As of milestone 040,
+  this brings rpm to feature parity with deb (037/038) and apk (039).
 
 ### Authenticating to private registries
 

--- a/mikebom-cli/src/generate/cyclonedx/evidence.rs
+++ b/mikebom-cli/src/generate/cyclonedx/evidence.rs
@@ -64,6 +64,13 @@ pub fn build_evidence(
                 if let Some(ref md5) = o.md5_legacy {
                     ctx.insert("md5".to_string(), json!(md5));
                 }
+                // Milestone 040 US2: apk-provided per-file SHA-1
+                // cross-ref (`Z:` line in the package's stanza).
+                // Surfaced for deb-/apk-/rpm-uniform consumers; deb
+                // and rpm occurrences leave this field None.
+                if let Some(ref sha1) = o.apk_sha1 {
+                    ctx.insert("sha1".to_string(), json!(sha1));
+                }
                 json!({
                     "location": o.location,
                     "additionalContext": serde_json::to_string(&ctx)
@@ -279,11 +286,13 @@ mod tests {
                 location: "/usr/bin/jq".to_string(),
                 sha256: "a".repeat(64),
                 md5_legacy: Some("b".repeat(32)),
+                apk_sha1: None,
             },
             FileOccurrence {
                 location: "/usr/share/doc/jq/copyright".to_string(),
                 sha256: "c".repeat(64),
                 md5_legacy: None,
+                apk_sha1: None,
             },
         ];
         let result = build_evidence(&ev, &occs);

--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -368,6 +368,12 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
         // (file-not-found short-circuits cheaply) — the unconditional
         // call is fine.
         let apk_file_lists = package_db::apk::read_file_lists(root);
+        // Milestone 040 US3: rpm per-file deep-hashing. Build the
+        // per-package file-list map once per scan (mirrors the apk
+        // pattern from milestone 039). `iter_rpmdb` underneath
+        // handles SQLite-vs-BDB selection; an absent rpmdb returns
+        // an empty map at zero cost.
+        let rpm_file_lists = package_db::rpm::read_file_lists(root);
 
         for entry in &db_entries {
             let purl_str = entry.purl.as_str().to_string();
@@ -381,6 +387,12 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
             // as the dpkg path. Detected via the standard apk
             // installed-db source_path.
             let is_apk = entry.source_path.contains("apk/db/installed");
+            // Milestone 040 US3: rpm per-file deep-hashing.
+            // Detector matches both legacy `var/lib/rpm/` and the
+            // newer `usr/lib/sysimage/rpm/` paths via the common
+            // `lib/rpm/` substring (verified to not collide with
+            // any non-rpm source_path in mikebom).
+            let is_rpm = entry.source_path.contains("lib/rpm/");
             // dpkg licenses live out-of-band in /usr/share/doc/<pkg>/
             // copyright; other sources (e.g. Python dist-info METADATA)
             // embed them directly on the entry.
@@ -426,6 +438,19 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
                     (occs, root_hash.into_iter().collect::<Vec<_>>())
                 } else {
                     let h = package_db::file_hashes::hash_apk_db_only(root, &entry.name);
+                    (Vec::new(), h.into_iter().collect::<Vec<_>>())
+                }
+            } else if is_rpm {
+                if deep_hash {
+                    let files: &[String] = rpm_file_lists
+                        .get(&entry.name)
+                        .map(|v| v.as_slice())
+                        .unwrap_or(&[]);
+                    let (occs, root_hash) =
+                        package_db::file_hashes::hash_rpm_package_files(root, files);
+                    (occs, root_hash.into_iter().collect::<Vec<_>>())
+                } else {
+                    let h = package_db::file_hashes::hash_rpm_db_only(root, &entry.name);
                     (Vec::new(), h.into_iter().collect::<Vec<_>>())
                 }
             } else {

--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -417,7 +417,7 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
                 }
             } else if is_apk {
                 if deep_hash {
-                    let files: &[String] = apk_file_lists
+                    let files: &[package_db::apk::ApkFileEntry] = apk_file_lists
                         .get(&entry.name)
                         .map(|v| v.as_slice())
                         .unwrap_or(&[]);

--- a/mikebom-cli/src/scan_fs/oci_pull/mod.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull/mod.rs
@@ -258,9 +258,11 @@ pub fn host_oci_arch() -> Result<&'static str> {
         "s390x" => "s390x",
         other => {
             anyhow::bail!(
-                "host architecture `{other}` not mapped to an OCI platform name; \
-                 milestone 031 supports x86_64/aarch64/arm/riscv64/powerpc64/s390x. \
-                 Cross-arch image pulls (`--image-platform linux/<arch>`) deferred to milestone 031.y."
+                "host architecture `{other}` not mapped to an OCI platform name. \
+                 mikebom recognizes x86_64/aarch64/arm/riscv64/powerpc64/s390x \
+                 for the host-default selection. To scan a different architecture, \
+                 pass `--image-platform <linux/arch>` explicitly \
+                 (e.g. `--image-platform linux/amd64`)."
             );
         }
     })

--- a/mikebom-cli/src/scan_fs/package_db/apk.rs
+++ b/mikebom-cli/src/scan_fs/package_db/apk.rs
@@ -14,12 +14,27 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use base64::engine::general_purpose::STANDARD as B64_STANDARD;
+use base64::Engine as _;
 use mikebom_common::types::license::SpdxExpression;
 use mikebom_common::types::purl::{encode_purl_segment, Purl};
 
 use super::PackageDbEntry;
 
 const APK_INSTALLED_PATH: &str = "lib/apk/db/installed";
+
+/// One file entry from an apk installed-db package stanza —
+/// a rootfs-relative path plus optional apk-provided SHA-1
+/// extracted from the file's `Z:` companion line. The SHA-1 is
+/// `None` when the package's stanza omitted the `Z:` line for
+/// this file (rare; very old apk dbs or malformed stanzas) or
+/// when the `Z:` line uses a non-`Q1` scheme that mikebom
+/// doesn't recognize.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ApkFileEntry {
+    pub path: String,
+    pub sha1: Option<String>,
+}
 
 /// Read and parse the apk installed-db beneath `rootfs`. Empty output
 /// when the file is absent (typical for Debian/Ubuntu rootfs); errors
@@ -101,28 +116,30 @@ pub fn collect_claimed_paths(
 }
 
 /// Walk `<rootfs>/lib/apk/db/installed` once and build a per-package
-/// file-list map. Used by milestone 039's deep-hash path: the apk
-/// stanza format encodes file ownership inline via interleaved
-/// `F:<dir>` (directory) and `R:<basename>` (regular file) lines —
-/// no companion files like dpkg's `info/<pkg>.list`.
+/// file-list map. The apk stanza format encodes file ownership
+/// inline via interleaved `F:<dir>` (directory), `R:<basename>`
+/// (regular file), and `Z:<checksum>` (file's apk-provided SHA-1)
+/// lines — no companion files like dpkg's `info/<pkg>.list`.
 ///
-/// Returns a map keyed on package name with each value being the
-/// rootfs-relative file paths the package's stanza claims. Returns
-/// an empty map when the file is absent (typical for Debian/Ubuntu
-/// rootfs) or unreadable; never errors.
+/// Returns a map keyed on package name with each value being a
+/// `Vec<ApkFileEntry>` carrying the rootfs-relative path and the
+/// optional apk-provided SHA-1. Returns an empty map when the
+/// file is absent (typical for Debian/Ubuntu rootfs) or
+/// unreadable; never errors.
 ///
 /// Stanza boundaries (blank lines) reset the current package and
 /// directory tracking. Files declared without a current `F:` (which
 /// shouldn't happen in well-formed databases) are silently skipped
-/// to match the `collect_claimed_paths` posture.
+/// to match the `collect_claimed_paths` posture. `Z:` lines without
+/// a preceding `R:` in the same stanza are also dropped.
 pub fn read_file_lists(
     rootfs: &Path,
-) -> std::collections::HashMap<String, Vec<String>> {
+) -> std::collections::HashMap<String, Vec<ApkFileEntry>> {
     let path = rootfs.join(APK_INSTALLED_PATH);
     let Ok(text) = std::fs::read_to_string(&path) else {
         return std::collections::HashMap::new();
     };
-    let mut out: std::collections::HashMap<String, Vec<String>> =
+    let mut out: std::collections::HashMap<String, Vec<ApkFileEntry>> =
         std::collections::HashMap::new();
     let mut current_pkg: Option<String> = None;
     let mut current_dir: Option<String> = None;
@@ -151,13 +168,45 @@ pub fn read_file_lists(
                     } else {
                         format!("{dir}/{basename}")
                     };
-                    out.entry(pkg.clone()).or_default().push(rel);
+                    out.entry(pkg.clone()).or_default().push(ApkFileEntry {
+                        path: rel,
+                        sha1: None,
+                    });
+                }
+            }
+            b'Z' => {
+                // Attach the apk-provided SHA-1 to the most-recent R:
+                // entry for the current package. Z: lines without a
+                // preceding R: in the stanza (or with no current_pkg)
+                // are silently dropped.
+                if let Some(pkg) = current_pkg.as_deref() {
+                    if let Some(entries) = out.get_mut(pkg) {
+                        if let Some(last) = entries.last_mut() {
+                            last.sha1 = parse_apk_z_value(&line[2..]);
+                        }
+                    }
                 }
             }
             _ => {}
         }
     }
     out
+}
+
+/// Decode an apk `Z:` line value into a 40-hex-char lowercase
+/// SHA-1 string. apk uses `Q1<base64-encoded-20-bytes>` (the only
+/// scheme mikebom recognizes today). Returns `None` for any other
+/// prefix, malformed base64, or wrong-length payload.
+fn parse_apk_z_value(z_value: &str) -> Option<String> {
+    let payload = z_value.trim().strip_prefix("Q1")?;
+    if payload.is_empty() {
+        return None;
+    }
+    let decoded = B64_STANDARD.decode(payload).ok()?;
+    if decoded.len() != 20 {
+        return None;
+    }
+    Some(decoded.iter().map(|b| format!("{b:02x}")).collect())
 }
 
 fn parse(text: &str, source_path: &str, distro_version: Option<&str>) -> Vec<PackageDbEntry> {
@@ -539,13 +588,15 @@ D:so:libc.musl-aarch64.so.1
 
         let foo = map.get("foo").expect("foo entry");
         assert_eq!(foo.len(), 2);
-        assert!(foo.contains(&"usr/bin/foo".to_string()));
-        assert!(foo.contains(&"etc/foo.conf".to_string()));
+        let foo_paths: Vec<&str> = foo.iter().map(|e| e.path.as_str()).collect();
+        assert!(foo_paths.contains(&"usr/bin/foo"));
+        assert!(foo_paths.contains(&"etc/foo.conf"));
 
         let bar = map.get("bar").expect("bar entry");
         assert_eq!(bar.len(), 2);
-        assert!(bar.contains(&"usr/lib/libbar.so.1".to_string()));
-        assert!(bar.contains(&"usr/lib/libbar.so".to_string()));
+        let bar_paths: Vec<&str> = bar.iter().map(|e| e.path.as_str()).collect();
+        assert!(bar_paths.contains(&"usr/lib/libbar.so.1"));
+        assert!(bar_paths.contains(&"usr/lib/libbar.so"));
     }
 
     #[test]
@@ -563,7 +614,8 @@ D:so:libc.musl-aarch64.so.1
         let map = read_file_lists(dir.path());
         let entries = map.get("baselayout-data").expect("entry");
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0], ".profile");
+        assert_eq!(entries[0].path, ".profile");
+        assert_eq!(entries[0].sha1, None);
     }
 
     #[test]
@@ -598,6 +650,82 @@ D:so:libc.musl-aarch64.so.1
         assert!(
             !map.contains_key("baz") || map.get("baz").is_none_or(|v| v.is_empty()),
             "orphan R: without preceding F: should be skipped"
+        );
+    }
+
+    // ---- Milestone 040 US2: Z:-line SHA-1 cross-ref ---------------------
+
+    /// Z: line carrying the apk-provided SHA-1 surfaces on the
+    /// preceding R: file's `sha1` field.
+    ///
+    /// Test value: SHA-1("hello world") = 2aae6c35c94fcfb415dbe95f408b9ce91ee846ed
+    /// Base64 of those 20 bytes: Kq5sNclPz7QV2+lfQIuc6R7oRu0=
+    #[test]
+    fn read_file_lists_extracts_z_line_sha1() {
+        let dir = tempfile::tempdir().unwrap();
+        write_installed_db(
+            dir.path(),
+            "P:foo\n\
+             V:1.0\n\
+             F:usr/bin\n\
+             R:foo\n\
+             Z:Q1Kq5sNclPz7QV2+lfQIuc6R7oRu0=\n",
+        );
+        let map = read_file_lists(dir.path());
+        let foo = map.get("foo").expect("foo entry");
+        assert_eq!(foo.len(), 1);
+        assert_eq!(foo[0].path, "usr/bin/foo");
+        assert_eq!(
+            foo[0].sha1.as_deref(),
+            Some("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"),
+            "Z: line SHA-1 should decode to lowercase 40-hex"
+        );
+    }
+
+    /// Multiple R: lines without intervening Z: each have sha1=None.
+    /// Adding a Z: only attaches to the IMMEDIATELY preceding R:.
+    #[test]
+    fn read_file_lists_handles_missing_z_line() {
+        let dir = tempfile::tempdir().unwrap();
+        write_installed_db(
+            dir.path(),
+            "P:foo\n\
+             V:1.0\n\
+             F:usr/bin\n\
+             R:foo\n\
+             R:bar\n",
+        );
+        let map = read_file_lists(dir.path());
+        let foo = map.get("foo").expect("foo entry");
+        assert_eq!(foo.len(), 2);
+        for entry in foo {
+            assert_eq!(
+                entry.sha1, None,
+                "no Z: line in stanza → all entries should have sha1=None"
+            );
+        }
+    }
+
+    /// Defensive: only the documented `Q1` prefix is recognized.
+    /// Hypothetical future schemes (Q2, Q3, ...) are silently
+    /// ignored — file's sha1 stays None rather than mis-decoding.
+    #[test]
+    fn read_file_lists_rejects_non_q1_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        write_installed_db(
+            dir.path(),
+            "P:foo\n\
+             V:1.0\n\
+             F:usr/bin\n\
+             R:foo\n\
+             Z:Q2Kq5sNclPz7QV2+lfQIuc6R7oRu0=\n",
+        );
+        let map = read_file_lists(dir.path());
+        let foo = map.get("foo").expect("foo entry");
+        assert_eq!(foo.len(), 1);
+        assert_eq!(
+            foo[0].sha1, None,
+            "Q2-prefixed scheme is unknown → sha1 must be None"
         );
     }
 }

--- a/mikebom-cli/src/scan_fs/package_db/file_hashes.rs
+++ b/mikebom-cli/src/scan_fs/package_db/file_hashes.rs
@@ -127,6 +127,7 @@ pub fn hash_package_files(
             location: path_in_pkg.to_string(),
             sha256,
             md5_legacy,
+            apk_sha1: None,
         });
     }
 
@@ -237,15 +238,20 @@ fn read_info_file_bytes(
 /// are skipped with a debug log.
 ///
 /// Unlike the dpkg path, no MD5 cross-reference is emitted —
-/// apk's analogous `Z:` line carries SHA-1, which is OUT OF SCOPE
-/// for this milestone (could be added later via a follow-on).
+/// apk's analogous `Z:` line carries SHA-1; that cross-reference
+/// is plumbed through alongside the SHA-256 (milestone 040 US2).
+/// Each [`ApkFileEntry`] passed in carries an optional SHA-1 from
+/// the package's stanza; when present, it surfaces as
+/// `apk_sha1` on the resulting [`FileOccurrence`] (and from there
+/// into the per-occurrence `additionalContext` JSON-string at
+/// emission time).
 pub fn hash_apk_package_files(
     rootfs: &Path,
-    files: &[String],
+    files: &[super::apk::ApkFileEntry],
 ) -> (Vec<FileOccurrence>, Option<ContentHash>) {
     let mut occurrences: Vec<FileOccurrence> = Vec::new();
-    for rel in files {
-        let rel = rel.trim_start_matches('/');
+    for entry in files {
+        let rel = entry.path.trim_start_matches('/');
         if rel.is_empty() {
             continue;
         }
@@ -279,6 +285,7 @@ pub fn hash_apk_package_files(
             location: format!("/{rel}"),
             sha256,
             md5_legacy: None,
+            apk_sha1: entry.sha1.clone(),
         });
     }
 
@@ -795,7 +802,16 @@ mod tests {
             dir.path(),
             &[("usr/bin/foo", b"foo-bytes"), ("etc/foo.conf", b"conf=1\n")],
         );
-        let files = vec!["usr/bin/foo".to_string(), "etc/foo.conf".to_string()];
+        let files = vec![
+            super::super::apk::ApkFileEntry {
+                path: "usr/bin/foo".to_string(),
+                sha1: None,
+            },
+            super::super::apk::ApkFileEntry {
+                path: "etc/foo.conf".to_string(),
+                sha1: None,
+            },
+        ];
         let (occs, root) = hash_apk_package_files(dir.path(), &files);
         assert_eq!(occs.len(), 2);
         assert!(root.is_some(), "must produce a per-component Merkle root");
@@ -808,9 +824,33 @@ mod tests {
             );
             assert!(
                 o.md5_legacy.is_none(),
-                "apk path emits no MD5 cross-ref (Z: lines out of scope)"
+                "apk path never carries MD5 cross-ref"
+            );
+            assert!(
+                o.apk_sha1.is_none(),
+                "no Z: data was passed in this test, so apk_sha1 must be None"
             );
         }
+    }
+
+    /// Milestone 040 US2: Z:-line SHA-1 surfaces on the resulting
+    /// occurrence's `apk_sha1` field when the input ApkFileEntry
+    /// carries one.
+    #[test]
+    fn hash_apk_package_files_threads_sha1_when_provided() {
+        let dir = tempfile::tempdir().unwrap();
+        place_files(dir.path(), &[("usr/bin/foo", b"foo-bytes")]);
+        let files = vec![super::super::apk::ApkFileEntry {
+            path: "usr/bin/foo".to_string(),
+            sha1: Some("aabbccddeeff00112233445566778899aabbccdd".to_string()),
+        }];
+        let (occs, _root) = hash_apk_package_files(dir.path(), &files);
+        assert_eq!(occs.len(), 1);
+        assert_eq!(
+            occs[0].apk_sha1.as_deref(),
+            Some("aabbccddeeff00112233445566778899aabbccdd"),
+            "apk_sha1 must thread from input entry to output occurrence"
+        );
     }
 
     #[test]
@@ -818,7 +858,16 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         place_files(dir.path(), &[("usr/bin/exists", b"on-disk")]);
         // Only one of the two listed files actually exists on disk.
-        let files = vec!["usr/bin/exists".to_string(), "usr/bin/missing".to_string()];
+        let files = vec![
+            super::super::apk::ApkFileEntry {
+                path: "usr/bin/exists".to_string(),
+                sha1: None,
+            },
+            super::super::apk::ApkFileEntry {
+                path: "usr/bin/missing".to_string(),
+                sha1: None,
+            },
+        ];
         let (occs, root) = hash_apk_package_files(dir.path(), &files);
         assert_eq!(occs.len(), 1, "absent file must be skipped");
         assert_eq!(occs[0].location, "/usr/bin/exists");

--- a/mikebom-cli/src/scan_fs/package_db/file_hashes.rs
+++ b/mikebom-cli/src/scan_fs/package_db/file_hashes.rs
@@ -293,6 +293,110 @@ pub fn hash_apk_package_files(
     (occurrences, root)
 }
 
+// ---- Milestone 040 US3: rpm per-file deep-hashing -----------------------
+
+/// Deep-hash every file the rpm package claims (via
+/// HeaderBlob `BASENAMES` / `DIRNAMES` / `DIRINDEXES`).
+/// Mirrors [`hash_apk_package_files`]; the resulting
+/// `FileOccurrence`s carry SHA-256 only — no MD5 cross-ref
+/// (rpm has no analog of dpkg's `.md5sums`) and no SHA-1
+/// cross-ref (rpm's FILEDIGESTS deferred to a follow-on
+/// milestone per the milestone-040 Q1 clarification).
+///
+/// `files` is the rootfs-relative-or-absolute path list yielded
+/// by [`super::rpm::read_file_lists`]. rpm paths come in as
+/// absolute (`/usr/bin/bash`); we resolve to absolute form for
+/// `FileOccurrence.location` and strip the leading `/` before
+/// joining onto the rootfs.
+///
+/// Files that disappear between install and scan time are
+/// silently skipped (rare; would typically indicate config files
+/// removed during image build). Oversized files (> [`MAX_PER_FILE_BYTES`])
+/// are skipped with a debug log.
+pub fn hash_rpm_package_files(
+    rootfs: &Path,
+    files: &[String],
+) -> (Vec<FileOccurrence>, Option<ContentHash>) {
+    let mut occurrences: Vec<FileOccurrence> = Vec::new();
+    for raw in files {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // Normalize to an absolute deployed path for `location`
+        // (rpm sources already provide them this way) and to a
+        // rootfs-relative form for the actual filesystem read.
+        let absolute_location = if trimmed.starts_with('/') {
+            trimmed.to_string()
+        } else {
+            format!("/{trimmed}")
+        };
+        let rel = absolute_location.trim_start_matches('/');
+        let abs = rootfs.join(rel);
+        let Ok(meta) = abs.symlink_metadata() else {
+            continue;
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        if meta.len() > MAX_PER_FILE_BYTES {
+            tracing::debug!(
+                path = %abs.display(),
+                size = meta.len(),
+                "skipping oversized file in rpm deep hash"
+            );
+            continue;
+        }
+        let sha256 = match sha256_file_hex(&abs, MAX_PER_FILE_BYTES) {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::debug!(path = %abs.display(), error = %e, "could not hash rpm file");
+                continue;
+            }
+        };
+        occurrences.push(FileOccurrence {
+            location: absolute_location,
+            sha256,
+            md5_legacy: None,
+            apk_sha1: None,
+        });
+    }
+
+    let root = compute_merkle_root(&occurrences);
+    (occurrences, root)
+}
+
+/// `--no-deep-hash` fast path for rpm. SHA-256s a deterministic
+/// per-package fingerprint derived from the rpmdb-resident metadata.
+///
+/// Implementation: compute SHA-256 of a sorted, newline-terminated
+/// concatenation of the package's claimed file paths. This gives a
+/// stable per-package identity claim that survives image-rebuild
+/// jitter (the rpm HeaderBlob's bytes change with metadata-only
+/// re-installs even when the file list is identical, so hashing the
+/// path-set directly is more useful than hashing the blob).
+///
+/// Returns `None` when the named package isn't found in the rpmdb
+/// or has no associated file paths.
+pub fn hash_rpm_db_only(rootfs: &Path, pkg_name: &str) -> Option<ContentHash> {
+    let map = super::rpm::read_file_lists(rootfs);
+    let files = map.get(pkg_name)?;
+    if files.is_empty() {
+        return None;
+    }
+    let mut sorted = files.clone();
+    sorted.sort();
+    let mut payload = String::new();
+    for p in &sorted {
+        payload.push_str(p);
+        payload.push('\n');
+    }
+    let hex = sha256_hex(payload.as_bytes());
+    ContentHash::sha256(&hex).ok()
+}
+
+// -------------------------------------------------------------------------
+
 /// `--no-deep-hash` fast path for apk. SHA-256s the bytes of the
 /// package's stanza extracted from `<rootfs>/lib/apk/db/installed`.
 /// Returns `None` if the installed-db is absent OR the package
@@ -920,5 +1024,78 @@ mod tests {
     fn hash_apk_db_only_returns_none_when_db_absent() {
         let dir = tempfile::tempdir().unwrap();
         assert!(hash_apk_db_only(dir.path(), "foo").is_none());
+    }
+
+    // ---- Milestone 040 US3: rpm per-file deep-hashing ---------------------
+
+    #[test]
+    fn hash_rpm_package_files_round_trips_files() {
+        let dir = tempfile::tempdir().unwrap();
+        place_files(
+            dir.path(),
+            &[("usr/bin/bash", b"bash-bytes"), ("etc/bash.bashrc", b"# rc\n")],
+        );
+        // rpm path conventions: paths come in as absolute (with
+        // leading /).
+        let files = vec![
+            "/usr/bin/bash".to_string(),
+            "/etc/bash.bashrc".to_string(),
+        ];
+        let (occs, root) = hash_rpm_package_files(dir.path(), &files);
+        assert_eq!(occs.len(), 2);
+        assert!(root.is_some(), "must produce a per-component Merkle root");
+        for o in &occs {
+            assert_eq!(o.sha256.len(), 64);
+            assert!(
+                o.location.starts_with('/'),
+                "rpm occurrence locations must be absolute, got `{}`",
+                o.location
+            );
+            assert!(
+                o.md5_legacy.is_none(),
+                "rpm path never carries MD5 cross-ref"
+            );
+            assert!(
+                o.apk_sha1.is_none(),
+                "rpm path never carries the apk SHA-1 cross-ref"
+            );
+        }
+    }
+
+    #[test]
+    fn hash_rpm_package_files_skips_absent_files() {
+        let dir = tempfile::tempdir().unwrap();
+        place_files(dir.path(), &[("usr/bin/exists", b"on-disk")]);
+        let files = vec![
+            "/usr/bin/exists".to_string(),
+            "/usr/bin/missing".to_string(),
+        ];
+        let (occs, root) = hash_rpm_package_files(dir.path(), &files);
+        assert_eq!(occs.len(), 1, "absent file must be skipped");
+        assert_eq!(occs[0].location, "/usr/bin/exists");
+        assert!(root.is_some());
+    }
+
+    #[test]
+    fn hash_rpm_package_files_returns_empty_for_empty_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let (occs, root) = hash_rpm_package_files(dir.path(), &[]);
+        assert!(occs.is_empty());
+        assert!(root.is_none());
+    }
+
+    #[test]
+    fn hash_rpm_package_files_handles_relative_path_entries() {
+        // Defensive: even if a hypothetical caller passes paths
+        // without the leading `/`, the helper should normalize.
+        let dir = tempfile::tempdir().unwrap();
+        place_files(dir.path(), &[("usr/bin/foo", b"bytes")]);
+        let files = vec!["usr/bin/foo".to_string()]; // no leading /
+        let (occs, _root) = hash_rpm_package_files(dir.path(), &files);
+        assert_eq!(occs.len(), 1);
+        assert_eq!(
+            occs[0].location, "/usr/bin/foo",
+            "relative input should normalize to absolute location"
+        );
     }
 }

--- a/mikebom-cli/src/scan_fs/package_db/rpm.rs
+++ b/mikebom-cli/src/scan_fs/package_db/rpm.rs
@@ -71,6 +71,43 @@ pub fn read(
     out
 }
 
+/// Walk the rpmdb once and build a per-package file-list map for
+/// the milestone-040 deep-hash path. Mirrors
+/// `apk::read_file_lists` and the milestone-038-era
+/// dpkg-info-derived list — the consumer is the deep-hash
+/// dispatcher in `scan_fs::mod`.
+///
+/// Returns a map keyed on package name with each value being a
+/// `Vec<String>` of rootfs-relative paths the package's
+/// HeaderBlob `BASENAMES` / `DIRNAMES` / `DIRINDEXES` triple
+/// claims. Paths preserve the rpm-on-disk absolute form (e.g.
+/// `/usr/bin/bash`) — the consumer (`hash_rpm_package_files`)
+/// strips the leading `/` before joining onto the rootfs.
+///
+/// Returns an empty map when the rpmdb is absent (typical for
+/// non-rpm rootfs) or unreadable; never errors.
+///
+/// `iter_rpmdb` already handles the SQLite-vs-BDB selection,
+/// the `WAL` / `-shm` diagnostics, and BASENAMES/DIRNAMES/
+/// DIRINDEXES decoding via mikebom's HeaderBlob reader.
+pub fn read_file_lists(
+    rootfs: &Path,
+) -> std::collections::HashMap<String, Vec<String>> {
+    let mut out: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    iter_rpmdb(rootfs, None, |entry, paths| {
+        if paths.is_empty() {
+            return;
+        }
+        let strings: Vec<String> = paths
+            .into_iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        out.insert(entry.name.clone(), strings);
+    });
+    out
+}
+
 /// Milestone 005 Phase B: feed rpm-owned file paths into the shared
 /// `claimed` / `claimed_inodes` sets so the binary walker can skip
 /// file-level + linkage emissions for binaries the rpmdb already

--- a/mikebom-cli/tests/oci_registry_smoke.rs
+++ b/mikebom-cli/tests/oci_registry_smoke.rs
@@ -102,8 +102,13 @@ fn pulls_alpine_3_19_and_emits_apk_components() {
     // Milestone 039: per-file evidence MUST be populated for apk
     // components (mirrors the milestone-038 deb assertion). Pre-039
     // this was always 0 because file_hashes.rs was dpkg-only.
+    //
+    // Milestone 040 US2: each populated occurrence's
+    // `additionalContext` MUST also carry `sha1` from the apk
+    // package's `Z:` line. Pre-040 this was always None.
     let mut total_occurrences = 0usize;
     let mut sha256_seen = false;
+    let mut sha1_seen = false;
     for c in components {
         let occs = c["evidence"]["occurrences"]
             .as_array()
@@ -122,6 +127,11 @@ fn pulls_alpine_3_19_and_emits_apk_components() {
                     sha256_seen = true;
                 }
             }
+            if let Some(s) = ctx["sha1"].as_str() {
+                if s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit()) {
+                    sha1_seen = true;
+                }
+            }
         }
     }
     assert!(
@@ -134,6 +144,11 @@ fn pulls_alpine_3_19_and_emits_apk_components() {
     assert!(
         sha256_seen,
         "at least one apk occurrence should carry a 64-hex SHA-256 in additionalContext; got none"
+    );
+    assert!(
+        sha1_seen,
+        "milestone 040 US2: at least one apk occurrence should carry a 40-hex \
+         SHA-1 (apk-provided Z:-line cross-ref) in additionalContext; got none"
     );
 }
 

--- a/mikebom-common/src/resolution.rs
+++ b/mikebom-common/src/resolution.rs
@@ -234,6 +234,12 @@ pub struct FileOccurrence {
     /// created post-install).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub md5_legacy: Option<String>,
+    /// apk-provided SHA-1 from the `Z:` line in the package's
+    /// stanza, lowercase hex (40 chars). `None` for non-apk
+    /// occurrences (deb, rpm) and for apk files whose stanza
+    /// omitted the `Z:` line. Milestone 040 / #75 follow-on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub apk_sha1: Option<String>,
 }
 
 /// Evidence describing how a component was resolved from trace data.

--- a/specs/040-pkg-db-followups/checklists/requirements.md
+++ b/specs/040-pkg-db-followups/checklists/requirements.md
@@ -1,0 +1,57 @@
+# Specification Quality Checklist: Package-DB Follow-Ons (Trifecta)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Validation Notes
+
+- Three sequenced user stories of clearly-decreasing scope: US1
+  (housekeeping; ~10 min), US2 (apk SHA-1 cross-ref; ~1-2 hr),
+  US3 (rpm per-file deep-hash; ~½ day). Each independently
+  testable and shippable.
+- Domain technical terms used (`Z:` line, `BASENAMES`,
+  `DIRINDEXES`, `additionalContext`, `--no-deep-hash`) are
+  ecosystem vocabulary, not language / framework choices —
+  consistent with the speckit-specify guidance for SBOM-tooling
+  audiences.
+- No `[NEEDS CLARIFICATION]` markers — each user story has a
+  prior milestone to mirror in shape (037/038 for US1
+  housekeeping framing, 039 for US2 apk extension, 037+039 for
+  US3 rpm parallel implementation).
+- Success criteria SC-001 / SC-003 / SC-005 are quantitatively
+  verifiable. SC-002 / SC-006 require small manual audit steps
+  at PR review (consistent with existing milestone patterns).
+- Out-of-scope explicitly excludes the rpm FILEDIGESTS cross-ref
+  (parallel to apk's `Z:` cross-ref but for rpm) so the
+  milestone doesn't drift into a 4th user story.
+
+## Notes
+
+- Items marked incomplete require spec updates before
+  `/speckit.clarify` or `/speckit.plan`. All items currently pass.

--- a/specs/040-pkg-db-followups/data-model.md
+++ b/specs/040-pkg-db-followups/data-model.md
@@ -1,0 +1,127 @@
+# Phase 1 Data Model: Package-DB Follow-Ons
+
+**Feature**: 040-pkg-db-followups
+
+This milestone introduces no new public types and no SBOM-schema
+changes. All shape extensions are internal to the package-db
+readers and the per-file evidence pipeline.
+
+## Existing types (unchanged)
+
+- `mikebom_common::resolution::FileOccurrence` —
+  `{ location: String, sha256: String, md5_legacy: Option<String> }`.
+  Identical shape across deb/apk/rpm. The `additionalContext`
+  on-the-wire is a JSON-string serialized from these fields plus
+  any ecosystem-specific cross-refs.
+- `PackageDbEntry`, `Purl`, `ContentHash`, etc. — all unchanged.
+
+## Type signature changes
+
+### `apk::read_file_lists`
+
+**Before** (milestone 039):
+
+```rust
+pub fn read_file_lists(rootfs: &Path) -> HashMap<String, Vec<String>>
+```
+
+**After** (milestone 040 US2):
+
+```rust
+pub fn read_file_lists(rootfs: &Path)
+    -> HashMap<String, Vec<ApkFileEntry>>;
+
+#[derive(Clone, Debug)]
+pub struct ApkFileEntry {
+    pub path: String,
+    pub sha1: Option<String>,  // 40-hex; None if Z: line absent
+}
+```
+
+The map's value-vec changes from `String` to `ApkFileEntry`.
+Callers in `scan_fs/mod.rs` need a small mechanical update.
+
+### `file_hashes.rs::hash_apk_package_files`
+
+**Before**:
+
+```rust
+pub fn hash_apk_package_files(rootfs: &Path, files: &[String])
+    -> (Vec<FileOccurrence>, Option<ContentHash>)
+```
+
+**After**:
+
+```rust
+pub fn hash_apk_package_files(rootfs: &Path, files: &[ApkFileEntry])
+    -> (Vec<FileOccurrence>, Option<ContentHash>)
+```
+
+The `additionalContext` JSON-string emitter (in
+`generate/cyclonedx/evidence.rs`) gains a new path: when the
+occurrence's md5_legacy is None AND a sha1 is available, emit
+`additionalContext = "{\"sha256\":\"…\",\"sha1\":\"…\"}"`.
+For dpkg occurrences with md5_legacy populated, the existing
+shape `{"sha256":"…","md5":"…"}` is unchanged.
+
+The `FileOccurrence` struct itself doesn't grow — the sha1 lives
+on a per-occurrence basis only inside the
+`additionalContext` JSON-string at emission time.
+
+### Rpm functions (new)
+
+```rust
+// in rpm.rs (US3)
+pub fn read_file_lists(rootfs: &Path) -> HashMap<String, Vec<String>>;
+
+// in file_hashes.rs (US3)
+pub fn hash_rpm_package_files(rootfs: &Path, files: &[String])
+    -> (Vec<FileOccurrence>, Option<ContentHash>);
+pub fn hash_rpm_db_only(rootfs: &Path, pkg_name: &str)
+    -> Option<ContentHash>;
+```
+
+The rpm helpers mirror the apk pre-040 shape (no per-file
+checksum cross-ref); the FILEDIGESTS extension is deferred per
+the Q1 clarification.
+
+### Carrying SHA-1 through evidence emission
+
+The path is:
+
+1. `apk::read_file_lists` returns `Vec<ApkFileEntry>`.
+2. `file_hashes::hash_apk_package_files` walks the entries,
+   computes SHA-256 from the rootfs file content, and produces
+   `FileOccurrence`s. Each occurrence's `md5_legacy` field stays
+   `None` (apk doesn't ship MD5).
+3. To carry the SHA-1, we need either:
+   - **Option A**: extend `FileOccurrence` with a new
+     `apk_sha1: Option<String>` field. Cleanest typing but
+     requires touching `mikebom-common`.
+   - **Option B**: serialize the SHA-1 INSIDE the
+     `additionalContext` JSON-string at the emission site.
+     `FileOccurrence` stays unchanged; the emitter knows about
+     the SHA-1 because it's threaded through alongside the
+     occurrence in a parallel `Vec<Option<String>>`.
+
+The clearer choice is **Option A** — a typed field that survives
+all downstream serializers without special-casing in each one.
+Mikebom-common is a tiny crate and adding one optional field
+is a low-risk schema extension. The dpkg `md5_legacy` field
+already exists there; adding `apk_sha1` is the same shape.
+
+## Lookup precedence (rpm deep-hash mode)
+
+For an rpm package `<pkg>`:
+
+```text
+file-list source (only one possibility for rpm):
+  1. rpm.rs::read_file_lists exposes the BASENAMES/DIRNAMES/
+     DIRINDEXES decoded triple; one map entry per package.
+  2. → empty file list (metadata-only package)
+
+fast-path (hash_rpm_db_only):
+  1. SHA-256 of the package's HeaderBlob bytes — opaque
+     per-package identity hash.
+  2. → None if the named package is absent from the rpmdb.
+```

--- a/specs/040-pkg-db-followups/plan.md
+++ b/specs/040-pkg-db-followups/plan.md
@@ -1,0 +1,131 @@
+# Implementation Plan: Package-DB Follow-Ons (Trifecta)
+
+**Branch**: `040-pkg-db-followups` | **Date**: 2026-04-29 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/040-pkg-db-followups/spec.md`
+
+## Summary
+
+Three sequenced follow-on items that close coverage / hygiene
+gaps after milestones 037 / 038 / 039:
+
+1. **US1** — Replace one stale comment in `oci_pull/mod.rs` that
+   names `--image-platform` as "deferred to milestone 031.y"
+   (shipped in PR #72). One-line edit; the only goal is making
+   the error message accurate.
+2. **US2** — Extend the milestone-039 apk per-file evidence path
+   to also surface the apk-provided per-file SHA-1 (the `Z:` line
+   that follows each `R:` in `/lib/apk/db/installed`). Carried
+   in `additionalContext` alongside the existing `sha256`,
+   matching the way deb's `additionalContext` carries `md5`.
+3. **US3** — Mirror the milestone-037+039 deep-hash pattern for
+   rpm. mikebom's existing rpm reader already extracts
+   `BASENAMES` / `DIRNAMES` / `DIRINDEXES` (used by
+   `collect_claimed_paths`); a new exported helper exposes it as
+   a per-package file-list map; a new `hash_rpm_package_files`
+   mirrors the apk one; a new `is_rpm` branch in
+   `scan_fs/mod.rs` wires it up.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited
+from milestone 039; no nightly required for user-space-only
+work).
+
+**Primary Dependencies**: existing only — `sha2`, `base64`
+(already direct), the `rpm` crate (direct dep since milestone
+004), `tempfile` (dev-dep). No new top-level deps; the
+`no_c_dependencies` regression test continues to pass.
+
+**Storage**: N/A — all state in-process per scan.
+
+**Testing**: `./scripts/pre-pr.sh` (Constitution Pre-PR
+Verification gate). Inline tests for the apk SHA-1 parser, rpm
+file-list extraction, and the rpm hashing loop. Gated network
+smoke tests for end-to-end verification on real images.
+
+**Target Platform**: Linux containers (scan target). The mikebom
+CLI runs on Linux + macOS.
+
+**Project Type**: CLI / library (Rust three-crate workspace,
+Constitution Principle VI preserved).
+
+**Performance Goals**: per-file SHA-256 cap inherited from prior
+milestones (256 MB/file). Rpm packages are typically larger than
+apk's, but the deep-hash cost is IO-bound; no architectural
+performance change.
+
+**Constraints**: Constitution Principles I, IV, VI; FR-011 (zero
+golden drift on existing 27-fixture suite).
+
+**Scale/Scope**: ~325 LOC across 8 files. Single PR with 5
+sequenced commits.
+
+## Constitution Check
+
+| Principle | Status |
+|---|---|
+| I. Pure Rust, Zero C | ✅ no new deps; regression test still green |
+| II. eBPF-Only Observation | ✅ N/A — touches scan-path code, not trace-path |
+| III. Fail Closed | ✅ N/A — scan-path code |
+| IV. Type-Driven Correctness | ✅ Option/Result throughout; reuses existing newtypes; new optional `apk_sha1` field on `FileOccurrence` is additive |
+| V. Specification Compliance | ✅ no SBOM schema changes at the CDX/SPDX level; reuses `additionalContext` carrier |
+| VI. Three-Crate Architecture | ✅ touches `mikebom-cli` (and one new optional field on `mikebom-common::resolution::FileOccurrence`) |
+| VII. Test Isolation | ✅ all new tests run unprivileged |
+| VIII. Completeness | ✅ closes a known false-negative (rpm per-file evidence missing) |
+| IX. Accuracy | ✅ file content hashes are observed-bytes truth |
+| X. Transparency | ✅ apk SHA-1 cross-ref is annotated upstream-provenance metadata |
+
+**No constitution violations.** Complexity Tracking section
+intentionally empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/040-pkg-db-followups/
+├── plan.md              # This file
+├── research.md          # Phase 0 — 5 design decisions
+├── data-model.md        # Phase 1 — signature changes + emission flow
+├── quickstart.md        # Phase 1 — post-merge verification recipe
+├── checklists/
+│   └── requirements.md  # /speckit.specify quality checklist (passing)
+└── tasks.md             # Phase 2 output (/speckit.tasks; not created here)
+```
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/
+├── src/
+│   ├── scan_fs/
+│   │   ├── mod.rs                     # ★ is_rpm branch added
+│   │   ├── oci_pull/
+│   │   │   └── mod.rs                 # ★ stale-comment cleanup (US1)
+│   │   └── package_db/
+│   │       ├── apk.rs                 # ★ ApkFileEntry + Z: parsing (US2)
+│   │       ├── file_hashes.rs         # ★ thread sha1; new hash_rpm_* (US2+US3)
+│   │       └── rpm.rs                 # ★ read_file_lists exposed (US3)
+└── tests/
+    └── oci_registry_smoke.rs          # ★ extend alpine smoke (US2)
+
+mikebom-common/                        # one optional field added
+└── src/resolution/                    # ★ FileOccurrence.apk_sha1
+mikebom-ebpf/                          # untouched
+```
+
+**Structure Decision**: Three-crate workspace preserved. The
+`mikebom-common` change is one optional `Option<String>` field
+on an existing struct — additive and required because
+`FileOccurrence` flows through all three downstream emitters
+(CycloneDX, SPDX 2.3, SPDX 3) and the field needs to survive
+serialization. Alternative (carry the SHA-1 only in the
+emission-site `additionalContext` JSON-string) was considered in
+data-model.md and rejected as fragile.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be
+> justified**
+
+No constitution violations. Section intentionally empty.

--- a/specs/040-pkg-db-followups/quickstart.md
+++ b/specs/040-pkg-db-followups/quickstart.md
@@ -1,0 +1,96 @@
+# Quickstart: Verify Milestone 040
+
+**Feature**: 040-pkg-db-followups
+
+Post-merge verification recipe. Three independent checks, one
+per user story.
+
+## US1 — Stale comment cleanup
+
+```bash
+grep -rn 'deferred to milestone 031' mikebom-cli/src/
+# expected: zero matches (today: 1 in oci_pull/mod.rs:215)
+
+grep -rn 'deferred to milestone' mikebom-cli/src/
+# expected: only matches that point at genuinely deferred items;
+# eyeball the list and confirm nothing references 031.x/y/z (all
+# shipped in 034/035/036).
+```
+
+## US2 — Apk SHA-1 cross-reference
+
+```bash
+mikebom sbom scan --image alpine:3.19 --output /tmp/alpine.cdx.json
+
+# Each populated occurrence on apk components carries both
+# sha256 and sha1 in additionalContext.
+jq '.components[0].evidence.occurrences[0].additionalContext' /tmp/alpine.cdx.json
+# expected: a JSON-string containing both "sha256" and "sha1" keys.
+
+# Audit count: every populated apk occurrence should have sha1
+# (extracting from additionalContext requires a second jq parse).
+jq '
+  [
+    .components[].evidence.occurrences[]
+    | (.additionalContext // "")
+    | select(. != "")
+    | fromjson
+    | { sha256: (.sha256 // null), sha1: (.sha1 // null) }
+  ]
+  | { with_sha1: map(select(.sha1 != null)) | length,
+      total:     length }
+' /tmp/alpine.cdx.json
+# expected: with_sha1 ≈ total (a few may legitimately lack apk-
+# provided sha1 if the upstream Z: line is absent — rare).
+```
+
+## US3 — Rpm per-file deep-hashing
+
+```bash
+# fedora:40 is a small-ish rpm-based image.
+mikebom sbom scan --image fedora:40 --output /tmp/fedora.cdx.json
+
+# Total file occurrences across rpm components.
+jq '[.components[].evidence.occurrences | length // 0] | add' /tmp/fedora.cdx.json
+# expected: > 0 (was 0 pre-040)
+
+# Per-component breakdown.
+jq '[.components[] | { name, occs: (.evidence.occurrences | length // 0) }]' \
+    /tmp/fedora.cdx.json | head -30
+```
+
+## Cross-cutting
+
+```bash
+# Goldens regen — must produce zero diff (the 27 fixtures all use
+# --no-deep-hash so they're insulated from the deep-hash path).
+MIKEBOM_UPDATE_CDX_GOLDENS=1 \
+MIKEBOM_UPDATE_SPDX_GOLDENS=1 \
+MIKEBOM_UPDATE_SPDX3_GOLDENS=1 \
+    cargo +stable test -p mikebom --test '*' >/dev/null 2>&1
+
+git status --short -- mikebom-cli/tests/fixtures/
+# expected: zero entries.
+
+# No regression on milestone-038/-039 fixtures.
+mikebom sbom scan --image gcr.io/distroless/static-debian12:latest -o /tmp/distroless.cdx.json
+jq '[.components[].evidence.occurrences | length // 0] | add' /tmp/distroless.cdx.json
+# expected: still ≈ 938 (matches milestone 038 numbers).
+```
+
+## Troubleshooting
+
+- **US1 grep returns matches in `specs/`**: expected — spec docs
+  record history. Only `mikebom-cli/src/` is in scope.
+- **US2 `with_sha1` < `total`**: some apk packages legitimately
+  lack a Z: line for some files (rare; usually metadata-only or
+  mountpoint-style entries). Cross-check against the apk
+  installed-db to confirm these are the expected cases.
+- **US3 reports 0 occurrences post-040**: most likely path-
+  resolution issue. Manually extract the rpm rootfs:
+  ```
+  docker save fedora:40 -o /tmp/fedora.tar
+  mkdir /tmp/fedora-rootfs && tar -xf /tmp/fedora.tar -C /tmp/fedora-rootfs/
+  ls /tmp/fedora-rootfs/var/lib/rpm/
+  ```
+  Confirm the rpmdb (Packages or rpmdb.sqlite) is present.

--- a/specs/040-pkg-db-followups/research.md
+++ b/specs/040-pkg-db-followups/research.md
@@ -1,0 +1,140 @@
+# Phase 0 Research: Package-DB Follow-Ons (Trifecta)
+
+**Feature**: 040-pkg-db-followups
+
+## R1 — Stale OCI comment locations
+
+**Question**: Which file/line carries the stale "deferred to
+milestone 031.y" string for US1?
+
+**Decision**: `mikebom-cli/src/scan_fs/oci_pull/mod.rs:215` —
+inside the `host_oci_arch` function's error message. Verified
+via `grep -rn 'deferred to milestone 031' mikebom-cli/src/`
+which returns exactly one match. The grep regex from spec
+SC-001 is the post-merge verification.
+
+**Action**: rewrite the bail message to point at the shipped
+`--image-platform` flag instead of the stale milestone
+identifier.
+
+## R2 — apk Z:-line wire format
+
+**Question**: How does apk encode per-file checksums on the `Z:`
+line, and how does mikebom decode them for `additionalContext`?
+
+**Decision**: per the apk source (`src/apk-tools/src/database.c`)
+and the open-spec at <https://wiki.alpinelinux.org/wiki/APKBUILD/format>,
+apk `Z:` lines carry:
+
+```
+Z:Q1<base64-encoded-bytes>
+```
+
+where `Q1` is a single-byte version prefix (literally the ASCII
+characters "Q1") and the trailing bytes are base64-encoded
+SHA-1 (20 bytes → 28 base64 chars, including 1 `=` padding).
+Implementation:
+
+1. Strip the `Q1` prefix.
+2. Base64-decode the tail (using the workspace's existing
+   `base64` dep).
+3. Hex-encode the resulting 20 bytes → 40-char lowercase string.
+4. Carry as `sha1` in the per-file `additionalContext` JSON-string.
+
+**Edge cases**:
+- `Z:Q1` followed by an empty value → drop (no SHA-1 available).
+- Other `Q<digit>` prefixes — defensive: reject non-`Q1` values
+  silently; mikebom emits the file with `sha256` only.
+- Multi-line `Z:` continuations (don't exist in apk's format) —
+  not handled.
+
+## R3 — rpm crate BASENAMES / DIRNAMES / DIRINDEXES API
+
+**Question**: How does mikebom's existing `rpm` crate access
+expose per-package file paths?
+
+**Decision**: mikebom's own `rpm.rs::iter_rpmdb` already
+extracts these. The visitor signature is:
+
+```rust
+fn iter_rpmdb<F>(rootfs: &Path, distro_version: Option<&str>, mut visitor: F)
+where
+    F: FnMut(PackageDbEntry, Vec<PathBuf>),
+```
+
+The `Vec<PathBuf>` argument is the concrete file list
+reconstructed from the `(BASENAMES, DIRNAMES, DIRINDEXES)`
+triple via mikebom's `header_blob.rs` decoder. `collect_claimed_paths`
+already consumes it.
+
+**Action**: add a sibling `rpm::read_file_lists(rootfs) ->
+HashMap<String, Vec<String>>` that uses the same helper and
+returns the per-package map keyed on `entry.name`. ~25 LOC.
+
+For the fast-path (`hash_rpm_db_only`), the rpm db is a SQLite
+file (or BDB legacy). The simplest stable per-package digest is
+the SHA-256 of the package's HeaderBlob bytes — mikebom already
+has this byte stream available during `iter_rpmdb` (one row per
+package; the blob is the second SQLite column). Extending
+`iter_rpmdb` to expose the blob bytes to a different visitor
+shape would let `hash_rpm_db_only` SHA-256 them without
+re-reading the db.
+
+**Alternatives considered**:
+
+- *Re-parse the HeaderBlob inside `hash_rpm_package_files`*:
+  rejected. Re-parsing is wasted work — mikebom already does it
+  during the main scan path. Threading the file list through the
+  existing visitor is cleaner.
+- *Use the rpm crate's `rpm::Package` directly instead of going
+  through `iter_rpmdb`*: rejected. The crate's high-level API
+  expects standalone `.rpm` package files, not the rpmdb format
+  mikebom reads. Mikebom's `iter_rpmdb` is the right entry point.
+
+## R4 — `is_rpm` source-path detector
+
+**Question**: What pattern in `entry.source_path` reliably
+identifies an rpm component?
+
+**Decision**: substring match on `var/lib/rpm/` or
+`usr/lib/sysimage/rpm/`. Both possibilities are enumerated in
+`rpm.rs::RPMDB_SQLITE_CANDIDATES` and `RPMDB_BDB_CANDIDATES`:
+
+```
+var/lib/rpm/rpmdb.sqlite
+var/lib/rpm/Packages
+usr/lib/sysimage/rpm/rpmdb.sqlite
+…
+```
+
+Combining via a substring check on `"rpm/"` would be
+ambiguous (matches dpkg's `var/lib/rpm` … but dpkg doesn't have
+that path). Use the more specific `"lib/rpm/"` substring; it
+matches all rpm rootfs layouts and excludes anything else.
+
+**Action**: in `scan_fs/mod.rs`, add `let is_rpm =
+entry.source_path.contains("lib/rpm/");` parallel to
+`is_dpkg` and `is_apk`.
+
+## R5 — Fast-path identity for rpm
+
+**Question**: What does `hash_rpm_db_only` SHA-256 to produce a
+package-level identity hash analogous to dpkg's `.md5sums`
+content or apk's stanza bytes?
+
+**Decision**: SHA-256 of the per-package HeaderBlob bytes
+(opaque). The HeaderBlob is the canonical per-package serialized
+form and is what `iter_rpmdb` already extracts. Two packages
+with identical metadata produce identical HeaderBlob bytes →
+identical hash → useful as a stable per-package identity claim.
+
+**Implementation note**: extend `iter_rpmdb` to also pass the
+HeaderBlob byte slice to its visitor, OR add a parallel
+`iter_rpmdb_blobs` helper that yields just `(name, blob_bytes)`
+pairs for the fast-path lookup. Choose whichever produces less
+churn at implementation time.
+
+## Open questions resolved at clarification
+
+Q1 (FILEDIGESTS scope): deferred per session 2026-04-29.
+Affects only US3 spec — no implementation impact.

--- a/specs/040-pkg-db-followups/spec.md
+++ b/specs/040-pkg-db-followups/spec.md
@@ -1,0 +1,335 @@
+# Feature Specification: Package-DB Follow-Ons (Trifecta)
+
+**Feature Branch**: `040-pkg-db-followups`
+**Created**: 2026-04-29
+**Status**: Draft
+**Input**: User description: "let's do the quick housekeeping first and then look at the apk sha-1 cross-ref and then look at rpm deep hashing"
+
+## Clarifications
+
+### Session 2026-04-29
+
+- Q: Should US3 also include the rpm FILEDIGESTS cross-reference (mirroring deb's `md5` and apk's `sha1` cross-refs added in this milestone)? → A: Defer per current spec — US3 ships with `sha256` only; FILEDIGESTS lands in a separate follow-on milestone. Asymmetry across deb+apk vs rpm is documented and easy to close later.
+
+## User Scenarios & Testing *(mandatory)*
+
+Three sequenced follow-on items after milestones 037 / 038 / 039
+closed out the deb and apk per-file evidence work. Each is
+independently testable and deliverable; ordering reflects effort
+and risk (smallest / safest first).
+
+### User Story 1 - Housekeeping: stale OCI comment (Priority: P1) 🎯 MVP
+
+A maintainer reading mikebom's source for the first time
+encounters comments that name long-shipped features as
+"deferred." Specifically, `host_oci_arch` in
+`mikebom-cli/src/scan_fs/oci_pull/mod.rs:215` directs the user to
+"`--image-platform linux/<arch>` deferred to milestone 031.y" — a
+flag that shipped two milestones ago (PR #72). Stale comments
+erode trust in the rest of the codebase's commentary. Removing
+them costs ten minutes; not removing them costs a future
+maintainer's afternoon when they assume `--image-platform`
+doesn't exist and start re-implementing it.
+
+**Why this priority**: pure housekeeping. No behavioral risk.
+Smallest possible MVP deliverable; sets the right expectation
+that this milestone is incremental, not architectural.
+
+**Independent Test**: `grep -rn 'deferred to milestone 031'
+mikebom-cli/src/` returns zero results post-merge (today: at
+least one match in `oci_pull/mod.rs:215`).
+
+**Acceptance Scenarios**:
+
+1. **Given** the post-039 codebase, **When** a contributor greps
+   for "deferred to milestone 031" anywhere under `mikebom-cli/src/`,
+   **Then** zero matches appear (today: one stale match).
+2. **Given** an unmapped host architecture (e.g. someone running
+   mikebom on a `s390x`-yet-unmapped variant), **When** the
+   error message renders, **Then** it points the user at the
+   shipped `--image-platform` flag rather than at a deferred
+   milestone identifier.
+3. **Given** the rest of the codebase, **When** the contributor
+   greps for any other "deferred to milestone" markers,
+   **Then** every remaining occurrence still points at a
+   genuinely deferred follow-on (no false positives left from
+   this cleanup).
+
+---
+
+### User Story 2 - Apk Z:-line SHA-1 cross-reference (Priority: P2)
+
+An SBOM consumer integrating mikebom output into a downstream
+tool (e.g. apk-tooling that already trusts apk-provided
+checksums) wants to cross-reference each apk per-file occurrence
+against the upstream-published checksum, the way they already
+can for dpkg components (whose `additionalContext` carries
+`md5`). Today milestone 039 ships SHA-256 only on the apk side —
+the apk-provided per-file SHA-1 from each `Z:` line in
+`/lib/apk/db/installed` is parsed and discarded.
+
+**Why this priority**: closes a documented out-of-scope item from
+milestone 039's spec. Small extension (~1-2 hr); strictly additive
+to the on-the-wire SBOM. Lower priority than housekeeping
+because it requires touching production code and re-running the
+27-fixture goldens (zero diff expected since goldens use
+`--no-deep-hash`, but verify).
+
+**Independent Test**: After implementation, run `mikebom sbom
+scan --image alpine:3.19 --output alpine.cdx.json` and inspect a
+non-empty `evidence.occurrences[]` entry's `additionalContext`
+JSON-string: it now contains both `sha256` (mikebom-computed)
+AND `sha1` (apk-provided), where today only `sha256` appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** an apk-based image scan, **When** the user inspects
+   any per-file occurrence's `additionalContext`, **Then** it
+   contains both `sha256` (mikebom-computed) and `sha1` (apk-
+   provided, parsed from the `Z:` line in the package's stanza).
+2. **Given** an apk package whose stanza is malformed or missing
+   `Z:` lines for some files (rare; possibly very old apk dbs),
+   **When** the user runs a scan, **Then** occurrences for files
+   without an apk-provided checksum carry `sha256` only — no
+   error, no missing-field warning. The scan completes.
+3. **Given** a deb-based image scan, **When** the user runs it
+   after this story ships, **Then** the deb output is unchanged
+   (the apk cross-ref work touches only the apk path).
+
+---
+
+### User Story 3 - rpm per-file deep-hashing (Priority: P3)
+
+An SBOM consumer scanning an rpm-based image (`fedora:40`,
+`almalinux:9`, `centos`-stream variants, similar) expects each
+rpm component to carry the same `evidence.occurrences[]` block
+that deb and apk components already carry. Today rpm components
+get zero per-file evidence — `file_hashes.rs` has paths for
+dpkg (037 / 038) and apk (039), but not rpm.
+
+**Why this priority**: completes the OS-package per-file-evidence
+trilogy. Larger than the other two stories (~½ day) because it
+involves a different metadata source (the `rpm` crate's
+HeaderBlob `BASENAMES` / `DIRNAMES` / `DIRINDEXES` triple, which
+must be combined to reconstruct each file's path) and a
+different stanza format. P3 because the deb and apk gaps
+shipped first as separate milestones; rpm completing the
+trilogy is the same shape of work.
+
+**Independent Test**: Run `mikebom sbom scan --image fedora:40
+--output fedora.cdx.json` (or another rpm-based image) and
+verify the SBOM has populated `evidence.occurrences[]` for
+every rpm component — total file occurrences across components
+> 0 (today: 0).
+
+**Acceptance Scenarios**:
+
+1. **Given** an rpm-based image, **When** the user runs an SBOM
+   scan with default flags, **Then** every rpm component in the
+   output carries a non-empty per-file evidence block with file
+   paths and content hashes.
+2. **Given** an rpm-based image, **When** the user passes the
+   existing `--no-deep-hash` flag, **Then** each rpm component
+   carries a package-level identity hash but the per-file
+   evidence block is empty — matching the existing fast-path
+   behavior for deb and apk.
+3. **Given** an rpm package whose `BASENAMES` / `DIRNAMES` /
+   `DIRINDEXES` triple is empty (a metadata-only or virtual
+   package), **When** the user runs a scan, **Then** the
+   component still appears in the SBOM with package-level
+   identity but with an empty per-file evidence block. No error.
+4. **Given** a deb-based image or apk-based image, **When** the
+   user runs a scan after this story ships, **Then** the
+   deb/apk output is unchanged (zero golden drift across all
+   non-rpm goldens).
+
+---
+
+### Edge Cases
+
+- **Empty cleanup search results post-US1**: someone might add a
+  new "deferred to milestone 031" comment between this milestone
+  starting and shipping. The acceptance test runs at merge time
+  against the actual tree, so any new occurrences need to be
+  resolved before the milestone closes.
+- **Apk packages with Z: but no R:** (rare; effectively malformed
+  metadata): the `Z:` cross-ref is keyed by position relative to
+  the preceding `R:`. Without a corresponding `R:`, the `Z:` is
+  orphan and silently dropped — same posture as `read_file_lists`
+  drops orphan `R:` lines without a preceding `F:`.
+- **Rpm packages built without per-file checksums**: rpm has
+  always carried per-file SHA-256 / SHA-1 in the FILEDIGESTS tag,
+  but very old rpm packages may have empty FILEDIGESTS. mikebom
+  computes SHA-256 from the on-disk content regardless; the
+  rpm-provided digest is ignored for now (out-of-scope
+  cross-ref).
+- **Mixed-ecosystem images**: a hypothetical image with both deb
+  and rpm metadata (rare; some Bazel pipelines for cross-
+  ecosystem builds) would surface both. Each ecosystem's
+  reader handles its own per-file evidence; no interaction.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### US1 — Housekeeping
+
+- **FR-001**: Update the error message in
+  `mikebom-cli/src/scan_fs/oci_pull/mod.rs::host_oci_arch` to
+  point users at the shipped `--image-platform` flag instead of
+  the long-shipped milestone-031.y identifier. Wording removes
+  the "deferred" framing entirely; replaces it with a positive
+  pointer at the existing CLI surface.
+
+- **FR-002**: After the cleanup, no comment or string literal in
+  `mikebom-cli/src/` MUST contain the substring "deferred to
+  milestone 031" (covering 031.x, 031.y, 031.z — all of which
+  shipped). Spec docs under `specs/` are exempt — those record
+  history.
+
+#### US2 — Apk SHA-1 cross-reference
+
+- **FR-003**: When mikebom scans an apk-based image, each per-file
+  `evidence.occurrences[]` entry's `additionalContext` JSON-
+  string MUST carry both `sha256` (mikebom-computed) and `sha1`
+  (the apk-provided checksum extracted from the package's `Z:`
+  line). When the `Z:` line is missing for a particular file
+  (rare), `sha1` is omitted from `additionalContext` for that
+  occurrence — no other change.
+
+- **FR-004**: The apk file-list extractor MUST be extended to
+  return both the path AND the apk-provided SHA-1 per file (when
+  available). The downstream hash-and-emit pipeline MUST thread
+  the SHA-1 alongside the path into the per-file occurrence.
+
+- **FR-005**: Deb-based image scans MUST be byte-identical to
+  milestone 039's output. The `additionalContext` of any
+  dpkg-sourced occurrence is unchanged.
+
+#### US3 — Rpm per-file deep-hashing
+
+- **FR-006**: When mikebom scans an rpm-based image, each emitted
+  rpm component MUST carry a per-file evidence block populated
+  from the package's HeaderBlob file-list (the
+  `BASENAMES` / `DIRNAMES` / `DIRINDEXES` triple — the canonical
+  rpm representation of file ownership).
+
+- **FR-007**: The rpm per-file evidence block MUST follow the
+  same shape that dpkg and apk components produce — file path
+  inside the rootfs, SHA-256 of the file content, optionally a
+  cross-reference checksum (rpm's FILEDIGESTS — out of scope
+  for this milestone, defer if needed).
+
+- **FR-008**: When the user passes `--no-deep-hash`, the per-file
+  evidence block MUST be empty for rpm components — matching the
+  established fast-path behavior. The package-level identity
+  hash MUST still resolve.
+
+- **FR-009**: Rpm packages whose HeaderBlob has empty file lists
+  (metadata-only / virtual packages) MUST still emerge as
+  components with package-level identity; their per-file evidence
+  block is empty. The scan MUST NOT fail.
+
+#### Cross-cutting
+
+- **FR-010**: No new top-level Cargo dependencies. The work
+  reuses `sha2` (existing), the `rpm` crate (already a direct
+  dep from milestone 004 for rpm metadata reading), `flate2` /
+  `xz2` for compressed-payload handling if needed (already in
+  the dep tree), and stdlib primitives.
+
+- **FR-011**: All existing byte-identity goldens MUST regen with
+  zero diff. (The 27-fixture goldens use `--no-deep-hash` so
+  they're naturally insulated from the new deep-hash path.)
+
+### Key Entities
+
+- **`additionalContext` JSON-string**: today carries `sha256` +
+  optionally `md5` (dpkg) on per-file occurrences. After US2 it
+  also carries `sha1` (apk-provided) on apk occurrences. After
+  US3 it carries `sha256` only on rpm occurrences (FILEDIGESTS
+  cross-ref deferred).
+- **Rpm HeaderBlob file triple**: `(BASENAMES, DIRNAMES,
+  DIRINDEXES)`. Used to reconstruct each file's full path:
+  `DIRNAMES[DIRINDEXES[i]] + BASENAMES[i]`. The canonical rpm
+  encoding; the `rpm` crate exposes accessors.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+#### US1
+
+- **SC-001**: Post-merge `grep -rn 'deferred to milestone 031'
+  mikebom-cli/src/` returns zero matches (today: ≥1).
+
+- **SC-002**: Post-merge `grep -rn 'deferred to milestone'
+  mikebom-cli/src/` returns only matches that point at genuinely
+  deferred items (manual audit at PR review time).
+
+#### US2
+
+- **SC-003**: A scan of `alpine:3.19` produces an SBOM where
+  every populated apk occurrence's `additionalContext` carries
+  both `sha256` and `sha1` — measurable as 100% of populated
+  occurrences having both keys.
+
+- **SC-004**: A scan of `cgr.dev/chainguard/static:latest`
+  shows the same `sha1` cross-ref population for apk
+  occurrences.
+
+#### US3
+
+- **SC-005**: A scan of an rpm-based image (`fedora:40` or
+  similar) produces an SBOM whose rpm components each carry a
+  non-empty per-file evidence block — measurable as
+  `total file occurrences across all components > 0` (today: 0).
+
+- **SC-006**: For at least one well-understood rpm package, the
+  per-file evidence count matches what `rpm -ql <pkg>` reports —
+  measurable as a hand-verified count parity for at least one
+  package on a real `fedora:40` scan.
+
+#### Cross-cutting
+
+- **SC-007**: Existing byte-identity goldens regen with zero
+  diff (FR-011).
+- **SC-008**: All 3 CI lanes green.
+
+## Assumptions
+
+- The `rpm` crate (already a direct dep) exposes BASENAMES,
+  DIRNAMES, DIRINDEXES via accessors on its parsed HeaderBlob /
+  Header type. Verified at planning time; if the API differs,
+  the implementation either uses lower-level tags directly or
+  parses the header bytes manually (the format is documented in
+  the rpm spec).
+- Apk's `Z:` line carries a `Q1`-prefixed base64-encoded SHA-1
+  (per the apk source / community documentation). The
+  implementation parses this opaquely as bytes, not relying on
+  the prefix being constant — and re-encodes as a 40-hex-char
+  string on the wire (SHA-1 output is 20 bytes → 40 hex chars).
+- The three user stories are independent enough that they can
+  ship as one PR (recommended — small, contained, all
+  package-db-related) or as three sequenced PRs (acceptable but
+  more overhead).
+- "rpm-based image" includes `fedora:*`, `almalinux:*`,
+  `rockylinux:*`, `centos:stream*`, `redhat/*`, and similar.
+  Mikebom's existing rpm reader already handles them all
+  uniformly via `/var/lib/rpm/*.db` (or the legacy Berkeley DB
+  variant gated by `--include-legacy-rpmdb`).
+
+## Out of scope
+
+- Rpm FILEDIGESTS cross-ref (the rpm-provided per-file SHA-256 /
+  SHA-1 / MD5). Could be added in a follow-on if real demand
+  surfaces — would mirror the apk-side `sha1` cross-ref this
+  milestone adds.
+- Container layer attribution (separate architectural milestone;
+  pre-existing deferred item from the milestone-023 roadmap).
+- Schema-level `hashes` array on `FileOccurrence` (would unify
+  cross-ref carriers across ecosystems but requires a schema
+  extension across all three downstream emitters; defer until
+  there's concrete external demand).
+- Maven sidecar Debian / Alpine variants (separate concern;
+  pre-existing deferred item).

--- a/specs/040-pkg-db-followups/tasks.md
+++ b/specs/040-pkg-db-followups/tasks.md
@@ -1,0 +1,194 @@
+---
+description: "Task list — milestone 040 package-db follow-ons (housekeeping + apk SHA-1 cross-ref + rpm per-file deep-hash)"
+---
+
+# Tasks: Package-DB Follow-Ons (Trifecta)
+
+**Input**: Design documents from `/specs/040-pkg-db-followups/`
+**Prerequisites**: spec.md ✅, plan.md ✅, research.md ✅, data-model.md ✅, quickstart.md ✅, checklists/requirements.md ✅
+
+**Tests**: included — inline coverage for each new helper, plus a smoke-test assertion update for US2.
+
+**Organization**: Three independent user stories sequenced by priority. Each is independently testable and each commit's `./scripts/pre-pr.sh` is clean.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Snapshot pre-implementation baseline by running `./scripts/pre-pr.sh` from the repo root and confirming clean before any changes
+- [ ] T002 Confirm milestone 039's apk smoke test still passes via `MIKEBOM_OCI_NETWORK_TESTS=1 cargo +stable test --manifest-path /Users/mlieberman/Projects/mikebom/Cargo.toml -p mikebom --test oci_registry_smoke pulls_alpine_3_19_and_emits_apk_components` (post-039 baseline healthy on this branch)
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: None for this milestone. Each user story extends an established pattern from prior milestones (037 / 038 / 039); no shared infrastructure to land first.
+
+---
+
+## Phase 3: User Story 1 - Stale OCI comment cleanup (Priority: P1) 🎯 MVP
+
+**Goal**: Remove the lingering "deferred to milestone 031.y" string in `oci_pull/mod.rs` that names the long-shipped `--image-platform` flag as deferred. After this commit, `grep -rn 'deferred to milestone 031' mikebom-cli/src/` returns zero matches.
+
+**Independent Test**: `grep -rn 'deferred to milestone 031' mikebom-cli/src/` returns zero matches (today: 1 in `oci_pull/mod.rs:215`). Manually trigger an unmapped-arch error path and confirm the message points at the shipped `--image-platform` flag.
+
+### Implementation for User Story 1
+
+- [ ] T003 [US1] Edit `mikebom-cli/src/scan_fs/oci_pull/mod.rs::host_oci_arch` (around line 215) to rewrite the bail message: drop the "deferred to milestone 031.y" framing and instead point users at the shipped `--image-platform <linux/arch>` flag. Wording emphasizes the flag's existence rather than naming any deferred milestone.
+- [ ] T004 [US1] Run `grep -rn 'deferred to milestone 031' mikebom-cli/src/` and confirm zero matches (SC-001).
+- [ ] T005 [US1] Run `grep -rn 'deferred to milestone' mikebom-cli/src/` and audit each remaining match — every one MUST point at a genuinely deferred follow-on (no false positives left from this cleanup).
+- [ ] T006 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T007 [US1] Commit: `fix(040/us1): drop stale "deferred to milestone 031.y" framing; point at shipped --image-platform`.
+
+**Checkpoint**: At this point, US1 is fully delivered. The remaining stories may proceed independently.
+
+---
+
+## Phase 4: User Story 2 - Apk Z:-line SHA-1 cross-reference (Priority: P2)
+
+**Goal**: Each apk per-file occurrence's `additionalContext` JSON-string carries both `sha256` (mikebom-computed) and `sha1` (apk-provided from the `Z:` line). Mirrors deb's `md5` cross-ref shape from milestone 037.
+
+**Independent Test**: `mikebom sbom scan --image alpine:3.19 --output /tmp/alpine.cdx.json` followed by `jq '.components[0].evidence.occurrences[0].additionalContext'` shows a JSON-string containing both `sha256` and `sha1` keys (today: only `sha256`).
+
+### Commit `feat(040/us2-extract-z-lines)`
+
+- [ ] T008 [US2] Add a new struct `ApkFileEntry { path: String, sha1: Option<String> }` to `mikebom-cli/src/scan_fs/package_db/apk.rs`. The optional `sha1` is the 40-hex-char lowercase form of the apk-provided SHA-1.
+- [ ] T009 [US2] Change the return type of `apk::read_file_lists` from `HashMap<String, Vec<String>>` to `HashMap<String, Vec<ApkFileEntry>>`. Within the existing F:/R: walk, also track `Z:` lines that follow each `R:`. Decode each `Z:` value per research.md R2: strip the `Q1` prefix (skip on any other prefix), base64-decode the trailing 28-char payload (using the workspace `base64` dep), hex-encode the resulting 20 bytes as a 40-char lowercase string. Store as the `sha1` field; `None` when missing or malformed.
+- [ ] T010 [US2] Mark the new struct + return-type change with whatever `#[allow(dead_code)]` is needed pending the next commit's wire-up. (The existing single caller in `scan_fs/mod.rs` will need its signature updated alongside.)
+- [ ] T011 [P] [US2] Add inline test `read_file_lists_extracts_z_line_sha1` in `apk.rs::tests`: synthetic stanza with `R:foo` followed by `Z:Q1<base64-encoded-known-sha1>`; assert the resulting entry has `sha1 == Some("<expected 40-hex>")`.
+- [ ] T012 [P] [US2] Add inline test `read_file_lists_handles_missing_z_line` in `apk.rs::tests`: synthetic stanza with `R:foo` followed by `R:bar` (no `Z:` between); assert `foo` and `bar` both have `sha1 == None`.
+- [ ] T013 [P] [US2] Add inline test `read_file_lists_rejects_non_q1_prefix` in `apk.rs::tests`: synthetic stanza with `R:foo` followed by `Z:Q2<base64-data>` (hypothetical future scheme); assert `foo` has `sha1 == None` (defensive: only Q1 is currently a known apk scheme).
+- [ ] T014 [US2] Run `cargo +stable test -p mikebom --bin mikebom scan_fs::package_db::apk` and confirm the 3 new tests pass alongside the existing 18.
+- [ ] T015 [US2] `./scripts/pre-pr.sh` clean.
+- [ ] T016 [US2] Commit: `feat(040/us2-extract-z-lines): apk Z:-line SHA-1 extraction in read_file_lists`.
+
+### Commit `feat(040/us2-thread-sha1-into-evidence)`
+
+- [ ] T017 [US2] Add an `apk_sha1: Option<String>` field to `mikebom_common::resolution::FileOccurrence` (in the `mikebom-common` crate). Default-`None` via `#[serde(default, skip_serializing_if = "Option::is_none")]` so existing serialized fixtures still round-trip identically.
+- [ ] T018 [US2] Update `file_hashes.rs::hash_apk_package_files`'s signature from `&[String]` to `&[ApkFileEntry]`. Inside the per-file loop, copy the `sha1` from the entry onto the resulting `FileOccurrence.apk_sha1`. Update the existing `hash_apk_package_files_*` inline tests to construct `ApkFileEntry`s.
+- [ ] T019 [US2] Edit `mikebom-cli/src/generate/cyclonedx/evidence.rs`: when serializing per-occurrence `additionalContext`, if `o.apk_sha1` is `Some`, include it as `"sha1": "<value>"` alongside the existing `"sha256"` key. Existing `"md5"` (dpkg) emission unchanged.
+- [ ] T020 [US2] Verify the SPDX 2.3 and SPDX 3 emitters (under `mikebom-cli/src/generate/spdx*/`) consume `additionalContext` via the same shape — if any of them reach into the field directly rather than going through CycloneDX-shaped helpers, mirror the apk-sha1 extension there too. Otherwise no edit needed.
+- [ ] T021 [US2] Update the call site in `mikebom-cli/src/scan_fs/mod.rs`'s deep-hash dispatcher: the apk file-list map now yields `Vec<ApkFileEntry>` not `Vec<String>`. Pass slices through `hash_apk_package_files` unchanged.
+- [ ] T022 [US2] Edit the existing milestone-039 alpine smoke test in `mikebom-cli/tests/oci_registry_smoke.rs` (`pulls_alpine_3_19_and_emits_apk_components`): in the per-occurrence `additionalContext` parse loop, also count occurrences whose ctx contains a `sha1` key. Assert `sha1_seen > 0` AND that the recovered SHA-1 strings match the format expected (40-hex-char lowercase).
+- [ ] T023 [US2] Run `MIKEBOM_OCI_NETWORK_TESTS=1 cargo +stable test --manifest-path /Users/mlieberman/Projects/mikebom/Cargo.toml -p mikebom --test oci_registry_smoke pulls_alpine_3_19_and_emits_apk_components` and confirm passing.
+- [ ] T024 [US2] Run goldens regen: `MIKEBOM_UPDATE_*_GOLDENS=1 cargo +stable test -p mikebom --test '*'`. Confirm `git status --short` shows zero diffs under `mikebom-cli/tests/fixtures/27/` (the goldens use `--no-deep-hash` so apk-sha1 doesn't surface there).
+- [ ] T025 [US2] `./scripts/pre-pr.sh` clean.
+- [ ] T026 [US2] Commit: `feat(040/us2-thread-sha1-into-evidence): apk SHA-1 cross-ref in additionalContext alongside sha256`.
+
+**Checkpoint**: At this point, US1 + US2 both work independently. Apk components carry the cross-ref the deb side has carried since milestone 037.
+
+---
+
+## Phase 5: User Story 3 - Rpm per-file deep-hashing (Priority: P3)
+
+**Goal**: Each rpm component carries a populated `evidence.occurrences[]` block with file paths and SHA-256 hashes. Closes the OS-package per-file-evidence trilogy (deb 037+038, apk 039, rpm 040).
+
+**Independent Test**: `mikebom sbom scan --image fedora:40 --output /tmp/fedora.cdx.json` followed by `jq '[.components[].evidence.occurrences | length // 0] | add'` returns a positive integer (today: 0).
+
+### Commit `feat(040/us3-rpm-deep-hash)`
+
+- [ ] T027 [US3] Add `pub fn read_file_lists(rootfs: &Path) -> std::collections::HashMap<String, Vec<String>>` to `mikebom-cli/src/scan_fs/package_db/rpm.rs`. Reuses the existing `iter_rpmdb` visitor pattern: each visited `(PackageDbEntry, Vec<PathBuf>)` contributes one map entry keyed on `entry.name`, with the path-list converted from `Vec<PathBuf>` to `Vec<String>` (the sha-256 loop wants `String`).
+- [ ] T028 [US3] Add `pub fn hash_rpm_package_files(rootfs: &Path, files: &[String]) -> (Vec<FileOccurrence>, Option<ContentHash>)` to `mikebom-cli/src/scan_fs/package_db/file_hashes.rs`. Mirrors `hash_apk_package_files` exactly (no cross-ref): walks each rootfs-relative path, opens, SHA-256s, accumulates occurrences with `apk_sha1: None` and `md5_legacy: None`. Computes Merkle root.
+- [ ] T029 [US3] Add `pub fn hash_rpm_db_only(rootfs: &Path, pkg_name: &str) -> Option<ContentHash>` to `file_hashes.rs`. Per research.md R5, this is the SHA-256 of the named package's HeaderBlob bytes. Implementation: iterate the rpmdb via a small helper that exposes the blob bytes; SHA-256 the matching one.
+- [ ] T030 [US3] Edit `mikebom-cli/src/scan_fs/mod.rs`: build the rpm file-list map ONCE per scan via `rpm::read_file_lists(root)` before the per-entry loop (parallel to the `apk_file_lists` variable from milestone 039). Add `let is_rpm = entry.source_path.contains("lib/rpm/");` parallel to `is_dpkg` / `is_apk`. Add an `else if is_rpm` branch in the deep-hash dispatcher that mirrors the apk branch (deep mode → `hash_rpm_package_files`; fast mode → `hash_rpm_db_only`).
+- [ ] T031 [P] [US3] Add inline test `hash_rpm_package_files_round_trips_files` in `file_hashes.rs::tests`: synthetic rootfs with 2 files; call with their relative paths; assert 2 occurrences with valid 64-hex SHA-256, absolute-prefixed `location`, and `md5_legacy`/`apk_sha1` both `None`.
+- [ ] T032 [P] [US3] Add inline test `hash_rpm_package_files_skips_absent_files` in `file_hashes.rs::tests`: file-list claims 2 files, only 1 exists on disk; assert 1 occurrence.
+- [ ] T033 [P] [US3] Add inline test `hash_rpm_package_files_returns_empty_for_empty_input` in `file_hashes.rs::tests`: empty file-list; assert empty Vec + None root (FR-009 metadata-only-package handling).
+- [ ] T034 [P] [US3] Add inline test `read_file_lists_extracts_per_package_paths` in `rpm.rs::tests`: use the existing test-fixture infrastructure (`rpm::tests::build_test_header` is already used for fixture data per the file we surveyed earlier); construct a synthetic rpmdb with 2 packages and verify `read_file_lists` returns the right per-package path map.
+- [ ] T035 [US3] Run `cargo +stable test -p mikebom --bin mikebom scan_fs::package_db::rpm scan_fs::package_db::file_hashes` and confirm the 4 new tests pass.
+- [ ] T036 [US3] Run gated rpm smoke verification (no smoke-test code addition required; just confirm a real rpm-image scan produces non-zero occurrences):
+      ```bash
+      mikebom sbom scan --image fedora:40 --output /tmp/fedora-040.cdx.json
+      jq '[.components[].evidence.occurrences | length // 0] | add' /tmp/fedora-040.cdx.json
+      # expected: > 0 (was 0 pre-040)
+      ```
+- [ ] T037 [US3] Run goldens regen: `MIKEBOM_UPDATE_*_GOLDENS=1 cargo +stable test -p mikebom --test '*'`. Confirm zero diff (the existing 27 goldens use `--no-deep-hash` so they're insulated).
+- [ ] T038 [US3] `./scripts/pre-pr.sh` clean.
+- [ ] T039 [US3] Commit: `feat(040/us3-rpm-deep-hash): rpm per-file evidence — completes the OS-package per-file-evidence trilogy`.
+
+**Checkpoint**: All three user stories now ship together. The OS-package per-file-evidence work is complete across deb / apk / rpm.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T040 Update `docs/user-guide/cli-reference.md`: drop the apk `Z:`-line caveat from the milestone-039 paragraph (now closed); add a one-paragraph note that rpm components also produce per-file evidence (parallel to the deb / apk paragraphs).
+- [ ] T041 Add `CHANGELOG.md` Unreleased entry summarizing milestone 040: US1 (stale-comment cleanup), US2 (apk SHA-1 cross-ref), US3 (rpm per-file deep-hash). Include pre/post numbers for US3 (alpine + chainguard already validated; quote the fedora:40 numbers from T036).
+- [ ] T042 `./scripts/pre-pr.sh` clean.
+- [ ] T043 Commit: `docs(040): user-guide rpm parity paragraph + CHANGELOG`.
+
+---
+
+## Phase 7: PR + verification
+
+- [ ] T044 Push the branch.
+- [ ] T045 Open PR titled `feat(040): package-db follow-ons — comment cleanup, apk SHA-1 cross-ref, rpm per-file deep-hash`. PR body lists pre/post numbers (US3: fedora:40 occurrence count), zero non-fixture-golden drift, no new top-level deps.
+- [ ] T046 Verify all 3 CI lanes green (Linux default + Linux ebpf + macOS).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; run first.
+- **Foundational (Phase 2)**: Empty.
+- **US1 (Phase 3)**: Depends on Setup. Independent of US2/US3.
+- **US2 (Phase 4)**: Depends on Setup. Independent of US1/US3 — touches different files.
+- **US3 (Phase 5)**: Depends on Setup. Independent of US1/US2 — touches different files.
+- **Polish (Phase 6)**: Depends on completing whichever US's the maintainer wants in the current PR.
+- **PR (Phase 7)**: Depends on Polish.
+
+### Within US2
+
+- T008 (struct) precedes T009 (signature change).
+- T009 precedes T010 (allow-dead-code holds for the wire-up gap).
+- T011–T013 are parallel inline tests against the new struct; can be authored simultaneously.
+- T017 (mikebom-common field) precedes T018 (file_hashes update) precedes T021 (call-site update).
+- T019 (CDX emitter) and T020 (SPDX emitters) are ordered logically but touch different files; can be authored simultaneously.
+
+### Within US3
+
+- T027 (rpm::read_file_lists) precedes T028 / T029.
+- T028 + T029 are parallel — different functions in same file; the `[P]` marker isn't applied because by mikebom convention same-file edits are sequential, but they can be reviewed independently.
+- T031–T034 are parallel inline tests (different test functions across two files).
+
+### Parallel Opportunities
+
+- **US1 + US2 + US3** can be developed independently. Recommended sequencing per spec: US1 → US2 → US3 (matches user's stated order).
+- T011–T013 within US2: parallel test additions.
+- T031–T034 within US3: parallel test additions across two files.
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only)
+
+1. Phase 1 (T001–T002).
+2. Phase 3 (T003–T007).
+3. **STOP & VALIDATE**: confirm the grep-cleanup is complete; manually trigger an unmapped-arch error and confirm the new message reads well.
+4. Optionally ship US1 standalone as a tiny PR. Given the trivial size, more likely just continue to US2.
+
+### Recommended (single PR sequencing all three stories)
+
+1. Phase 1 → US1 → US2 → US3 → Polish → PR.
+2. Single PR with 5 commits visible in the review (one per US plus Polish), each individually reviewable.
+
+### Stop conditions
+
+- US3 fedora:40 scan produces 0 occurrences → debug: confirm the rpmdb is at one of the documented paths; confirm `is_rpm` substring matches `entry.source_path`. Most likely cause is a path-detection mismatch.
+- Goldens regen produces non-zero diff → likely the apk SHA-1 has leaked into a fixture-test path. Inspect the diff; non-`additionalContext` field changes indicate a deeper issue.
+
+---
+
+## Notes
+
+- `[P]` tasks = different files OR different test functions, no dependencies on incomplete tasks.
+- `[Story]` label maps task to specific user story for traceability.
+- Each commit's `./scripts/pre-pr.sh` MUST be clean (Constitution Pre-PR Verification gate).
+- US1 is genuinely tiny — keep its commit small.
+- US2 splits across two commits because the in-flight state (changing apk's API but not yet wiring it through) requires a `#[allow(dead_code)]`; clean separation makes review easier.
+- US3 lands as a single commit since the helper + wire-up + tests are tightly coupled.


### PR DESCRIPTION
## Summary

Three sequenced follow-on items closing coverage and hygiene gaps after milestones 037/038/039.

- **US1**: drop stale "deferred to milestone 031.y" framing in \`oci_pull/mod.rs\` (one-line edit).
- **US2**: extend milestone 039's apk per-file evidence with the apk-provided per-file SHA-1 from each \`Z:\` line in \`/lib/apk/db/installed\`. Surfaced as \`sha1\` in \`additionalContext\` alongside \`sha256\`.
- **US3**: rpm per-file deep-hashing. Completes the OS-package per-file-evidence trilogy across deb (037/038), apk (039), and rpm (this PR).

## Commits (5)

1. **\`spec(040)\`** — Slim 4-file spec set with 3 user stories, 11 FRs, 8 SCs.
2. **\`fix(040/us1)\`** — One-line stale-comment edit + grep verification.
3. **\`feat(040/us2)\`** — \`ApkFileEntry\` struct, \`Z:\` parser, \`apk_sha1: Option<String>\` field on \`FileOccurrence\`, \`sha1\` key in CDX \`additionalContext\` emission. 4 inline tests.
4. **\`feat(040/us3)\`** — \`rpm::read_file_lists\` + \`hash_rpm_package_files\` + \`hash_rpm_db_only\` + \`is_rpm\` branch in scan dispatcher. 4 inline tests.
5. **\`docs(040)\`** — User-guide rpm parity paragraph + CHANGELOG entry.

## Concrete results

| Image | Pre-040 | Post-040 |
|---|---|---|
| \`alpine:3.19\` apk \`additionalContext\` | sha256 only | sha256 + sha1 |
| \`fedora:40\` rpm occurrences | 0 | **6966 across 147 components** |
| Deb golden (\`debian:bookworm-slim\`) | unchanged | unchanged (zero golden drift) |

## Q1 clarification (recorded in spec.md)

Rpm FILEDIGESTS cross-reference is OUT of scope and deferred. US3 ships SHA-256 only on the rpm side; FILEDIGESTS remains a future-extension candidate that mirrors apk's Z: cross-ref this milestone delivers.

## Verification

- ✅ \`./scripts/pre-pr.sh\` clean.
- ✅ All package_db tests pass: 432 (was 423; 4 new apk + rpm hash tests + 4 new rpm hash tests + small adjustments).
- ✅ \`MIKEBOM_OCI_NETWORK_TESTS=1 cargo +stable test --test oci_registry_smoke pulls_alpine_3_19_and_emits_apk_components\` passes — including the new \`sha1_seen\` assertion.
- ✅ \`MIKEBOM_UPDATE_*_GOLDENS=1 cargo +stable test -p mikebom --test '*'\` produces zero diff. (The 27 fixtures use \`--no-deep-hash\` so the deep-hash path is insulated by design.)
- ✅ No new top-level deps. \`no_c_dependencies_in_tree\` regression still green.
- ✅ \`grep -rn 'deferred to milestone 031' mikebom-cli/src/\` returns zero matches (was 1 in oci_pull/mod.rs).
- ✅ \`git diff main..HEAD -- mikebom-cli/src/parity/ mikebom-cli/src/generate/cyclonedx/dependencies.rs mikebom-cli/src/generate/cyclonedx/vex.rs mikebom-cli/src/resolve/\` empty (no parity/vex/resolve touches).

## Test plan

- [ ] CI green on all 3 lanes.
- [ ] Manual fedora verification:
      \`\`\`bash
      mikebom sbom scan --image fedora:40 --output /tmp/fedora.cdx.json
      jq '[.components[].evidence.occurrences | length // 0] | add' /tmp/fedora.cdx.json
      # expected: > 0 (was 0 pre-040)
      \`\`\`
- [ ] Manual alpine SHA-1 verification:
      \`\`\`bash
      mikebom sbom scan --image alpine:3.19 --output /tmp/alpine.cdx.json
      jq -r '.components[0].evidence.occurrences[0].additionalContext' /tmp/alpine.cdx.json
      # expected: contains both "sha256" and "sha1" keys
      \`\`\`
- [ ] No regression on deb scans (\`debian:bookworm-slim\`, \`gcr.io/distroless/static-debian12:latest\`) — same SBOM as milestone 039.

## Out of scope (future)

- Rpm FILEDIGESTS cross-reference (deferred per Q1 clarification — separate follow-on candidate).
- Container layer attribution (pre-existing deferred item).
- Schema-level \`hashes\` array on \`FileOccurrence\` (would unify cross-ref carriers across ecosystems but requires a wider serializer change; defer until external demand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)