### PR TITLE
feat(041): rpm FILEDIGESTS cross-reference (closes milestone-040 Q1 deferral)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 ## [Unreleased]
 
 ### Added
+- **Milestone 041 — Rpm FILEDIGESTS cross-reference.** Closes
+  the milestone-040 Q1 deferral. Every populated rpm
+  `evidence.occurrences[]` entry's `additionalContext` JSON-
+  string now carries `rpm_filedigest` alongside the existing
+  `sha256`, in algorithm-prefixed form (e.g.
+  `"sha256:abc..."` for modern rpm packages,
+  `"md5:def..."` for legacy ones). The algorithm matches the
+  package's `FILEDIGESTALGO` value (or defaults to MD5 when
+  absent per the rpm spec). Brings rpm to full cross-ref
+  symmetry with deb (`md5`, since milestone 037) and apk
+  (`sha1`, since milestone 040 US2).
+  Verified end-to-end against `fedora:40`: 6938 of 6966
+  total file occurrences carry the cross-ref (99.6%; the
+  28 remainder are non-regular files whose `FILEDIGESTS`
+  entry is empty by rpm-spec convention). Sample value
+  `rpm_filedigest = "sha256:7544bd..."` matches the
+  mikebom-observed `sha256` for the same file — the
+  integrity-check arrow goes both ways. New
+  `rpm_file_digest: Option<String>` field on
+  `mikebom_common::resolution::FileOccurrence` (additive,
+  `#[serde(default, skip_serializing_if = "Option::is_none")]`).
+  No new top-level dependencies. 27-fixture goldens regen
+  with zero diff. See `specs/041-rpm-filedigests/spec.md`.
 - **Milestone 040 — Package-DB follow-ons (trifecta).** Three
   sequenced follow-on items closing coverage and hygiene gaps
   after milestones 037 / 038 / 039:

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -194,9 +194,14 @@ Behaviour notes:
   / redhat/*): same shape as deb and apk. mikebom decodes each
   package's `BASENAMES` / `DIRNAMES` / `DIRINDEXES` triple from the
   rpmdb HeaderBlob, walks the rootfs, and emits SHA-256 per file.
-  rpm-side `additionalContext` carries SHA-256 only — the rpm-provided
-  FILEDIGESTS cross-ref is a future extension. As of milestone 040,
-  this brings rpm to feature parity with deb (037/038) and apk (039).
+  As of milestone 041, rpm-side `additionalContext` also carries the
+  rpm-provided per-file digest from the package's `FILEDIGESTS` tag
+  as `rpm_filedigest`, in algorithm-prefixed form
+  (e.g. `"sha256:abc..."` for modern packages, `"md5:def..."` for
+  legacy CentOS-7-era ones — the algorithm matches the package's
+  `FILEDIGESTALGO` value or defaults to MD5 when absent per the rpm
+  spec). This brings rpm to full cross-ref symmetry with deb (which
+  carries `md5`) and apk (which carries `sha1`).
 
 ### Authenticating to private registries
 

--- a/mikebom-cli/src/generate/cyclonedx/evidence.rs
+++ b/mikebom-cli/src/generate/cyclonedx/evidence.rs
@@ -71,6 +71,15 @@ pub fn build_evidence(
                 if let Some(ref sha1) = o.apk_sha1 {
                     ctx.insert("sha1".to_string(), json!(sha1));
                 }
+                // Milestone 041: rpm-provided per-file digest
+                // from the package's FILEDIGESTS tag,
+                // algorithm-prefixed (e.g. "sha256:abc...",
+                // "md5:def..."). Carried alongside mikebom's own
+                // `sha256` so consumers can correlate observed
+                // bytes against the upstream-claimed digest.
+                if let Some(ref rpm_fd) = o.rpm_file_digest {
+                    ctx.insert("rpm_filedigest".to_string(), json!(rpm_fd));
+                }
                 json!({
                     "location": o.location,
                     "additionalContext": serde_json::to_string(&ctx)
@@ -287,12 +296,14 @@ mod tests {
                 sha256: "a".repeat(64),
                 md5_legacy: Some("b".repeat(32)),
                 apk_sha1: None,
+                rpm_file_digest: None,
             },
             FileOccurrence {
                 location: "/usr/share/doc/jq/copyright".to_string(),
                 sha256: "c".repeat(64),
                 md5_legacy: None,
                 apk_sha1: None,
+                rpm_file_digest: None,
             },
         ];
         let result = build_evidence(&ev, &occs);

--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -442,7 +442,7 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
                 }
             } else if is_rpm {
                 if deep_hash {
-                    let files: &[String] = rpm_file_lists
+                    let files: &[package_db::rpm::RpmFileListEntry] = rpm_file_lists
                         .get(&entry.name)
                         .map(|v| v.as_slice())
                         .unwrap_or(&[]);

--- a/mikebom-cli/src/scan_fs/package_db/file_hashes.rs
+++ b/mikebom-cli/src/scan_fs/package_db/file_hashes.rs
@@ -128,6 +128,7 @@ pub fn hash_package_files(
             sha256,
             md5_legacy,
             apk_sha1: None,
+            rpm_file_digest: None,
         });
     }
 
@@ -286,6 +287,7 @@ pub fn hash_apk_package_files(
             sha256,
             md5_legacy: None,
             apk_sha1: entry.sha1.clone(),
+            rpm_file_digest: None,
         });
     }
 
@@ -297,17 +299,14 @@ pub fn hash_apk_package_files(
 
 /// Deep-hash every file the rpm package claims (via
 /// HeaderBlob `BASENAMES` / `DIRNAMES` / `DIRINDEXES`).
-/// Mirrors [`hash_apk_package_files`]; the resulting
-/// `FileOccurrence`s carry SHA-256 only — no MD5 cross-ref
-/// (rpm has no analog of dpkg's `.md5sums`) and no SHA-1
-/// cross-ref (rpm's FILEDIGESTS deferred to a follow-on
-/// milestone per the milestone-040 Q1 clarification).
+/// Mirrors [`hash_apk_package_files`].
 ///
-/// `files` is the rootfs-relative-or-absolute path list yielded
-/// by [`super::rpm::read_file_lists`]. rpm paths come in as
-/// absolute (`/usr/bin/bash`); we resolve to absolute form for
-/// `FileOccurrence.location` and strip the leading `/` before
-/// joining onto the rootfs.
+/// `files` is the path-and-digest list yielded by
+/// [`super::rpm::read_file_lists`]. Each entry's `path` is
+/// rpm-on-disk absolute (`/usr/bin/bash`); the optional `digest`
+/// is the upstream-provided cross-ref in algorithm-prefixed
+/// form (e.g. `"sha256:abc..."`) and threads through to the
+/// resulting `FileOccurrence.rpm_file_digest` (milestone 041).
 ///
 /// Files that disappear between install and scan time are
 /// silently skipped (rare; would typically indicate config files
@@ -315,11 +314,11 @@ pub fn hash_apk_package_files(
 /// are skipped with a debug log.
 pub fn hash_rpm_package_files(
     rootfs: &Path,
-    files: &[String],
+    files: &[super::rpm::RpmFileListEntry],
 ) -> (Vec<FileOccurrence>, Option<ContentHash>) {
     let mut occurrences: Vec<FileOccurrence> = Vec::new();
-    for raw in files {
-        let trimmed = raw.trim();
+    for entry in files {
+        let trimmed = entry.path.trim();
         if trimmed.is_empty() {
             continue;
         }
@@ -359,6 +358,7 @@ pub fn hash_rpm_package_files(
             sha256,
             md5_legacy: None,
             apk_sha1: None,
+            rpm_file_digest: entry.digest.clone(),
         });
     }
 
@@ -384,10 +384,10 @@ pub fn hash_rpm_db_only(rootfs: &Path, pkg_name: &str) -> Option<ContentHash> {
     if files.is_empty() {
         return None;
     }
-    let mut sorted = files.clone();
-    sorted.sort();
+    let mut paths: Vec<&str> = files.iter().map(|e| e.path.as_str()).collect();
+    paths.sort();
     let mut payload = String::new();
-    for p in &sorted {
+    for p in &paths {
         payload.push_str(p);
         payload.push('\n');
     }
@@ -1028,6 +1028,16 @@ mod tests {
 
     // ---- Milestone 040 US3: rpm per-file deep-hashing ---------------------
 
+    /// Helper: build an RpmFileListEntry with no cross-ref digest
+    /// (matches packages whose FILEDIGESTS isn't being exercised
+    /// by the test).
+    fn rpm_path(p: &str) -> super::super::rpm::RpmFileListEntry {
+        super::super::rpm::RpmFileListEntry {
+            path: p.to_string(),
+            digest: None,
+        }
+    }
+
     #[test]
     fn hash_rpm_package_files_round_trips_files() {
         let dir = tempfile::tempdir().unwrap();
@@ -1037,10 +1047,7 @@ mod tests {
         );
         // rpm path conventions: paths come in as absolute (with
         // leading /).
-        let files = vec![
-            "/usr/bin/bash".to_string(),
-            "/etc/bash.bashrc".to_string(),
-        ];
+        let files = vec![rpm_path("/usr/bin/bash"), rpm_path("/etc/bash.bashrc")];
         let (occs, root) = hash_rpm_package_files(dir.path(), &files);
         assert_eq!(occs.len(), 2);
         assert!(root.is_some(), "must produce a per-component Merkle root");
@@ -1059,17 +1066,38 @@ mod tests {
                 o.apk_sha1.is_none(),
                 "rpm path never carries the apk SHA-1 cross-ref"
             );
+            assert!(
+                o.rpm_file_digest.is_none(),
+                "no FILEDIGESTS data was passed in this test, so rpm_file_digest must be None"
+            );
         }
+    }
+
+    /// Milestone 041: rpm_file_digest threads from input
+    /// `RpmFileListEntry.digest` to output
+    /// `FileOccurrence.rpm_file_digest` unchanged.
+    #[test]
+    fn hash_rpm_package_files_threads_digest_when_provided() {
+        let dir = tempfile::tempdir().unwrap();
+        place_files(dir.path(), &[("usr/bin/bash", b"bash-bytes")]);
+        let files = vec![super::super::rpm::RpmFileListEntry {
+            path: "/usr/bin/bash".to_string(),
+            digest: Some("sha256:aabbccdd...".to_string()),
+        }];
+        let (occs, _root) = hash_rpm_package_files(dir.path(), &files);
+        assert_eq!(occs.len(), 1);
+        assert_eq!(
+            occs[0].rpm_file_digest.as_deref(),
+            Some("sha256:aabbccdd..."),
+            "rpm_file_digest must thread from input entry to output"
+        );
     }
 
     #[test]
     fn hash_rpm_package_files_skips_absent_files() {
         let dir = tempfile::tempdir().unwrap();
         place_files(dir.path(), &[("usr/bin/exists", b"on-disk")]);
-        let files = vec![
-            "/usr/bin/exists".to_string(),
-            "/usr/bin/missing".to_string(),
-        ];
+        let files = vec![rpm_path("/usr/bin/exists"), rpm_path("/usr/bin/missing")];
         let (occs, root) = hash_rpm_package_files(dir.path(), &files);
         assert_eq!(occs.len(), 1, "absent file must be skipped");
         assert_eq!(occs[0].location, "/usr/bin/exists");
@@ -1090,7 +1118,7 @@ mod tests {
         // without the leading `/`, the helper should normalize.
         let dir = tempfile::tempdir().unwrap();
         place_files(dir.path(), &[("usr/bin/foo", b"bytes")]);
-        let files = vec!["usr/bin/foo".to_string()]; // no leading /
+        let files = vec![rpm_path("usr/bin/foo")]; // no leading /
         let (occs, _root) = hash_rpm_package_files(dir.path(), &files);
         assert_eq!(occs.len(), 1);
         assert_eq!(

--- a/mikebom-cli/src/scan_fs/package_db/rpm.rs
+++ b/mikebom-cli/src/scan_fs/package_db/rpm.rs
@@ -21,6 +21,19 @@ use super::rpmdb_sqlite::{RecordValue, SqliteFile};
 use super::{rpm_vendor_from_id, PackageDbEntry};
 use crate::scan_fs::os_release;
 
+/// One file owned by an rpm package — path on disk + optional
+/// upstream-provided cross-reference digest from the package's
+/// `FILEDIGESTS` tag. The digest is the algorithm-prefixed form
+/// (e.g. `"sha256:abc..."`, `"md5:def..."`); `None` for non-
+/// regular files (devices, fifos) whose FILEDIGESTS entry is
+/// empty by spec, or for entries whose digest length doesn't
+/// match the declared algorithm (defensive: damaged HeaderBlob).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RpmFileEntry {
+    pub path: PathBuf,
+    pub digest: Option<String>,
+}
+
 /// Hard cap on rpmdb.sqlite size — an honest RHEL rpmdb is ~5 MB;
 /// anything above 200 MB is refused as defense-in-depth.
 const MAX_RPMDB_BYTES: u64 = 200 * 1024 * 1024;
@@ -67,43 +80,54 @@ pub fn read(
     distro_version: Option<&str>,
 ) -> Vec<PackageDbEntry> {
     let mut out: Vec<PackageDbEntry> = Vec::new();
-    iter_rpmdb(rootfs, distro_version, |entry, _paths| out.push(entry));
+    iter_rpmdb(rootfs, distro_version, |entry, _files| out.push(entry));
     out
 }
 
+/// One rpm file-list entry as exposed to the deep-hash path:
+/// rootfs-absolute path string + optional algorithm-prefixed
+/// upstream digest. Mirrors the shape of `apk::ApkFileEntry`
+/// from milestone 039 / 040.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RpmFileListEntry {
+    pub path: String,
+    /// Algorithm-prefixed FILEDIGESTS value (e.g.
+    /// `"sha256:abc..."`, `"md5:def..."`), or `None` for files
+    /// whose stanza had no usable cross-ref (non-regular files,
+    /// missing FILEDIGESTS, unknown FILEDIGESTALGO).
+    pub digest: Option<String>,
+}
+
 /// Walk the rpmdb once and build a per-package file-list map for
-/// the milestone-040 deep-hash path. Mirrors
-/// `apk::read_file_lists` and the milestone-038-era
-/// dpkg-info-derived list — the consumer is the deep-hash
-/// dispatcher in `scan_fs::mod`.
+/// the deep-hash path. Mirrors `apk::read_file_lists`.
 ///
 /// Returns a map keyed on package name with each value being a
-/// `Vec<String>` of rootfs-relative paths the package's
-/// HeaderBlob `BASENAMES` / `DIRNAMES` / `DIRINDEXES` triple
-/// claims. Paths preserve the rpm-on-disk absolute form (e.g.
-/// `/usr/bin/bash`) — the consumer (`hash_rpm_package_files`)
-/// strips the leading `/` before joining onto the rootfs.
+/// `Vec<RpmFileListEntry>` carrying the rootfs-absolute path
+/// plus the optional algorithm-prefixed FILEDIGESTS cross-ref
+/// (milestone 041). Paths preserve the rpm-on-disk absolute
+/// form (e.g. `/usr/bin/bash`) — the consumer
+/// (`hash_rpm_package_files`) strips the leading `/` before
+/// joining onto the rootfs.
 ///
 /// Returns an empty map when the rpmdb is absent (typical for
 /// non-rpm rootfs) or unreadable; never errors.
-///
-/// `iter_rpmdb` already handles the SQLite-vs-BDB selection,
-/// the `WAL` / `-shm` diagnostics, and BASENAMES/DIRNAMES/
-/// DIRINDEXES decoding via mikebom's HeaderBlob reader.
 pub fn read_file_lists(
     rootfs: &Path,
-) -> std::collections::HashMap<String, Vec<String>> {
-    let mut out: std::collections::HashMap<String, Vec<String>> =
+) -> std::collections::HashMap<String, Vec<RpmFileListEntry>> {
+    let mut out: std::collections::HashMap<String, Vec<RpmFileListEntry>> =
         std::collections::HashMap::new();
-    iter_rpmdb(rootfs, None, |entry, paths| {
-        if paths.is_empty() {
+    iter_rpmdb(rootfs, None, |entry, files| {
+        if files.is_empty() {
             return;
         }
-        let strings: Vec<String> = paths
+        let mapped: Vec<RpmFileListEntry> = files
             .into_iter()
-            .map(|p| p.to_string_lossy().into_owned())
+            .map(|f| RpmFileListEntry {
+                path: f.path.to_string_lossy().into_owned(),
+                digest: f.digest,
+            })
             .collect();
-        out.insert(entry.name.clone(), strings);
+        out.insert(entry.name.clone(), mapped);
     });
     out
 }
@@ -124,8 +148,9 @@ pub fn collect_claimed_paths(
     // `distro_version` isn't needed here — we only care about file
     // paths, not PURLs. Pass None to keep the helper signature
     // uniform.
-    iter_rpmdb(rootfs, None, |_entry, paths| {
-        for rel in paths {
+    iter_rpmdb(rootfs, None, |_entry, files| {
+        for entry in files {
+            let rel = entry.path;
             // `rel` is absolute on the packaged system (e.g.
             // `/usr/bin/bash`). Strip the leading `/` and join onto the
             // rootfs to get the on-disk path.
@@ -143,11 +168,12 @@ pub fn collect_claimed_paths(
 
 /// Shared rpmdb iteration: opens the db, applies BDB / WAL diagnostics,
 /// iterates `Packages` via `iter_table_blobs`, and invokes `visitor`
-/// with the decoded `PackageDbEntry` and its file paths (paths are
-/// empty for fixture-shaped rows that carry no file list).
+/// with the decoded `PackageDbEntry` and its files (path + optional
+/// upstream FILEDIGESTS cross-ref). Files are empty for
+/// fixture-shaped rows that carry no file list.
 fn iter_rpmdb<F>(rootfs: &Path, distro_version: Option<&str>, mut visitor: F)
 where
-    F: FnMut(PackageDbEntry, Vec<PathBuf>),
+    F: FnMut(PackageDbEntry, Vec<RpmFileEntry>),
 {
     // v7 Phase H: try each candidate rpmdb location in order. Fedora ≥34
     // and RHEL ≥9.4 moved to `/usr/lib/sysimage/rpm/`; older distros
@@ -225,11 +251,11 @@ where
         if start.elapsed() > ITERATION_BUDGET {
             return;
         }
-        if let Some((entry, paths)) =
+        if let Some((entry, files)) =
             row_to_entry(values, blob, &vendor, &source_path, distro_version)
         {
             row_count += 1;
-            visitor(entry, paths);
+            visitor(entry, files);
         }
     });
     if start.elapsed() > ITERATION_BUDGET {
@@ -276,7 +302,7 @@ fn row_to_entry(
     vendor: &str,
     source_path: &str,
     distro_version: Option<&str>,
-) -> Option<(PackageDbEntry, Vec<PathBuf>)> {
+) -> Option<(PackageDbEntry, Vec<RpmFileEntry>)> {
     // Production path: attempt header-blob parse on any non-trivial
     // blob. Real rpmdb.sqlite stores headers in the **stripped
     // immutable-region form** (no magic prefix, 8-byte intro); `.rpm`
@@ -291,8 +317,8 @@ fn row_to_entry(
                 if let Some(entry) =
                     build_entry_from_header(&header, vendor, source_path, distro_version)
                 {
-                    let paths = header.file_paths();
-                    return Some((entry, paths));
+                    let files = build_rpm_file_entries(&header);
+                    return Some((entry, files));
                 }
                 // Header parsed but required fields missing — fall
                 // through to fixture-path attempt.
@@ -309,6 +335,56 @@ fn row_to_entry(
     let entry =
         build_entry_from_text_columns(values, vendor, source_path, distro_version)?;
     Some((entry, Vec::new()))
+}
+
+/// Combine an `RpmHeader`'s file paths (BASENAMES + DIRNAMES +
+/// DIRINDEXES) with the optional FILEDIGESTS / FILEDIGESTALGO
+/// cross-ref into a `Vec<RpmFileEntry>` aligned by basename
+/// index. When FILEDIGESTS is absent (older rpm packages built
+/// without it, metapackages, fixture rows), every entry's
+/// `digest` is `None`. When present, we emit
+/// `<algo>:<lowercase-hex>` for entries whose hex string matches
+/// the algorithm's expected length, and `None` otherwise (rpm
+/// records empty FILEDIGESTS strings for non-regular files like
+/// devices and fifos; we want those `None` rather than
+/// algorithm-prefixed-empty).
+fn build_rpm_file_entries(header: &RpmHeader) -> Vec<RpmFileEntry> {
+    let basenames = header
+        .string_array(rpm_header::TAG_BASENAMES)
+        .unwrap_or_default();
+    let dirnames = header
+        .string_array(rpm_header::TAG_DIRNAMES)
+        .unwrap_or_default();
+    let dirindexes = header
+        .int32_array(rpm_header::TAG_DIRINDEXES)
+        .unwrap_or_default();
+    let digests = header.file_digests();
+    let n = basenames.len().min(dirindexes.len());
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let idx = dirindexes[i] as usize;
+        if idx >= dirnames.len() {
+            continue;
+        }
+        let mut p = String::with_capacity(dirnames[idx].len() + basenames[i].len());
+        p.push_str(dirnames[idx]);
+        p.push_str(basenames[i]);
+        let digest = digests.as_ref().and_then(|d| {
+            let raw = d.values.get(i)?;
+            if raw.is_empty() || raw.len() != d.algo.hex_len() {
+                return None;
+            }
+            // rpm emits hex in lowercase already, but normalize
+            // defensively so the wire form is uniform across
+            // legacy / modern packages.
+            Some(format!("{}:{}", d.algo.name(), raw.to_ascii_lowercase()))
+        });
+        out.push(RpmFileEntry {
+            path: PathBuf::from(p),
+            digest,
+        });
+    }
+    out
 }
 
 /// Build a `PackageDbEntry` from a parsed RPM header (production blob
@@ -692,13 +768,19 @@ mod tests {
             "pkg:rpm/redhat/bash@5.2.15-1.fc40?arch=x86_64"
         );
         assert_eq!(entry.depends, vec!["glibc", "ncurses-libs"]);
+        let path_only: Vec<PathBuf> = paths.iter().map(|f| f.path.clone()).collect();
         assert_eq!(
-            paths,
+            path_only,
             vec![
                 PathBuf::from("/usr/bin/bash"),
                 PathBuf::from("/usr/share/man/man1/bash.1.gz"),
             ]
         );
+        // Milestone 041: this fixture has no FILEDIGESTS, so all
+        // file entries should have digest=None.
+        for f in &paths {
+            assert!(f.digest.is_none(), "no FILEDIGESTS → digest must be None");
+        }
     }
 
     /// VENDOR wins over PACKAGER when both are present — matches the

--- a/mikebom-cli/src/scan_fs/package_db/rpmdb_sqlite/rpm_header.rs
+++ b/mikebom-cli/src/scan_fs/package_db/rpmdb_sqlite/rpm_header.rs
@@ -56,6 +56,17 @@ pub const TAG_REQUIRENAME: u32 = 1049;
 pub const TAG_DIRINDEXES: u32 = 1116;
 pub const TAG_BASENAMES: u32 = 1117;
 pub const TAG_DIRNAMES: u32 = 1118;
+/// Per-file content digests, parallel-indexed with `BASENAMES`. Each
+/// entry is a hex-encoded digest string. The algorithm is named by
+/// [`TAG_FILEDIGESTALGO`]; when that tag is absent, MD5 is the
+/// rpm-spec-defined default. Populated by `rpmbuild` at package
+/// creation; mikebom uses it for the milestone-041 cross-ref on
+/// per-file evidence.
+pub const TAG_FILEDIGESTS: u32 = 1035;
+/// IANA hash-algorithm code for [`TAG_FILEDIGESTS`]. Common values:
+/// `1`=MD5, `2`=SHA-1, `8`=SHA-256, `9`=SHA-384, `10`=SHA-512. Absent
+/// or `0` defaults to MD5 per the rpm spec (legacy behavior).
+pub const TAG_FILEDIGESTALGO: u32 = 5011;
 
 // --- RPM type codes (subset we handle) ---
 
@@ -283,6 +294,43 @@ impl RpmHeader {
         Some(out)
     }
 
+    /// Read the per-file FILEDIGESTS values + their algorithm.
+    /// Returns `None` when FILEDIGESTS is absent, when the
+    /// FILEDIGESTALGO is set to a code mikebom doesn't recognize
+    /// (defensive — defer to a follow-on rather than emit a
+    /// mis-prefixed cross-ref), or when the digest array is empty.
+    ///
+    /// Per the rpm spec, FILEDIGESTALGO absent or `0` means MD5
+    /// (legacy default); we honor that. Algorithm codes other than
+    /// the standard `{1, 2, 8, 9, 10}` set return `None` with a
+    /// debug-log breadcrumb.
+    pub fn file_digests(&self) -> Option<RpmFileDigests<'_>> {
+        let values = self.string_array(TAG_FILEDIGESTS)?;
+        if values.is_empty() {
+            return None;
+        }
+        let algo_code: u32 = self
+            .int32_array(TAG_FILEDIGESTALGO)
+            .and_then(|v| v.first().copied())
+            .unwrap_or(0);
+        let algo = match algo_code {
+            0 | 1 => RpmDigestAlgo::Md5,
+            2 => RpmDigestAlgo::Sha1,
+            8 => RpmDigestAlgo::Sha256,
+            9 => RpmDigestAlgo::Sha384,
+            10 => RpmDigestAlgo::Sha512,
+            other => {
+                tracing::debug!(
+                    code = other,
+                    "rpm FILEDIGESTALGO is an unknown IANA hash code; \
+                     omitting rpm_filedigest cross-ref for this package"
+                );
+                return None;
+            }
+        };
+        Some(RpmFileDigests { algo, values })
+    }
+
     /// Reconstruct the owned file paths from the
     /// BASENAMES/DIRNAMES/DIRINDEXES triple. Returns an empty vec for
     /// metapackages (no files) or if any tag is missing; individual
@@ -311,6 +359,66 @@ impl RpmHeader {
             paths.push(PathBuf::from(p));
         }
         paths
+    }
+}
+
+/// Per-file digests + algorithm extracted from a HeaderBlob's
+/// FILEDIGESTS / FILEDIGESTALGO tags. Borrows the digest strings
+/// from the underlying `RpmHeader` to avoid cloning during the
+/// per-package walk; consumers that need owned data clone at
+/// emission time.
+pub struct RpmFileDigests<'a> {
+    /// Hash algorithm rpm used to compute the digests. Encoded as
+    /// the IANA hash-algorithm-name slug for emission (e.g.
+    /// `"sha256"`, `"md5"`).
+    pub algo: RpmDigestAlgo,
+    /// Hex-encoded per-file digest values, parallel-indexed with
+    /// `BASENAMES`. Each entry's length matches `algo.hex_len()`
+    /// when populated; empty entries (non-regular files) and
+    /// shorter-than-expected ones are filtered at emission time.
+    pub values: Vec<&'a str>,
+}
+
+/// Hash-algorithm name for the rpm FILEDIGESTS tag, decoded from
+/// the IANA hash-algorithm registry code carried in
+/// FILEDIGESTALGO. Set is restricted to the 5 algorithms rpm
+/// actually uses today; unknown codes fall through to `None` at
+/// the call site rather than getting a `RpmDigestAlgo::Other`
+/// variant (defensive against mis-prefixing the cross-ref).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RpmDigestAlgo {
+    Md5,
+    Sha1,
+    Sha256,
+    Sha384,
+    Sha512,
+}
+
+impl RpmDigestAlgo {
+    /// IANA-spec lowercase name. Used as the algorithm prefix in
+    /// the wire form `<algo>:<hex>`.
+    pub fn name(&self) -> &'static str {
+        match self {
+            RpmDigestAlgo::Md5 => "md5",
+            RpmDigestAlgo::Sha1 => "sha1",
+            RpmDigestAlgo::Sha256 => "sha256",
+            RpmDigestAlgo::Sha384 => "sha384",
+            RpmDigestAlgo::Sha512 => "sha512",
+        }
+    }
+
+    /// Expected hex-string length for this algorithm. Used to
+    /// filter out empty or truncated FILEDIGESTS entries (rpm
+    /// records empty strings for non-regular files like devices /
+    /// fifos).
+    pub fn hex_len(&self) -> usize {
+        match self {
+            RpmDigestAlgo::Md5 => 32,
+            RpmDigestAlgo::Sha1 => 40,
+            RpmDigestAlgo::Sha256 => 64,
+            RpmDigestAlgo::Sha384 => 96,
+            RpmDigestAlgo::Sha512 => 128,
+        }
     }
 }
 
@@ -559,5 +667,88 @@ mod tests {
         let h = RpmHeader::parse(&blob).unwrap();
         // "good" resolves, "bad" is skipped.
         assert_eq!(h.file_paths(), vec![PathBuf::from("/usr/bin/good")]);
+    }
+
+    // ---- Milestone 041: FILEDIGESTS / FILEDIGESTALGO --------------------
+
+    #[test]
+    fn file_digests_decodes_sha256_payload() {
+        let aaa = "a".repeat(64);
+        let bbb = "b".repeat(64);
+        let blob = build_test_header(&[
+            (TAG_FILEDIGESTS, TagValue::StrArray(&[&aaa, &bbb])),
+            (TAG_FILEDIGESTALGO, TagValue::Int32Array(&[8])),
+        ]);
+        let h = RpmHeader::parse(&blob).unwrap();
+        let fd = h.file_digests().expect("FILEDIGESTS present");
+        assert_eq!(fd.algo, RpmDigestAlgo::Sha256);
+        assert_eq!(fd.values.len(), 2);
+        assert_eq!(fd.values[0], aaa);
+        assert_eq!(fd.values[1], bbb);
+    }
+
+    #[test]
+    fn file_digests_defaults_to_md5_when_algo_absent() {
+        let md5 = "0".repeat(32);
+        let blob = build_test_header(&[
+            (TAG_FILEDIGESTS, TagValue::StrArray(&[&md5])),
+            // No FILEDIGESTALGO — must default to MD5.
+        ]);
+        let h = RpmHeader::parse(&blob).unwrap();
+        let fd = h.file_digests().expect("FILEDIGESTS present");
+        assert_eq!(fd.algo, RpmDigestAlgo::Md5);
+    }
+
+    #[test]
+    fn file_digests_defaults_to_md5_when_algo_zero() {
+        let md5 = "0".repeat(32);
+        let blob = build_test_header(&[
+            (TAG_FILEDIGESTS, TagValue::StrArray(&[&md5])),
+            (TAG_FILEDIGESTALGO, TagValue::Int32Array(&[0])),
+        ]);
+        let h = RpmHeader::parse(&blob).unwrap();
+        let fd = h.file_digests().expect("FILEDIGESTS present");
+        assert_eq!(fd.algo, RpmDigestAlgo::Md5);
+    }
+
+    #[test]
+    fn file_digests_returns_none_when_filedigests_absent() {
+        let blob = build_test_header(&[
+            (TAG_NAME, TagValue::Str("bash")),
+            // No FILEDIGESTS.
+        ]);
+        let h = RpmHeader::parse(&blob).unwrap();
+        assert!(h.file_digests().is_none());
+    }
+
+    #[test]
+    fn file_digests_returns_none_for_unknown_algo() {
+        let blob = build_test_header(&[
+            (TAG_FILEDIGESTS, TagValue::StrArray(&["abc"])),
+            (TAG_FILEDIGESTALGO, TagValue::Int32Array(&[99])), // unknown
+        ]);
+        let h = RpmHeader::parse(&blob).unwrap();
+        assert!(
+            h.file_digests().is_none(),
+            "unknown FILEDIGESTALGO must reject (defensive against mis-prefixing)"
+        );
+    }
+
+    #[test]
+    fn rpm_digest_algo_names_match_iana_lowercase() {
+        assert_eq!(RpmDigestAlgo::Md5.name(), "md5");
+        assert_eq!(RpmDigestAlgo::Sha1.name(), "sha1");
+        assert_eq!(RpmDigestAlgo::Sha256.name(), "sha256");
+        assert_eq!(RpmDigestAlgo::Sha384.name(), "sha384");
+        assert_eq!(RpmDigestAlgo::Sha512.name(), "sha512");
+    }
+
+    #[test]
+    fn rpm_digest_algo_hex_lengths_are_correct() {
+        assert_eq!(RpmDigestAlgo::Md5.hex_len(), 32);
+        assert_eq!(RpmDigestAlgo::Sha1.hex_len(), 40);
+        assert_eq!(RpmDigestAlgo::Sha256.hex_len(), 64);
+        assert_eq!(RpmDigestAlgo::Sha384.hex_len(), 96);
+        assert_eq!(RpmDigestAlgo::Sha512.hex_len(), 128);
     }
 }

--- a/mikebom-common/src/resolution.rs
+++ b/mikebom-common/src/resolution.rs
@@ -240,6 +240,14 @@ pub struct FileOccurrence {
     /// omitted the `Z:` line. Milestone 040 / #75 follow-on.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub apk_sha1: Option<String>,
+    /// rpm-provided per-file digest from the package's
+    /// `FILEDIGESTS` tag, in algorithm-prefixed form
+    /// (`"sha256:<hex>"`, `"md5:<hex>"`, etc.). `None` for non-rpm
+    /// occurrences (deb, apk) and for rpm files whose stanza had
+    /// no usable cross-ref (non-regular files, missing
+    /// FILEDIGESTS, unknown FILEDIGESTALGO). Milestone 041.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rpm_file_digest: Option<String>,
 }
 
 /// Evidence describing how a component was resolved from trace data.

--- a/specs/041-rpm-filedigests/checklists/requirements.md
+++ b/specs/041-rpm-filedigests/checklists/requirements.md
@@ -1,0 +1,53 @@
+# Specification Quality Checklist: Rpm FILEDIGESTS Cross-Reference
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Validation Notes
+
+- Single-story milestone closing a documented Q1 deferral from
+  milestone 040. Mirrors milestone-040 US2 (apk SHA-1 cross-ref)
+  in shape; the relevant differences are algorithm-awareness
+  (rpm digests vary by package vintage; apk's are always SHA-1)
+  and the tag-source (rpm HeaderBlob vs apk Z: line).
+- Domain technical terms used (FILEDIGESTS, FILEDIGESTALGO, IANA
+  hash-algorithm registry codes, additionalContext) are
+  ecosystem vocabulary appropriate for the SBOM-tooling
+  audience.
+- No `[NEEDS CLARIFICATION]` markers — the milestone-040 work
+  established the pattern; algorithm-awareness is a small
+  scope adjustment.
+- Out-of-scope explicitly excludes the schema-level `hashes`
+  array refactor and the container layer attribution work.
+
+## Notes
+
+- Items marked incomplete require spec updates before
+  `/speckit.clarify` or `/speckit.plan`. All items currently
+  pass.

--- a/specs/041-rpm-filedigests/plan.md
+++ b/specs/041-rpm-filedigests/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: Rpm FILEDIGESTS Cross-Reference
+
+**Branch**: `041-rpm-filedigests` | **Date**: 2026-04-29 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Mirror milestone 040 US2 (apk SHA-1 cross-ref) for rpm. The rpm
+HeaderBlob already carries per-file digests inline via the
+FILEDIGESTS (1035) and FILEDIGESTALGO (5011) tags; mikebom's
+existing `RpmHeader::string_array` and `int32_array` accessors
+expose them with no new parsing infrastructure. The work is:
+
+1. Extend `RpmHeader` with a `file_digests()` accessor that
+   returns the per-file digests + algorithm code.
+2. Thread the digests through `iter_rpmdb`'s visitor signature so
+   `read_file_lists` can return them alongside the path list.
+3. Add a new optional `rpm_file_digest: Option<String>` field on
+   `mikebom_common::resolution::FileOccurrence`.
+4. Surface the value in CDX `additionalContext` under the key
+   `rpm_filedigest`.
+
+Total ~200 LOC across 5 files; single PR with 3 atomic commits.
+
+## Technical Context
+
+**Language**: Rust stable.
+**Primary Dependencies**: existing only. No new top-level deps.
+**Project Type**: CLI / library (three-crate workspace).
+**Performance**: zero impact — FILEDIGESTS extraction reuses the
+HeaderBlob walk that already happens for BASENAMES / DIRNAMES /
+DIRINDEXES. Per-file emission is a String clone.
+**Constraints**: Constitution Principles I, IV, V (output schema
+unchanged at the CDX/SPDX wire level — `additionalContext` is a
+JSON-string opaque to the spec), VI (three-crate preserved).
+
+## Constitution Check
+
+| Principle | Status |
+|---|---|
+| I. Pure Rust, Zero C | ✅ no new deps |
+| IV. Type-Driven Correctness | ✅ optional field; algorithm-prefixed string preserves provenance |
+| V. Specification Compliance | ✅ wire shape unchanged; new key carried opaquely in `additionalContext` |
+| VI. Three-Crate Architecture | ✅ touches mikebom-cli + one additive field on mikebom-common |
+| VIII. Completeness | ✅ closes a known false-negative on cross-ref symmetry |
+| X. Transparency | ✅ rpm_filedigest is annotated upstream-provenance metadata |
+
+**No constitution violations.**
+
+## Touched files
+
+| File | Change | LOC |
+|---|---|---|
+| `mikebom-cli/src/scan_fs/package_db/rpmdb_sqlite/rpm_header.rs` | + TAG_FILEDIGESTS / TAG_FILEDIGESTALGO consts; + `file_digests()` accessor + algo-code → name mapper | +60 |
+| `mikebom-cli/src/scan_fs/package_db/rpm.rs` | + `iter_rpmdb` visitor signature gains a 3rd arg (digests); + `read_file_lists` returns `Vec<RpmFileEntry>` not `Vec<String>` | +80 |
+| `mikebom-cli/src/scan_fs/package_db/file_hashes.rs` | thread digest into per-file emission; update `hash_rpm_package_files` signature; tests | +50 |
+| `mikebom-cli/src/scan_fs/mod.rs` | mechanical signature update at the call site | +5 |
+| `mikebom-cli/src/generate/cyclonedx/evidence.rs` | + `rpm_filedigest` key emission alongside `sha1` | +5 |
+| `mikebom-common/src/resolution.rs` | + `rpm_file_digest: Option<String>` field on `FileOccurrence` | +6 |
+| `mikebom-cli/tests/oci_registry_smoke.rs` | OPTIONAL: add gated fedora smoke test that asserts the new key | +60 |
+
+Total ~265 LOC.
+
+## Phasing
+
+Three commits.
+
+1. **`feat(041/extract-filedigests)`** — Add tag consts +
+   `RpmHeader::file_digests` accessor; thread through
+   `iter_rpmdb` + `read_file_lists`. New `RpmFileEntry` struct.
+   Behind dead-code allow for the wire-up gap.
+2. **`feat(041/thread-and-emit)`** — `FileOccurrence` field;
+   `hash_rpm_package_files` signature change; emitter clause.
+   Smoke-test extension (optional gated test).
+3. **`docs(041)`** — User-guide rpm paragraph update; CHANGELOG.
+
+## Risks
+
+- **R1 (algorithm registry)**: rpm uses IANA hash-algorithm
+  numbers per RFC 4880-ish convention. The set
+  `{1: md5, 2: sha1, 8: sha256, 9: sha384, 10: sha512}` is well-
+  documented. SHA-3 family codes (11+) aren't typically used by
+  rpm yet — silently skip the cross-ref for unknown codes.
+- **R2 (FILEDIGESTS array length)**: should always match
+  BASENAMES per the rpm spec. If they differ (damaged
+  HeaderBlob), use `min(len)` and skip the over-extension —
+  matches the `iter_rpmdb` posture for DIRINDEXES out-of-range
+  entries.
+
+## Constitution alignment
+
+All twelve principles green. No new C deps; no `.unwrap()` in
+production paths; three-crate preserved; spec compliance
+preserved (wire format unchanged at the CycloneDX / SPDX level).

--- a/specs/041-rpm-filedigests/spec.md
+++ b/specs/041-rpm-filedigests/spec.md
@@ -1,0 +1,189 @@
+# Feature Specification: Rpm FILEDIGESTS Cross-Reference
+
+**Feature Branch**: `041-rpm-filedigests`
+**Created**: 2026-04-29
+**Status**: Draft
+**Input**: User description: "Rpm FILEDIGESTS cross-reference for additionalContext (per-file upstream-provided digest)"
+
+## User Scenarios & Testing *(mandatory)*
+
+Milestone 040 Q1 deferred the rpm FILEDIGESTS cross-reference to a
+follow-on. This milestone closes that. After it ships, every
+populated rpm `evidence.occurrences[]` entry's `additionalContext`
+JSON-string carries both `sha256` (mikebom-computed from on-disk
+bytes at scan time) AND `rpm_filedigest` (the upstream-provided
+per-file digest from the rpm package's HeaderBlob FILEDIGESTS
+tag). This brings rpm to full cross-ref symmetry with deb (which
+carries `md5`) and apk (which carries `sha1`).
+
+### User Story 1 - Per-file digest cross-ref for rpm components (Priority: P1)
+
+An SBOM consumer correlating a rpm component's per-file evidence
+against an upstream-published checksum (rpm-sigcheck-style
+verification, vulnerability-scan tooling that already trusts the
+rpm-distro digests, or compliance audits that require an
+upstream-provenance claim) wants the same cross-reference checksum
+deb and apk components carry. Today rpm components ship with
+mikebom-computed SHA-256 only — the upstream digest from the
+package's FILEDIGESTS tag is parsed but discarded.
+
+**Why this priority**: small, contained symmetry-completion
+milestone. Closes a documented Q1 deferral from milestone 040.
+Mirrors milestone 040 US2 (apk SHA-1 cross-ref) almost exactly in
+shape — single new field, single new emitter clause, single new
+ecosystem-specific accessor on the rpm header.
+
+**Independent Test**: Run `mikebom sbom scan --image fedora:40
+--output fedora.cdx.json` and inspect a populated rpm
+occurrence's `additionalContext`: it now contains both `sha256`
+(mikebom-computed) AND `rpm_filedigest` (algorithm-prefixed:
+`sha256:<hex>` for modern rpm packages, `md5:<hex>` for older
+ones), where today only `sha256` appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a modern rpm-based image (`fedora:40`,
+   `almalinux:9`, etc.), **When** the user runs an SBOM scan,
+   **Then** every populated rpm occurrence's `additionalContext`
+   carries both `sha256` AND `rpm_filedigest`. The
+   `rpm_filedigest` value uses the algorithm-prefix form
+   (e.g. `sha256:<64-hex>`).
+2. **Given** an older rpm-based image whose FILEDIGESTS use a
+   non-default algorithm (e.g. an old CentOS-7-era package using
+   MD5-encoded digests), **When** the user runs a scan, **Then**
+   the `rpm_filedigest` carries the algorithm prefix that
+   matches the package's actual choice (e.g. `md5:<32-hex>`).
+3. **Given** a malformed or empty FILEDIGESTS tag (rare; would
+   indicate a damaged rpmdb), **When** the user runs a scan,
+   **Then** the affected occurrences carry `sha256` only —
+   `rpm_filedigest` is omitted from `additionalContext` for
+   those entries; no error.
+4. **Given** a deb-based image scan or an apk-based image scan,
+   **When** the user runs it after this milestone ships,
+   **Then** the deb / apk output is byte-identical to milestone
+   040's output — only the rpm path's `additionalContext`
+   carries the new `rpm_filedigest` key.
+
+---
+
+### Edge Cases
+
+- **FILEDIGESTALGO tag missing or zero**: per the rpm spec, when
+  FILEDIGESTALGO is absent or set to `0`, the algorithm defaults
+  to MD5. mikebom honors this default rather than failing.
+- **FILEDIGESTS array length mismatched against BASENAMES**:
+  rare; would indicate a damaged HeaderBlob. mikebom emits
+  `rpm_filedigest` only for indices where both arrays have a
+  value; out-of-range entries get no cross-ref (sha256-only).
+- **Unknown / future FILEDIGESTALGO codes**: the IANA hash-
+  algorithm registry has codes for SHA-3 family etc. that
+  aren't typically used by rpm yet. mikebom silently omits
+  `rpm_filedigest` for unknown codes rather than emitting a
+  partial / mis-prefixed string. A debug log notes the unknown
+  code so operators can surface it if needed.
+- **Empty per-file digest string**: rpm sometimes ships empty
+  FILEDIGESTS entries for non-regular files (devices, fifos,
+  symlinks). mikebom omits `rpm_filedigest` for those entries.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When mikebom scans an rpm-based image, each
+  populated `evidence.occurrences[]` entry MUST carry an
+  `rpm_filedigest` key in its `additionalContext` JSON-string
+  alongside the existing `sha256` key, taking the form
+  `<algorithm>:<lowercase-hex>` where `<algorithm>` is one of:
+  `md5`, `sha1`, `sha256`, `sha384`, `sha512` (the algorithms
+  rpm currently uses; matches the IANA hash-algorithm registry
+  values rpm honors).
+
+- **FR-002**: The algorithm encoded in `rpm_filedigest` MUST
+  match the package's actual FILEDIGESTALGO value (or default
+  to MD5 when FILEDIGESTALGO is absent / zero, per the rpm
+  spec).
+
+- **FR-003**: Occurrences whose underlying FILEDIGESTS entry is
+  empty (non-regular files in the package) or missing
+  (mismatched array lengths) MUST appear in the SBOM with the
+  existing `sha256` cross-ref but with `rpm_filedigest` OMITTED
+  from `additionalContext`. The scan MUST NOT fail.
+
+- **FR-004**: Deb-based image scans and apk-based image scans
+  MUST be byte-identical to milestone 040's output. Only the
+  rpm-side `additionalContext` adds the new key.
+
+- **FR-005**: No new top-level Cargo dependencies. Reuses
+  `sha2`, the existing rpm header reader, and stdlib.
+
+- **FR-006**: The byte-identity goldens MUST regen with zero
+  diff (the 27-fixture suite uses `--no-deep-hash`, which
+  emits no per-file occurrences and is therefore insulated
+  from this change by design).
+
+### Key Entities
+
+- **Rpm FILEDIGESTS tag (1035)**: a string-array tag in the
+  rpm HeaderBlob, parallel to BASENAMES. Each entry is a
+  hex-encoded digest of the corresponding file's content as
+  computed by the rpm packager at build time.
+- **Rpm FILEDIGESTALGO tag (5011)**: an int32 tag carrying
+  the IANA hash-algorithm code that FILEDIGESTS uses. Common
+  values: `1`=MD5, `2`=SHA-1, `8`=SHA-256, `9`=SHA-384,
+  `10`=SHA-512. Absent / `0` → MD5 (legacy default).
+- **`FileOccurrence.rpm_file_digest`**: new optional
+  `Option<String>` field on the existing
+  `mikebom_common::resolution::FileOccurrence` carrying the
+  algorithm-prefixed form (e.g. `"sha256:abc..."`) for rpm
+  occurrences. None for non-rpm occurrences (deb, apk).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A scan of `fedora:40` produces an SBOM where every
+  populated rpm occurrence's `additionalContext` carries both
+  `sha256` and `rpm_filedigest` — measurable as `100%` of
+  populated rpm occurrences having both keys (today: 0%).
+
+- **SC-002**: For at least one rpm package in `fedora:40`, the
+  `rpm_filedigest` value MUST match the upstream-published rpm
+  for that package — verifiable by hand-checking against
+  `rpm -ql --dump <pkg>` (which emits per-file SHA-256 digests).
+
+- **SC-003**: A scan of `alpine:3.19` (apk) and
+  `debian:bookworm-slim` (deb) produces an SBOM byte-identical
+  to milestone 040's output — measurable as the existing
+  byte-identity goldens regenning with zero diff AND the
+  apk/deb portions of the live-image SBOMs comparing equal
+  via canonical-JSON diff.
+
+- **SC-004**: All 3 CI lanes green.
+
+## Assumptions
+
+- The rpm packages in `fedora:40` use SHA-256 FILEDIGESTS
+  (the modern default since dnf 4 / rpm 4.14, ~2018). Older
+  RHEL / CentOS rpm versions use SHA-1 or MD5; mikebom
+  handles all three uniformly via the FILEDIGESTALGO tag.
+- "rpm-based image" includes the same set as milestone 040:
+  `fedora:*`, `almalinux:*`, `rockylinux:*`,
+  `centos:stream*`, `redhat/*`. No additional rpm-variant
+  detection is needed.
+- mikebom's existing `RpmHeader::string_array` /
+  `int32_array` accessors handle the FILEDIGESTS / FILEDIGESTALGO
+  tag-types correctly (FILEDIGESTS is a STRING_ARRAY = type 8;
+  FILEDIGESTALGO is INT32 = type 4).
+
+## Out of scope
+
+- Modifying the on-disk Merkle root computation. The
+  per-component Merkle root remains a function of
+  occurrence locations + observed SHA-256s only. The new
+  cross-ref is purely advisory metadata.
+- Schema-level `hashes` array on `FileOccurrence` (would
+  unify cross-ref carriers across deb / apk / rpm; defer
+  until external demand surfaces).
+- Container layer attribution (separate architectural
+  milestone; pre-existing deferred item).
+- Maven sidecar Debian / Alpine variants (separate concern).

--- a/specs/041-rpm-filedigests/tasks.md
+++ b/specs/041-rpm-filedigests/tasks.md
@@ -1,0 +1,67 @@
+---
+description: "Task list — milestone 041 rpm FILEDIGESTS cross-reference"
+---
+
+# Tasks: Rpm FILEDIGESTS Cross-Reference
+
+**Input**: spec.md ✅, plan.md ✅, checklists/requirements.md ✅.
+
+**Tests**: included — inline coverage for the new accessor + the
+threading + a gated smoke test.
+
+**Organization**: Single user story (P1). Three atomic commits.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 `./scripts/pre-pr.sh` clean before any changes (baseline).
+- [ ] T002 Confirm milestone 040's distroless / alpine / fedora pipelines still resolve via gated smoke run (or local manual `mikebom sbom scan --image fedora:40`).
+
+---
+
+## Phase 2: Commit `feat(041/extract-filedigests)`
+
+- [ ] T003 [US1] Add `pub const TAG_FILEDIGESTS: u32 = 1035;` and `pub const TAG_FILEDIGESTALGO: u32 = 5011;` to `mikebom-cli/src/scan_fs/package_db/rpmdb_sqlite/rpm_header.rs` (alongside the existing TAG_BASENAMES etc.).
+- [ ] T004 [US1] Add `pub fn file_digests(&self) -> Option<RpmFileDigests>` to `RpmHeader` returning `{ algo: RpmDigestAlgo, values: Vec<&str> }`. Looks up FILEDIGESTS via `string_array` and FILEDIGESTALGO via `int32_array().first()`. Algorithm decoding: `1=md5, 2=sha1, 8=sha256, 9=sha384, 10=sha512`. Absent / `0` defaults to MD5 per the rpm spec.
+- [ ] T005 [US1] Add `pub enum RpmDigestAlgo { Md5, Sha1, Sha256, Sha384, Sha512 }` with a `pub fn name(&self) -> &'static str` returning the lowercase form (`"md5"`, `"sha1"`, etc.).
+- [ ] T006 [US1] Add inline test `file_digests_decodes_sha256_payload` in `rpm_header.rs::tests`: synthetic header with FILEDIGESTS=["abc...", "def..."], FILEDIGESTALGO=8; assert returned struct has algo=Sha256 and values match.
+- [ ] T007 [US1] Add inline test `file_digests_defaults_to_md5_when_algo_absent` in `rpm_header.rs::tests`: synthetic header with FILEDIGESTS but no FILEDIGESTALGO; assert algo=Md5.
+- [ ] T008 [US1] Add inline test `file_digests_returns_none_when_filedigests_absent` in `rpm_header.rs::tests`: synthetic header with no FILEDIGESTS; assert None.
+- [ ] T009 [US1] Add inline test `file_digests_returns_none_for_unknown_algo` in `rpm_header.rs::tests`: synthetic header with FILEDIGESTALGO=99; assert None (defensive — unknown algo treated as no cross-ref rather than mis-prefixed).
+- [ ] T010 [US1] Update `iter_rpmdb` in `mikebom-cli/src/scan_fs/package_db/rpm.rs`: extend the visitor signature from `FnMut(PackageDbEntry, Vec<PathBuf>)` to `FnMut(PackageDbEntry, Vec<PathBuf>, Option<RpmFileDigests<'_>>)` (or owned variant). Existing call sites add an `_` for the new arg.
+- [ ] T011 [US1] Update `pub fn read_file_lists` in `rpm.rs`: change return type from `HashMap<String, Vec<String>>` to `HashMap<String, Vec<RpmFileEntry>>` where `RpmFileEntry { path: String, digest: Option<String> }`. The digest is the algorithm-prefixed form, e.g. `"sha256:<hex>"`. Empty-or-mismatched-length per-file digests yield `digest: None`.
+- [ ] T012 [P] [US1] Add inline test in `rpm.rs::tests` for `read_file_lists` returning per-file digests using the existing fixture-builder. (Use `build_test_header` with FILEDIGESTS + FILEDIGESTALGO=8.)
+- [ ] T013 [US1] Existing `collect_claimed_paths` and the `read` function visitor adapter need updating (they ignore the new arg).
+- [ ] T014 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T015 [US1] Commit: `feat(041/extract-filedigests): rpm FILEDIGESTS + FILEDIGESTALGO accessor on HeaderBlob`.
+
+---
+
+## Phase 3: Commit `feat(041/thread-and-emit)`
+
+- [ ] T016 [US1] Add `rpm_file_digest: Option<String>` field to `mikebom_common::resolution::FileOccurrence`. `#[serde(default, skip_serializing_if = "Option::is_none")]` for backwards-compat.
+- [ ] T017 [US1] Update `hash_rpm_package_files` in `file_hashes.rs`: change signature from `&[String]` to `&[RpmFileEntry]`. Inside the per-file loop, copy `entry.digest` onto the resulting `FileOccurrence.rpm_file_digest`.
+- [ ] T018 [US1] Update existing `hash_rpm_package_files_*` inline tests to construct `RpmFileEntry`s with `digest: None`.
+- [ ] T019 [US1] Edit `mikebom-cli/src/generate/cyclonedx/evidence.rs`: when serializing per-occurrence `additionalContext`, if `o.rpm_file_digest.is_some()`, include `"rpm_filedigest": "<value>"` alongside the existing keys.
+- [ ] T020 [US1] Update the call site in `mikebom-cli/src/scan_fs/mod.rs`: `rpm_file_lists` now yields `Vec<RpmFileEntry>` not `Vec<String>`. Pass through unchanged.
+- [ ] T021 [US1] Update existing `evidence.rs` inline tests that construct `FileOccurrence`s — add `rpm_file_digest: None` to each.
+- [ ] T022 [P] [US1] Add inline test `hash_rpm_package_files_threads_digest_when_provided` in `file_hashes.rs::tests`: pass an `RpmFileEntry` with `digest: Some("sha256:<hex>")`; assert resulting occurrence's `rpm_file_digest` matches.
+- [ ] T023 [US1] [optional] Extend `mikebom-cli/tests/oci_registry_smoke.rs` with a gated test that pulls `fedora:40`, asserts `> 0` rpm occurrences carry an `rpm_filedigest` key in `additionalContext`. Gated on `MIKEBOM_OCI_NETWORK_TESTS=1` like the existing alpine smoke.
+- [ ] T024 [US1] Run goldens regen: `MIKEBOM_UPDATE_*_GOLDENS=1 cargo +stable test -p mikebom --test '*'`. Confirm zero diff under `mikebom-cli/tests/fixtures/27/` (the goldens use `--no-deep-hash` so they're insulated).
+- [ ] T025 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T026 [US1] Commit: `feat(041/thread-and-emit): rpm_filedigest cross-ref in additionalContext alongside sha256`.
+
+---
+
+## Phase 4: Commit `docs(041)` + PR
+
+- [ ] T027 [US1] Update `docs/user-guide/cli-reference.md` rpm paragraph: drop the "FILEDIGESTS as a future extension" qualifier (now closed); note that `rpm_filedigest` carries the algorithm-prefixed form.
+- [ ] T028 [US1] Add CHANGELOG Unreleased entry summarizing milestone 041 — closes the Q1 deferral from milestone 040; rpm now has full cross-ref symmetry with deb (md5) and apk (sha1).
+- [ ] T029 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T030 [US1] Commit: `docs(041): rpm_filedigest cross-ref — user-guide + CHANGELOG`.
+- [ ] T031 Push branch.
+- [ ] T032 Open PR titled `feat(041): rpm FILEDIGESTS cross-reference (closes milestone-040 Q1 deferral)`.
+- [ ] T033 Verify all 3 CI lanes green.


### PR DESCRIPTION
## Summary

Closes the milestone-040 Q1 deferral. Rpm components now carry the upstream-provided per-file digest from each package's \`FILEDIGESTS\` tag as a cross-reference checksum in \`additionalContext\`, alongside the existing mikebom-computed \`sha256\`. Brings rpm to full cross-ref symmetry with deb (\`md5\`, milestone 037) and apk (\`sha1\`, milestone 040).

## Commits (3)

1. **\`spec(041)\`** — Slim 4-file spec set with 1 user story, 6 FRs, 4 SCs.
2. **\`feat(041)\`** — Implementation across 6 files (rpm_header.rs constants + accessor; rpm.rs RpmFileEntry/RpmFileListEntry + visitor signature; file_hashes.rs hash_rpm_package_files signature; mod.rs call site; evidence.rs CDX emitter; mikebom-common FileOccurrence field). 8 new inline tests + 1 updated existing test.
3. **\`docs(041)\`** — User-guide rpm paragraph update + CHANGELOG.

## Concrete results

Verified end-to-end against \`fedora:40\`:

| Metric | Pre-041 | Post-041 |
|---|---|---|
| Components | 147 | 147 |
| Total file occurrences | 6966 | 6966 |
| Occurrences with \`rpm_filedigest\` | 0 | **6938 (99.6%)** |

The 28 remainder (~0.4%) are non-regular files (devices, fifos, symlinks) whose FILEDIGESTS entry is empty by rpm-spec convention — handled gracefully per FR-003.

Sample value: \`rpm_filedigest = "sha256:7544bd2997fcbd130100d023ab0cc191e1ea1b7d50818673148f088ae6002827"\`, matching mikebom's own observed \`sha256\` for that file (integrity-check is working: rpm-claimed digest equals rpm-observed digest = no tampering detected).

## Wire format

Algorithm-prefixed value carries the algorithm name from the IANA hash-algorithm registry code in FILEDIGESTALGO:

\`\`\`json
// modern rpm packages (rpm 4.14+, ~2018+)
{ "sha256": "<mikebom-observed>", "rpm_filedigest": "sha256:<upstream-claimed>" }

// legacy CentOS-7-era packages (FILEDIGESTALGO=2)
{ "sha256": "<mikebom-observed>", "rpm_filedigest": "sha1:<upstream-claimed>" }

// pre-FILEDIGESTALGO packages (default to MD5 per rpm spec)
{ "sha256": "<mikebom-observed>", "rpm_filedigest": "md5:<upstream-claimed>" }
\`\`\`

Unknown / future FILEDIGESTALGO codes (e.g. SHA-3 family) silently skip the cross-ref rather than emit a mis-prefixed string.

## Cross-ref symmetry across OS-package ecosystems

After this PR:

| Ecosystem | Cross-ref key | Algorithm | Source |
|---|---|---|---|
| deb (037) | \`md5\` | MD5 (fixed) | dpkg \`.md5sums\` |
| apk (040 US2) | \`sha1\` | SHA-1 (fixed) | apk \`Z:\` line |
| **rpm (041)** | **\`rpm_filedigest\`** | **algorithm-prefixed (md5 / sha1 / sha256 / sha384 / sha512)** | **rpm FILEDIGESTS + FILEDIGESTALGO** |

## Verification

- ✅ \`./scripts/pre-pr.sh\` clean.
- ✅ Binary tests went 1176 → 1184 (8 new rpm tests).
- ✅ \`MIKEBOM_UPDATE_*_GOLDENS=1 cargo +stable test -p mikebom --test '*'\` produces zero diff (the goldens use \`--no-deep-hash\` so they're insulated from the deep-hash path by design).
- ✅ No new top-level deps. \`no_c_dependencies_in_tree\` regression still green.
- ✅ \`git diff main..HEAD -- mikebom-cli/src/parity/ mikebom-cli/src/generate/cyclonedx/dependencies.rs mikebom-cli/src/generate/cyclonedx/vex.rs mikebom-cli/src/resolve/\` empty.

## Test plan

- [ ] CI green on all 3 lanes.
- [ ] Manual fedora verification:
      \`\`\`bash
      mikebom sbom scan --image fedora:40 --output /tmp/fedora.cdx.json
      jq -r '[.components[].evidence.occurrences[]?.additionalContext] | map(fromjson?) | map(select(.rpm_filedigest != null)) | length' /tmp/fedora.cdx.json
      # expected: > 0 (was 0 pre-041)
      \`\`\`
- [ ] No regression on deb / apk: existing \`alpine:3.19\` and \`debian:bookworm-slim\` SBOMs unchanged.

## Out of scope (future)

- Schema-level \`hashes\` array on \`FileOccurrence\` (would unify cross-ref carriers across deb \`md5\`, apk \`sha1\`, rpm \`rpm_filedigest\` — but requires a wider serializer change; defer until external demand surfaces).
- Container layer attribution (pre-existing deferred item from the milestone-023 roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)