### PR TITLE
feat(047): SBOM-scope self-description (README explainer + SPDX comment parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,27 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 
 ## [Unreleased]
 
-(Nothing yet. Land changes here, then cut a release per the
-`release.yml` workflow trigger documented in
-`docs/contributing/release.md`.)
+### Added
+
+- **SPDX-side document-level scope hint** (047). SPDX 2.3
+  `creationInfo.comment` and SPDX 3 `SpdxDocument.comment` now
+  carry a free-text scope summary naming the scope mode
+  (artifact vs manifest, derived from `--include-declared-deps`),
+  the observed lifecycle phases (mirroring CDX
+  `metadata.lifecycles[]`), and a pointer to the per-component
+  `mikebom:sbom-tier` annotation for finer-grained detail. SPDX
+  consumers reading metadata-only now get the same scope
+  context CDX consumers already had via
+  `metadata.lifecycles[]`. CDX output unchanged.
+- **README "What kind of SBOM does mikebom emit?" section**
+  (047). New top-level section between "Why" and "Install"
+  explaining mikebom's two scope axes (document-level
+  artifact-vs-manifest mode + per-component lifecycle tier),
+  how each format self-describes its scope, and how mikebom's
+  default scopes map to industry / NTIA-style terminology — so
+  operators comparing component counts to trivy / syft can see
+  the question being asked rather than wonder whether mikebom
+  is undercounting.
 
 ## [0.1.0-alpha.6] — 2026-04-29
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-29
+Auto-generated from all feature plans. Last updated: 2026-04-30
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -28,6 +28,7 @@ Auto-generated from all feature plans. Last updated: 2026-04-29
 - Rust stable (workspace toolchain inherited + existing only — `sha2` (per-file SHA-256, (038-minimal-image-deep-hash)
 - N/A — all state in-process per scan; reuses milestone (038-minimal-image-deep-hash)
 - N/A — this milestone touches Markdown only. + None new. (046-docs-refresh)
+- Rust stable (workspace toolchain inherited). + existing only — `serde`, `serde_json`, (047-scope-self-description)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -90,9 +91,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 047-scope-self-description: Added Rust stable (workspace toolchain inherited). + existing only — `serde`, `serde_json`,
 - 046-docs-refresh: Added N/A — this milestone touches Markdown only. + None new.
 - 040-pkg-db-followups: Added [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
-- 038-minimal-image-deep-hash: Added Rust stable (workspace toolchain inherited + existing only — `sha2` (per-file SHA-256,
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -141,6 +141,77 @@ On top of scan-mode, mikebom adds:
 - **Witness-collection v0.1** output compatible with `sbomit generate`
   and any go-witness-aware verifier.
 
+## What kind of SBOM does mikebom emit?
+
+A common question when comparing mikebom's component count to
+trivy's, syft's, or another scanner's: **are we counting the
+same thing?** Often the answer is no — and the gap is a scope
+choice, not a bug. mikebom self-describes its scope on every
+output so consumers can answer the question by reading the SBOM
+rather than reverse-engineering it from the component list.
+
+### Two axes
+
+mikebom uses two orthogonal scope axes:
+
+**1. Document-level scope mode** — the answer to "what set of
+things is this SBOM trying to describe?"
+
+| Mode | Meaning | When |
+|---|---|---|
+| **Artifact** (default for `--image`) | On-disk components only — every emitted component has its bytes physically present in the scanned tree or image. CDX phase aggregation typically shows `operations` (deployed runtime) plus build-time tiers from installed packages. | Scanning a container image or a built artifact — answers "what's actually here right now?" |
+| **Manifest** (default for `--path`) | On-disk components plus declared-but-not-on-disk transitives (lockfile-pinned but absent from local caches, deps.dev-resolved, Maven cache-miss BFS). | Scanning a source tree — answers "what would this build pull in?" |
+
+The mode is controlled by `--include-declared-deps` (auto-on for
+`--path`, auto-off for `--image`; explicit override available).
+
+**2. Per-component lifecycle tier** — the answer to "where in
+the build/deploy lifecycle was this component observed?"
+Annotated as `mikebom:sbom-tier` on every component, with five
+values:
+
+| Tier | Meaning |
+|---|---|
+| `design` | Declared but not pinned (e.g., `>=1.0` ranges in `requirements.txt`). |
+| `source` | Lockfile-pinned, byte-resolvable (e.g., `Cargo.lock`, `package-lock.json`). |
+| `build` | Captured during a live build event via eBPF tracing. |
+| `deployed` | Installed in the runtime image — dpkg, apk, rpm, populated `node_modules`, populated venv `dist-info`. |
+| `analyzed` | Artifact file on disk, identified by filename + content hash. |
+
+### How mikebom self-describes scope in each format
+
+mikebom ships scope information through native fields in every
+output format, not as `mikebom:`-prefixed extensions, so any
+spec-compliant SBOM reader picks it up:
+
+| Format | Document-level scope hint | Per-component tier |
+|---|---|---|
+| **CycloneDX 1.6** | `metadata.lifecycles[]` (aggregated from per-component tiers, deduplicated, sorted) + `compositions[].aggregate` | `properties[].name = "mikebom:sbom-tier"` |
+| **SPDX 2.3** | `creationInfo.comment` (free-text scope summary) | `packages[].annotations[]` with `mikebom:sbom-tier` |
+| **SPDX 3.0.1** | `SpdxDocument.comment` (free-text scope summary) | top-level `annotations[]` with `mikebom:sbom-tier` |
+
+### Industry / consumer terminology bridge
+
+When operators compare mikebom's count to other scanners, the
+delta usually traces back to a different scope choice rather
+than a real coverage gap. As a rule of thumb:
+
+- mikebom's `--image` output ≈ NTIA "deployed" SBOM. CDX phase
+  `operations` dominates. Tighter than tools that walk a build
+  cache (e.g. trivy's `~/.m2/`) but more accurate for "what's
+  actually running in this image."
+- mikebom's `--path` output ≈ NTIA "build" SBOM. CDX phases
+  `pre-build` (lockfile entries) and `build` (eBPF-traced
+  events, when applicable) dominate. Closer to a manifest
+  view; useful for license compliance and full transitive
+  coverage.
+
+For the deeper rationale on why mikebom takes this stance — and
+why class-presence verification (milestone 009) deliberately
+prunes Maven shade-relocation ancestors that *aren't actually in
+the JAR* — see [`docs/design-notes.md`](docs/design-notes.md)'s
+"Scope: artifact vs manifest SBOM" section.
+
 ## Install
 
 Source-only today. Pre-built binaries and crates.io publication are

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -873,6 +873,11 @@ pub async fn execute(
         include_dev,
         include_hashes: !args.no_hashes,
         include_source_files: true, // path-pattern evidence is the whole value prop here
+        scope_mode: if effective_include_declared_deps {
+            crate::generate::ScopeMode::Manifest
+        } else {
+            crate::generate::ScopeMode::Artifact
+        },
     };
     let output_cfg = OutputConfig {
         mikebom_version: env!("CARGO_PKG_VERSION"),

--- a/mikebom-cli/src/generate/cyclonedx/metadata.rs
+++ b/mikebom-cli/src/generate/cyclonedx/metadata.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 
 use chrono::Utc;
 use mikebom_common::attestation::integrity::TraceIntegrity;
@@ -30,21 +29,6 @@ fn cpe_sanitize(raw: &str) -> String {
     out
 }
 
-/// Map a `mikebom:sbom-tier` value (per research.md R13) to its
-/// corresponding CycloneDX 1.5+ `lifecycles[].phase` value. Returns
-/// `None` for unrecognised tier strings so unknown tiers don't pollute
-/// the envelope declaration.
-fn tier_to_lifecycle_phase(tier: &str) -> Option<&'static str> {
-    match tier {
-        "build" => Some("build"),
-        "deployed" => Some("operations"),
-        "analyzed" => Some("post-build"),
-        "source" => Some("pre-build"),
-        "design" => Some("design"),
-        _ => None,
-    }
-}
-
 /// Build the CycloneDX `metadata` section.
 ///
 /// Includes:
@@ -74,19 +58,14 @@ pub fn build_metadata(
         .unwrap_or_else(|| "unknown".to_string());
 
     // Aggregate lifecycle phases from the observed component tiers.
-    // BTreeSet → sorted, deterministic output.
-    let mut phases: BTreeSet<&'static str> = BTreeSet::new();
-    for c in components {
-        if let Some(ref tier) = c.sbom_tier {
-            if let Some(phase) = tier_to_lifecycle_phase(tier) {
-                phases.insert(phase);
-            }
-        }
-    }
-    let lifecycles: Vec<serde_json::Value> = phases
-        .into_iter()
-        .map(|p| json!({"phase": p}))
-        .collect();
+    // Source-of-truth lives in `crate::generate::lifecycle_phases`
+    // so the SPDX serializers' document-level scope comment uses the
+    // same phase set.
+    let lifecycles: Vec<serde_json::Value> =
+        crate::generate::lifecycle_phases::aggregate_phases(components)
+            .into_iter()
+            .map(|p| json!({"phase": p}))
+            .collect();
 
     let mut properties = vec![json!({
         "name": "mikebom:generation-context",

--- a/mikebom-cli/src/generate/lifecycle_phases.rs
+++ b/mikebom-cli/src/generate/lifecycle_phases.rs
@@ -1,0 +1,81 @@
+//! Lifecycle-phase aggregation shared between CDX and SPDX
+//! serializers (milestone 047).
+//!
+//! Maps the per-component `mikebom:sbom-tier` value (one of
+//! `design`, `source`, `build`, `deployed`, `analyzed`) to the
+//! corresponding CycloneDX 1.6 / SPDX-comment phase name, and
+//! aggregates the observed phase set across a scan's components.
+//!
+//! Source-of-truth for CDX `metadata.lifecycles[]` and the SPDX
+//! 2.3 `creationInfo.comment` / SPDX 3 `SpdxDocument.comment`
+//! fields. Both serializers MUST call into this module so the
+//! phase set is identical regardless of output format.
+//!
+//! Sort order is deterministic (lexicographic via `BTreeSet`)
+//! so byte-identity goldens regen cleanly.
+//!
+//! Coverage: end-to-end byte-identity goldens
+//! (`mikebom-cli/tests/cdx_regression.rs`,
+//! `mikebom-cli/tests/spdx_regression.rs`,
+//! `mikebom-cli/tests/spdx3_regression.rs`) exercise both
+//! functions through the live serializer pipeline. Any change
+//! to phase mapping or aggregation order surfaces as a goldens
+//! regression.
+
+use std::collections::BTreeSet;
+
+use mikebom_common::resolution::ResolvedComponent;
+
+/// Map a `mikebom:sbom-tier` string to its corresponding
+/// CycloneDX 1.5+ `lifecycles[].phase` value. Returns `None` for
+/// unrecognised tier strings so unknown tiers don't pollute the
+/// aggregated phase set.
+pub fn tier_to_phase(tier: &str) -> Option<&'static str> {
+    match tier {
+        "build" => Some("build"),
+        "deployed" => Some("operations"),
+        "analyzed" => Some("post-build"),
+        "source" => Some("pre-build"),
+        "design" => Some("design"),
+        _ => None,
+    }
+}
+
+/// Aggregate the unique set of CDX phase names observed across
+/// the given components' `sbom_tier` values. Returns the phase
+/// list sorted lexicographically (deterministic for byte-identity
+/// goldens).
+pub fn aggregate_phases<'a>(
+    components: impl IntoIterator<Item = &'a ResolvedComponent>,
+) -> Vec<&'static str> {
+    let mut phases: BTreeSet<&'static str> = BTreeSet::new();
+    for c in components {
+        if let Some(ref tier) = c.sbom_tier {
+            if let Some(phase) = tier_to_phase(tier) {
+                phases.insert(phase);
+            }
+        }
+    }
+    phases.into_iter().collect()
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier_to_phase_maps_known_tiers() {
+        assert_eq!(tier_to_phase("design"), Some("design"));
+        assert_eq!(tier_to_phase("source"), Some("pre-build"));
+        assert_eq!(tier_to_phase("build"), Some("build"));
+        assert_eq!(tier_to_phase("deployed"), Some("operations"));
+        assert_eq!(tier_to_phase("analyzed"), Some("post-build"));
+    }
+
+    #[test]
+    fn tier_to_phase_returns_none_for_unknown() {
+        assert_eq!(tier_to_phase("unknown-tier"), None);
+        assert_eq!(tier_to_phase(""), None);
+    }
+}

--- a/mikebom-cli/src/generate/mod.rs
+++ b/mikebom-cli/src/generate/mod.rs
@@ -22,6 +22,7 @@
 
 pub mod cpe;
 pub mod cyclonedx;
+pub mod lifecycle_phases;
 pub mod openvex;
 pub mod spdx;
 
@@ -55,6 +56,43 @@ pub struct ScanArtifacts<'a> {
     pub include_dev: bool,
     pub include_hashes: bool,
     pub include_source_files: bool,
+    /// Document-level scope mode. Resolved from
+    /// `--include-declared-deps` (with the `--path`/`--image`
+    /// auto-default rule). Surfaced in CDX `metadata.lifecycles[]`
+    /// (component-derived, indirect) and SPDX
+    /// `creationInfo.comment` / `SpdxDocument.comment` (direct).
+    /// Milestone 047.
+    pub scope_mode: ScopeMode,
+}
+
+/// Document-level scope mode for a single mikebom scan. Surfaced
+/// in SPDX 2.3 `creationInfo.comment` and SPDX 3
+/// `SpdxDocument.comment` so consumers reading metadata-only know
+/// whether the document represents on-disk-only emission
+/// (`Artifact`) or includes declared transitives that may not be
+/// on disk yet (`Manifest`).
+///
+/// The value derives from the resolution of
+/// `--include-declared-deps`: when that flag resolves true (the
+/// default for `--path` scans), the scan is `Manifest`; when
+/// false (the default for `--image` scans), the scan is
+/// `Artifact`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopeMode {
+    /// On-disk components only — every emitted component has its
+    /// bytes physically present in the scanned tree or image.
+    /// Default for `--image`. CDX phase aggregation typically
+    /// shows `operations` (deployed runtime) plus whatever
+    /// build-time tiers happen to be present in installed
+    /// packages.
+    Artifact,
+    /// On-disk components plus declared-but-not-on-disk
+    /// transitives (lockfile-pinned but absent from local
+    /// caches, deps.dev-resolved, Maven cache-miss BFS, etc.).
+    /// Default for `--path` scans (source trees) so SBOM
+    /// consumers get the full "what would this build pull in"
+    /// view.
+    Manifest,
 }
 
 /// Per-invocation configuration threaded through every serializer.

--- a/mikebom-cli/src/generate/openvex/mod.rs
+++ b/mikebom-cli/src/generate/openvex/mod.rs
@@ -232,6 +232,7 @@ mod tests {
             include_dev: false,
             include_hashes: true,
             include_source_files: false,
+            scope_mode: crate::generate::ScopeMode::Artifact,
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/document.rs
+++ b/mikebom-cli/src/generate/spdx/document.rs
@@ -119,7 +119,7 @@ pub struct SpdxExternalDocumentRef {
     pub checksum: super::packages::SpdxChecksum,
 }
 
-/// SPDX 2.3 `creationInfo` object (spec §6.8 / §6.9).
+/// SPDX 2.3 `creationInfo` object (spec §6.8 / §6.9 / §6.13).
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct CreationInfo {
     /// RFC 3339 UTC timestamp — sourced from `OutputConfig.created`,
@@ -131,6 +131,14 @@ pub struct CreationInfo {
     pub creators: Vec<String>,
     #[serde(rename = "licenseListVersion", skip_serializing_if = "Option::is_none")]
     pub license_list_version: Option<String>,
+    /// SPDX 2.3 §6.13 free-text `comment` slot. mikebom populates it
+    /// with a document-level scope hint (scope mode + observed
+    /// lifecycle phases + pointer to per-component
+    /// `mikebom:sbom-tier` annotations) so SPDX consumers reading
+    /// only `creationInfo` get parity with CDX consumers reading
+    /// `metadata.lifecycles[]`. Milestone 047.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
 }
 
 /// SPDX 2.3 top-level document (spec §6).
@@ -297,6 +305,7 @@ pub fn build_document(
             "Organization: mikebom contributors".to_string(),
         ],
         license_list_version: None,
+        comment: Some(build_scope_comment(artifacts)),
     };
 
     // Document-level mikebom annotations (Sections C21–C23 + E1).
@@ -317,6 +326,37 @@ pub fn build_document(
         has_extracted_licensing_infos,
         document_describes: vec![root_id],
     }
+}
+
+/// Build the document-level scope-hint string for SPDX 2.3
+/// `creationInfo.comment` and SPDX 3 `SpdxDocument.comment`
+/// (milestone 047). Names the scope mode (artifact vs manifest),
+/// the observed CDX-style lifecycle phases (sorted
+/// lexicographically via the `lifecycle_phases::aggregate_phases`
+/// helper), and a pointer to the per-component
+/// `mikebom:sbom-tier` annotation for finer-grained scope detail.
+///
+/// Always returns a string. When no component carries a tier
+/// (atypical), the phases-list line degrades to "no lifecycle
+/// phases observed" rather than omitting the whole comment, so
+/// downstream consumers can rely on the field being present.
+pub(super) fn build_scope_comment(scan: &ScanArtifacts<'_>) -> String {
+    use crate::generate::ScopeMode;
+
+    let mode = match scan.scope_mode {
+        ScopeMode::Artifact => "artifact (on-disk components only)",
+        ScopeMode::Manifest => "manifest (declared transitives included)",
+    };
+    let phases = crate::generate::lifecycle_phases::aggregate_phases(scan.components);
+    let phases_text = if phases.is_empty() {
+        "no lifecycle phases observed".to_string()
+    } else {
+        phases.join(", ")
+    };
+    format!(
+        "Scope: {mode}. Observed lifecycle phases: {phases_text}. \
+         Per-component scope detail in mikebom:sbom-tier annotations."
+    )
 }
 
 /// Deterministically derive a synthetic-root SPDXID and a
@@ -487,6 +527,7 @@ mod tests {
             include_dev: false,
             include_hashes: true,
             include_source_files: false,
+            scope_mode: crate::generate::ScopeMode::Artifact,
         }
     }
 
@@ -563,6 +604,72 @@ mod tests {
             ns.as_str().starts_with(NAMESPACE_BASE),
             "namespace {} should start with {NAMESPACE_BASE}",
             ns.as_str()
+        );
+    }
+
+    /// Test helper: build a component with a specific `sbom_tier`
+    /// for the `build_scope_comment` tests below.
+    fn mk_component_with_tier(
+        purl: &str,
+        tier: Option<&str>,
+    ) -> ResolvedComponent {
+        let mut c = mk_component(purl, "x", "1");
+        c.sbom_tier = tier.map(|s| s.to_string());
+        c
+    }
+
+    #[test]
+    fn build_scope_comment_emits_artifact_mode_with_phases() {
+        let integ = empty_integrity();
+        let comps = vec![
+            mk_component_with_tier("pkg:cargo/a@1", Some("build")),
+            mk_component_with_tier("pkg:cargo/b@1", Some("deployed")),
+            mk_component_with_tier("pkg:cargo/c@1", Some("analyzed")),
+        ];
+        let mut arts = mk_artifacts("demo", &comps, &[], &integ);
+        arts.scope_mode = crate::generate::ScopeMode::Artifact;
+        let comment = build_scope_comment(&arts);
+        assert!(
+            comment.starts_with("Scope: artifact"),
+            "expected artifact-mode prefix; got: {comment}"
+        );
+        // Phase order is lexicographic via BTreeSet:
+        //   build → "build", deployed → "operations", analyzed → "post-build"
+        assert!(
+            comment.contains("build, operations, post-build"),
+            "expected sorted phase list; got: {comment}"
+        );
+        assert!(
+            comment.contains("mikebom:sbom-tier"),
+            "expected pointer to per-component annotation; got: {comment}"
+        );
+    }
+
+    #[test]
+    fn build_scope_comment_emits_manifest_mode() {
+        let integ = empty_integrity();
+        let comps = vec![mk_component_with_tier("pkg:cargo/a@1", Some("source"))];
+        let mut arts = mk_artifacts("demo", &comps, &[], &integ);
+        arts.scope_mode = crate::generate::ScopeMode::Manifest;
+        let comment = build_scope_comment(&arts);
+        assert!(
+            comment.starts_with("Scope: manifest"),
+            "expected manifest-mode prefix; got: {comment}"
+        );
+    }
+
+    #[test]
+    fn build_scope_comment_handles_empty_phases() {
+        let integ = empty_integrity();
+        let comps = vec![
+            mk_component_with_tier("pkg:cargo/a@1", None),
+            mk_component_with_tier("pkg:cargo/b@1", Some("not-a-known-tier")),
+        ];
+        let arts = mk_artifacts("demo", &comps, &[], &integ);
+        let comment = build_scope_comment(&arts);
+        assert!(
+            comment.contains("no lifecycle phases observed"),
+            "expected empty-phases degradation; got: {comment}"
         );
     }
 }

--- a/mikebom-cli/src/generate/spdx/mod.rs
+++ b/mikebom-cli/src/generate/spdx/mod.rs
@@ -346,6 +346,7 @@ mod tests {
             include_dev: false,
             include_hashes: true,
             include_source_files: false,
+            scope_mode: crate::generate::ScopeMode::Artifact,
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/packages.rs
+++ b/mikebom-cli/src/generate/spdx/packages.rs
@@ -444,6 +444,7 @@ mod tests {
             include_dev: false,
             include_hashes: true,
             include_source_files: false,
+            scope_mode: crate::generate::ScopeMode::Artifact,
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/relationships.rs
+++ b/mikebom-cli/src/generate/spdx/relationships.rs
@@ -268,6 +268,7 @@ mod tests {
             include_dev: false,
             include_hashes: true,
             include_source_files: false,
+            scope_mode: crate::generate::ScopeMode::Artifact,
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/v3_document.rs
+++ b/mikebom-cli/src/generate/spdx/v3_document.rs
@@ -110,6 +110,14 @@ pub fn build_document(
     // Assessment` (the most specific match in SPDX 3.0.1's
     // `prop_ExternalRef_externalRefType` enum for an OpenVEX
     // payload).
+    // Document-level scope hint (milestone 047) — same prose the
+    // SPDX 2.3 path emits in `creationInfo.comment`. Per the
+    // SPDX 3.0.1 model docs, Element-level `comment` is "comments
+    // by the creator of the Element about the Element"; on the
+    // SpdxDocument that's exactly the document-level scope note.
+    // The shared `spdx-context.jsonld` already maps the
+    // unprefixed `comment` key, so no @context change needed.
+    let scope_comment = super::document::build_scope_comment(scan);
     let mut spdx_document = json!({
         "type": "SpdxDocument",
         "spdxId": doc_iri,
@@ -117,6 +125,7 @@ pub fn build_document(
         "name": scan.target_name,
         "dataLicense": "https://spdx.org/licenses/CC0-1.0",
         "rootElement": [root_iri.clone()],
+        "comment": scope_comment,
     });
     if let Some(locator) = openvex_locator {
         spdx_document["externalRef"] = json!([

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/apk.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/apk.spdx.json
@@ -39,6 +39,7 @@
     }
   ],
   "creationInfo": {
+    "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: operations. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
       "Tool: mikebom-0.1.0-alpha.6",

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/cargo.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/cargo.spdx.json
@@ -45,6 +45,7 @@
     }
   ],
   "creationInfo": {
+    "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
       "Tool: mikebom-0.1.0-alpha.6",

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/deb.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/deb.spdx.json
@@ -39,6 +39,7 @@
     }
   ],
   "creationInfo": {
+    "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: operations. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
       "Tool: mikebom-0.1.0-alpha.6",

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/gem.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/gem.spdx.json
@@ -45,6 +45,7 @@
     }
   ],
   "creationInfo": {
+    "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
       "Tool: mikebom-0.1.0-alpha.6",

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/golang.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/golang.spdx.json
@@ -45,6 +45,7 @@
     }
   ],
   "creationInfo": {
+    "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
       "Tool: mikebom-0.1.0-alpha.6",

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/maven.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/maven.spdx.json
@@ -45,6 +45,7 @@
     }
   ],
   "creationInfo": {
+    "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
       "Tool: mikebom-0.1.0-alpha.6",

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/npm.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/npm.spdx.json
@@ -45,6 +45,7 @@
     }
   ],
   "creationInfo": {
+    "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: operations. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
       "Tool: mikebom-0.1.0-alpha.6",

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/pip.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/pip.spdx.json
@@ -45,6 +45,7 @@
     }
   ],
   "creationInfo": {
+    "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: operations. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
       "Tool: mikebom-0.1.0-alpha.6",

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/rpm.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/rpm.spdx.json
@@ -39,6 +39,7 @@
     }
   ],
   "creationInfo": {
+    "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: no lifecycle phases observed. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
       "Tool: mikebom-0.1.0-alpha.6",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/apk.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/apk.spdx3.json
@@ -17,6 +17,7 @@
       "type": "Tool"
     },
     {
+      "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: operations. Per-component scope detail in mikebom:sbom-tier annotations.",
       "creationInfo": "_:creation-info",
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "synthetic",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/cargo.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/cargo.spdx3.json
@@ -17,6 +17,7 @@
       "type": "Tool"
     },
     {
+      "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in mikebom:sbom-tier annotations.",
       "creationInfo": "_:creation-info",
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "lockfile-v3",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/deb.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/deb.spdx3.json
@@ -17,6 +17,7 @@
       "type": "Tool"
     },
     {
+      "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: operations. Per-component scope detail in mikebom:sbom-tier annotations.",
       "creationInfo": "_:creation-info",
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "synthetic",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/gem.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/gem.spdx3.json
@@ -17,6 +17,7 @@
       "type": "Tool"
     },
     {
+      "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in mikebom:sbom-tier annotations.",
       "creationInfo": "_:creation-info",
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "simple-bundle",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/golang.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/golang.spdx3.json
@@ -17,6 +17,7 @@
       "type": "Tool"
     },
     {
+      "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in mikebom:sbom-tier annotations.",
       "creationInfo": "_:creation-info",
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "simple-module",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/maven.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/maven.spdx3.json
@@ -17,6 +17,7 @@
       "type": "Tool"
     },
     {
+      "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in mikebom:sbom-tier annotations.",
       "creationInfo": "_:creation-info",
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "pom-three-deps",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/npm.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/npm.spdx3.json
@@ -17,6 +17,7 @@
       "type": "Tool"
     },
     {
+      "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: operations. Per-component scope detail in mikebom:sbom-tier annotations.",
       "creationInfo": "_:creation-info",
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "node-modules-walk",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/pip.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/pip.spdx3.json
@@ -17,6 +17,7 @@
       "type": "Tool"
     },
     {
+      "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: operations. Per-component scope detail in mikebom:sbom-tier annotations.",
       "creationInfo": "_:creation-info",
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "simple-venv",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/rpm.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/rpm.spdx3.json
@@ -17,6 +17,7 @@
       "type": "Tool"
     },
     {
+      "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: no lifecycle phases observed. Per-component scope detail in mikebom:sbom-tier annotations.",
       "creationInfo": "_:creation-info",
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "bdb-only",

--- a/specs/047-scope-self-description/checklists/requirements.md
+++ b/specs/047-scope-self-description/checklists/requirements.md
@@ -1,0 +1,55 @@
+# Specification Quality Checklist: Self-describe SBOM scope
+
+**Purpose**: Validate specification completeness and quality before
+proceeding to planning.
+**Created**: 2026-04-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Validation Notes
+
+- Spec is grounded in a pre-spec audit that verified the
+  recommendation's premises against the codebase. The audit
+  found the recommendation's headline P1 items already
+  shipped (`metadata.lifecycles[]`, `compositions[]`,
+  `mikebom:sbom-tier`); this spec scopes only the two real
+  gaps: (1) README documentation explaining the scope axes,
+  (2) SPDX `creationInfo.comment` parity with the existing
+  CDX self-description.
+- All FRs have grep-shaped or jq-shaped acceptance tests
+  (testable + automatable + deterministic).
+- Cross-cutting FR-011 (CDX goldens unchanged) plus FR-010
+  (SPDX goldens regen with one delta) prevents accidental
+  scope creep into CDX.
+- One open scope question parked in Assumptions: which slot in
+  SPDX 3 carries the document-level comment. Resolved at plan
+  time, not blocking spec quality.
+
+## Notes
+
+- Items marked incomplete require spec updates before
+  `/speckit.clarify` or `/speckit.plan`. All items currently pass.

--- a/specs/047-scope-self-description/plan.md
+++ b/specs/047-scope-self-description/plan.md
@@ -1,0 +1,247 @@
+# Implementation Plan: Self-describe SBOM scope
+
+**Branch**: `047-scope-self-description` | **Date**: 2026-04-30 | **Spec**: [spec.md](./spec.md)
+**Input**: [spec.md](./spec.md)
+
+## Summary
+
+Two-prong milestone surfacing existing scope information through (a)
+a new README "What kind of SBOM does mikebom emit?" explainer, and
+(b) a new document-level scope hint in SPDX 2.3 + SPDX 3 output for
+parity with CDX `metadata.lifecycles[]`. No new CLI flags. No new
+component-level emissions. Reuses existing per-component
+`sbom_tier` data and the existing
+`--include-declared-deps`-derived scope-mode resolution.
+
+The audit found mikebom already emits CDX `metadata.lifecycles[]`
+and `compositions[]`; only the SPDX side lacks an equivalent
+document-level slot, and only the README lacks a user-facing
+mental-model explainer. This plan closes both gaps surgically.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited).
+**Primary Dependencies**: existing only — `serde`, `serde_json`,
+`chrono`. No new crates.
+**Storage**: N/A.
+**Testing**: byte-identity goldens regen for SPDX 2.3 + SPDX 3
+(18 files); inline tests for the new comment-text builder; new
+jq-shaped acceptance tests for SC-003 / SC-004; `holistic_parity`
+must remain green.
+**Target Platform**: cross-platform (any platform mikebom builds
+on).
+**Project Type**: code-modifying milestone (SPDX serializers) +
+docs (README).
+**Performance Goals**: N/A — adding a single string field per
+document; no measurable runtime impact.
+**Constraints**: zero CDX golden diff (FR-011 / SC-006), 18 SPDX
+goldens regen with one comment-field delta + the SHA-derived
+`SPDXID`/`documentNamespace` re-stamps that follow from content
+change (already-accepted pattern from prior alpha bumps).
+**Scale/Scope**: 5 source files modified, ~80 LOC of Rust + ~50
+LOC of Markdown.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1
+design.*
+
+| Principle | Engaged? | Status |
+|---|---|---|
+| I. Pure Rust, Zero C | Yes — Rust-only edits | ✅ |
+| II. eBPF-Only Observation | No — no discovery code change | ✅ vacuous |
+| III–IV. (existing principles) | No — no behavior change to scan / resolve / enrich pipeline | ✅ vacuous |
+| V. Specification Compliance | Yes — adds a `comment` field to SPDX 2.3 `creationInfo` and a `comment` key to SPDX 3 `SpdxDocument`. Both are spec-defined slots (SPDX 2.3 §6.13, SPDX 3.0.1 Element/comment). No format violation. | ✅ |
+| VI. Three-crate architecture | No code in `mikebom-common` or `mikebom-ebpf` | ✅ untouched |
+| Pre-PR Verification | All 4 commits' `./scripts/pre-pr.sh` clean | ✅ enforced by SC-007 |
+
+No gate violations.
+
+## Phase 0: Research (resolved inline)
+
+The spec deferred one item to plan: which SPDX 3 slot carries the
+document-level scope comment.
+
+**Decision**: emit `comment` on the `SpdxDocument` Element (NOT
+on `CreationInfo`).
+
+**Rationale**:
+- Semantically correct per SPDX 3.0.1 Core/Element property
+  definitions: Element-level `comment` is "comments by the creator
+  about the Element" — exactly what a scope hint is. `description`
+  / `summary` are about the *artifact described*, not *the SBOM
+  document itself*.
+- `CreationInfo` is a shared sub-element referenced by every
+  Element in the graph; a comment there reads as "note about how
+  this batch of elements was created", not "note about the SBOM's
+  scope." `SpdxDocument` is the singular document-identity
+  Element; a comment there is unambiguously the document-level
+  note this milestone wants.
+- JSON-LD shape is plain `comment` — the `spdx-context.jsonld`
+  already maps the unprefixed local name (mikebom uses the same
+  pattern for `comment` on existing `ExternalRef` emission at
+  `v3_document.rs:128`). No `@context` change needed.
+- For SPDX 2.3, the natural slot is `creationInfo.comment` (SPDX
+  2.3 §6.13). The two formats are not byte-identical here — they
+  use the same JSON key `comment` in different parent objects,
+  which matches each format's spec intent.
+
+**Alternatives considered**:
+- `CreationInfo.comment` for SPDX 3 (parallel to SPDX 2.3) —
+  rejected because the SPDX 3 `CreationInfo` is shared, not
+  document-scoped.
+- `SpdxDocument.description` / `SpdxDocument.summary` — rejected
+  because both describe the *artifact* per the SPDX 3 spec, not
+  the document.
+- New `mikebom:` annotation slot on the document — rejected
+  because using the spec-native slot is more interoperable; any
+  SPDX-aware tool that reads `comment` will see this hint without
+  knowing about mikebom-specific extensions.
+
+Sources consulted:
+- https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/CreationInfo/
+- https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/SpdxDocument/
+- https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/Element/
+- https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Properties/comment/
+
+## Approach
+
+Four commits, ordered so the SPDX-side emission lands before the
+README explainer (FR-002(c) lets the README authoritatively
+reference the just-shipped SPDX field).
+
+### Commit 1 — `feat(047/us2-1)` — SPDX 2.3 `creationInfo.comment` + scope-mode plumbing + shared phase utility
+
+Touched files:
+- `mikebom-cli/src/generate/mod.rs` — add `pub scope_mode: ScopeMode` field to `ScanArtifacts` (new enum `ScopeMode { Artifact, Manifest }`). Field populated at `ScanArtifacts` construction time.
+- `mikebom-cli/src/cli/scan_cmd.rs` — at lines ~743–760, after `effective_include_declared_deps` resolves, set `scope_mode` on the `ScanArtifacts` builder: `Manifest` when `effective_include_declared_deps` is true, `Artifact` otherwise.
+- New module `mikebom-cli/src/generate/lifecycle_phases.rs` — extract two functions out of `cyclonedx/metadata.rs` (lines 37–46 + 76–89):
+  - `pub fn tier_to_phase(tier: &str) -> Option<&'static str>`
+  - `pub fn aggregate_phases<'a>(components: impl Iterator<Item = &'a ResolvedComponent>) -> Vec<&'static str>` (returns sorted unique phase list)
+  - cyclonedx/metadata.rs imports from this module instead of holding the source. Goldens unchanged (same algorithm, same sort order).
+- `mikebom-cli/src/generate/spdx/document.rs:122-160` — add `pub comment: Option<String>` field to `CreationInfo` struct with `#[serde(skip_serializing_if = "Option::is_none")]`. In `build_document` (line 217+), call a new `build_scope_comment(scan, cfg)` helper that:
+  - Reads `scan.scope_mode`
+  - Aggregates phases via `lifecycle_phases::aggregate_phases(scan.components)`
+  - Returns prose like: `"Scope: artifact (on-disk components only). Observed lifecycle phases: build, post-build, operations. Per-component scope detail in mikebom:sbom-tier annotations."`
+  - Phase list is deterministic (sorted via the existing `BTreeSet` collector)
+  - Returns `Some(comment)` always (per spec edge-case decision: always emit; degrade phases-list to "no lifecycle phases observed" if empty)
+- Inline tests in `document.rs` for `build_scope_comment`: artifact-mode + manifest-mode, with-phases + empty-phases.
+- Regen 9 SPDX 2.3 goldens: `MIKEBOM_UPDATE_SPDX_GOLDENS=1 cargo +stable test --test spdx_regression`.
+
+Verification:
+- `jq -r '.creationInfo.comment' <any-spdx-2.3-output>` returns non-empty containing `Scope:` and `mikebom:sbom-tier`.
+- `git diff main..HEAD -- mikebom-cli/tests/fixtures/golden/cyclonedx/` empty (FR-011).
+- `./scripts/pre-pr.sh` clean.
+
+### Commit 2 — `feat(047/us2-2)` — SPDX 3 `SpdxDocument.comment` (reuses commit 1's helper)
+
+Touched files:
+- `mikebom-cli/src/generate/spdx/v3_document.rs:113–132` — at the `spdx_document` JSON-LD object construction, add a `comment` key populated by reusing `build_scope_comment` from commit 1 (or a thin wrapper that calls into the same lifecycle_phases utility). Same prose, same deterministic order, same emission policy (always emit).
+- Inline tests in `v3_document.rs` mirroring commit 1's test cases.
+- Regen 9 SPDX 3 goldens: `MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test --test spdx3_regression`.
+
+Verification:
+- `jq -r '.[\"@graph\"][] | select(.type == \"SpdxDocument\") | .comment' <any-spdx-3-output>` returns non-empty containing `Scope:` and `mikebom:sbom-tier`.
+- SPDX 3 byte-identity goldens reflect the comment field plus the standard SHA-derived `SPDXID` / `documentNamespace` re-stamps that follow from any content change (same pattern as the alpha-6 release commit).
+- `holistic_parity` test still green (document-level metadata is outside the C-row catalog).
+
+### Commit 3 — `docs(047/us1)` — README explainer
+
+Touched file:
+- `README.md` — insert a new section titled `## What kind of SBOM does mikebom emit?` between the existing "Why" section and "Install" section. ~50 lines covering:
+  - Two-axis framing: scope-mode (artifact vs manifest) + per-component lifecycle tier.
+  - The five `mikebom:sbom-tier` values with one-line definitions each: `design`, `source`, `build`, `deployed`, `analyzed`.
+  - The CDX self-description trio: `metadata.lifecycles[]`, `compositions[]`, per-component `mikebom:sbom-tier` annotation.
+  - The SPDX self-description: `creationInfo.comment` (SPDX 2.3) / `SpdxDocument.comment` (SPDX 3) plus the same per-component annotation.
+  - One-paragraph mapping to industry / consumer terminology so readers comparing mikebom to trivy / syft don't assume the tools are answering the same question.
+  - Default scope: artifact for `--image`, manifest for `--path` — name `--include-declared-deps` as the toggle.
+  - Pointer to `docs/design-notes.md`'s "Scope: artifact vs manifest SBOM" for deeper rationale.
+
+Verification:
+- `grep -nE '^## .*[Ww]hat kind of SBOM' README.md` matches.
+- Section enumerates all 5 sbom-tier values (grep for each).
+- Section names `--include-declared-deps`.
+
+### Commit 4 — `chore(047)` + `docs(046)` — CHANGELOG + spec scaffolding
+
+Touched files:
+- `CHANGELOG.md` — Unreleased entry naming the SPDX 2.3 / SPDX 3 document-level comment as new emission and the README explainer as docs.
+- `specs/047-scope-self-description/` — spec.md + plan.md + tasks.md + checklists/requirements.md (matches milestone 046's convention of committing speckit artifacts).
+- `CLAUDE.md` — auto-update if `update-agent-context.sh` produced changes.
+
+## Touched files
+
+| File | Commit | Purpose |
+|---|---|---|
+| `mikebom-cli/src/generate/mod.rs` | 1 | + `ScopeMode` enum + `ScanArtifacts.scope_mode` field |
+| `mikebom-cli/src/cli/scan_cmd.rs` | 1 | populate `scope_mode` on `ScanArtifacts` from `effective_include_declared_deps` |
+| `mikebom-cli/src/generate/lifecycle_phases.rs` (new) | 1 | extract `tier_to_phase` + `aggregate_phases` from `cyclonedx/metadata.rs` |
+| `mikebom-cli/src/generate/cyclonedx/metadata.rs` | 1 | re-import phase utilities; goldens unchanged |
+| `mikebom-cli/src/generate/spdx/document.rs` | 1 | + `CreationInfo.comment` field + `build_scope_comment` helper |
+| `mikebom-cli/src/generate/spdx/v3_document.rs` | 2 | + `comment` key on `SpdxDocument` JSON-LD object |
+| `mikebom-cli/tests/fixtures/golden/spdx-2.3/*.json` (9) | 1 | regen |
+| `mikebom-cli/tests/fixtures/golden/spdx-3/*.json` (9) | 2 | regen |
+| `README.md` | 3 | + "What kind of SBOM does mikebom emit?" section |
+| `CHANGELOG.md` | 4 | Unreleased entry |
+| `specs/047-scope-self-description/` | 4 | spec scaffolding |
+
+Total: ~80 LOC Rust + ~50 LOC Markdown + 18 golden regens.
+
+## Risks
+
+- **R1: SPDX 3 goldens cascade re-stamp.** SPDX 3 emits content-addressed `SPDXID` / `documentNamespace` (SHA-derived from doc content). Adding a comment field changes the doc content → those identifiers shift. Same pattern alpha-bump release commits already accepted; mitigation is to inspect the diff post-regen and confirm only the comment-derived deltas + SHA cascade. No special handling beyond a careful goldens diff review.
+- **R2: Comment text determinism.** The phase list MUST be sorted deterministically across runs (same fixture → same comment string). The existing `cyclonedx/metadata.rs` collector uses a `BTreeSet` for this exact reason; the extracted `aggregate_phases` preserves that. No new test infra needed beyond the byte-identity goldens which already enforce determinism.
+- **R3: Empty-phases edge case.** When no component carries an `sbom_tier`, the comment degrades to "no lifecycle phases observed" rather than omitting the comment entirely. Spec edge-case section parked this as either-or; plan picks "always emit" for predictability (consumers can rely on the field being present). Inline test in commit 1 covers this case.
+- **R4: Shared utility `lifecycle_phases.rs` introduces a new module.** Small module; matches mikebom's existing per-feature module convention. Both CDX and SPDX serializers import from it. No risk of circular imports — the new module has no dependencies on either format.
+- **R5: README placement debate.** Inserting between "Why" and "Install" is the recommended placement; reviewer may prefer another location. Editorial discussion within the milestone, not a scope change.
+
+## Phasing
+
+| Phase | Commits | Effort |
+|---|---|---|
+| Setup + recon | done (audit + Phase 0 research above) | 0 |
+| Commit 1 (SPDX 2.3 + plumb + utility) | 1 | 1 hr |
+| Commit 2 (SPDX 3) | 1 | 30 min (reuses helper) |
+| Commit 3 (README) | 1 | 30 min |
+| Commit 4 (CHANGELOG + scaffold) | 1 | 10 min |
+| Verify + PR | 0 | 15 min |
+| **Total** | **4 commits** | **~2.5 hr** |
+
+## What this milestone does NOT do
+
+- Does not add a new CLI flag (e.g., `--sbom-scope` from the
+  original recommendation). The spec's audit found the concept
+  already exists via `--include-declared-deps`; this milestone
+  surfaces existing state, doesn't add new state.
+- Does not walk host `~/.m2/repository/` wholesale (the
+  recommendation's "build scope = +.m2 walk"). Audit found this
+  is deliberately not done today; whether to change is a separate
+  conversation.
+- Does not emit `--sbom-scope all`-style multi-doc SBOMs. Today
+  users get both views by running mikebom twice; convenience
+  flag is a follow-on if demand surfaces.
+- Does not change CDX output. CDX already self-describes via
+  `metadata.lifecycles[]` + `compositions[]`; this milestone
+  closes the SPDX gap to match.
+- Does not modify the per-component `mikebom:sbom-tier` annotation
+  or the `holistic_parity` C-row catalog. Document-level
+  metadata is outside that matrix.
+- Does not introduce reachability analysis (the recommendation's
+  "runtime scope"). Defer to a future milestone if scoped.
+
+## Why no `data-model.md` / `contracts/` / `quickstart.md`
+
+Same rationale milestones 021 / 022 / 023 / 042 / 046 used (the
+project's tighter 4-file template):
+- `data-model.md`: one new tiny enum (`ScopeMode { Artifact,
+  Manifest }`) inline in `generate/mod.rs`. Not worth a separate
+  doc.
+- `contracts/`: the public-API change is the SPDX comment field's
+  shape; spec.md FR-005 + FR-006 already specify it (scope mode +
+  phases + pointer to per-component annotation). No external
+  consumer needs a separate contract doc.
+- `quickstart.md`: spec's User Stories include
+  acceptance-scenario verifications that read like quickstart
+  steps. Duplicating noise.
+
+This is the sixth use of the tighter template — pattern stable.

--- a/specs/047-scope-self-description/spec.md
+++ b/specs/047-scope-self-description/spec.md
@@ -1,0 +1,357 @@
+# Feature Specification: Self-describe SBOM scope (README explainer + SPDX creationInfo.comment)
+
+**Feature Branch**: `047-scope-self-description`
+**Created**: 2026-04-30
+**Status**: Draft
+**Input**: User description: "Add a 'What kind of SBOM does mikebom emit?' README section explaining the artifact/manifest scope axis + per-component sbom-tier system + CDX lifecycles aggregation, plus SPDX creationInfo.comment document-level scope hint for parity with CDX metadata.lifecycles"
+
+## Background
+
+A pre-spec audit verified that mikebom **already self-describes
+lifecycle scope** through three independent channels:
+
+- CDX `metadata.lifecycles[]` (CDX 1.6 native, aggregated from
+  per-component tiers; phases observed in goldens: `pre-build`,
+  `operations`).
+- CDX `compositions[]` (CDX 1.6 native, with
+  `aggregate: complete | incomplete_first_party_only` plus
+  `assemblies[]` and `dependencies[]` per aggregate).
+- The `mikebom:sbom-tier` annotation on every component, in all
+  three formats (CDX property + SPDX 2.3 annotation + SPDX 3
+  annotation; `tier` values: `design`, `source`, `build`,
+  `deployed`, `analyzed`).
+
+What's missing is **not** another emission channel — it's:
+
+1. **A reader-facing explanation** of how those signals map to
+   the question "what kind of SBOM is this?" Today users have to
+   reverse-engineer the intent from the component list, comparing
+   counts to other tools (trivy, syft) without knowing whether
+   they're asking the same question. The README has no section
+   that names mikebom's scope axes or how to read the lifecycle /
+   composition / tier signals.
+2. **SPDX-side parity for document-level scope hint.** SPDX 2.3's
+   `creationInfo` struct currently emits only `created`,
+   `creators`, and (sometimes) `licenseListVersion`. The
+   `creationInfo.comment` field is unused. SPDX consumers parsing
+   only metadata (without walking the per-component
+   `mikebom:sbom-tier` annotation) get strictly less scope
+   information than CDX consumers reading
+   `metadata.lifecycles[]`. SPDX 3 has the same gap on its
+   `CreationInfo` element.
+
+This milestone closes both.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — README explainer for "what kind of SBOM is this?" (Priority: P1) 🎯 MVP
+
+An operator runs `mikebom sbom scan --image alpine:3.19` and gets
+a CycloneDX with N components. The same image, scanned with trivy
+or syft, produces a different N. Without a project-side
+explanation of mikebom's scope choices, the operator can't tell
+whether the difference is mikebom undercounting, the other tool
+overcounting, or both tools answering different questions
+correctly.
+
+The README needs a short, opinionated section that names the two
+axes mikebom uses today and tells the reader how to interpret the
+signals it emits.
+
+**Why this priority**: closes a documentation gap that's been
+audibly costing user trust ("is mikebom undercounting?"). Pure
+docs work; cheap; high leverage.
+
+**Independent Test**: After the milestone ships, README contains
+a section whose heading matches `what kind of SBOM` (case-insensitive
+grep), naming at minimum:
+
+- The artifact-vs-manifest scope axis and how
+  `--include-declared-deps` toggles it (auto-defaults differ by
+  `--path` vs `--image`).
+- The per-component `mikebom:sbom-tier` system and what each
+  tier means.
+- The CDX `metadata.lifecycles[]` aggregation and CDX
+  `compositions[]` self-description signals — and the SPDX
+  parity slots for both.
+- A short mapping to NTIA / industry lifecycle terminology so
+  readers comparing mikebom against other tools have a shared
+  vocabulary.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator who just scanned an image and is
+   confused why mikebom's component count differs from trivy's,
+   **When** they read the README's "What kind of SBOM does
+   mikebom emit?" section, **Then** they can name (a) which
+   scope mikebom emits by default for `--image` scans, (b) how
+   to switch scope, and (c) which CDX/SPDX field tells a
+   downstream tool what scope this document represents.
+2. **Given** a developer integrating mikebom into a pipeline
+   that already uses trivy or syft, **When** they read the
+   README, **Then** the section explicitly names how mikebom's
+   "artifact" scope corresponds to common lifecycle terminology
+   (post-build / runtime / deployment) so the developer can
+   choose between tools rather than treating them as
+   interchangeable.
+
+---
+
+### User Story 2 — SPDX document-level scope hint via `creationInfo.comment` (Priority: P2)
+
+A consumer parses an SPDX 2.3 document mikebom produced and reads
+only `creationInfo` to identify the document's provenance. Today
+that block carries `created` (timestamp), `creators` (`Tool:
+mikebom-<version>` plus `Organization: …`), and sometimes
+`licenseListVersion`. It carries **nothing** about which scope
+the document represents — that information lives on per-component
+annotations the consumer must walk to discover.
+
+The `creationInfo.comment` field exists in the SPDX 2.3 spec for
+exactly this kind of document-level hint. SPDX 3 has an analogous
+slot on its `CreationInfo` element. Populating both with a short
+structured note closes the metadata-only-consumer gap.
+
+**Why this priority**: SPDX-side parity with CDX
+`metadata.lifecycles[]`. Smaller user surface than US1 (most
+operators use CDX); not blocking. Bundles cleanly with US1
+because the README explainer can name `creationInfo.comment` as
+the SPDX equivalent in its cross-format mapping.
+
+**Independent Test**: After the milestone ships:
+
+- `jq -r '.creationInfo.comment // empty' <any-spdx-2.3-output>`
+  returns a non-empty string.
+- The string contains, at minimum: (a) the scope mode (artifact
+  or manifest), (b) the lifecycle phases observed (mirroring CDX
+  `metadata.lifecycles[]`), and (c) a short pointer to the
+  per-component `mikebom:sbom-tier` annotation for the
+  full per-component breakdown.
+- SPDX 3 has equivalent self-description on its `CreationInfo`
+  element (slot TBD in plan; either `comment` if SPDX 3 has one,
+  or the document's top-level `Element/comment`).
+
+**Acceptance Scenarios**:
+
+1. **Given** a consumer parsing only `creationInfo` from an
+   SPDX 2.3 document mikebom produced, **When** they read
+   `creationInfo.comment`, **Then** they learn the scope mode
+   and the lifecycle phases without needing to walk every
+   `packages[].annotations[]` entry.
+2. **Given** a CDX consumer who already reads
+   `metadata.lifecycles[]` for scope context, **When** they
+   compare the same scan's SPDX 2.3 output, **Then**
+   `creationInfo.comment` carries equivalent (not byte-identical)
+   information — phases agree, scope mode agrees.
+3. **Given** an SPDX 3 consumer, **When** they read the
+   document's `CreationInfo`, **Then** the same scope hint is
+   present (in whichever slot SPDX 3 designates for free-text
+   metadata commentary).
+
+---
+
+### Edge Cases
+
+- **Empty per-component tiers**: if no component carries an
+  `sbom_tier` value (atypical — most ecosystems set one), the
+  CDX `metadata.lifecycles[]` array is omitted today. The SPDX
+  `creationInfo.comment` should also degrade gracefully —
+  either omit the comment, or emit a comment that names the
+  scope mode without phase info. Goal: the comment is never
+  misleading; absence is acceptable.
+- **README + per-format docs duplication**: the README
+  explainer is the canonical user-facing description. Avoid
+  duplicating it verbatim in `docs/user-guide/cli-reference.md`
+  — link instead, so updates have one source of truth.
+- **NTIA terminology mapping**: NTIA's "minimum elements"
+  document doesn't itself define lifecycle phases (it defines
+  data fields). The recommendation cited NTIA loosely; the
+  README explainer should use CDX 1.6's phase names (which
+  align with the broader industry convention)
+  rather than inventing a parallel taxonomy.
+- **Parity-extractor framework**: the existing per-component
+  parity tests (`mikebom-cli/tests/holistic_parity.rs`) cover
+  C-row catalog annotations. Document-level metadata isn't in
+  the catalog; this milestone's emissions are intentionally
+  outside the parity matrix. No new catalog rows; no
+  `holistic_parity` regression risk.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### US1 — README explainer
+
+- **FR-001**: `README.md` MUST contain a section whose heading
+  matches `what kind of SBOM` (case-insensitive). The section
+  is reachable from the README's documentation table of
+  contents.
+- **FR-002**: The section MUST cover (in any reasonable order):
+  (a) the artifact-vs-manifest scope axis, naming
+  `--include-declared-deps` and the auto-default rule
+  (`--path` → manifest, `--image` → artifact); (b) the
+  per-component `mikebom:sbom-tier` system listing all five
+  current tier values (`design`, `source`, `build`,
+  `deployed`, `analyzed`) with a one-line definition each;
+  (c) the CDX `metadata.lifecycles[]` aggregation and SPDX
+  `creationInfo.comment` SPDX equivalent (after US2 lands);
+  (d) at least a one-paragraph mapping to industry / consumer
+  lifecycle terminology so cross-tool comparisons aren't
+  miscalibrated.
+- **FR-003**: The section MUST explicitly state that mikebom's
+  default scope for `--image` is artifact (on-disk components
+  only) so operators comparing component counts to other
+  tools have a clear "we deliberately answer a tighter
+  question" framing — without claiming the other tools are
+  wrong.
+
+#### US2 — SPDX document-level scope hint
+
+- **FR-004**: SPDX 2.3 output MUST carry a non-empty
+  `creationInfo.comment` field describing the scope.
+- **FR-005**: The comment MUST name (a) the scope mode
+  (artifact or manifest, derived from the resolution of
+  `--include-declared-deps` for that scan), (b) the
+  lifecycle phases observed (mirroring the CDX
+  `metadata.lifecycles[]` set the same scan emits), (c) a
+  pointer to the per-component `mikebom:sbom-tier`
+  annotation for finer-grained per-component scope.
+- **FR-006**: SPDX 3 output MUST carry equivalent
+  document-level self-description in its `CreationInfo` (slot
+  decision deferred to the plan; the plan picks
+  `comment` if it exists in SPDX 3 or the top-level
+  document's `Element/comment` field, whichever the SPDX 3
+  spec designates as the canonical free-text metadata slot).
+- **FR-007**: Comment text format SHOULD be human-readable
+  prose (not JSON-as-string) so operators reading raw SPDX
+  output can absorb the hint at a glance. Structured
+  machine-parseable form is out of scope; if downstream tools
+  need structured data, they walk the existing
+  per-component `mikebom:sbom-tier` annotations.
+- **FR-008**: The comment MUST NOT carry per-component
+  detail. It's strictly a document-level summary; the
+  per-component breakdown is the job of the existing
+  `mikebom:sbom-tier` annotation.
+
+#### Cross-cutting
+
+- **FR-009**: No new CLI flags. No changes to `--include-declared-deps`
+  semantics. No changes to per-component
+  `mikebom:sbom-tier` emission.
+- **FR-010**: SPDX 2.3 + SPDX 3 byte-identity goldens regen
+  cleanly. The added `creationInfo.comment` is the only
+  semantic delta in the affected goldens; no other field
+  shifts.
+- **FR-011**: CDX goldens DO NOT change. CDX already
+  self-describes via `metadata.lifecycles[]` and
+  `compositions[]`; this milestone adds nothing to CDX.
+- **FR-012**: `holistic_parity` tests remain green. Document-
+  level metadata is outside the per-component catalog matrix.
+- **FR-013**: Pre-PR gate (`./scripts/pre-pr.sh`) clean.
+
+### Key Entities
+
+- **Scope mode**: a binary attribute of any single mikebom
+  scan, derived from the resolution of
+  `--include-declared-deps`. Values: `artifact` (on-disk
+  presence required for emission) or `manifest` (declared
+  transitives + .pom-cached coords also emitted). Already
+  computed today; this milestone surfaces it in human-readable
+  metadata.
+- **Lifecycle phases set**: the union of CDX 1.6 phase names
+  observed across the scan's components (today: subset of
+  `design`, `pre-build`, `build`, `post-build`, `operations`).
+  Already aggregated for `metadata.lifecycles[]`; this
+  milestone reuses the same aggregation for the SPDX comment.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+#### US1
+
+- **SC-001**: A grep for `[Ww]hat kind of SBOM` in `README.md`
+  matches at least one heading (`#`-style heading line).
+- **SC-002**: The new section names all five sbom-tier values
+  AND names the scope-mode toggle flag explicitly.
+
+#### US2
+
+- **SC-003**: After running `mikebom sbom scan
+  --format spdx-2.3-json --path tests/fixtures/<any>`,
+  `jq -r '.creationInfo.comment' <output>` returns a string
+  containing the substring `scope:` (or equivalent
+  designator) AND the substring `mikebom:sbom-tier`.
+- **SC-004**: Equivalent assertion holds for SPDX 3 output
+  (location TBD per FR-006).
+- **SC-005**: All 9 SPDX 2.3 goldens regen with the new
+  comment field present and otherwise byte-identical to
+  pre-milestone output.
+
+#### Cross-cutting
+
+- **SC-006**: `git diff main..HEAD -- mikebom-cli/tests/fixtures/golden/cyclonedx/`
+  is empty (CDX goldens unchanged per FR-011).
+- **SC-007**: `./scripts/pre-pr.sh` clean. All 3 CI lanes
+  green on the milestone PR.
+- **SC-008**: A second pass against the audit findings finds
+  zero remaining SPDX-comment-emission gaps in the
+  scope-self-description category.
+
+## Assumptions
+
+- The audit's findings about current self-describing
+  emissions (`metadata.lifecycles[]`, `compositions[]`,
+  `mikebom:sbom-tier`) are accurate and don't need
+  re-verification before this milestone ships. The audit
+  cited specific files (`generate/cyclonedx/metadata.rs:218`,
+  `generate/cyclonedx/compositions.rs`,
+  `generate/spdx/annotations.rs:141`) and confirmed via
+  goldens.
+- The artifact-vs-manifest scope axis is the right primary
+  framing in the README explainer. The five
+  `mikebom:sbom-tier` values are the secondary
+  per-component framing. The CDX phase names are the tertiary
+  "where does this end up in the SBOM document" framing. The
+  README explainer threads all three into a single
+  consistent narrative; if a reviewer prefers a different
+  primary framing, that's an editorial discussion within
+  this milestone, not a scope change.
+- SPDX 3's free-text comment slot is on `CreationInfo`
+  similarly to SPDX 2.3, OR on the top-level
+  `SpdxDocument` element as `comment`. Plan phase will
+  resolve which.
+- No CHANGELOG entry needed for the README explainer (US1) —
+  pure docs. US2 (the SPDX comment) IS user-visible (SPDX
+  consumers will see new metadata), so it warrants a small
+  CHANGELOG entry.
+
+## Out of scope
+
+- Adding a new CLI flag (e.g., `--sbom-scope` or
+  `--sbom-scope all`). The existing `--include-declared-deps`
+  already controls scope; this milestone surfaces existing
+  state, doesn't add new state.
+- Walking host `~/.m2/repository/` wholesale to emit every
+  cached JAR as a component. The recommendation that
+  prompted this milestone proposed this as a "build scope"
+  emission; the audit found mikebom deliberately does not
+  do this today (rootfs `.m2/` is walked, host `~/.m2/` is
+  used only for resolution data). Whether to change that is
+  a separate conversation.
+- Multi-document emission (`--sbom-scope all` style: emit
+  artifact + manifest in one run). Could be a follow-on if
+  user demand surfaces; today users get both views by
+  running mikebom twice.
+- Reachability analysis (the recommendation's "runtime"
+  scope). Defer; not scoped to anything concrete yet.
+- Conformance-suite changes (per-fixture `expected_sbom_scope`
+  ground-truth, `MISMATCHED_SBOM_SCOPE` finding kind). These
+  belong in the sbom-conformance repo, not this one. Mark as
+  follow-on for that repo's maintainer.
+- CDX-side document-level scope-mode property
+  (`metadata.properties[]` entry for `mikebom:scan-mode`).
+  CDX already has `metadata.lifecycles[]`; adding a parallel
+  property would duplicate existing self-description. If
+  later experience shows lifecycles isn't enough, scope a
+  separate milestone.

--- a/specs/047-scope-self-description/tasks.md
+++ b/specs/047-scope-self-description/tasks.md
@@ -1,0 +1,210 @@
+---
+description: "Task list — milestone 047 SBOM-scope self-description"
+---
+
+# Tasks: Self-describe SBOM scope (README explainer + SPDX `comment` parity)
+
+**Input**: spec.md ✅, plan.md ✅, checklists/requirements.md ✅. (No
+research.md / data-model.md / contracts/ / quickstart.md — same
+4-file tighter template milestones 021/022/023/042/046 use; the
+plan resolves the SPDX 3 slot lookup inline in §Phase 0.)
+
+**Tests**: included as inline unit tests for the new comment-text
+builder, plus jq-shaped acceptance assertions per FR, plus the
+existing byte-identity goldens regen surface (18 SPDX files), plus
+`holistic_parity` continuing to pass.
+
+**Organization**: Two user stories. Phase ordering inverts strict
+priority (US2 before US1) because US1's README explainer
+references US2's just-shipped SPDX comment field per FR-002(c) —
+shipping US2 first lets the README cite real behavior. Story
+labels still reflect spec priority. See "Dependency graph"
+section.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm clean working tree on branch `047-scope-self-description`. `git status` shows only the un-tracked `specs/047-scope-self-description/` scaffolding from `/speckit.specify`.
+- [ ] T002 `./scripts/pre-pr.sh` clean (baseline; should pass since no edits yet).
+
+---
+
+## Phase 2: Foundational
+
+- [ ] T003 Add `pub enum ScopeMode { Artifact, Manifest }` to `mikebom-cli/src/generate/mod.rs`. Place near `OutputConfig` / `ScanArtifacts` definitions. Derive `Debug, Clone, Copy, PartialEq, Eq`.
+- [ ] T004 Add `pub scope_mode: ScopeMode` field to `mikebom-cli/src/generate/mod.rs::ScanArtifacts`. Update Default impl + any test fixture builders that construct `ScanArtifacts` directly to set the new field. Default for tests: `ScopeMode::Artifact`.
+- [ ] T005 Plumb `scope_mode` through `mikebom-cli/src/cli/scan_cmd.rs` at lines ~743–760: after `effective_include_declared_deps` resolves, set `scope_mode = if effective_include_declared_deps { ScopeMode::Manifest } else { ScopeMode::Artifact }` on the `ScanArtifacts` builder.
+- [ ] T006 Create new module `mikebom-cli/src/generate/lifecycle_phases.rs` with two `pub fn`s: `tier_to_phase(tier: &str) -> Option<&'static str>` (extract from `cyclonedx/metadata.rs:37–46`) and `aggregate_phases<'a>(components: impl Iterator<Item = &'a ResolvedComponent>) -> Vec<&'static str>` (extract from `cyclonedx/metadata.rs:76–89`; preserve `BTreeSet` collector for deterministic sort). Register the module in `mikebom-cli/src/generate/mod.rs`.
+- [ ] T007 Update `mikebom-cli/src/generate/cyclonedx/metadata.rs`: replace the inlined `tier_to_lifecycle_phase` and per-component aggregation with calls into `lifecycle_phases::tier_to_phase` / `lifecycle_phases::aggregate_phases`. Same algorithm, same sort order — CDX goldens MUST be byte-identical post-extraction.
+- [ ] T008 Verify CDX goldens unchanged: `cargo +stable test -p mikebom --test cdx_regression` passes without regen. Any failure here means the extraction altered emission shape — fix before proceeding.
+
+---
+
+## Phase 3: Commit `feat(047/us2-1)` — SPDX 2.3 `creationInfo.comment`
+
+**Goal**: Populate SPDX 2.3 `creationInfo.comment` with a document-level scope hint (scope mode + observed lifecycle phases + pointer to per-component annotations).
+
+**Independent test**: `jq -r '.creationInfo.comment'` on any SPDX 2.3 output returns a non-empty string containing `Scope:` and `mikebom:sbom-tier`.
+
+- [ ] T009 [US2] Edit `mikebom-cli/src/generate/spdx/document.rs:122–134`: add `pub comment: Option<String>` field to the `CreationInfo` struct with `#[serde(skip_serializing_if = "Option::is_none")]`. Default for the field is `None`.
+- [ ] T010 [US2] Add a new `pub(super) fn build_scope_comment(scan: &ScanArtifacts<'_>) -> String` helper to `mikebom-cli/src/generate/spdx/document.rs` that:
+    - Reads `scan.scope_mode` (`Artifact` → `"artifact (on-disk components only)"`, `Manifest` → `"manifest (declared transitives included)"`).
+    - Calls `crate::generate::lifecycle_phases::aggregate_phases(scan.components)` for the deterministic sorted phase list.
+    - Returns prose: `"Scope: <mode>. Observed lifecycle phases: <comma-list> (or 'no lifecycle phases observed' when the slice is empty). Per-component scope detail in mikebom:sbom-tier annotations."`
+- [ ] T011 [US2] Edit `mikebom-cli/src/generate/spdx/document.rs::build_document` (line 217+): set `creation_info.comment = Some(build_scope_comment(scan))`. Always emit (per spec edge-case decision: predictable presence > conditional emission).
+- [ ] T012 [P] [US2] Add inline test `build_scope_comment_emits_artifact_mode_with_phases` in `document.rs::tests`: synthetic `ScanArtifacts` with `scope_mode = Artifact` and 3 components carrying tiers `build`, `deployed`, `analyzed`; assert the returned string contains `Scope: artifact`, `Observed lifecycle phases: build, operations, post-build` (lexicographic phase order), and `mikebom:sbom-tier`.
+- [ ] T013 [P] [US2] Add inline test `build_scope_comment_emits_manifest_mode` in `document.rs::tests`: synthetic `ScanArtifacts` with `scope_mode = Manifest` and any tier set; assert `Scope: manifest`.
+- [ ] T014 [P] [US2] Add inline test `build_scope_comment_handles_empty_phases` in `document.rs::tests`: synthetic `ScanArtifacts` with all components carrying `sbom_tier = None`; assert the string contains `Scope:` and `no lifecycle phases observed` (per the empty-phases edge-case decision).
+- [ ] T015 [US2] Run `cargo +stable test -p mikebom --bin mikebom -- spdx::document` and confirm 3 new tests pass.
+- [ ] T016 [US2] Regen 9 SPDX 2.3 goldens: `MIKEBOM_UPDATE_SPDX_GOLDENS=1 cargo +stable test -p mikebom --test spdx_regression`.
+- [ ] T017 [US2] Verify goldens regen is "comment-field delta + SHA cascade only" (no other semantic shifts): `git diff main..HEAD -- mikebom-cli/tests/fixtures/golden/spdx-2.3/ | grep -E '^[+-]' | grep -vE '^[+-]{3}|"comment":|"creationInfo":|SPDXRef|documentNamespace'` should be empty.
+- [ ] T018 [US2] Verify SC-003 with the regen'd goldens: `jq -r '.creationInfo.comment' mikebom-cli/tests/fixtures/golden/spdx-2.3/maven.spdx.json` returns non-empty containing both `Scope:` and `mikebom:sbom-tier`.
+- [ ] T019 [US2] Verify FR-011 / SC-006 (CDX unchanged): `git diff main..HEAD --stat -- mikebom-cli/tests/fixtures/golden/cyclonedx/` empty.
+- [ ] T020 [US2] `./scripts/pre-pr.sh` clean.
+- [ ] T021 [US2] Commit: `feat(047/us2-1): SPDX 2.3 creationInfo.comment with document-level scope hint + extract lifecycle_phases shared utility`.
+
+---
+
+## Phase 4: Commit `feat(047/us2-2)` — SPDX 3 `SpdxDocument.comment`
+
+**Goal**: Same comment text on the SPDX 3 `SpdxDocument` Element. Per Phase 0 research: comment goes on `SpdxDocument` (not `CreationInfo`); JSON-LD key is plain `comment` (the existing `spdx-context.jsonld` already maps it).
+
+**Independent test**: `jq -r '.["@graph"][] | select(.type == "SpdxDocument") | .comment'` returns non-empty containing `Scope:` and `mikebom:sbom-tier`.
+
+- [ ] T022 [US2] Edit `mikebom-cli/src/generate/spdx/v3_document.rs:113–132`: in the `spdx_document` JSON-LD object construction, add a `"comment": <string>` key. Reuse `super::document::build_scope_comment(scan)` (path TBD — if cross-module privacy requires it, lift `build_scope_comment` to `mikebom-cli/src/generate/spdx/scope_comment.rs` so both `document.rs` and `v3_document.rs` import from a sibling module).
+- [ ] T023 [P] [US2] Add inline test `spdx3_document_emits_scope_comment` in `v3_document.rs::tests`: synthetic minimal scan; assert the emitted JSON-LD has a `SpdxDocument` element with non-empty `comment` containing `Scope:` and `mikebom:sbom-tier`.
+- [ ] T024 [US2] Run `cargo +stable test -p mikebom --bin mikebom -- spdx::v3_document` and confirm the new test passes.
+- [ ] T025 [US2] Regen 9 SPDX 3 goldens: `MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test -p mikebom --test spdx3_regression`.
+- [ ] T026 [US2] Verify goldens regen is "comment + SHA cascade only" (the SHA-derived `SPDXID` / `documentNamespace` re-stamps are expected). Inspect the diff for any unexpected non-`comment`-related semantic shifts.
+- [ ] T027 [US2] Verify SC-004: `jq -r '.["@graph"][] | select(.type == "SpdxDocument") | .comment' mikebom-cli/tests/fixtures/golden/spdx-3/maven.spdx3.json` returns non-empty containing both `Scope:` and `mikebom:sbom-tier`.
+- [ ] T028 [US2] Verify `holistic_parity` still green: `cargo +stable test -p mikebom --test holistic_parity` 11/11 ok. (Document-level metadata is outside the C-row catalog so this should be untouched.)
+- [ ] T029 [US2] `./scripts/pre-pr.sh` clean.
+- [ ] T030 [US2] Commit: `feat(047/us2-2): SPDX 3 SpdxDocument.comment with document-level scope hint`.
+
+---
+
+## Phase 5: Commit `docs(047/us1)` — README "What kind of SBOM does mikebom emit?" explainer
+
+**Goal**: Add a new top-level README section threading the now-shipped self-describing signals (artifact/manifest scope + 5-value `mikebom:sbom-tier` system + CDX `metadata.lifecycles[]` + SPDX `comment`) into a coherent narrative for operators comparing mikebom to trivy / syft.
+
+**Independent test**: SC-001 (heading match), SC-002 (5 tier values + `--include-declared-deps` named).
+
+- [ ] T031 [US1] Edit `README.md`: insert a new `## What kind of SBOM does mikebom emit?` section between the existing "Why" section and the "Install" section. The section MUST contain (in any reasonable order):
+    - **The two-axis framing**: scope-mode (artifact vs manifest, document-level) + per-component lifecycle tier.
+    - **The 5 sbom-tier values** with one-line definitions each: `design` (declared but not pinned, e.g., `>=1.0` ranges), `source` (lockfile-pinned, byte-resolvable), `build` (eBPF-traced build event), `deployed` (installed in the runtime image — dpkg, venv, node_modules), `analyzed` (artifact hash on disk).
+    - **The CDX self-description trio**: `metadata.lifecycles[]` aggregation (CDX 1.6 native), `compositions[]` per-aggregate completeness, per-component `mikebom:sbom-tier` property.
+    - **The SPDX self-description**: `creationInfo.comment` (SPDX 2.3, just shipped) and `SpdxDocument.comment` (SPDX 3, just shipped) — name the slot location for each format. Plus the same per-component `mikebom:sbom-tier` annotation for cross-format symmetry.
+    - **One-paragraph mapping to industry / consumer terminology** so readers comparing mikebom to trivy / syft don't assume the tools answer the same question. Mikebom's default for `--image` is artifact (CDX phase: `operations`); trivy's container scan is closer to "build cache + image" hybrid.
+    - **Default scope per scan mode**: `--image` → artifact, `--path` → manifest. Name `--include-declared-deps` as the toggle (auto-on for `--path`, auto-off for `--image`; explicit override available).
+    - **Pointer to deeper rationale**: link to `docs/design-notes.md` "Scope: artifact vs manifest SBOM" section.
+- [ ] T032 [US1] Verify SC-001: `grep -nE '^## .*[Ww]hat kind of SBOM' /Users/mlieberman/Projects/mikebom/README.md` matches one heading line.
+- [ ] T033 [US1] Verify SC-002: the new section enumerates all 5 sbom-tier values AND names `--include-declared-deps`. Greppable assertion: each of the strings `design`, `source`, `build`, `deployed`, `analyzed`, `--include-declared-deps` appears within the new section's range.
+- [ ] T034 [US1] `./scripts/pre-pr.sh` clean.
+- [ ] T035 [US1] Commit: `docs(047/us1): README "What kind of SBOM does mikebom emit?" explainer`.
+
+---
+
+## Phase 6: Commit `chore(047)` — CHANGELOG + spec scaffolding
+
+**Goal**: Land the speckit artifacts and a CHANGELOG entry.
+
+- [ ] T036 Add a CHANGELOG `[Unreleased]` entry under "Added" naming (a) the new SPDX 2.3 `creationInfo.comment` document-level scope hint, (b) the new SPDX 3 `SpdxDocument.comment`, (c) the README explainer. Mention that no CDX output changes (CDX already self-describes via `metadata.lifecycles[]`).
+- [ ] T037 Stage `specs/047-scope-self-description/` (spec.md, plan.md, tasks.md, checklists/requirements.md) and any `CLAUDE.md` updates from `update-agent-context.sh`.
+- [ ] T038 `./scripts/pre-pr.sh` clean.
+- [ ] T039 Commit: `chore(047): CHANGELOG entry + speckit spec/plan/tasks scaffolding`.
+
+---
+
+## Phase 7: Polish & PR
+
+- [ ] T040 Verify SC-005 (SPDX 2.3 goldens regen with comment field present + otherwise byte-identical pre-milestone): grep one regen'd golden for the new comment, confirm via `jq` that all other top-level fields match pre-PR shapes.
+- [ ] T041 Verify SC-006 (CDX goldens unchanged): `git diff main..HEAD -- mikebom-cli/tests/fixtures/golden/cyclonedx/` empty.
+- [ ] T042 Verify SC-007 (pre-PR + CI green): final `./scripts/pre-pr.sh` clean from a fresh shell.
+- [ ] T043 Push branch: `git push -u origin 047-scope-self-description`.
+- [ ] T044 Open PR titled `feat(047): SBOM-scope self-description (README explainer + SPDX `comment` parity)`. Body covers: 4-commit summary, scope of audit findings, 8 SC verification commands, out-of-scope reminders.
+- [ ] T045 Verify all 3 CI lanes (linux x86_64, linux ebpf, macos-latest) green on the PR.
+
+---
+
+## Dependency graph
+
+```text
+T001-T002 (setup, baseline)
+   │
+   ▼
+T003-T008 (foundational: ScopeMode + ScanArtifacts plumbing
+           + extract lifecycle_phases utility — required by both
+           SPDX 2.3 and SPDX 3 commits)
+   │
+   ▼
+T009-T021  [Commit 1: Phase 3 — US2 SPDX 2.3 comment]
+   │
+   ▼
+T022-T030  [Commit 2: Phase 4 — US2 SPDX 3 comment, reuses Phase 3's helper]
+   │
+   ▼
+T031-T035  [Commit 3: Phase 5 — US1 README explainer, references shipped SPDX behavior]
+   │
+   ▼
+T036-T039  [Commit 4: Phase 6 — CHANGELOG + scaffolding]
+   │
+   ▼
+T040-T045 (verify + push + PR)
+```
+
+**Why phase ordering inverts spec priority** (US2 before US1):
+US1's README references `creationInfo.comment` and
+`SpdxDocument.comment` as concrete shipped behavior per FR-002(c).
+Shipping SPDX first lets the README cite real output rather than
+forward-reference unshipped fields. Story labels remain `[US1]` /
+`[US2]` reflecting spec-time priority; commit ordering reflects
+implementation dependency.
+
+## Parallel opportunities
+
+Within each commit, edits land in different files where possible:
+
+| Bucket | Parallel-eligible tasks |
+|---|---|
+| Foundational | T003 + T004 (mod.rs sequential) → T005 (scan_cmd.rs) || T006 (new file) — T007 depends on T006 |
+| Commit 1 | T009 + T010 + T011 (same file → sequential) but T012 / T013 / T014 (test functions in same file) can be added in any order; mark as [P] internally |
+| Commit 2 | T022 (single edit) — T023 follows |
+| Commit 3 | T031 (single file) |
+
+## Estimated effort
+
+| Phase | Effort | Notes |
+|---|---|---|
+| Phase 1 (setup) | 5 min | Just baseline check |
+| Phase 2 (foundational) | 30 min | New module + plumbing |
+| Phase 3 (SPDX 2.3) | 1 hr | Helper + struct field + 9 goldens regen |
+| Phase 4 (SPDX 3) | 30 min | Reuses helper; 9 goldens regen |
+| Phase 5 (README) | 30 min | New section, 50 lines of Markdown |
+| Phase 6 (CHANGELOG + scaffold) | 10 min | Mechanical |
+| Phase 7 (verify + PR) | 15 min | Push + CI |
+| **Total** | **~3 hr** | One focused session |
+
+## MVP scope
+
+US1 alone (commit 3) without US2 would still be valuable —
+documents the existing CDX self-description and the existing
+artifact/manifest axis. But the README would have to forward-
+reference the SPDX comment ("SPDX equivalent forthcoming") which
+is awkward.
+
+US2 alone (commits 1+2) ships the SPDX-side parity but leaves the
+documentation gap open — operators still have no project-side
+explanation of mikebom's scope choices.
+
+The intended MVP for this milestone is **US2 + US1 together** —
+US2 closes the SPDX-side parity gap; US1 documents what the
+combined CDX + SPDX self-description means. Shipping both in one
+PR is the cleanest UX outcome.
+
+If review bandwidth is tight, the US2 commits (1+2) could land
+first as a standalone PR ("SPDX comment parity") with US1
+following separately ("docs explainer"). Spec has no hard
+coupling that prevents this.


### PR DESCRIPTION
## Summary

A pre-spec audit verified that mikebom **already self-describes lifecycle scope** through three independent CDX channels (`metadata.lifecycles[]`, `compositions[]`, per-component `mikebom:sbom-tier` annotation). Two real gaps remained:

1. **SPDX consumers reading metadata-only got strictly less scope info than CDX consumers.** SPDX 2.3 left `creationInfo.comment` empty; SPDX 3 left `SpdxDocument.comment` empty. Both are spec-defined free-text slots for exactly this purpose.
2. **The README had no project-side explanation of mikebom's scope choices** — operators comparing component counts to trivy / syft had to reverse-engineer the intent from the component list.

This PR closes both, in a 4-commit shape that makes each change reviewable independently.

## Commits

1. **`feat(047/us2-1)`** — SPDX 2.3 `creationInfo.comment` + foundational `ScopeMode` plumbing through `ScanArtifacts` + new `lifecycle_phases.rs` shared utility (extracted from `cyclonedx/metadata.rs` so SPDX and CDX use the same phase-aggregation source-of-truth) + 9 SPDX 2.3 goldens regen + 3 inline tests for the comment builder.
2. **`feat(047/us2-2)`** — SPDX 3 `SpdxDocument.comment` (reuses the helper from US2-1; same prose for both formats) + 9 SPDX 3 goldens regen.
3. **`docs(047/us1)`** — README "What kind of SBOM does mikebom emit?" section explaining the two scope axes, how each format self-describes, and the industry / NTIA-style terminology bridge.
4. **`chore(047)`** — CHANGELOG `[Unreleased]` entry + speckit spec/plan/tasks scaffolding (matches milestones 041/042/046).

## Phase 0 research (resolved inline in plan.md)

The spec deferred one question to plan: which SPDX 3 slot for the document-level comment? Decision: **`SpdxDocument.comment`** (NOT `CreationInfo.comment`). Rationale: per SPDX 3.0.1 docs, Element-level `comment` is "the creator's observations about *this Element*" — on the singular `SpdxDocument` Element that's exactly the document-level scope note. `CreationInfo` is a shared sub-element referenced by every Element in the graph; a comment there reads as "note about this batch of element creations," not "note about the SBOM's scope." The existing `spdx-context.jsonld` already maps the unprefixed `comment` JSON-LD key, so no `@context` change.

Sources cited in plan.md §Phase 0.

## Verification (8 success criteria, all green locally)

- ✅ SC-001: `grep -nE '^## .*[Ww]hat kind of SBOM' README.md` → matches the new heading.
- ✅ SC-002: README section names all 5 sbom-tier values + `--include-declared-deps`.
- ✅ SC-003: `jq -r '.creationInfo.comment' <maven SPDX 2.3 golden>` → `Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in mikebom:sbom-tier annotations.`
- ✅ SC-004: `jq -r '.["@graph"][] | select(.type == "SpdxDocument") | .comment' <maven SPDX 3 golden>` → identical text.
- ✅ SC-005: 9 SPDX 2.3 goldens regen with comment field present.
- ✅ SC-006: CDX goldens unchanged (`git diff main..HEAD --stat -- mikebom-cli/tests/fixtures/golden/cyclonedx/` empty).
- ✅ SC-007: `./scripts/pre-pr.sh` clean; 11/11 `holistic_parity` ok.
- 📋 SC-008: post-merge re-audit recommended manually after merge.

## Out of scope

- New `--sbom-scope` CLI flag (the original recommendation's P1). Audit found the concept already exists via `--include-declared-deps` + the 5-value `mikebom:sbom-tier` system; this PR surfaces existing state, doesn't add new state.
- Walking host `~/.m2/repository/` wholesale (the recommendation's "build scope = +.m2 walk"). mikebom deliberately doesn't do this today; whether to change is a separate conversation.
- `--sbom-scope all` multi-doc emission. Today users get both views by running mikebom twice; convenience flag is a follow-on if demand surfaces.
- Reachability analysis (the recommendation's "runtime scope"). Defer.

## Test plan

- [x] `./scripts/pre-pr.sh` clean
- [x] 3 inline tests for `build_scope_comment` pass
- [x] 9 SPDX 2.3 goldens + 9 SPDX 3 goldens regen with `comment` field present
- [x] CDX goldens byte-identical pre-PR
- [x] `holistic_parity` 11/11 ok
- [ ] All 3 CI lanes (linux x86_64, linux ebpf, macos-latest) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)