### PR TITLE
test(045): CI flake hardening — pin timestamp + median-of-5 perf sampling

### DIFF
--- a/mikebom-cli/tests/dual_format_perf.rs
+++ b/mikebom-cli/tests/dual_format_perf.rs
@@ -223,18 +223,27 @@ fn time_scan(image: &std::path::Path, formats: &str) -> Duration {
     elapsed
 }
 
-/// Median of three wall-clock measurements of the same scan.
+/// Median of five wall-clock measurements of the same scan.
 /// Median is more robust than mean on noisy runners — a single
 /// slow run (kernel cache flush, neighbor process stealing a core,
-/// etc.) doesn't shift the reported timing much.
-fn median_of_3(image: &std::path::Path, formats: &str) -> Duration {
+/// etc.) doesn't shift the reported timing much. Bumped from
+/// median-of-3 in milestone 045 after macOS-latest CI runs
+/// produced a perf-gate failure at 9.0 % reduction (run
+/// 25095463014) while local distributions sit around 50 %.
+/// Five samples cuts the median's variance by ≈40 % vs three —
+/// gives headroom against macOS-runner CPU contention without
+/// weakening the regression-catch surface. CI gate stays at
+/// 25 %; spec target stays at 30 %.
+fn median_of_5(image: &std::path::Path, formats: &str) -> Duration {
     let mut samples = [
+        time_scan(image, formats),
+        time_scan(image, formats),
         time_scan(image, formats),
         time_scan(image, formats),
         time_scan(image, formats),
     ];
     samples.sort();
-    samples[1]
+    samples[2]
 }
 
 #[test]
@@ -262,9 +271,9 @@ fn dual_format_is_at_least_30_percent_faster_than_two_sequential_scans() {
     // serializer/dispatch overhead, not cold-cache I/O noise.
     let _ = time_scan(&image, "cyclonedx-json");
 
-    let cdx = median_of_3(&image, "cyclonedx-json");
-    let spdx = median_of_3(&image, "spdx-2.3-json");
-    let dual = median_of_3(&image, "cyclonedx-json,spdx-2.3-json");
+    let cdx = median_of_5(&image, "cyclonedx-json");
+    let spdx = median_of_5(&image, "spdx-2.3-json");
+    let dual = median_of_5(&image, "cyclonedx-json,spdx-2.3-json");
     let sequential = cdx + spdx;
 
     // Spec SC-009 target: dual ≤ 0.70 × sequential (≥ 30 %

--- a/mikebom-cli/tests/format_dispatch.rs
+++ b/mikebom-cli/tests/format_dispatch.rs
@@ -41,6 +41,13 @@ fn run_scan_in(
     let mut cmd = Command::new(bin());
     cmd.current_dir(cwd);
     apply_fake_home_env(&mut cmd, fake_home.path());
+    // Pin `OutputConfig.created` so two sequential subprocess
+    // invocations get the same timestamp even when they straddle a
+    // second-boundary on slow runners. Without this, byte-identity
+    // assertions (e.g. `spdx_3_alias_bytes_are_byte_identical_to_
+    // stable_identifier`) fail intermittently. The env var contract
+    // is documented at `cli::scan_cmd::scan_created_timestamp`.
+    cmd.env("MIKEBOM_FIXED_TIMESTAMP", "2026-01-01T00:00:00Z");
     cmd
         .arg("--offline")
         .arg("sbom")

--- a/mikebom-cli/tests/spdx3_us3_acceptance.rs
+++ b/mikebom-cli/tests/spdx3_us3_acceptance.rs
@@ -328,6 +328,14 @@ fn run_scan_with_format(
     let out_path = tmp.path().join("out.spdx3.json");
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_mikebom"));
     apply_fake_home_env(&mut cmd, fake_home.path());
+    // Pin `OutputConfig.created` so two sequential subprocess
+    // invocations of this helper produce byte-identical SPDX 3
+    // output (Scenario 7's contract). Without this, the two
+    // invocations may straddle a second-boundary on slow runners,
+    // surfacing as a CI flake on docs-only PRs and on main. Set
+    // before `extra_env` so callers can still override via that
+    // mechanism if a test specifically needs a non-fixed timestamp.
+    cmd.env("MIKEBOM_FIXED_TIMESTAMP", "2026-01-01T00:00:00Z");
     for (k, v) in extra_env {
         cmd.env(k, v);
     }

--- a/mikebom-cli/tests/triple_format_perf.rs
+++ b/mikebom-cli/tests/triple_format_perf.rs
@@ -175,14 +175,25 @@ fn time_scan(image: &std::path::Path, formats: &str) -> Duration {
 }
 
 /// Median of three measurements — robust to CI-runner noise.
-fn median_of_3(image: &std::path::Path, formats: &str) -> Duration {
+/// Median of five wall-clock measurements. Bumped from
+/// median-of-3 in milestone 045 after macOS-latest CI runners
+/// produced two perf-gate failures on otherwise-clean PRs (run
+/// 24967239854 at 14.4 %, run 25131817848 at 19.9 %), with the
+/// local distribution sitting around 50 % reduction. Five
+/// samples cuts the median's variance by ≈40 % vs three for the
+/// same per-iteration cost — buys headroom against macOS-runner
+/// CPU contention without weakening the regression-catch
+/// surface. Spec target stays at 30 %; CI gate stays at 25 %.
+fn median_of_5(image: &std::path::Path, formats: &str) -> Duration {
     let mut samples = [
+        time_scan(image, formats),
+        time_scan(image, formats),
         time_scan(image, formats),
         time_scan(image, formats),
         time_scan(image, formats),
     ];
     samples.sort();
-    samples[1]
+    samples[2]
 }
 
 #[test]
@@ -204,10 +215,10 @@ fn triple_format_is_at_least_25_percent_faster_than_three_sequential_scans() {
     // I/O noise.
     let _ = time_scan(&image, "cyclonedx-json");
 
-    let cdx = median_of_3(&image, "cyclonedx-json");
-    let spdx = median_of_3(&image, "spdx-2.3-json");
-    let spdx3 = median_of_3(&image, "spdx-3-json");
-    let triple = median_of_3(&image, "cyclonedx-json,spdx-2.3-json,spdx-3-json");
+    let cdx = median_of_5(&image, "cyclonedx-json");
+    let spdx = median_of_5(&image, "spdx-2.3-json");
+    let spdx3 = median_of_5(&image, "spdx-3-json");
+    let triple = median_of_5(&image, "cyclonedx-json,spdx-2.3-json,spdx-3-json");
     let sequential = cdx + spdx + spdx3;
 
     // Spec SC-007 target: triple ≤ 0.70 × sequential (≥ 30 %


### PR DESCRIPTION
## Summary

Two genuine CI flakes diagnosed from a 60-run audit; this PR fixes both without weakening any regression-catch gate.

| Flake | Cause | Fix |
|---|---|---|
| `spdx_3_alias_bytes_are_byte_identical_to_stable_identifier` (and 2 sibling tests) hitting both main and an unrelated docs-only PR | Two sequential subprocess invocations occasionally straddle a second-boundary; raw-byte comparison fails on the divergent `creationInfo.created` timestamp | Pin \`MIKEBOM_FIXED_TIMESTAMP=2026-01-01T00:00:00Z\` in the two helpers (\`format_dispatch::run_scan_in\`, \`spdx3_us3_acceptance::run_scan_with_format\`). The env var was added in milestone 011 specifically for this — the helpers just weren't using it. |
| \`dual_format_perf\` / \`triple_format_perf\` tests on macos-latest (9.0 %, 14.4 %, 19.9 % reductions seen vs the 25 % gate) | macOS GitHub runner CPU contention; 30+ point shortfall vs local distribution (47.7–52.6 %, mean 50.7 % over 10 iterations on an idle MacBook) | Bump \`median_of_3\` → \`median_of_5\`. Cuts the median's variance by ≈40 % at a per-test cost of +7–9 seconds. CI gate (25 %) and spec target (30 %) unchanged. |

## Diagnostic data

CI audit covered 189 runs over 8 days. 21 failures broke down as:
- **9 real test failures**, of which only **3 distinct tests** are real flakes (rest are in-flight feature work or one-shots).
- 12 build/clippy/install errors (not test flakes).

Failure clustering:
- All 4 perf-test failures on **macos-latest only**. Linux failures were on a branch literally tuning the perf gate.
- The 3 byte-identity failures hit on main + an unrelated docs PR — couldn't have been caused by either branch.

Local 10-iteration triple_format_perf distribution on this MacBook: 47.7, 49.6, 49.7, 50.3, 50.5, 51.2, 51.2, 51.7, 52.6, 52.6 (mean 50.7%, range 4.9 points). macOS CI extreme miss (14.4%) is **36 percentage points** below the local median — that's runner noise, not a regression.

## Commits

1. \`test(045): pin MIKEBOM_FIXED_TIMESTAMP in byte-identity test helpers\` — eliminates the second-boundary-race for 3 byte-comparison tests.
2. \`test(045): median-of-5 sampling for dual/triple format perf gates\` — variance reduction without weakening the gate.

## Test plan

- [x] \`./scripts/pre-pr.sh\` clean (clippy + workspace tests).
- [x] \`format_dispatch::spdx_3_alias_bytes_are_byte_identical_to_stable_identifier\` passes.
- [x] \`spdx3_us3_acceptance::scenario_7\` and \`scenario_8\` pass.
- [x] \`dual_format_perf\` produces 43.0% reduction at median-of-5.
- [x] \`triple_format_perf\` produces 51.7% reduction at median-of-5.
- [ ] CI lanes (linux x86_64 + ebpf + macOS) all green on this PR.

## Out of scope

- Investigating whether macOS GitHub runners are about to migrate to faster hardware (would let us tighten the gate back). Track separately if it surfaces.
- The other observed test failures from the audit (\`scan_go_source_tree_emits_transitive_edges_when_cache_present\`, single observation on a feature branch) — insufficient data to call it a flake yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)