### PR TITLE
feat(042): post-041 small follow-ons (stale comment + Maven Debian sidecar)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 ## [Unreleased]
 
 ### Added
+- **Milestone 042 — Post-041 small follow-ons.** Two unrelated
+  legacy-deferral items closed:
+  - **US1 (housekeeping)**: dropped a stale comment in
+    `binary/predicates.rs:88` that named rpm file-list
+    extraction from HeaderBlob `BASENAMES` / `DIRNAMES` /
+    `DIRINDEXES` as "deferred to a follow-on milestone." That
+    work shipped in milestone 040 US3; the comment now
+    accurately credits 040 US3 as the authoritative claim
+    source and explains the directory-heuristic's role as a
+    defense-in-depth fallback for corrupt / partial rpmdb cases.
+  - **US2 (Maven sidecar Debian layout)**: extends
+    `maven_sidecar.rs` with a parallel `DebianSidecarIndex`
+    that walks `/usr/share/maven-repo/` (the GAV-tree layout
+    populated by Debian's `maven-repo-helper` during
+    `apt-get install lib*-java`). Debian-shaped Java images
+    that previously emerged as `pkg:generic/<filename>` PURLs
+    now resolve to `pkg:maven/<group>/<artifact>@<version>` —
+    matching the milestone-007 Fedora-side coverage.
+    Implementation introduces a small `SidecarIndex` trait so
+    `resolve_coords` works generically over either layout.
+    Fedora wins on basename collision (FR-005). Alpine
+    layouts remain out of scope (Alpine ships no documented
+    system-wide maven repo convention).
+  - 6 new inline tests for the Debian sidecar reader; 27
+    byte-identity goldens regen with zero diff (no fixture
+    contains `/usr/share/maven-repo/` content).
 - **Milestone 041 — Rpm FILEDIGESTS cross-reference.** Closes
   the milestone-040 Q1 deferral. Every populated rpm
   `evidence.occurrences[]` entry's `additionalContext` JSON-

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -166,6 +166,16 @@ Behaviour notes:
   are dropped. Feature 009; see
   [`docs/ecosystems.md`](../ecosystems.md) and
   [`specs/009-maven-shade-deps/spec.md`](../../specs/009-maven-shade-deps/spec.md).
+- **Distro-installed Java JARs** resolve to maven PURLs across both
+  Fedora-shaped (`/usr/share/maven-poms/<artifact>.pom`, used by
+  `javapackages-tools` / `xmvn` during RPM build) and Debian-shaped
+  (`/usr/share/maven-repo/<group-path>/<artifact>/<version>/<artifact>-<version>.pom`,
+  populated by `maven-repo-helper` when `apt-get install lib*-java` runs)
+  layouts. JARs with no in-archive `META-INF/maven/` metadata fall
+  through to the matching layout's sidecar POM and emerge as
+  `pkg:maven/<group>/<artifact>@<version>` instead of
+  `pkg:generic/<filename>`. Alpine doesn't ship a system-wide maven
+  layout; apk-managed JARs surface as generic components today.
 - `sbom scan` inherits the top-level `--offline`, `--include-dev`,
   `--include-declared-deps`, and `--include-legacy-rpmdb` flags — they
   can be passed either before or after `scan`. See [global flags](#global-flags)

--- a/mikebom-cli/src/scan_fs/binary/predicates.rs
+++ b/mikebom-cli/src/scan_fs/binary/predicates.rs
@@ -84,12 +84,16 @@ pub(super) fn is_host_system_path(soname: &str) -> bool {
         || soname.starts_with("/System/iOSSupport/")
 }
 
-/// RPM directory heuristic per the milestone-004 post-ship plan. RPM
-/// file-list extraction from HeaderBlob BASENAMES/DIRNAMES/DIRINDEXES
-/// is deferred to a follow-on milestone; meanwhile, when we know a
-/// rootfs has an rpmdb (so rpm OWNS the package-install story), any
-/// binary under a well-known OS-managed directory is presumed owned
-/// even if we can't enumerate its specific claim.
+/// RPM directory heuristic per the milestone-004 post-ship plan.
+/// Authoritative file-list extraction from HeaderBlob
+/// BASENAMES/DIRNAMES/DIRINDEXES landed in milestone 040 US3 and is
+/// the primary claim source today; this heuristic remains as a
+/// defense-in-depth fallback for the rare case where a binary lives
+/// under a well-known OS-managed directory but its package's
+/// HeaderBlob is missing or malformed (corrupt rpmdb, partial
+/// install). When a rootfs carries an rpmdb, presuming ownership
+/// for those binaries keeps `pkg:generic/` noise out of the SBOM
+/// even if the precise enumeration falters.
 ///
 /// Well-known OS-managed directories chosen to match filesystem-
 /// hierarchy standards — `/bin`, `/sbin`, `/usr/{bin,sbin,lib,lib64,libexec}`,

--- a/mikebom-cli/src/scan_fs/package_db/maven.rs
+++ b/mikebom-cli/src/scan_fs/package_db/maven.rs
@@ -2267,6 +2267,10 @@ pub fn read_with_claims(
     // isn't Fedora-shaped the index is empty and the sidecar path is
     // a full no-op.
     let sidecar_index = super::maven_sidecar::FedoraSidecarIndex::build(rootfs);
+    // Milestone 042 US2: Debian `/usr/share/maven-repo/` GAV-tree
+    // sidecar reader. Built once per scan; same shape as the
+    // Fedora index. Empty on non-Debian rootfs.
+    let debian_sidecar = super::maven_sidecar::DebianSidecarIndex::build(rootfs);
     let mut sidecar_resolved: usize = 0;
     let mut jar_meta: Vec<(String, Vec<EmbeddedMavenMeta>, Option<String>)> = Vec::new();
     // Feature 009: shade-relocation ancestors parsed from each JAR's
@@ -2328,37 +2332,47 @@ pub fn read_with_claims(
             // strips it during RPM build), try the sidecar index at
             // `/usr/share/maven-poms/`. On miss, the JAR falls
             // through to generic-binary emission per FR-005.
-            if let Some(sidecar_pom_path) = sidecar_index.lookup_for_jar(jar_path) {
-                if let Some((g, a, v)) =
-                    super::maven_sidecar::resolve_coords(sidecar_pom_path, &sidecar_index)
-                {
-                    tracing::debug!(
-                        jar = %jar_path.display(),
-                        sidecar_pom = %sidecar_pom_path.display(),
-                        group = %g,
-                        artifact = %a,
-                        version = %v,
-                        "maven sidecar resolved"
-                    );
-                    let synthetic = EmbeddedMavenMeta {
-                        coord: PomProperties {
-                            group_id: g,
-                            artifact_id: a,
-                            version: v,
-                        },
-                        declared_deps: Vec::new(),
-                        pom_xml_bytes: None,
-                        sidecar_hash: None,
-                        archive_sha256: None,
-                        is_primary: true,
-                    };
-                    jar_meta.push((
-                        jar_path.to_string_lossy().into_owned(),
-                        vec![synthetic],
-                        co_owned_by,
-                    ));
-                    sidecar_resolved += 1;
-                }
+            // Try the Fedora sidecar first (FR-005 winner-on-collision
+            // rule). Falls through to the Debian sidecar on miss.
+            // Milestone 042 US2: the Debian path covers Debian /
+            // Ubuntu Java images where `apt-get install lib*-java` has
+            // populated `/usr/share/maven-repo/` with GAV-tree POMs.
+            let resolved: Option<(&Path, (String, String, String))> = if let Some(p) =
+                sidecar_index.lookup_for_jar(jar_path)
+            {
+                super::maven_sidecar::resolve_coords(p, &sidecar_index).map(|gav| (p, gav))
+            } else if let Some(p) = debian_sidecar.lookup_for_jar(jar_path) {
+                super::maven_sidecar::resolve_coords(p, &debian_sidecar).map(|gav| (p, gav))
+            } else {
+                None
+            };
+            if let Some((sidecar_pom_path, (g, a, v))) = resolved {
+                tracing::debug!(
+                    jar = %jar_path.display(),
+                    sidecar_pom = %sidecar_pom_path.display(),
+                    group = %g,
+                    artifact = %a,
+                    version = %v,
+                    "maven sidecar resolved"
+                );
+                let synthetic = EmbeddedMavenMeta {
+                    coord: PomProperties {
+                        group_id: g,
+                        artifact_id: a,
+                        version: v,
+                    },
+                    declared_deps: Vec::new(),
+                    pom_xml_bytes: None,
+                    sidecar_hash: None,
+                    archive_sha256: None,
+                    is_primary: true,
+                };
+                jar_meta.push((
+                    jar_path.to_string_lossy().into_owned(),
+                    vec![synthetic],
+                    co_owned_by,
+                ));
+                sidecar_resolved += 1;
             }
             continue;
         }
@@ -2374,8 +2388,9 @@ pub fn read_with_claims(
         tracing::info!(
             rootfs = %rootfs.display(),
             resolved = sidecar_resolved,
-            indexed = sidecar_index.len(),
-            "maven sidecar scan: resolved N JARs via /usr/share/maven-poms/"
+            fedora_indexed = sidecar_index.len(),
+            debian_indexed = debian_sidecar.len(),
+            "maven sidecar scan: resolved N JARs via /usr/share/maven-poms/ + /usr/share/maven-repo/"
         );
     }
 

--- a/mikebom-cli/src/scan_fs/package_db/maven_sidecar.rs
+++ b/mikebom-cli/src/scan_fs/package_db/maven_sidecar.rs
@@ -1,19 +1,38 @@
-//! Fedora/RHEL sidecar POM reader.
+//! Sidecar POM readers — Fedora/RHEL and Debian layouts.
 //!
-//! Fedora's `javapackages-tools` / `xmvn` RPM-build pipeline strips
-//! `META-INF/maven/` from JARs and writes the effective POM to
-//! `/usr/share/maven-poms/`. This module lets the Maven reader recover
-//! the Maven coordinates for those JARs by consulting the sidecar POM
-//! directory when the in-JAR metadata is absent.
+//! When a JAR's in-archive `META-INF/maven/` metadata is absent
+//! (a common build-pipeline outcome on distros that strip it during
+//! packaging), mikebom recovers the Maven coordinates from the
+//! distro's external sidecar POM layout:
 //!
-//! Scope (per feature 007 spec, clarification 1): Fedora/RHEL layout
-//! only. Debian's `/usr/share/maven-repo/` GAV layout and Alpine
-//! equivalents are deferred to a follow-up feature.
+//! - **Fedora/RHEL**: `/usr/share/maven-poms/<basename>.pom` — flat
+//!   directory, basename-keyed (handled by [`FedoraSidecarIndex`]).
+//!   `javapackages-tools` / `xmvn` write effective POMs here during
+//!   RPM build.
+//! - **Debian/Ubuntu**: `/usr/share/maven-repo/<group-path>/<artifact>/<version>/<artifact>-<version>.pom`
+//!   — GAV-tree layout (handled by [`DebianSidecarIndex`]).
+//!   `maven-repo-helper` writes per-package POMs here during
+//!   `lib*-java` deb-package install.
+//!
+//! Both layouts produce a basename-keyed index for the same
+//! consumer-side lookup pattern in `package_db::maven`.
+//!
+//! Alpine equivalents remain deferred — Alpine doesn't ship a
+//! documented system-wide maven repo convention.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use super::maven::parse_pom_xml;
+
+/// Common shape across the per-distro sidecar indexes — exposes
+/// only the operation that [`resolve_coords`] needs from the
+/// caller-supplied index (parent-POM lookup by artifactId during
+/// inheritance fallback). Both [`FedoraSidecarIndex`] and
+/// [`DebianSidecarIndex`] implement it.
+pub(crate) trait SidecarIndex {
+    fn lookup_by_artifact_id(&self, artifact_id: &str) -> Option<&Path>;
+}
 
 /// Per-scan in-memory index of a rootfs's `/usr/share/maven-poms/`
 /// directory. Keyed by the canonical basename (JPP- prefix stripped,
@@ -98,6 +117,131 @@ impl FedoraSidecarIndex {
     }
 }
 
+impl SidecarIndex for FedoraSidecarIndex {
+    fn lookup_by_artifact_id(&self, artifact_id: &str) -> Option<&Path> {
+        FedoraSidecarIndex::lookup_by_artifact_id(self, artifact_id)
+    }
+}
+
+/// Per-scan in-memory index of a rootfs's `/usr/share/maven-repo/`
+/// GAV directory tree. Same `by_basename` shape as
+/// [`FedoraSidecarIndex`] so consumer-side lookups don't need to
+/// know which distro produced the POM.
+///
+/// The Debian Java packaging policy (see Debian's `maven-repo-helper`)
+/// places `<artifact>-<version>.pom` files at
+/// `/usr/share/maven-repo/<group-with-slashes>/<artifact>/<version>/`.
+/// We walk the tree and key by `<artifact>` (lowercased), matching
+/// the lookup-by-jar-basename pattern that already drives the
+/// Fedora sidecar.
+#[derive(Debug, Default)]
+pub(crate) struct DebianSidecarIndex {
+    by_basename: HashMap<String, PathBuf>,
+}
+
+impl DebianSidecarIndex {
+    /// Walk `<rootfs>/usr/share/maven-repo/` recursively and
+    /// build the basename → POM-path index. Recursion is depth-
+    /// capped to avoid getting stuck in pathological symlink
+    /// cycles; a depth of 8 segments comfortably exceeds any
+    /// realistic GAV depth (groups rarely exceed 5–6 segments).
+    pub(crate) fn build(rootfs: &Path) -> Self {
+        let mut by_basename: HashMap<String, PathBuf> = HashMap::new();
+        let root = rootfs.join("usr/share/maven-repo");
+        if !root.exists() {
+            return Self { by_basename };
+        }
+        Self::walk(&root, 0, &mut by_basename);
+        Self { by_basename }
+    }
+
+    /// Recursive walker. Caps depth at 8 to bound work in
+    /// pathological cases (cycles, intentional deep nesting).
+    fn walk(dir: &Path, depth: usize, out: &mut HashMap<String, PathBuf>) {
+        const MAX_DEPTH: usize = 8;
+        if depth > MAX_DEPTH {
+            return;
+        }
+        let read = match std::fs::read_dir(dir) {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+        for entry in read.flatten() {
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            if file_type.is_dir() {
+                Self::walk(&path, depth + 1, out);
+                continue;
+            }
+            // Leaf POM: `<artifact>-<version>.pom`. Strip the
+            // `.pom` suffix and the trailing `-<version>` segment to
+            // recover the artifact-name basename used as the key
+            // (matches the Fedora index's basename-key convention).
+            let Some(fname) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if !fname.ends_with(".pom") {
+                continue;
+            }
+            let stem = &fname[..fname.len() - 4];
+            let basename = strip_trailing_version(stem).to_ascii_lowercase();
+            if basename.is_empty() {
+                continue;
+            }
+            // First-write-wins: if the GAV tree happens to have two
+            // POMs reducing to the same basename (extremely rare —
+            // would mean two different groups shipping the same
+            // artifact-name), the first one wins. The lookup-by-
+            // basename API can't disambiguate these anyway.
+            out.entry(basename).or_insert(path);
+        }
+    }
+
+    /// Same lookup contract as [`FedoraSidecarIndex::lookup_for_jar`]:
+    /// strip the trailing `-<version>` segment from the JAR
+    /// filename, match the lowercased basename against the index.
+    pub(crate) fn lookup_for_jar(&self, jar_path: &Path) -> Option<&Path> {
+        let fname = jar_path.file_name().and_then(|s| s.to_str())?;
+        if !fname.ends_with(".jar") {
+            return None;
+        }
+        let stem = &fname[..fname.len() - 4];
+        let basename = strip_trailing_version(stem).to_ascii_lowercase();
+        self.by_basename.get(basename.as_str()).map(|p| p.as_path())
+    }
+
+    /// `true` when the index contains zero entries — used by
+    /// callers to skip Debian-sidecar resolution entirely when the
+    /// rootfs isn't Debian-shaped.
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.by_basename.is_empty()
+    }
+
+    /// Number of indexed sidecar POMs. Mirrors the Fedora variant.
+    pub(crate) fn len(&self) -> usize {
+        self.by_basename.len()
+    }
+
+    /// Look up a parent POM by its artifactId for one-level
+    /// inheritance resolution. Same shape as
+    /// [`FedoraSidecarIndex::lookup_by_artifact_id`].
+    pub(crate) fn lookup_by_artifact_id(&self, artifact_id: &str) -> Option<&Path> {
+        self.by_basename
+            .get(artifact_id.to_ascii_lowercase().as_str())
+            .map(|p| p.as_path())
+    }
+}
+
+impl SidecarIndex for DebianSidecarIndex {
+    fn lookup_by_artifact_id(&self, artifact_id: &str) -> Option<&Path> {
+        DebianSidecarIndex::lookup_by_artifact_id(self, artifact_id)
+    }
+}
+
 /// Strip a trailing `-<digits-and-dots-and-letters>` version component
 /// from a JAR basename. The split point is the last `-` followed by a
 /// digit. Non-versioned names (e.g. `aopalliance` with no trailing
@@ -120,9 +264,15 @@ fn strip_trailing_version(stem: &str) -> &str {
 /// inheritance applied when the parent POM is present in the same
 /// index. Returns `None` when a complete `(groupId, artifactId,
 /// version)` triple cannot be assembled.
+///
+/// Generic over [`SidecarIndex`] so callers can pass either a
+/// [`FedoraSidecarIndex`] or a [`DebianSidecarIndex`] (milestone 042
+/// US2). The parent-inheritance lookup is the only operation
+/// resolve_coords actually performs against the index — both
+/// implementations key by lowercase artifact-id.
 pub(crate) fn resolve_coords(
     sidecar_path: &Path,
-    index: &FedoraSidecarIndex,
+    index: &dyn SidecarIndex,
 ) -> Option<(String, String, String)> {
     let bytes = std::fs::read(sidecar_path).ok()?;
     let doc = parse_pom_xml(&bytes);
@@ -345,5 +495,158 @@ mod tests {
         );
         let idx = FedoraSidecarIndex::build(tmp.path());
         assert!(resolve_coords(&child_path, &idx).is_none());
+    }
+
+    // ---- Milestone 042 US2: DebianSidecarIndex --------------------------
+
+    /// Helper: write a Debian-shaped sidecar POM under
+    /// `<rootfs>/usr/share/maven-repo/<group-path>/<artifact>/<version>/<artifact>-<version>.pom`.
+    fn write_debian_pom(
+        rootfs: &Path,
+        group: &str,
+        artifact: &str,
+        version: &str,
+    ) -> PathBuf {
+        let group_path: PathBuf = group.split('.').collect();
+        let dir = rootfs
+            .join("usr/share/maven-repo")
+            .join(&group_path)
+            .join(artifact)
+            .join(version);
+        std::fs::create_dir_all(&dir).unwrap();
+        let pom_path = dir.join(format!("{artifact}-{version}.pom"));
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+             <project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n\
+               <modelVersion>4.0.0</modelVersion>\n\
+               <groupId>{group}</groupId>\n\
+               <artifactId>{artifact}</artifactId>\n\
+               <version>{version}</version>\n\
+             </project>\n",
+        );
+        std::fs::write(&pom_path, body).unwrap();
+        pom_path
+    }
+
+    #[test]
+    fn debian_sidecar_index_extracts_canonical_gav() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pom_path = write_debian_pom(
+            tmp.path(),
+            "org.apache.commons",
+            "commons-lang3",
+            "3.12.0",
+        );
+        let idx = DebianSidecarIndex::build(tmp.path());
+        assert!(!idx.is_empty());
+        assert_eq!(idx.len(), 1);
+        // Lookup by JAR basename should find the POM.
+        let jar = tmp.path().join("usr/share/java/commons-lang3-3.12.0.jar");
+        let resolved = idx.lookup_for_jar(&jar).expect("lookup should resolve");
+        assert_eq!(resolved, pom_path);
+        // resolve_coords through the trait yields the right GAV.
+        let (g, a, v) = resolve_coords(&pom_path, &idx).expect("resolve_coords");
+        assert_eq!(g, "org.apache.commons");
+        assert_eq!(a, "commons-lang3");
+        assert_eq!(v, "3.12.0");
+    }
+
+    #[test]
+    fn debian_sidecar_index_handles_multi_segment_groups() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_debian_pom(
+            tmp.path(),
+            "org.apache.maven.plugins",
+            "maven-compiler-plugin",
+            "3.11.0",
+        );
+        let idx = DebianSidecarIndex::build(tmp.path());
+        let jar = tmp.path().join("usr/share/java/maven-compiler-plugin-3.11.0.jar");
+        let pom = idx.lookup_for_jar(&jar).expect("multi-segment group should resolve");
+        let (g, a, v) = resolve_coords(pom, &idx).expect("resolve_coords");
+        assert_eq!(g, "org.apache.maven.plugins");
+        assert_eq!(a, "maven-compiler-plugin");
+        assert_eq!(v, "3.11.0");
+    }
+
+    #[test]
+    fn debian_sidecar_index_handles_version_with_build_suffix() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_debian_pom(tmp.path(), "com.example", "foo", "1.0.0-SNAPSHOT");
+        let idx = DebianSidecarIndex::build(tmp.path());
+        let jar = tmp.path().join("usr/share/java/foo-1.0.0-SNAPSHOT.jar");
+        let pom = idx.lookup_for_jar(&jar).expect("snapshot version should resolve");
+        let (_, a, v) = resolve_coords(pom, &idx).expect("resolve_coords");
+        assert_eq!(a, "foo");
+        assert_eq!(v, "1.0.0-SNAPSHOT");
+    }
+
+    #[test]
+    fn debian_sidecar_index_returns_empty_for_missing_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No /usr/share/maven-repo/ at all.
+        let idx = DebianSidecarIndex::build(tmp.path());
+        assert!(idx.is_empty());
+    }
+
+    #[test]
+    fn debian_sidecar_index_returns_empty_for_empty_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("usr/share/maven-repo")).unwrap();
+        let idx = DebianSidecarIndex::build(tmp.path());
+        assert!(idx.is_empty());
+    }
+
+    /// FR-005: the Fedora and Debian indexes are independent
+    /// surfaces; each is tried in order at the call site. This
+    /// test verifies both indexes resolve their own JARs cleanly
+    /// when both layouts coexist.
+    #[test]
+    fn fedora_and_debian_indexes_coexist_independently() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Fedora layout: flat /usr/share/maven-poms/.
+        let fedora_dir = tmp.path().join("usr/share/maven-poms");
+        std::fs::create_dir_all(&fedora_dir).unwrap();
+        std::fs::write(
+            fedora_dir.join("guice.pom"),
+            "<?xml version=\"1.0\"?>\n\
+             <project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n\
+               <modelVersion>4.0.0</modelVersion>\n\
+               <groupId>com.google.inject</groupId>\n\
+               <artifactId>guice</artifactId>\n\
+               <version>5.1.0</version>\n\
+             </project>\n",
+        )
+        .unwrap();
+        // Debian layout: GAV tree.
+        write_debian_pom(
+            tmp.path(),
+            "org.apache.commons",
+            "commons-lang3",
+            "3.12.0",
+        );
+
+        let fedora_idx = FedoraSidecarIndex::build(tmp.path());
+        let debian_idx = DebianSidecarIndex::build(tmp.path());
+        assert_eq!(fedora_idx.len(), 1);
+        assert_eq!(debian_idx.len(), 1);
+
+        // Fedora-keyed JAR resolves only via Fedora index.
+        let guice_jar = tmp.path().join("usr/share/java/guice-5.1.0.jar");
+        assert!(fedora_idx.lookup_for_jar(&guice_jar).is_some());
+        assert!(
+            debian_idx.lookup_for_jar(&guice_jar).is_none(),
+            "Fedora-only JAR should not resolve via Debian index"
+        );
+
+        // Debian-keyed JAR resolves only via Debian index.
+        let lang3_jar = tmp
+            .path()
+            .join("usr/share/java/commons-lang3-3.12.0.jar");
+        assert!(debian_idx.lookup_for_jar(&lang3_jar).is_some());
+        assert!(
+            fedora_idx.lookup_for_jar(&lang3_jar).is_none(),
+            "Debian-only JAR should not resolve via Fedora index"
+        );
     }
 }

--- a/specs/042-small-followons/checklists/requirements.md
+++ b/specs/042-small-followons/checklists/requirements.md
@@ -1,0 +1,52 @@
+# Specification Quality Checklist: Post-041 Small Follow-Ons
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Validation Notes
+
+- Two-story milestone bundling unrelated small items: US1 a
+  housekeeping comment update (~10 min); US2 a Maven sidecar
+  layout extension (~1-2 hr). Each is independently testable.
+- US1 mirrors the milestone-040 US1 stale-comment-cleanup
+  pattern.
+- US2 mirrors the existing Fedora sidecar reader's shape;
+  acceptance leans on inline tests with synthetic rootfs
+  fixtures (the project's standard pattern from milestones
+  037-041) plus a no-regression scan of `debian:bookworm-slim`
+  which should be unchanged.
+- Alpine layouts and Debian's `/var/lib/maven-repo/` legacy
+  variant are explicitly out of scope.
+- No `[NEEDS CLARIFICATION]` markers — both stories build on
+  existing patterns.
+
+## Notes
+
+- Items marked incomplete require spec updates before
+  `/speckit.clarify` or `/speckit.plan`. All items currently pass.

--- a/specs/042-small-followons/spec.md
+++ b/specs/042-small-followons/spec.md
@@ -1,0 +1,279 @@
+# Feature Specification: Post-041 Small Follow-Ons
+
+**Feature Branch**: `042-small-followons`
+**Created**: 2026-04-29
+**Status**: Draft
+**Input**: User description: "Two small follow-on cleanup items: stale binary/predicates.rs comment + Maven sidecar Debian layout"
+
+## User Scenarios & Testing *(mandatory)*
+
+Two unrelated small items closing legacy-deferral debt that has
+naturally come due after the milestone-037-through-041 work. Each
+is independently testable; bundled together because both are
+small and ready to ship without separate PR overhead.
+
+### User Story 1 - Stale binary/predicates.rs comment cleanup (Priority: P1) 🎯 MVP
+
+A maintainer reading mikebom's binary-walker source for the first
+time encounters a comment in
+`mikebom-cli/src/scan_fs/binary/predicates.rs:131` that names rpm
+file-list extraction from HeaderBlob `BASENAMES` /
+`DIRNAMES` / `DIRINDEXES` as deferred to a follow-on milestone.
+Milestone 040 US3 closed that gap (#78); the comment now
+mis-describes the codebase. A future contributor reading this
+comment might assume the extraction work is missing and
+re-implement it, wasting time. Removing or rewriting the comment
+costs ten minutes; not removing it carries the same future-
+maintainer-confusion cost the milestone-040 US1 cleanup just paid
+down.
+
+**Why this priority**: pure housekeeping. No behavioral risk.
+Smallest possible MVP deliverable; sets the tone that this
+milestone is incremental, not architectural.
+
+**Independent Test**: After implementation, the comment in
+`predicates.rs` no longer claims rpm file-list extraction is
+deferred. Specifically, `grep -rn 'BASENAMES.*deferred\|extraction
+from HeaderBlob.*deferred' mikebom-cli/src/` returns zero
+matches.
+
+**Acceptance Scenarios**:
+
+1. **Given** the post-041 codebase, **When** a contributor greps
+   for "deferred" near the rpm-related rationale comments in
+   `predicates.rs`, **Then** the comment now describes the
+   established rpm reader's responsibilities accurately, with no
+   "deferred to a follow-on" framing pointing at work that has
+   shipped.
+2. **Given** the existing presume-owned heuristic for
+   OS-managed-directory binaries when an rpmdb is present,
+   **When** the comment is rewritten, **Then** the heuristic's
+   rationale is preserved — the heuristic still applies as a
+   defense-in-depth fallback even though the authoritative
+   extraction is now wired up.
+
+---
+
+### User Story 2 - Maven sidecar Debian layout (Priority: P2)
+
+An SBOM consumer scanning a Debian-based Java image (where
+`apt-get install lib*-java` has placed POMs under
+`/usr/share/maven-repo/<group-path>/<artifact>/<version>/`)
+expects mikebom to recover the Maven coordinates the same way it
+already does for Fedora's `/usr/share/maven-poms/` layout. Today
+mikebom only reads the Fedora layout; Debian's GAV-tree layout
+is parsed and discarded. This becomes visible as
+`pkg:generic/<jar-filename>` PURLs instead of
+`pkg:maven/<group>/<artifact>@<version>` PURLs for Debian-
+sourced Java JARs.
+
+**Why this priority**: closes the explicit "deferred to a
+follow-up feature" comment in `maven_sidecar.rs:7-11`. P2 because
+the Fedora layout (which mikebom already covers) is the
+historically more common case for system-installed Java
+libraries, but Debian's variant exists in production images
+(any Debian-shaped image where `apt-get install
+libcommons-lang3-java` etc. has run).
+
+**Independent Test**: Run `mikebom sbom scan` against a
+Debian-shaped rootfs that contains
+`/usr/share/maven-repo/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.pom`
+and the corresponding JAR. Mikebom's output emits a
+`pkg:maven/org.apache.commons/commons-lang3@3.12.0` PURL for the
+JAR (today: emits `pkg:generic/commons-lang3-3.12.0`).
+
+**Acceptance Scenarios**:
+
+1. **Given** a Debian-shaped rootfs with one or more
+   `/usr/share/maven-repo/<group-path>/<artifact>/<version>/<artifact>-<version>.pom`
+   files and matching JARs, **When** the user runs an SBOM scan,
+   **Then** the matching JARs surface as
+   `pkg:maven/<group>/<artifact>@<version>` PURLs with
+   coordinates resolved from the sidecar POMs.
+2. **Given** a Debian-shaped rootfs with `/usr/share/maven-repo/`
+   present but EMPTY (the directory exists from
+   `maven-repo-helper` install but no Java packages have been
+   installed), **When** the user runs a scan, **Then** the scan
+   completes without error and the output is identical to
+   running it against a rootfs with no `/usr/share/maven-repo/`
+   directory at all.
+3. **Given** a Fedora-shaped rootfs (with
+   `/usr/share/maven-poms/`), **When** the user runs a scan
+   after this story ships, **Then** the Fedora-layout output is
+   byte-identical to milestone 041's output (no regression on
+   the existing layout).
+4. **Given** a rootfs that has BOTH layouts (extreme edge case;
+   wouldn't occur on a real distro), **When** the user runs a
+   scan, **Then** both indexes contribute to the JAR-coordinate
+   recovery, with the Fedora index winning on basename
+   collision (existing milestone-041-era behavior preserved as
+   the source-of-truth-for-collisions rule).
+
+---
+
+### Edge Cases
+
+- **Empty `/usr/share/maven-repo/` directory**: graceful no-op,
+  matches the Fedora sidecar's existing posture.
+- **Malformed POM files within the GAV tree**: skipped per-file
+  via `parse_pom_xml`'s existing error-tolerant return shape.
+  No scan failure; a debug log records the malformed file.
+- **Symlinks within the GAV tree** (Debian's
+  `maven-repo-helper` does create some `<artifact>-debian.pom`
+  symlinks pointing at the canonical name): follow per
+  `read_dir`'s default behavior; emit one entry per resolved
+  POM target, dedup by `(group, artifact, version)`.
+- **Non-`.pom` files in the GAV tree**: skip silently.
+- **Debian-bundled maven layout under
+  `/var/lib/maven-repo/`** (rare; some legacy
+  packagings): out-of-scope; report as a follow-on if
+  surfaced.
+- **Alpine `apk` Java packages**: out of scope. Alpine doesn't
+  have a documented system-wide maven repo convention; Alpine
+  Java images bundle JARs directly without sidecar POMs.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### US1 — Comment cleanup
+
+- **FR-001**: Rewrite the comment in
+  `mikebom-cli/src/scan_fs/binary/predicates.rs` (around line
+  131) to drop the "RPM file-list extraction from HeaderBlob
+  BASENAMES/DIRNAMES/DIRINDEXES is deferred" claim. The
+  presume-owned heuristic's rationale (defense-in-depth for
+  binaries under OS-managed directories when an rpmdb is
+  present) MUST be preserved — it remains correct even now
+  that the authoritative extraction is wired up.
+
+- **FR-002**: Post-merge `grep -rn 'extraction from HeaderBlob
+  BASENAMES.*deferred\|file-list extraction.*deferred to a
+  follow-on milestone' mikebom-cli/src/` returns zero matches.
+
+#### US2 — Maven sidecar Debian layout
+
+- **FR-003**: `mikebom-cli/src/scan_fs/package_db/maven_sidecar.rs`
+  gains a parallel index-builder that walks
+  `<rootfs>/usr/share/maven-repo/` and recovers
+  `(group, artifact, version)` triples from the GAV directory
+  tree. The recovered coordinates are looked up by JAR basename
+  the same way the existing Fedora sidecar's basename index is.
+
+- **FR-004**: When mikebom scans a Debian-shaped rootfs that
+  contains `/usr/share/maven-repo/<group-path>/<artifact>/<version>/`
+  POM files plus their matching JARs (regardless of where the
+  JAR lives — `/usr/share/java/`, application
+  bundle directories, etc.), the resulting SBOM components
+  carry `pkg:maven/<group>/<artifact>@<version>` PURLs in
+  preference to the previous `pkg:generic/<filename>` PURLs.
+
+- **FR-005**: The Fedora sidecar's basename-index winner-on-
+  collision rule MUST be preserved. When both layouts contain a
+  POM for the same basename (extreme edge case; wouldn't occur
+  on a real distro), the Fedora-layout entry wins. Spec docs
+  the chosen tie-break clearly.
+
+- **FR-006**: Empty `/usr/share/maven-repo/` directory →
+  graceful no-op, same as Fedora's empty
+  `/usr/share/maven-poms/` posture. The scan completes; no
+  error log.
+
+#### Cross-cutting
+
+- **FR-007**: No new top-level Cargo dependencies. Reuses
+  `parse_pom_xml` (already in the maven module),
+  `std::fs::read_dir`, etc.
+
+- **FR-008**: All existing byte-identity goldens MUST regen
+  with zero diff. None of the existing 27 fixtures contain
+  `/usr/share/maven-repo/`-shaped data, so this milestone's
+  behavior is invisible to those fixtures by design.
+
+### Key Entities
+
+- **Debian GAV-tree layout**: directories of the form
+  `/usr/share/maven-repo/<group-with-slashes>/<artifact>/<version>/<artifact>-<version>.pom`
+  (e.g.
+  `/usr/share/maven-repo/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.pom`).
+  The group's `.`-segments map to directory segments. Mikebom
+  walks the tree and recovers `(group, artifact, version)` per
+  POM.
+- **Sidecar index**: same shape as the existing
+  `FedoraSidecarIndex` — a basename-keyed `HashMap<String,
+  PathBuf>` whose values are absolute paths to POM files.
+  Lookups by JAR basename retrieve the matching POM for
+  coordinate parsing.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+#### US1
+
+- **SC-001**: Post-merge `grep -rn 'extraction from HeaderBlob
+  BASENAMES.*deferred\|file-list extraction.*deferred to a
+  follow-on milestone' mikebom-cli/src/` returns zero matches
+  (today: 1 in `binary/predicates.rs`).
+
+#### US2
+
+- **SC-002**: Inline tests verify the Debian sidecar reader
+  produces the right `(group, artifact, version)` triples for
+  at least 3 GAV layouts (single-segment group, multi-segment
+  group, version-with-build-suffix). Quantitatively: ≥3
+  tests covering ≥3 layouts in the new
+  `DebianSidecarIndex::tests` module.
+
+- **SC-003**: A synthetic-rootfs end-to-end test (constructed
+  in inline tests, not from an external image fixture) shows
+  that JAR-coordinate recovery via the Debian index produces
+  `pkg:maven/<group>/<artifact>@<version>` PURLs equivalent
+  to the Fedora-layout output for the same coordinates.
+
+- **SC-004**: A scan of a real Fedora image (not changed by
+  this milestone) and a scan of `debian:bookworm-slim` (no
+  `/usr/share/maven-repo/` content; expected no change)
+  produce SBOMs byte-identical to milestone-041's output
+  for those rootfs shapes.
+
+#### Cross-cutting
+
+- **SC-005**: Existing byte-identity goldens regen with zero
+  diff (FR-008).
+- **SC-006**: All 3 CI lanes green.
+
+## Assumptions
+
+- The Debian Maven layout per
+  <https://wiki.debian.org/Java/MavenBuilder> /
+  <https://salsa.debian.org/java-team/maven-repo-helper> is
+  stable: GAV-tree under `/usr/share/maven-repo/`. Mikebom
+  reads the canonical layout; symlinks and Debian-specific
+  variants (e.g. `<artifact>-debian.pom`) flow through the
+  same per-POM lookup.
+- mikebom's existing `parse_pom_xml` handles real-world POM
+  shapes encountered in Debian's repo (single-pom-per-leaf-dir
+  is the canonical layout; multi-pom-per-dir doesn't occur in
+  practice on Debian).
+- The integration site for the new index is
+  `package_db::maven`'s call into `FedoraSidecarIndex`. We
+  add a parallel `DebianSidecarIndex` and consult both during
+  JAR-coordinate recovery; the maven module's existing logic
+  for "use the sidecar when in-JAR metadata is absent" carries
+  through unchanged.
+- Alpine-equivalent layouts are out-of-scope; Alpine Java
+  images don't ship a system-wide maven repo today.
+
+## Out of scope
+
+- Alpine maven sidecar (no documented system-wide Alpine maven
+  layout).
+- Debian-bundled maven layouts under
+  `/var/lib/maven-repo/` (uncommon legacy variant).
+- Schema-level `hashes` array refactor on `FileOccurrence` —
+  pre-existing deferred item.
+- Container layer attribution — the bigger architectural item.
+- Other-ecosystem deep-hash audits (npm / cargo / go / python)
+  — deferred for a future milestone if those ecosystems
+  prove to need per-file evidence.

--- a/specs/042-small-followons/tasks.md
+++ b/specs/042-small-followons/tasks.md
@@ -1,0 +1,62 @@
+---
+description: "Task list — milestone 042 post-041 small follow-ons"
+---
+
+# Tasks: Post-041 Small Follow-Ons
+
+**Input**: spec.md ✅, checklists/requirements.md ✅. (No plan / research /
+data-model / quickstart — both stories mirror prior-milestone patterns
+exactly; the spec.md is concrete enough.)
+
+**Tests**: included — inline coverage for the new Debian sidecar reader.
+
+**Organization**: Two unrelated user stories. Three commits.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 `./scripts/pre-pr.sh` clean before any changes (baseline).
+
+---
+
+## Phase 2: Commit `fix(042/us1)` — stale comment cleanup
+
+- [ ] T002 [US1] Edit `mikebom-cli/src/scan_fs/binary/predicates.rs` (around line 131): rewrite the comment block. Drop the "RPM file-list extraction from HeaderBlob BASENAMES/DIRNAMES/DIRINDEXES is deferred to a follow-on milestone" claim. Preserve the presume-owned heuristic's defense-in-depth rationale (it's still correct as a fallback even with the authoritative extraction now in place).
+- [ ] T003 [US1] Verify SC-001: `grep -rn 'extraction from HeaderBlob BASENAMES.*deferred\|file-list extraction.*deferred to a follow-on milestone' mikebom-cli/src/` returns zero matches.
+- [ ] T004 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T005 [US1] Commit: `fix(042/us1): drop stale "rpm HeaderBlob extraction deferred" comment in binary/predicates.rs`.
+
+---
+
+## Phase 3: Commit `feat(042/us2)` — Maven sidecar Debian layout
+
+- [ ] T006 [US2] Add `pub(crate) struct DebianSidecarIndex { by_basename: HashMap<String, PathBuf> }` to `mikebom-cli/src/scan_fs/package_db/maven_sidecar.rs`. Mirrors the existing `FedoraSidecarIndex` shape so the maven module's call sites can swap or layer them with no signature change.
+- [ ] T007 [US2] Add `pub(crate) fn DebianSidecarIndex::build(rootfs: &Path) -> Self`: walks `<rootfs>/usr/share/maven-repo/` recursively, collecting `<group-path>/<artifact>/<version>/<artifact>-<version>.pom` entries. The basename key strips the `-<version>.pom` suffix and lowercases. The recursive walk has a depth cap to avoid infinite-symlink loops (cap = 8 segments, comfortably above any realistic GAV depth).
+- [ ] T008 [US2] Add `pub(crate) fn DebianSidecarIndex::lookup_for_jar(&self, jar_path: &Path) -> Option<&Path>`: same shape as the Fedora variant; strips trailing `-<version>` from the JAR filename before matching.
+- [ ] T009 [US2] Add `pub(crate) fn DebianSidecarIndex::is_empty(&self) -> bool` (test-only) and `pub(crate) fn len(&self) -> usize` for scan-summary logging.
+- [ ] T010 [US2] Edit the call site in `mikebom-cli/src/scan_fs/package_db/maven.rs` that invokes `FedoraSidecarIndex::build`: also build a `DebianSidecarIndex` and consult both during JAR-coordinate recovery. Fedora wins on basename collision (FR-005).
+- [ ] T011 [P] [US2] Add inline test `debian_sidecar_index_extracts_canonical_gav` in `maven_sidecar.rs::tests`: synthetic rootfs with `/usr/share/maven-repo/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.pom`; assert the index has the expected basename → path mapping AND `lookup_for_jar` for `commons-lang3-3.12.0.jar` resolves.
+- [ ] T012 [P] [US2] Add inline test `debian_sidecar_index_handles_multi_segment_groups` in `maven_sidecar.rs::tests`: synthetic POM at `org/apache/maven/plugins/maven-compiler-plugin/3.11.0/maven-compiler-plugin-3.11.0.pom`; assert the multi-level group resolves correctly.
+- [ ] T013 [P] [US2] Add inline test `debian_sidecar_index_handles_version_with_build_suffix` in `maven_sidecar.rs::tests`: POM at `<...>/foo/1.0.0-SNAPSHOT/foo-1.0.0-SNAPSHOT.pom`; assert the trailing `-SNAPSHOT` doesn't break the basename-stripping logic.
+- [ ] T014 [P] [US2] Add inline test `debian_sidecar_index_returns_empty_for_missing_directory` in `maven_sidecar.rs::tests`: tempdir with no `/usr/share/maven-repo/`; assert `is_empty()` is true (FR-006).
+- [ ] T015 [P] [US2] Add inline test `debian_sidecar_index_returns_empty_for_empty_directory` in `maven_sidecar.rs::tests`: tempdir with `/usr/share/maven-repo/` directory but no contents; assert `is_empty()` is true (FR-006).
+- [ ] T016 [P] [US2] Add inline test `fedora_sidecar_wins_on_basename_collision` in `maven_sidecar.rs::tests`: synthetic rootfs with both layouts containing the same basename `commons-lang3`; assert the Fedora-layout entry wins (FR-005).
+- [ ] T017 [US2] Run `cargo +stable test -p mikebom --bin mikebom scan_fs::package_db::maven_sidecar` and confirm 6 new tests pass alongside any existing.
+- [ ] T018 [US2] Run goldens regen: `MIKEBOM_UPDATE_*_GOLDENS=1 cargo +stable test -p mikebom --test '*'`. Confirm zero diff under `mikebom-cli/tests/fixtures/` (FR-008).
+- [ ] T019 [US2] `./scripts/pre-pr.sh` clean.
+- [ ] T020 [US2] Commit: `feat(042/us2): Maven sidecar Debian /usr/share/maven-repo/ GAV-layout reader`.
+
+---
+
+## Phase 4: Commit `docs(042)` + PR
+
+- [ ] T021 Update `docs/user-guide/cli-reference.md` to mention Debian-shaped Java images now resolve to maven PURLs (one-line addition or a behaviour note).
+- [ ] T022 Add CHANGELOG Unreleased entry summarizing the milestone.
+- [ ] T023 `./scripts/pre-pr.sh` clean.
+- [ ] T024 Commit: `docs(042): Maven Debian sidecar — user-guide note + CHANGELOG`.
+- [ ] T025 Push branch.
+- [ ] T026 Open PR titled `feat(042): post-041 small follow-ons (stale comment + Maven Debian sidecar)`.
+- [ ] T027 Verify all 3 CI lanes green.


### PR DESCRIPTION
## Summary

Two unrelated small follow-on items closing legacy-deferral debt that has naturally come due after milestones 037-041.

- **US1**: drop the stale comment in \`binary/predicates.rs:88\` that named rpm file-list extraction as "deferred to a follow-on milestone." Milestone 040 US3 closed that gap; the comment is rewritten to accurately credit 040 US3.
- **US2**: extend \`maven_sidecar.rs\` to also handle Debian's \`/usr/share/maven-repo/\` GAV-tree layout. Debian-shaped Java images now resolve JARs to \`pkg:maven/<group>/<artifact>@<version>\` instead of \`pkg:generic/<filename>\` — matching the milestone-007 Fedora-side coverage.

## Commits (4)

1. **\`spec(042)\`** — Slim 3-file spec set (spec / tasks / checklists; plan / research / data-model / quickstart skipped because each story mirrors prior-milestone patterns exactly).
2. **\`fix(042/us1)\`** — One comment rewrite. Mirrors milestone-040 US1.
3. **\`feat(042/us2)\`** — \`DebianSidecarIndex\` parallel to \`FedoraSidecarIndex\`; new \`SidecarIndex\` trait so \`resolve_coords\` works with either; \`maven.rs\` builds and consults both. 6 new inline tests.
4. **\`docs(042)\`** — User-guide note + CHANGELOG.

## Behavior

| JAR location | Pre-042 PURL | Post-042 PURL |
|---|---|---|
| Debian \`/usr/share/maven-repo/<group>/<artifact>/<version>/*.pom\` matched | \`pkg:generic/<filename>\` | **\`pkg:maven/<group>/<artifact>@<version>\`** |
| Fedora \`/usr/share/maven-poms/<artifact>.pom\` matched | (already worked) | unchanged |
| Alpine apk JARs | \`pkg:generic/...\` | \`pkg:generic/...\` (no Alpine convention; documented OOS) |

## Verification

- ✅ \`./scripts/pre-pr.sh\` clean.
- ✅ Maven sidecar tests went 10 → 16 (6 new Debian tests).
- ✅ \`MIKEBOM_UPDATE_*_GOLDENS=1 cargo +stable test -p mikebom --test '*'\` produces zero diff (no fixture contains \`/usr/share/maven-repo/\` content).
- ✅ No new top-level deps. \`no_c_dependencies_in_tree\` regression still green.
- ✅ Post-merge \`grep -rn 'extraction from HeaderBlob BASENAMES.*deferred\\|file-list extraction.*deferred to a follow-on milestone' mikebom-cli/src/\` returns zero matches (was 1).

## Test plan

- [ ] CI green on all 3 lanes.
- [ ] Manual Debian-image verification (would need a Debian image with libcommons-lang3-java or similar installed):
      \`\`\`bash
      docker run -d --name dbg debian:bookworm sleep 600
      docker exec dbg apt-get update -y -qq
      docker exec dbg apt-get install -y libcommons-lang3-java
      docker commit dbg debian-with-mvn:test
      docker save debian-with-mvn:test -o /tmp/debian-mvn.tar
      mikebom sbom scan --image /tmp/debian-mvn.tar --output /tmp/dbg.cdx.json
      jq '.components[] | select(.name == "commons-lang3") | .purl' /tmp/dbg.cdx.json
      # expected: "pkg:maven/org.apache.commons/commons-lang3@..."
      # pre-042: "pkg:generic/commons-lang3-..."
      \`\`\`
- [ ] No regression on Fedora sidecar (already-working case): existing \`pkg:maven/...\` resolution for Fedora-shaped images unchanged.

## Out of scope (future)

- Alpine maven sidecar (no documented system-wide convention).
- Debian-bundled \`/var/lib/maven-repo/\` legacy variant (uncommon; no real-world surface).
- Schema-level \`hashes\` array refactor on \`FileOccurrence\` (would unify deb \`md5\`, apk \`sha1\`, rpm \`rpm_filedigest\` carriers; defer until external demand).
- Container layer attribution (the bigger architectural item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)