### PR TITLE
feat(044): docker-daemon-first image source + ECR Basic-auth challenge support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 
 ### Added
 
+- **`Basic` auth challenge support for the OCI registry pull** (044
+  commit 2). The 401-retry path now accepts both `Bearer` (existing
+  Docker Hub / GHCR / gcr.io flow) and `Basic` (AWS ECR's flavor)
+  `WWW-Authenticate` challenges. For `Basic`, mikebom applies the
+  cached docker-config credentials directly on the original request
+  — no token-realm round-trip. Resolves the previous
+  `WWW-Authenticate is not a Bearer challenge: Basic ...` error
+  on `mikebom sbom scan --image <ecr-ref> --image-src remote`. The
+  `~/.docker/config.json` lookup is unchanged (already supported
+  `auths.<host>.auth`, `credHelpers`, `credsStore` since milestone
+  034); only the challenge parser was Bearer-only.
 - **Local docker daemon as a default image source** (044 commit 1).
   `mikebom sbom scan --image <ref>` now consults the local docker
   daemon before reaching for a registry pull, matching trivy and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 
 ## [Unreleased]
 
-(Nothing yet. Land changes here, then cut a release per the
-`release.yml` workflow trigger documented in
-`docs/contributing/release.md`.)
+### Added
+
+- **Local docker daemon as a default image source** (044 commit 1).
+  `mikebom sbom scan --image <ref>` now consults the local docker
+  daemon before reaching for a registry pull, matching trivy and
+  syft conventions. New `--image-src docker,remote` flag controls
+  the source-resolution order; default is `docker,remote`. Force a
+  fresh registry fetch with `--image-src remote`. Docker source
+  shells out to `docker image inspect` + `docker save`, so the
+  user's existing `DOCKER_HOST` / contexts are honored. Resolves
+  the case where an ECR image is already cached locally but the
+  registry pull is failing (e.g. on a Basic-auth challenge).
 
 ## [0.1.0-alpha.5] — 2026-04-29
 

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
-use clap::Args;
+use clap::{Args, ValueEnum};
 
 use mikebom_common::attestation::integrity::TraceIntegrity;
 use mikebom_common::attestation::metadata::GenerationContext;
@@ -36,6 +36,18 @@ const OPENVEX_PSEUDO_FORMAT: &str = "openvex";
 /// may opt in in a future milestone, at which point this list grows.
 const OPENVEX_EMITTING_FORMATS: &[&str] = &["spdx-2.3-json"];
 
+/// Image source for `--image <ref>` resolution. Selected via
+/// `--image-src` (comma-separated, in order of preference).
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ImageSource {
+    /// Local docker daemon: shell out to `docker image inspect` to
+    /// probe, then `docker save` to materialize a tarball.
+    Docker,
+    /// OCI distribution-spec registry pull (the milestone-031+
+    /// `oci_pull` path).
+    Remote,
+}
+
 #[derive(Args, Debug)]
 pub struct ScanArgs {
     /// Directory to walk for package artifacts.
@@ -54,6 +66,28 @@ pub struct ScanArgs {
     /// then the resulting rootfs is scanned exactly like `--path`.
     #[arg(long, conflicts_with = "path")]
     pub image: Option<PathBuf>,
+
+    /// Image source-resolution order for `--image <ref>` (when the
+    /// argument is an OCI reference, not a tarball path on disk).
+    ///
+    /// Comma-separated list; mikebom tries each source in order and
+    /// stops at the first one that has the image. Default
+    /// `docker,remote` matches trivy's `--image-src` and syft's
+    /// auto-detection: prefer the local docker daemon's cache, fall
+    /// back to a registry pull. Pass `--image-src remote` to force
+    /// a fresh registry fetch (skipping any locally-cached copy);
+    /// pass `--image-src docker` to fail rather than touch the
+    /// network.
+    ///
+    /// When `--image` resolves to an existing tarball file on disk,
+    /// this flag is ignored — the file is loaded directly.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        default_value = "docker,remote",
+        value_name = "SRC[,SRC...]",
+    )]
+    pub image_src: Vec<ImageSource>,
 
     /// Override the platform that's resolved from a multi-arch image
     /// index. Only meaningful when `--image` points at a registry
@@ -420,6 +454,130 @@ fn canonicalize_for_collision(path: &Path) -> PathBuf {
     }
 }
 
+/// Resolve an `--image <ref>` OCI reference to a `docker save`-format
+/// tarball on disk by trying each source in `args.image_src` in order.
+/// First hit wins. The `tempdir` slot is populated with the holder
+/// dir so the caller's tarball path stays valid through extraction.
+///
+/// The OCI-ref parse check from milestone 031 still runs (rejects
+/// arguments that are neither tarballs nor parseable refs) so the
+/// error message remains the same as before.
+async fn resolve_image_ref(
+    arg_str: &str,
+    args: &ScanArgs,
+    tempdir: &mut Option<tempfile::TempDir>,
+) -> anyhow::Result<PathBuf> {
+    #[cfg(feature = "oci-registry")]
+    {
+        let archive_path = std::path::Path::new(arg_str);
+        let kind = scan_fs::oci_pull::detect_image_arg_kind(archive_path);
+        if kind != scan_fs::oci_pull::ImageArgKind::OciRef {
+            anyhow::bail!(
+                "--image argument is neither an existing tarball file nor a parseable OCI image reference: {arg_str}"
+            );
+        }
+    }
+
+    let mut tried: Vec<&'static str> = Vec::new();
+    for src in &args.image_src {
+        match src {
+            ImageSource::Docker => {
+                tried.push("docker");
+                // `--image-platform` asks for a specific arch/variant
+                // pulled from a multi-arch index; the local docker
+                // daemon only has whatever it was told to cache. Skip
+                // the docker source when a platform is requested.
+                if args.image_platform.is_some() {
+                    tracing::info!(
+                        image_ref = arg_str,
+                        "--image-platform set; skipping local docker source (only registry pulls honor platform)"
+                    );
+                    continue;
+                }
+                match scan_fs::docker_daemon::inspect(arg_str) {
+                    scan_fs::docker_daemon::InspectOutcome::Present => {
+                        tracing::info!(
+                            image_ref = arg_str,
+                            "found image in local docker daemon; exporting via `docker save`"
+                        );
+                        let td = tempfile::tempdir()
+                            .context("creating tempdir for docker-save tarball")?;
+                        let tarball = td.path().join("image.tar");
+                        scan_fs::docker_daemon::save(arg_str, &tarball)?;
+                        *tempdir = Some(td);
+                        return Ok(tarball);
+                    }
+                    scan_fs::docker_daemon::InspectOutcome::Absent => {
+                        tracing::info!(
+                            image_ref = arg_str,
+                            "image not present in local docker daemon"
+                        );
+                    }
+                    scan_fs::docker_daemon::InspectOutcome::DockerUnavailable => {
+                        tracing::info!(
+                            image_ref = arg_str,
+                            "local docker daemon not available; trying next source"
+                        );
+                    }
+                }
+            }
+            ImageSource::Remote => {
+                tried.push("remote");
+                #[cfg(feature = "oci-registry")]
+                {
+                    tracing::info!(image_ref = arg_str, "pulling image from registry");
+                    let cache_disabled = args.no_oci_cache
+                        || std::env::var("MIKEBOM_OCI_CACHE").as_deref() == Ok("0");
+                    let cache_size_cap = if cache_disabled {
+                        None
+                    } else {
+                        let env_size = std::env::var("MIKEBOM_OCI_CACHE_SIZE")
+                            .ok()
+                            .and_then(|s| s.parse::<u64>().ok());
+                        Some(
+                            args.oci_cache_size
+                                .or(env_size)
+                                .unwrap_or(10 * 1024 * 1024 * 1024),
+                        )
+                    };
+                    let td = scan_fs::oci_pull::pull_to_tarball(
+                        arg_str,
+                        args.image_platform.as_deref(),
+                        cache_size_cap,
+                    )
+                    .await?;
+                    let tarball = td.path().join("image.tar");
+                    *tempdir = Some(td);
+                    return Ok(tarball);
+                }
+                #[cfg(not(feature = "oci-registry"))]
+                {
+                    anyhow::bail!(
+                        "--image-src includes `remote`, but this build of \
+                         mikebom was compiled with `--no-default-features` \
+                         (the `oci-registry` Cargo feature is OFF), so OCI \
+                         image references like `alpine:3.19` cannot be \
+                         pulled from a registry. Either:\n\
+                         (a) reinstall with the default feature set: \
+                         `cargo install mikebom`, or\n\
+                         (b) pre-extract the image with \
+                         `docker save <ref> -o image.tar` and pass \
+                         `--image image.tar`, or\n\
+                         (c) pass `--image-src docker` and ensure the \
+                         image is in the local docker daemon."
+                    );
+                }
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "image `{arg_str}` not found in any of the configured `--image-src` sources: [{}]. \
+         Pull or build it first, or change `--image-src`.",
+        tried.join(", ")
+    )
+}
+
 pub async fn execute(
     args: ScanArgs,
     offline: bool,
@@ -472,14 +630,20 @@ pub async fn execute(
     // Dropped immediately after `extract` finishes — the tarball
     // bytes have been read by then and the rootfs lives in its
     // own tempdir.
-    #[cfg(feature = "oci-registry")]
-    let mut _oci_pull_tempdir: Option<tempfile::TempDir> = None;
+    // OCI-pull tempdir holder; same lifetime as the docker-save
+    // tempdir below — both keep the on-disk tarball alive through the
+    // `extract` call further down. Held in an `Option` so the
+    // docker-save and remote-pull branches can both populate it
+    // without conflict.
+    let mut _image_tempdir: Option<tempfile::TempDir> = None;
 
     let (root_path, target_name, generation_context, auto_codename, _extracted) =
         if let Some(archive) = args.image.as_ref() {
-            // Milestone 031 — `--image` accepts either a file path
-            // (existing tarball-extract) or an OCI image reference
-            // (new feature-gated registry pull).
+            // `--image` accepts either an on-disk tarball OR an OCI
+            // image reference. Tarballs are loaded directly. References
+            // are resolved through one or more sources (`--image-src`)
+            // — local docker daemon first by default, then registry
+            // pull (milestone 044 commit 1).
             let archive_path: std::path::PathBuf = if archive.is_file() {
                 // `--image-platform` is registry-pull-only; for a
                 // pre-extracted tarball the platform is fixed by
@@ -495,64 +659,10 @@ pub async fn execute(
                 }
                 archive.clone()
             } else {
-                #[cfg(feature = "oci-registry")]
-                {
-                    let arg_str = archive.to_str().context(
-                        "--image argument is not valid UTF-8 — required for OCI ref parsing",
-                    )?;
-                    let kind = scan_fs::oci_pull::detect_image_arg_kind(archive);
-                    if kind != scan_fs::oci_pull::ImageArgKind::OciRef {
-                        anyhow::bail!(
-                            "--image argument is neither an existing tarball file nor a parseable OCI image reference: {}",
-                            archive.display()
-                        );
-                    }
-                    tracing::info!(image_ref = %arg_str, "pulling image from registry");
-                    // Resolve the layer-cache size cap. `--no-oci-cache`
-                    // (or `MIKEBOM_OCI_CACHE=0`) disables; otherwise
-                    // `--oci-cache-size` overrides
-                    // `MIKEBOM_OCI_CACHE_SIZE` overrides the 10-GB
-                    // default. None disables the cache entirely.
-                    let cache_disabled = args.no_oci_cache
-                        || std::env::var("MIKEBOM_OCI_CACHE").as_deref() == Ok("0");
-                    let cache_size_cap = if cache_disabled {
-                        None
-                    } else {
-                        let env_size = std::env::var("MIKEBOM_OCI_CACHE_SIZE")
-                            .ok()
-                            .and_then(|s| s.parse::<u64>().ok());
-                        Some(
-                            args.oci_cache_size
-                                .or(env_size)
-                                .unwrap_or(10 * 1024 * 1024 * 1024),
-                        )
-                    };
-                    let tempdir = scan_fs::oci_pull::pull_to_tarball(
-                        arg_str,
-                        args.image_platform.as_deref(),
-                        cache_size_cap,
-                    )
-                    .await?;
-                    let tarball = tempdir.path().join("image.tar");
-                    _oci_pull_tempdir = Some(tempdir);
-                    tarball
-                }
-                #[cfg(not(feature = "oci-registry"))]
-                {
-                    anyhow::bail!(
-                        "--image argument `{}` is not an existing file, and this \
-                         build of mikebom was compiled with `--no-default-features` \
-                         (the `oci-registry` Cargo feature is OFF), so OCI image \
-                         references like `alpine:3.19` cannot be pulled from a \
-                         registry. Either:\n\
-                         (a) reinstall with the default feature set: \
-                         `cargo install mikebom`, or\n\
-                         (b) pre-extract the image with \
-                         `docker save <ref> -o image.tar` and pass \
-                         `--image image.tar`.",
-                        archive.display()
-                    );
-                }
+                let arg_str = archive.to_str().context(
+                    "--image argument is not valid UTF-8 — required for OCI ref parsing",
+                )?;
+                resolve_image_ref(arg_str, &args, &mut _image_tempdir).await?
             };
             tracing::info!(archive = %archive_path.display(), "extracting docker image");
             let extracted = scan_fs::docker_image::extract(&archive_path)?;
@@ -1114,5 +1224,72 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert!(err.contains("conflicts with --output"), "got: {err}");
+    }
+
+    /// Wrapper Parser for clap-parsing tests — `ScanArgs` derives
+    /// `Args`, not `Parser`, so we flatten it into a top-level Parser.
+    #[derive(clap::Parser, Debug)]
+    struct ScanArgsForTest {
+        #[command(flatten)]
+        inner: ScanArgs,
+    }
+
+    #[test]
+    fn image_src_defaults_to_docker_then_remote() {
+        let parsed = <ScanArgsForTest as clap::Parser>::try_parse_from([
+            "scan", "--path", ".",
+        ])
+        .unwrap();
+        assert_eq!(
+            parsed.inner.image_src,
+            vec![ImageSource::Docker, ImageSource::Remote]
+        );
+    }
+
+    #[test]
+    fn image_src_accepts_comma_separated_list() {
+        let parsed = <ScanArgsForTest as clap::Parser>::try_parse_from([
+            "scan",
+            "--path",
+            ".",
+            "--image-src",
+            "remote,docker",
+        ])
+        .unwrap();
+        assert_eq!(
+            parsed.inner.image_src,
+            vec![ImageSource::Remote, ImageSource::Docker]
+        );
+    }
+
+    #[test]
+    fn image_src_accepts_single_value() {
+        let parsed = <ScanArgsForTest as clap::Parser>::try_parse_from([
+            "scan",
+            "--path",
+            ".",
+            "--image-src",
+            "remote",
+        ])
+        .unwrap();
+        assert_eq!(parsed.inner.image_src, vec![ImageSource::Remote]);
+    }
+
+    #[test]
+    fn image_src_rejects_unknown_value() {
+        let err = <ScanArgsForTest as clap::Parser>::try_parse_from([
+            "scan",
+            "--path",
+            ".",
+            "--image-src",
+            "podman",
+        ])
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.to_lowercase().contains("invalid value")
+                || err.to_lowercase().contains("possible values"),
+            "expected clap to reject unknown image-src value, got: {err}"
+        );
     }
 }

--- a/mikebom-cli/src/scan_fs/docker_daemon.rs
+++ b/mikebom-cli/src/scan_fs/docker_daemon.rs
@@ -1,0 +1,182 @@
+//! Local Docker-daemon image source (milestone 044 commit 1).
+//!
+//! Trivy and syft both default to checking the local docker daemon
+//! before reaching for a registry pull. mikebom adopts the same
+//! convention via the `--image-src docker,remote` flag (see
+//! [`crate::cli::scan_cmd::ImageSource`]).
+//!
+//! Implementation: shell out to the `docker` CLI. We could talk to
+//! `/var/run/docker.sock` directly, but `docker save` / `docker image
+//! inspect` is what users already have configured (DOCKER_HOST,
+//! DOCKER_TLS_VERIFY, contexts) and avoids adding a daemon-API client.
+//! If `docker` is not on `$PATH`, callers fall through to the next
+//! configured source.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use anyhow::{bail, Context, Result};
+
+/// Outcome of probing the local docker daemon for a given image
+/// reference.
+#[derive(Debug, PartialEq, Eq)]
+pub enum InspectOutcome {
+    /// `docker image inspect <ref>` succeeded — the image is cached
+    /// locally and can be exported via [`save`].
+    Present,
+    /// `docker` ran but the image is not in the local cache (exit !=
+    /// 0 from `docker image inspect`).
+    Absent,
+    /// `docker` is not available — either the binary isn't on `$PATH`
+    /// or the daemon is unreachable. Callers treat this the same as
+    /// `Absent` for routing purposes; the variant exists so
+    /// diagnostic logs can distinguish "daemon down" from "image not
+    /// cached".
+    DockerUnavailable,
+}
+
+/// Check whether `image_ref` is present in the local docker daemon's
+/// cache. Pure read; never modifies state.
+///
+/// Returns:
+/// - `Present` if `docker image inspect <ref>` exits 0
+/// - `Absent` if the command runs but exits non-zero (e.g.
+///   "No such image: ...")
+/// - `DockerUnavailable` if the `docker` binary can't be spawned (not
+///   installed, or `$DOCKER_HOST` points at a dead daemon and the
+///   command fails before exec).
+pub fn inspect(image_ref: &str) -> InspectOutcome {
+    let mut cmd = Command::new("docker");
+    cmd.args(["image", "inspect", image_ref])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    match cmd.status() {
+        Ok(status) if status.success() => InspectOutcome::Present,
+        Ok(_) => InspectOutcome::Absent,
+        Err(e) => {
+            tracing::debug!(
+                image_ref,
+                error = %e,
+                "docker image inspect could not be spawned; skipping local-daemon source"
+            );
+            InspectOutcome::DockerUnavailable
+        }
+    }
+}
+
+/// Export `image_ref` from the local docker daemon to a `docker
+/// save`-format tarball at `dest`. Caller is responsible for the
+/// destination path's lifetime (typically a `tempfile::TempDir`).
+///
+/// Errors: `docker save` writes to stderr on failure; we capture and
+/// surface it. If `docker` isn't available the error mentions both
+/// possibilities (not installed / daemon unreachable) so the user
+/// can diagnose.
+pub fn save(image_ref: &str, dest: &Path) -> Result<()> {
+    let dest_arg = dest
+        .to_str()
+        .context("docker save destination path is not valid UTF-8")?;
+    let output = Command::new("docker")
+        .args(["save", image_ref, "-o", dest_arg])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .with_context(|| {
+            format!(
+                "spawning `docker save {image_ref} -o {dest_arg}` (is the `docker` \
+                 CLI installed and is the daemon reachable?)"
+            )
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        bail!(
+            "docker save {image_ref} failed with status {}: {}",
+            output.status,
+            stderr.trim()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    /// Whether the test host has `docker` available. Tests that need a
+    /// running daemon skip themselves when this is false so CI lanes
+    /// without docker (the default lane) don't fail.
+    fn docker_available() -> bool {
+        Command::new("docker")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn inspect_returns_unavailable_when_docker_not_on_path() {
+        // We can't easily simulate "docker missing" because the
+        // current process's $PATH may very well contain it. Instead,
+        // exercise the spawn-error path by overriding $PATH for this
+        // test only.
+        //
+        // SAFETY: Rust `set_var` is single-threaded-only as of edition
+        // 2024; in our test crate the runner spawns one thread per
+        // test. Cargo serializes env mutations within a single
+        // process otherwise. This test only mutates $PATH and
+        // restores it, so concurrent tests reading $PATH could see a
+        // transient empty value. None of the other tests in this
+        // file read $PATH, so the race window is unobservable in
+        // practice.
+        let saved_path = std::env::var_os("PATH");
+        // SAFETY: see comment above.
+        unsafe {
+            std::env::set_var("PATH", "/this/path/does/not/exist");
+        }
+        let outcome = inspect("alpine:3.19");
+        // SAFETY: see comment above.
+        unsafe {
+            match saved_path {
+                Some(p) => std::env::set_var("PATH", p),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+        assert_eq!(outcome, InspectOutcome::DockerUnavailable);
+    }
+
+    #[test]
+    fn inspect_returns_absent_for_image_not_in_local_cache() {
+        if !docker_available() {
+            eprintln!("skipping: `docker --version` failed; daemon not available");
+            return;
+        }
+        // A reference that cannot exist anywhere — random suffix in
+        // the tag space.
+        let outcome =
+            inspect("registry.invalid.mikebom-test.example/no-such-image:nope-d9f4b2");
+        assert_eq!(outcome, InspectOutcome::Absent);
+    }
+
+    #[test]
+    fn save_propagates_stderr_on_unknown_image() {
+        if !docker_available() {
+            eprintln!("skipping: `docker --version` failed; daemon not available");
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("image.tar");
+        let err = save(
+            "registry.invalid.mikebom-test.example/no-such-image:nope-d9f4b2",
+            &dest,
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("docker save") && msg.contains("failed"),
+            "expected error to mention `docker save` failure, got: {msg}"
+        );
+    }
+}

--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -10,6 +10,7 @@
 //!   the standalone `mikebom sbom scan` subcommand.
 
 pub mod binary;
+pub mod docker_daemon;
 pub mod docker_image;
 #[cfg(feature = "oci-registry")]
 pub mod oci_pull;

--- a/mikebom-cli/src/scan_fs/oci_pull/registry.rs
+++ b/mikebom-cli/src/scan_fs/oci_pull/registry.rs
@@ -100,7 +100,7 @@ impl RegistryClient {
         reference: &ImageReference,
     ) -> Result<ManifestOrIndex> {
         let url = manifest_url(reference);
-        let body = self.fetch_with_bearer_retry(&url, MANIFEST_MEDIA_TYPES).await?;
+        let body = self.fetch_with_auth_retry(&url, MANIFEST_MEDIA_TYPES).await?;
         let content_type = body.content_type;
         let bytes = body.bytes;
 
@@ -137,7 +137,7 @@ impl RegistryClient {
         }
         let url = blob_url(reference, digest);
         // Blob endpoint accepts any media type; we send `*/*`.
-        let body = self.fetch_with_bearer_retry(&url, &["*/*"]).await?;
+        let body = self.fetch_with_auth_retry(&url, &["*/*"]).await?;
         verify_sha256(&body.bytes, digest)
             .with_context(|| format!("verifying blob {digest} from {url}"))?;
         if let Some(cache) = self.cache.as_ref() {
@@ -153,9 +153,11 @@ impl RegistryClient {
     }
 
     /// GET `url` with the supplied Accept media types. Handles
-    /// 401 → bearer-token-fetch → retry. Returns the body bytes
-    /// + the Content-Type header so the caller can dispatch.
-    async fn fetch_with_bearer_retry(
+    /// 401 → auth-challenge → retry for both `Bearer` (token-realm
+    /// flow) and `Basic` (direct-credentials flow, used by ECR).
+    /// Returns the body bytes + the Content-Type header so the
+    /// caller can dispatch.
+    async fn fetch_with_auth_retry(
         &self,
         url: &str,
         accept: &[&str],
@@ -173,7 +175,6 @@ impl RegistryClient {
             return ResponseBody::from_response(first).await;
         }
         if status.as_u16() == 401 {
-            // Parse the bearer challenge, fetch a token, retry.
             let www_auth = first
                 .headers()
                 .get(reqwest::header::WWW_AUTHENTICATE)
@@ -183,30 +184,59 @@ impl RegistryClient {
                 .to_str()
                 .context("WWW-Authenticate is not valid UTF-8")?
                 .to_string();
-            let challenge = parse_bearer_challenge(&www_auth)?;
-            let token = self.fetch_bearer_token(&challenge).await?;
-            let retry = self
-                .http
-                .get(url)
-                .header("Accept", &accept_header)
-                .bearer_auth(&token)
-                .send()
-                .await
-                .with_context(|| format!("retrying GET {url} with bearer token"))?;
+            let challenge = parse_auth_challenge(&www_auth)?;
+            let retry = match challenge {
+                AuthChallenge::Bearer(bearer) => {
+                    let token = self.fetch_bearer_token(&bearer).await?;
+                    self.http
+                        .get(url)
+                        .header("Accept", &accept_header)
+                        .bearer_auth(&token)
+                        .send()
+                        .await
+                        .with_context(|| format!("retrying GET {url} with bearer token"))?
+                }
+                AuthChallenge::Basic { realm } => {
+                    tracing::debug!(
+                        url,
+                        %realm,
+                        "registry sent Basic auth challenge; applying cached docker credentials"
+                    );
+                    let creds = self.credentials.as_ref().ok_or_else(|| {
+                        anyhow!(
+                            "registry returned 401 with Basic auth challenge for GET {url}, \
+                             but no credentials are configured for this registry. \
+                             Run `docker login <registry>` (or for AWS ECR, \
+                             `aws ecr get-login-password | docker login --username AWS \
+                             --password-stdin <registry>`) so the credentials land in \
+                             ~/.docker/config.json."
+                        )
+                    })?;
+                    self.http
+                        .get(url)
+                        .header("Accept", &accept_header)
+                        .basic_auth(&creds.username, Some(&creds.secret))
+                        .send()
+                        .await
+                        .with_context(|| {
+                            format!("retrying GET {url} with Basic auth")
+                        })?
+                }
+            };
             if retry.status().is_success() {
                 return ResponseBody::from_response(retry).await;
             }
             if self.credentials.is_some() {
                 bail!(
                     "registry authentication failed for GET {url} \
-                     (got {} after bearer-token retry). Verify credentials \
+                     (got {} after auth retry). Verify credentials \
                      in ~/.docker/config.json or your credential helper.",
                     retry.status()
                 );
             }
             bail!(
                 "registry returned {} for GET {url} after anonymous \
-                 bearer-token retry. For private registries, configure \
+                 auth retry. For private registries, configure \
                  ~/.docker/config.json (`auth` or `identitytoken` field) \
                  or a credential helper.",
                 retry.status()
@@ -266,46 +296,82 @@ impl RegistryClient {
 /// The `WWW-Authenticate: Bearer realm="...",service="...",scope="..."`
 /// challenge fields. realm is required; service and scope are
 /// optional (some registries emit only realm).
+#[derive(Debug)]
 struct BearerChallenge {
     realm: String,
     service: Option<String>,
     scope: Option<String>,
 }
 
-/// Parse a `WWW-Authenticate: Bearer realm="...",service="...",scope="..."`
-/// header value into its fields.
-fn parse_bearer_challenge(value: &str) -> Result<BearerChallenge> {
-    // Strip the `Bearer ` prefix (case-insensitive).
-    let trimmed = value.trim_start();
-    let after_scheme = if trimmed.len() >= 7
-        && trimmed[..7].eq_ignore_ascii_case("Bearer ")
-    {
-        &trimmed[7..]
-    } else {
-        bail!("WWW-Authenticate is not a Bearer challenge: {value}");
-    };
+/// Parsed `WWW-Authenticate` challenge. Two schemes matter for OCI
+/// distribution-spec implementations in the wild:
+///
+/// - `Bearer`: standard distribution-spec auth (Docker Hub, GHCR,
+///   gcr.io, …) — fetch a token from the realm endpoint, retry the
+///   request with `Authorization: Bearer <token>`.
+/// - `Basic`: AWS ECR's flavor — apply `Authorization: Basic
+///   <base64(user:secret)>` directly on the original request from
+///   the credentials cached in `~/.docker/config.json` (populated
+///   by `aws ecr get-login-password | docker login`). No realm
+///   round-trip.
+#[derive(Debug)]
+enum AuthChallenge {
+    Bearer(BearerChallenge),
+    Basic { realm: String },
+}
 
-    // Split on commas at the top level. Values may contain commas
-    // inside double-quotes; we respect that.
-    let mut realm: Option<String> = None;
-    let mut service: Option<String> = None;
-    let mut scope: Option<String> = None;
-    for (k, v) in iter_kv_pairs(after_scheme) {
-        match k.as_str() {
-            "realm" => realm = Some(v),
-            "service" => service = Some(v),
-            "scope" => scope = Some(v),
-            _ => {}
+/// Parse a `WWW-Authenticate: <scheme> ...` header value. Supports
+/// both `Bearer` (token-realm flow) and `Basic` (direct cred apply)
+/// schemes. Anything else errors out.
+fn parse_auth_challenge(value: &str) -> Result<AuthChallenge> {
+    let trimmed = value.trim_start();
+    if trimmed.len() >= 7 && trimmed[..7].eq_ignore_ascii_case("Bearer ") {
+        let after = &trimmed[7..];
+        let mut realm: Option<String> = None;
+        let mut service: Option<String> = None;
+        let mut scope: Option<String> = None;
+        for (k, v) in iter_kv_pairs(after) {
+            match k.as_str() {
+                "realm" => realm = Some(v),
+                "service" => service = Some(v),
+                "scope" => scope = Some(v),
+                _ => {}
+            }
         }
+        let realm = realm.ok_or_else(|| {
+            anyhow!("WWW-Authenticate Bearer challenge missing `realm`: {value}")
+        })?;
+        return Ok(AuthChallenge::Bearer(BearerChallenge {
+            realm,
+            service,
+            scope,
+        }));
     }
-    let realm = realm.ok_or_else(|| {
-        anyhow!("WWW-Authenticate Bearer challenge missing `realm`: {value}")
-    })?;
-    Ok(BearerChallenge {
-        realm,
-        service,
-        scope,
-    })
+    // Match `Basic` followed by either whitespace (parameters
+    // present) or end-of-string (bare scheme token). RFC 7617
+    // requires `realm`; we accept its absence defensively (some
+    // non-conforming registries may omit it) and store an empty
+    // string. The `realm` value is purely diagnostic for this
+    // scheme — the credentials apply regardless.
+    let lower = trimmed.to_ascii_lowercase();
+    let basic_match = lower == "basic" || lower.starts_with("basic ");
+    if basic_match {
+        let after = if trimmed.len() > 5 {
+            &trimmed[5..]
+        } else {
+            ""
+        };
+        let mut realm: Option<String> = None;
+        for (k, v) in iter_kv_pairs(after) {
+            if k == "realm" {
+                realm = Some(v);
+            }
+        }
+        return Ok(AuthChallenge::Basic {
+            realm: realm.unwrap_or_default(),
+        });
+    }
+    bail!("WWW-Authenticate uses an unsupported scheme (mikebom understands Bearer and Basic): {value}")
 }
 
 /// Iterate `key="value"` pairs respecting double-quoted values
@@ -419,6 +485,7 @@ fn verify_sha256(bytes: &[u8], expected_digest: &str) -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 struct ResponseBody {
     bytes: Vec<u8>,
     content_type: String,
@@ -449,51 +516,93 @@ impl ResponseBody {
 mod tests {
     use super::*;
 
+    fn parse_bearer_for_test(value: &str) -> Result<BearerChallenge> {
+        match parse_auth_challenge(value)? {
+            AuthChallenge::Bearer(b) => Ok(b),
+            AuthChallenge::Basic { .. } => {
+                bail!("expected Bearer challenge, got Basic")
+            }
+        }
+    }
+
     #[test]
-    fn parse_bearer_challenge_extracts_realm_service_scope() {
+    fn parse_auth_challenge_extracts_realm_service_scope() {
         // Docker Hub's actual challenge format.
         let v = r#"Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/alpine:pull""#;
-        let c = parse_bearer_challenge(v).unwrap();
+        let c = parse_bearer_for_test(v).unwrap();
         assert_eq!(c.realm, "https://auth.docker.io/token");
         assert_eq!(c.service.as_deref(), Some("registry.docker.io"));
         assert_eq!(c.scope.as_deref(), Some("repository:library/alpine:pull"));
     }
 
     #[test]
-    fn parse_bearer_challenge_handles_realm_only() {
+    fn parse_auth_challenge_handles_realm_only() {
         let v = r#"Bearer realm="https://example.com/token""#;
-        let c = parse_bearer_challenge(v).unwrap();
+        let c = parse_bearer_for_test(v).unwrap();
         assert_eq!(c.realm, "https://example.com/token");
         assert_eq!(c.service, None);
         assert_eq!(c.scope, None);
     }
 
     #[test]
-    fn parse_bearer_challenge_handles_unquoted_values() {
+    fn parse_auth_challenge_handles_unquoted_values() {
         // RFC 7235 allows token-style values without quotes.
         let v = "Bearer realm=https://example.com/token,service=example.com";
-        let c = parse_bearer_challenge(v).unwrap();
+        let c = parse_bearer_for_test(v).unwrap();
         assert_eq!(c.realm, "https://example.com/token");
         assert_eq!(c.service.as_deref(), Some("example.com"));
     }
 
     #[test]
-    fn parse_bearer_challenge_rejects_basic_scheme() {
-        let v = r#"Basic realm="x""#;
-        assert!(parse_bearer_challenge(v).is_err());
+    fn parse_auth_challenge_recognizes_basic_scheme() {
+        // ECR's WWW-Authenticate response shape.
+        let v = r#"Basic realm="https://767397973649.dkr.ecr.us-east-1.amazonaws.com/",service="ecr.amazonaws.com""#;
+        let c = parse_auth_challenge(v).unwrap();
+        match c {
+            AuthChallenge::Basic { realm } => {
+                assert_eq!(
+                    realm,
+                    "https://767397973649.dkr.ecr.us-east-1.amazonaws.com/"
+                );
+            }
+            AuthChallenge::Bearer(_) => panic!("expected Basic challenge"),
+        }
     }
 
     #[test]
-    fn parse_bearer_challenge_rejects_missing_realm() {
+    fn parse_auth_challenge_basic_without_realm_succeeds_with_empty() {
+        let v = "Basic";
+        let c = parse_auth_challenge(v).unwrap();
+        match c {
+            AuthChallenge::Basic { realm } => assert_eq!(realm, ""),
+            AuthChallenge::Bearer(_) => panic!("expected Basic challenge"),
+        }
+    }
+
+    #[test]
+    fn parse_auth_challenge_rejects_unknown_scheme() {
+        let v = r#"Digest realm="x""#;
+        let err = parse_auth_challenge(v).unwrap_err().to_string();
+        assert!(
+            err.contains("unsupported scheme"),
+            "expected error mentioning unsupported scheme, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_auth_challenge_rejects_missing_realm_on_bearer() {
         let v = r#"Bearer service="x",scope="y""#;
-        assert!(parse_bearer_challenge(v).is_err());
+        assert!(parse_auth_challenge(v).is_err());
     }
 
     #[test]
-    fn parse_bearer_challenge_handles_case_insensitive_scheme() {
+    fn parse_auth_challenge_handles_case_insensitive_scheme() {
         let v = r#"bearer realm="https://example.com/token""#;
-        let c = parse_bearer_challenge(v).unwrap();
+        let c = parse_bearer_for_test(v).unwrap();
         assert_eq!(c.realm, "https://example.com/token");
+        let v2 = r#"basic realm="x""#;
+        let c2 = parse_auth_challenge(v2).unwrap();
+        assert!(matches!(c2, AuthChallenge::Basic { .. }));
     }
 
     #[test]
@@ -705,6 +814,162 @@ mod tests {
             !has_auth,
             "anonymous realm GET must not carry Authorization header; got request:\n{request}"
         );
+    }
+
+    /// End-to-end Basic-auth wire-up test (milestone 044 commit 2):
+    /// when a registry returns 401 with `WWW-Authenticate: Basic
+    /// realm="..."` (ECR's flavor) and the `RegistryClient` has
+    /// credentials, the retry carries `Authorization: Basic
+    /// <b64(user:secret)>` directly on the original URL — no realm
+    /// round-trip.
+    ///
+    /// We spin up a TCP listener that speaks two HTTP request/response
+    /// pairs over a single connection: first the unauthenticated
+    /// challenge, then the authenticated retry that returns the
+    /// manifest body.
+    #[tokio::test]
+    async fn fetch_with_auth_retry_handles_basic_challenge_with_credentials() {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            // Connection 1: unauthenticated GET → 401 Basic challenge.
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let mut total = 0;
+            while total < buf.len() {
+                let n = stream.read(&mut buf[total..]).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                total += n;
+                if buf[..total].windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let req1 = String::from_utf8_lossy(&buf[..total]).into_owned();
+            let resp1 = "HTTP/1.1 401 Unauthorized\r\n\
+                         WWW-Authenticate: Basic realm=\"https://registry.example/\",service=\"ecr.amazonaws.com\"\r\n\
+                         Content-Length: 0\r\n\
+                         Connection: close\r\n\r\n";
+            stream.write_all(resp1.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+            drop(stream);
+
+            // Connection 2: authenticated retry → 200 with body.
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let mut total = 0;
+            while total < buf.len() {
+                let n = stream.read(&mut buf[total..]).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                total += n;
+                if buf[..total].windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let req2 = String::from_utf8_lossy(&buf[..total]).into_owned();
+            let body = r#"{"hello":"world"}"#;
+            let resp2 = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(resp2.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+            (req1, req2)
+        });
+
+        let client = RegistryClient {
+            http: reqwest::Client::new(),
+            credentials: Some(Credential {
+                username: "AWS".to_string(),
+                secret: "ecr-token-d34db33f".to_string(),
+            }),
+            cache: None,
+        };
+
+        let url = format!("http://{addr}/v2/foo/bar/manifests/latest");
+        let body = client
+            .fetch_with_auth_retry(&url, &["application/json"])
+            .await
+            .unwrap();
+        assert_eq!(body.bytes, br#"{"hello":"world"}"#.to_vec());
+
+        let (req1, req2) = server.await.unwrap();
+        let lower1 = req1.to_ascii_lowercase();
+        assert!(
+            !lower1
+                .lines()
+                .any(|l| l.starts_with("authorization:")),
+            "first GET must be unauthenticated; got:\n{req1}"
+        );
+        // base64("AWS:ecr-token-d34db33f") = QVdTOmVjci10b2tlbi1kMzRkYjMzZg==
+        assert!(
+            req2.contains("Authorization: Basic QVdTOmVjci10b2tlbi1kMzRkYjMzZg==")
+                || req2.contains("authorization: Basic QVdTOmVjci10b2tlbi1kMzRkYjMzZg=="),
+            "retry must carry Basic auth header; got:\n{req2}"
+        );
+    }
+
+    /// Counterpart: when the registry sends a Basic challenge but
+    /// `RegistryClient` has NO credentials, the error message
+    /// guides the user to `docker login` (or
+    /// `aws ecr get-login-password | docker login` for ECR).
+    #[tokio::test]
+    async fn fetch_with_auth_retry_basic_without_credentials_errors_helpfully() {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let mut total = 0;
+            while total < buf.len() {
+                let n = stream.read(&mut buf[total..]).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                total += n;
+                if buf[..total].windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let resp = "HTTP/1.1 401 Unauthorized\r\n\
+                        WWW-Authenticate: Basic realm=\"https://registry.example/\"\r\n\
+                        Content-Length: 0\r\n\
+                        Connection: close\r\n\r\n";
+            stream.write_all(resp.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+        });
+
+        let client = RegistryClient {
+            http: reqwest::Client::new(),
+            credentials: None,
+            cache: None,
+        };
+
+        let url = format!("http://{addr}/v2/foo/bar/manifests/latest");
+        let err = client
+            .fetch_with_auth_retry(&url, &["application/json"])
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Basic auth challenge")
+                && err.contains("docker login"),
+            "expected error to guide the user toward `docker login`; got: {err}"
+        );
+
+        server.await.unwrap();
     }
 
     /// End-to-end cache wire-up test (milestone 036 commit 2): when


### PR DESCRIPTION
## Summary

- Adds `--image-src docker,remote` flag (default in that order) to `mikebom sbom scan --image <ref>`. Local docker daemon is now consulted before reaching for a registry pull, matching trivy's `--image-src` and syft's auto-detection convention.
- Fixes the `WWW-Authenticate is not a Bearer challenge: Basic ...` error against AWS ECR by teaching the OCI registry client to handle `Basic` auth challenges in addition to `Bearer`. Cached docker-config credentials are applied directly on the original request — no realm round-trip needed for ECR.

Either fix on its own resolves the user-reported flow:
\`\`\`
docker pull <ecr-ref>           # cached locally
aws ecr get-login-password | docker login --username AWS --password-stdin <ecr-host>
mikebom sbom scan --image <ecr-ref>   # was failing; now succeeds
\`\`\`
Together they make mikebom's image-source UX conventional and self-sufficient against ECR even from CI runners that don't have docker installed.

## Commits

1. **`feat(044/us1): docker-daemon-first image source resolution`** — new `--image-src` flag, `docker_daemon` module (`docker image inspect` + `docker save` shell-out), dispatch loop, 4 clap-parsing tests + 3 daemon-shell-out tests.
2. **`fix(044/us2): handle Basic auth challenge for ECR registry pulls`** — `parse_bearer_challenge` → `parse_auth_challenge` (Bearer + Basic), 401-retry dispatch, 2 new wire-up tests + 6 challenge-parsing tests.

## Test plan

- [x] \`./scripts/pre-pr.sh\` clean (clippy + workspace tests).
- [x] \`cargo +stable test -p mikebom\` — 50 suites, 0 failed.
- [x] \`cargo +stable test -p mikebom --test holistic_parity\` — 11/11 ok.
- [x] \`docker_daemon::tests\` (3 new) and \`oci_pull::registry::tests\` (8 new) pass.
- [x] Existing \`--image <tarball-path>\` flow byte-identical (file-exists branch unchanged).
- [x] Docker Hub / GHCR \`Bearer\` auth path preserved (existing wire-up tests unchanged).
- [ ] (Manual) Repro the reporter's flow against an ECR image with the resulting \`mikebom\` binary — \`mikebom sbom scan --image <ecr-ref>\` should succeed via docker-daemon path; \`--image-src remote\` should succeed via Basic-auth path; uncached ref should fall through docker → registry.

## Out of scope

- containerd / podman socket support (trivy has these; tracked as a follow-on if asked for).
- Talking to docker daemon over Unix socket directly (no subprocess) — would replace the \`docker save\` shell-out; not needed for correctness.
- AWS SDK-based ECR auth path (cred-helper via \`~/.docker/config.json\` is what trivy and syft both do).
- syft-style URI-prefix schemes (\`docker:foo\`, \`registry:foo\`) — \`--image-src\` covers the same ground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)