### PR TITLE
feat(049): Go source-tree full transitive closure + test-vs-prod tagging via is_dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,27 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 
 ## [Unreleased]
 
-(Nothing yet. Land changes here, then cut a release per the
-`release.yml` workflow trigger documented in
-`docs/contributing/release.md`.)
+### Changed
+
+- **Go source-tree scans now emit the full go.sum closure by
+  default** (milestone 049). Previously the source-tree filter
+  dropped every entry not directly imported by this project's
+  non-`_test.go` files, collapsing legitimate transitive prod
+  deps (e.g., aws-sdk internals, gin's middleware chain) into
+  the test-only bucket. Audit on `apigatewayv2/config` showed
+  6 components emitted vs. 55 in trivy / 56 in syft. The new
+  default emits every `go.sum` entry as a component (matches
+  trivy/syft) and only TAGS the small subset proven test-only
+  by source-walking the project's `_test.go` imports. Test-only
+  deps carry the existing `mikebom:dev-dependency = true`
+  annotation when `--include-dev` is set; default-mode drops
+  them (mirrors npm/Poetry/Pipfile semantics). No new flag,
+  no new annotation, no new catalog row. CDX + SPDX 2.3 +
+  SPDX 3 outputs all carry the new emission via existing
+  parity wiring.
+
+  Scope: Go-only. cargo / gem / maven test-tagging extension
+  tracked as milestone 050 (see specs/049-go-source-scope/).
 
 ## [0.1.0-alpha.8] — 2026-04-30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-30
+Auto-generated from all feature plans. Last updated: 2026-05-01
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -30,6 +30,7 @@ Auto-generated from all feature plans. Last updated: 2026-04-30
 - N/A — this milestone touches Markdown only. + None new. (046-docs-refresh)
 - Rust stable (workspace toolchain inherited). + existing only — `serde`, `serde_json`, (047-scope-self-description)
 - Rust stable. + existing only — `std::path`, (048-component-role)
+- Rust stable. + existing only — `std::collections`, (049-go-source-scope)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -92,9 +93,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 049-go-source-scope: Added Rust stable. + existing only — `std::collections`,
 - 048-component-role: Added Rust stable. + existing only — `std::path`,
 - 047-scope-self-description: Added Rust stable (workspace toolchain inherited). + existing only — `serde`, `serde_json`,
-- 046-docs-refresh: Added N/A — this milestone touches Markdown only. + None new.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/scan_fs/package_db/golang.rs
+++ b/mikebom-cli/src/scan_fs/package_db/golang.rs
@@ -594,15 +594,23 @@ fn cache_lookup_depends(cache: &GoModCache, module: &str, version: &str) -> Vec<
 /// * `main_modules` — Go module paths declared as the project's own
 ///   `module` directive in any scanned go.mod. Feeds the G5 filter
 ///   (feature 007 US3): a project is never its own dependency.
-/// * `production_imports` — Go module paths that are reachable from
-///   at least one non-`_test.go` import anywhere in the scanned
-///   source tree. Feeds the G4 filter (feature 007 US2): modules
-///   only imported from `_test.go` files are test-scope transitives
-///   and shouldn't surface as runtime dependencies.
+/// * `production_imports` — Go module paths reachable from at least
+///   one non-`_test.go` import anywhere in the scanned source tree
+///   (this project's prod imports — direct only). Used as the prod
+///   baseline for the milestone 049 test-vs-prod tagging.
+/// * `test_only_imports` (milestone 049) — Go module paths reachable
+///   from `_test.go` imports of this project but NOT from any
+///   non-`_test.go` import. These deps are tagged
+///   `is_dev = Some(true)` and dropped when `--include-dev` is off.
+///   Source-walk only; we do not BFS through deps' go.mod `require`
+///   blocks because those don't distinguish prod-vs-test requires
+///   (a dep can declare testify in its go.mod purely for its own
+///   tests, but downstream consumers wouldn't load it in prod).
 #[derive(Debug, Default)]
 pub struct GoScanSignals {
     pub main_modules: HashSet<String>,
     pub production_imports: HashSet<String>,
+    pub test_only_imports: HashSet<String>,
 }
 
 pub fn read(rootfs: &Path, _include_dev: bool) -> (Vec<PackageDbEntry>, GoScanSignals) {
@@ -661,8 +669,9 @@ pub fn read(rootfs: &Path, _include_dev: bool) -> (Vec<PackageDbEntry>, GoScanSi
     known_modules.sort_by_key(|m| std::cmp::Reverse(m.len()));
     known_modules.dedup();
 
-    // Second pass: emit entries AND walk .go files for production
-    // imports.
+    // Second pass: emit entries AND walk .go files for production +
+    // test-only imports.
+    let mut test_imports: HashSet<String> = HashSet::new();
     for (project_root, doc, sums) in &parsed_roots {
         let go_sum_path = project_root.join("go.sum");
         let source_path = go_sum_path.to_string_lossy().into_owned();
@@ -673,24 +682,50 @@ pub fn read(rootfs: &Path, _include_dev: bool) -> (Vec<PackageDbEntry>, GoScanSi
                 out.push(entry);
             }
         }
-        // Feature 007 US2: walk .go source files under this project
-        // root (excluding `_test.go` files and test-adjacent subtrees)
-        // and record every imported module path that matches a known
-        // module in `known_modules`. Imports of stdlib or unknown
-        // paths are silently ignored.
+        // Feature 007 US2 / Milestone 049: walk .go source files for
+        // prod imports (non-`_test.go`) and test imports (`_test.go`
+        // only). The two sets together drive the test-vs-prod
+        // classification in `package_db::mod::apply_go_production_set_filter`.
         collect_production_imports(
             project_root,
             0,
             &known_modules,
             &mut signals.production_imports,
         );
+        collect_test_imports(
+            project_root,
+            0,
+            &known_modules,
+            &mut test_imports,
+        );
     }
+
+    // Test-only set: imports reachable from `_test.go` source MINUS
+    // imports reachable from non-test source. Modules in the difference
+    // get `is_dev = Some(true)` in the classifier.
+    //
+    // Milestone 049 R3 (revised): the test-only computation uses
+    // direct source imports only, NOT a go.mod-`require` BFS expansion.
+    // Reason: a dep's go.mod `require` block doesn't distinguish prod
+    // requires from test-only requires (Go test deps live in the dep's
+    // `_test.go` source, not in its go.mod). Conservative BFS through
+    // go.mod requires would falsely promote test-only deps to prod
+    // whenever a transitively-prod dep's go.mod also requires them
+    // (e.g., logrus's go.mod requires testify because logrus's own
+    // tests use it; from this project's perspective testify is still
+    // test-only). Output scope is unchanged — every go.sum entry is
+    // emitted (FR-001) — only the test-only TAG uses this difference.
+    signals.test_only_imports = test_imports
+        .difference(&signals.production_imports)
+        .cloned()
+        .collect();
 
     if !out.is_empty() {
         tracing::info!(
             rootfs = %rootfs.display(),
             modules = out.len(),
             production_imports = signals.production_imports.len(),
+            test_only_imports = signals.test_only_imports.len(),
             main_modules = signals.main_modules.len(),
             "parsed Go source tree",
         );
@@ -700,20 +735,63 @@ pub fn read(rootfs: &Path, _include_dev: bool) -> (Vec<PackageDbEntry>, GoScanSi
 
 /// Walk a Go project root collecting production-scope imports. Skips
 /// `_test.go` files (test-scope) and any directory `should_skip_descent`
-/// says to skip. For each remaining `.go` file, extracts import paths
-/// via [`extract_go_imports`] and longest-prefix-matches each one
-/// against `known_modules`. Matches are inserted into `out`.
-///
-/// The `known_modules` slice MUST be sorted by length descending so
-/// the first prefix match is the longest (e.g., import
-/// `github.com/foo/bar/baz` correctly attributes to module
-/// `github.com/foo/bar` when both `github.com/foo` and
-/// `github.com/foo/bar` are known modules).
+/// says to skip. Thin wrapper over [`collect_imports_filtered`] with the
+/// "non-test files only" predicate.
 fn collect_production_imports(
     dir: &Path,
     depth: usize,
     known_modules: &[String],
     out: &mut HashSet<String>,
+) {
+    collect_imports_filtered(
+        dir,
+        depth,
+        known_modules,
+        out,
+        FileScope::ProdOnly,
+    );
+}
+
+/// Walk a Go project root collecting test-scope imports. Visits ONLY
+/// `_test.go` files (the inverse predicate of [`collect_production_imports`]).
+/// Milestone 049: paired with `collect_production_imports` to compute
+/// the test-only set as a difference (`test_imports - prod_imports`).
+fn collect_test_imports(
+    dir: &Path,
+    depth: usize,
+    known_modules: &[String],
+    out: &mut HashSet<String>,
+) {
+    collect_imports_filtered(
+        dir,
+        depth,
+        known_modules,
+        out,
+        FileScope::TestOnly,
+    );
+}
+
+/// Which `.go` files to inspect in [`collect_imports_filtered`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FileScope {
+    /// Skip `_test.go` files; record imports from non-test source.
+    ProdOnly,
+    /// Only `_test.go` files; record imports from test source.
+    TestOnly,
+}
+
+/// Shared implementation for [`collect_production_imports`] and
+/// [`collect_test_imports`]. The `known_modules` slice MUST be sorted
+/// by length descending so the first prefix match is the longest
+/// (e.g., import `github.com/foo/bar/baz` correctly attributes to
+/// module `github.com/foo/bar` when both `github.com/foo` and
+/// `github.com/foo/bar` are known modules).
+fn collect_imports_filtered(
+    dir: &Path,
+    depth: usize,
+    known_modules: &[String],
+    out: &mut HashSet<String>,
+    scope: FileScope,
 ) {
     if depth >= MAX_PROJECT_ROOT_DEPTH {
         return;
@@ -730,7 +808,7 @@ fn collect_production_imports(
             if should_skip_descent(&path) {
                 continue;
             }
-            collect_production_imports(&path, depth + 1, known_modules, out);
+            collect_imports_filtered(&path, depth + 1, known_modules, out, scope);
             continue;
         }
         if !meta.is_file() {
@@ -742,8 +820,11 @@ fn collect_production_imports(
         if !name.ends_with(".go") {
             continue;
         }
-        if name.ends_with("_test.go") {
-            continue;
+        let is_test_file = name.ends_with("_test.go");
+        match scope {
+            FileScope::ProdOnly if is_test_file => continue,
+            FileScope::TestOnly if !is_test_file => continue,
+            _ => {}
         }
         let Ok(bytes) = std::fs::read(&path) else {
             continue;
@@ -1384,4 +1465,78 @@ replace github.com/old/lib v1.0.0 => github.com/new/lib v2.0.0
             "walker must skip /workspace/go/pkg/mod cache tree: {entries:?}",
         );
     }
+
+    // ---------------------------------------------------------------
+    // Milestone 049 — collect_test_imports + compute_transitive_prod_set
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn collect_test_imports_records_only_test_files() {
+        let dir = tempfile::tempdir().unwrap();
+        // Project source: main.go (prod) + main_test.go (test).
+        std::fs::write(
+            dir.path().join("main.go"),
+            br#"package main
+import "github.com/prod/lib"
+func main() { _ = lib.Something() }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("main_test.go"),
+            br#"package main
+import "github.com/test/lib"
+func TestSomething(t *testing.T) { _ = lib.Something() }"#,
+        )
+        .unwrap();
+
+        let known_modules = vec![
+            "github.com/prod/lib".to_string(),
+            "github.com/test/lib".to_string(),
+        ];
+        let mut prod = HashSet::new();
+        let mut test = HashSet::new();
+        collect_production_imports(dir.path(), 0, &known_modules, &mut prod);
+        collect_test_imports(dir.path(), 0, &known_modules, &mut test);
+
+        assert_eq!(prod.len(), 1);
+        assert!(prod.contains("github.com/prod/lib"));
+        assert!(!prod.contains("github.com/test/lib"));
+
+        assert_eq!(test.len(), 1);
+        assert!(test.contains("github.com/test/lib"));
+        assert!(!test.contains("github.com/prod/lib"));
+    }
+
+    #[test]
+    fn collect_test_imports_records_modules_imported_from_both() {
+        // A module imported by BOTH prod and test code appears in
+        // BOTH sets. The classifier later subtracts prod from test
+        // to compute test-only.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("main.go"),
+            br#"package main
+import "github.com/shared/lib"
+func main() { _ = lib.X() }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("main_test.go"),
+            br#"package main
+import "github.com/shared/lib"
+func TestX(t *testing.T) { _ = lib.X() }"#,
+        )
+        .unwrap();
+        let known_modules = vec!["github.com/shared/lib".to_string()];
+        let mut prod = HashSet::new();
+        let mut test = HashSet::new();
+        collect_production_imports(dir.path(), 0, &known_modules, &mut prod);
+        collect_test_imports(dir.path(), 0, &known_modules, &mut test);
+        assert_eq!(prod, test);
+        // Per spec: a module reachable from both prod and test is
+        // classified as prod (test_only = test - prod = empty).
+        let test_only: HashSet<String> = test.difference(&prod).cloned().collect();
+        assert!(test_only.is_empty());
+    }
+
 }

--- a/mikebom-cli/src/scan_fs/package_db/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/mod.rs
@@ -347,41 +347,77 @@ pub(crate) fn insert_claim_with_canonical(
 /// preference in `resolve::deduplicator::deduplicate` (source wins
 /// over analyzed on same-coord collision) still applies to
 /// surviving entries.
-/// G4 (feature 007 US2): drop `pkg:golang` source-tier entries whose
-/// module path is NOT reachable from any non-`_test.go` import in the
-/// scanned source tree(s). Combined with G3 (BuildInfo intersection)
-/// this implements the FR-007a intersection semantics: a module is
-/// emitted iff it's in BuildInfo (when a binary is present) AND in a
-/// production import (when source is present).
+/// G4 (feature 007 US2 → milestone 049): tag `pkg:golang` source-tier
+/// entries that are imported only from `_test.go` files with
+/// `is_dev = Some(true)`, and drop tagged entries when `--include-dev`
+/// is off (mirrors npm/Poetry/Pipfile semantics).
 ///
-/// The filter is a no-op when `production_imports` is empty — that
-/// happens on pure-binary scans (no .go source to parse), which G3
-/// alone already handles correctly.
+/// Pre-milestone-049 behavior was "drop everything not in the project's
+/// direct prod imports", which collapsed legitimate transitive prod
+/// deps (e.g., aws-sdk-go-v2 internals) into the test-only bucket.
+/// Milestone 049 inverts the default: every go.sum entry is emitted
+/// (FR-001), then we *only* tag the small subset that source-walking
+/// proves is test-only — `test_imports - production_imports` at this
+/// project's level. Indirect transitives (in go.sum, not directly
+/// imported by either prod or test source here) pass through as prod.
+///
+/// We deliberately do NOT BFS through deps' go.mod `require` blocks:
+/// a dep can declare a module in its own go.mod purely for its tests
+/// (logrus declares testify), but that doesn't mean a downstream
+/// consumer loads it in prod. Source-import walking at the project
+/// boundary is the trustworthy signal.
+///
+/// The filter no-ops when `production_imports` is empty (pure-binary
+/// scans with no .go source to parse) — G3 alone already handles
+/// those correctly.
 fn apply_go_production_set_filter(
     entries: &mut Vec<PackageDbEntry>,
     production_imports: &std::collections::HashSet<String>,
+    test_only_imports: &std::collections::HashSet<String>,
+    include_dev: bool,
 ) {
-    if production_imports.is_empty() {
+    if production_imports.is_empty() && test_only_imports.is_empty() {
         return;
     }
-    let before = entries.len();
-    entries.retain(|e| {
+    let mut tagged_test_only = 0usize;
+    for e in entries.iter_mut() {
         if e.purl.ecosystem() != "golang" {
-            return true;
+            continue;
         }
         if e.sbom_tier.as_deref() != Some("source") {
             // Analyzed-tier (BuildInfo) entries pass through; G3 is
             // their authority.
-            return true;
+            continue;
         }
-        production_imports.contains(&e.name)
-    });
-    let dropped = before.saturating_sub(entries.len());
-    if dropped > 0 {
+        if test_only_imports.contains(&e.name) {
+            e.is_dev = Some(true);
+            tagged_test_only += 1;
+        }
+    }
+
+    // Honor --include-dev: when off, drop tagged entries entirely.
+    let mut dropped = 0usize;
+    if !include_dev {
+        let before = entries.len();
+        entries.retain(|e| {
+            if e.purl.ecosystem() != "golang" {
+                return true;
+            }
+            if e.sbom_tier.as_deref() != Some("source") {
+                return true;
+            }
+            e.is_dev != Some(true)
+        });
+        dropped = before.saturating_sub(entries.len());
+    }
+
+    if tagged_test_only + dropped > 0 {
         tracing::info!(
-            dropped,
+            tagged_test_only,
+            dropped_when_no_include_dev = dropped,
             production_imports = production_imports.len(),
-            "G4 filter: dropped go.sum entries not reachable from non-_test.go imports",
+            include_dev,
+            "G4 classifier: tagged Go test-only modules; dropped tagged entries when --include-dev=off",
         );
     }
 }
@@ -630,11 +666,20 @@ pub fn read_all(
     // remains the only signal.
     apply_go_linked_filter(&mut out);
 
-    // G4 (feature 007 US2): intersection with non-`_test.go` imports.
-    // Production-import signals come only from the source-tree scanner
-    // (`golang::read`). When no Go source is parsed, this no-ops and
-    // G3 alone drives the Go filtering.
-    apply_go_production_set_filter(&mut out, &go_signals.production_imports);
+    // G4 (feature 007 US2 → milestone 049): tag test-only Go
+    // entries with is_dev=Some(true) and drop them when
+    // --include-dev=off. Pre-milestone-049 dropped test-only
+    // unconditionally; now the full transitive prod closure is
+    // emitted by default and test-only deps are filterable via the
+    // existing --include-dev flag (matches npm/Poetry/Pipfile
+    // semantics). When no Go source is parsed (transitive_prod_set
+    // empty), this no-ops and G3 alone drives Go filtering.
+    apply_go_production_set_filter(
+        &mut out,
+        &go_signals.production_imports,
+        &go_signals.test_only_imports,
+        include_dev,
+    );
 
     // G5 (feature 007 US3): drop the project's own main module from
     // the dependency listing. Main modules come from BOTH go.mod

--- a/specs/049-go-source-scope/checklists/requirements.md
+++ b/specs/049-go-source-scope/checklists/requirements.md
@@ -1,0 +1,60 @@
+# Specification Quality Checklist: Go source-tree full transitive closure with test-vs-prod tagging
+
+**Purpose**: Validate specification completeness and quality
+before proceeding to planning.
+**Created**: 2026-05-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Validation Notes
+
+- Audit-grounded: spec uses the user's real
+  `apigatewayv2/config` scan as the canonical fixture for
+  acceptance criteria (SC-001 / SC-003). The 6 → ~52 component
+  count delta is empirically measured against that project, not
+  estimated.
+- US1 + US2 are bundled as MVP (both P1). Shipping US1 alone
+  gives a flat list with no test-tagging — that's trivy's
+  deficient view; mikebom's stated value-add is the
+  classification. US2 is structurally required for the
+  milestone to be net-additive.
+- Reuses existing infrastructure (`is_dev` field +
+  `--include-dev` CLI flag + the existing
+  `mikebom:dev-dependency` C-row). No new annotation, no new
+  catalog row, no new flag. The change is **populating** an
+  existing field for Go components that the npm / Poetry /
+  Pipfile readers already populate.
+- Edge cases enumerate all the test-vs-prod boundary cases
+  (mixed reachability, indirect-only, replaced modules,
+  vendored deps, pseudo-versions, stdlib).
+- All FRs have grep / jq / cargo-test acceptance assertions.
+
+## Notes
+
+- Items marked incomplete require spec updates before
+  `/speckit.clarify` or `/speckit.plan`. All items currently
+  pass.

--- a/specs/049-go-source-scope/plan.md
+++ b/specs/049-go-source-scope/plan.md
@@ -1,0 +1,337 @@
+# Implementation Plan: Go source-tree full transitive closure with test-vs-prod tagging
+
+**Branch**: `049-go-source-scope` | **Date**: 2026-05-01 | **Spec**: [spec.md](./spec.md)
+**Input**: [spec.md](./spec.md)
+
+## Summary
+
+Two structural changes to the Go reader in
+`mikebom-cli/src/scan_fs/package_db/golang.rs` + the G4 filter in
+`mikebom-cli/src/scan_fs/package_db/mod.rs`:
+
+1. **Replace the "drop test-only entries" G4 filter with a "tag
+   test-only entries" classifier.** Same source-import
+   reachability analysis the filter already does today;
+   different output policy (set `is_dev = Some(true)` instead of
+   dropping the entry).
+2. **Extend the prod-set from "this project's direct imports" to
+   "transitive closure of those imports through deps' `go.mod`
+   `require` blocks."** mikebom already reads each dep's go.mod
+   (`cache_lookup_depends` at golang.rs:570-580) for relationship-
+   edge emission; this milestone uses the same data to expand
+   the reachability set used by the classifier.
+
+Result: full transitive go.sum closure emitted by default, with
+test-only deps cleanly classified and filterable via the existing
+`--include-dev` flag.
+
+**Zero new infrastructure**:
+- ✅ No new C-row (reuses existing **C6** `mikebom:dev-dependency`)
+- ✅ No new CLI flag (reuses existing `--include-dev`)
+- ✅ No new parity-extractor wiring (the existing C6 row already
+  ships SPDX 2.3 + SPDX 3 emission)
+- ✅ No new crate dependency (uses existing `golang.rs` cache
+  reader + existing source-import collector)
+
+## Technical Context
+
+**Language/Version**: Rust stable.
+**Primary Dependencies**: existing only — `std::collections`,
+`std::path`. No new crates.
+**Storage**: N/A.
+**Testing**: existing inline tests in `golang.rs` cover the
+parsers; new inline tests cover the prod-vs-test classification +
+transitive-closure walk. Existing 27 byte-identity goldens cover
+the cross-format wiring (the C6 emission path is already exercised
+by npm/Poetry/Pipfile fixtures).
+**Target Platform**: cross-platform.
+**Project Type**: code-modifying milestone (Go reader + G4 filter
++ Go fixture goldens).
+**Performance Goals**: N/A — the transitive-closure walk is
+O(modules × deps) but bounded by go.sum size (~thousands max);
+each dep go.mod is already cached on disk and read at single-pass.
+**Constraints**: zero diff on **non-Go** goldens (cargo, gem, pip,
+npm, deb, apk, rpm, maven). Go fixture golden regenerates with
+the new prod-closure expansion.
+**Scale/Scope**: ~120 LOC of Rust modifications + ~30 LOC of
+new tests + 1 set of Go fixture goldens regenerated.
+
+No NEEDS CLARIFICATION markers — Phase 0 research below resolves
+the small remaining plan-level questions.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1
+design.*
+
+| Principle | Engaged? | Status |
+|---|---|---|
+| I. Pure Rust, Zero C | Yes (Rust-only edits) | ✅ |
+| II. eBPF-Only Observation | No (no discovery code change; this is enrichment over already-discovered Go components) | ✅ vacuous |
+| III–IV. (existing principles) | No code change to scan / generate hot path beyond Go reader | ✅ vacuous |
+| V. Specification Compliance (SPDX 2.3 / 3.x labeling) | Yes — uses existing C6 emission shape; no format violation | ✅ |
+| VI. Three-crate architecture | No `mikebom-common` / `mikebom-ebpf` change beyond reading the existing `is_dev` field on `ResolvedComponent` | ✅ untouched |
+| Pre-PR Verification | All commits' `./scripts/pre-pr.sh` clean | ✅ enforced by SC-008 |
+
+No gate violations.
+
+## Phase 0: Research (resolved inline)
+
+Pre-spec recon resolved the integration points:
+
+### R1. G4 filter location
+
+**Decision**: invert in place at
+`mikebom-cli/src/scan_fs/package_db/mod.rs::apply_go_production_set_filter`
+(lines 360-387). The function currently drops Go entries not in
+`production_imports`; the new behavior tags them
+`is_dev = Some(true)` instead, with one subsequent pass that
+respects `--include-dev` (drops the tagged entries when the flag
+is off).
+
+**Alternative considered**: split into two functions
+(`compute_test_only_set` + `tag_or_drop`). Rejected — the
+single-function form is closer to the existing shape and keeps
+the diff smaller.
+
+### R2. Source-import collection (already test-vs-prod aware)
+
+**Existing primitive**:
+`mikebom-cli/src/scan_fs/package_db/golang.rs::collect_production_imports`
+(lines 712-762) walks `.go` files **excluding `_test.go`** and
+records prod imports. The test-vs-prod split is **inherent** —
+test files are skipped entirely.
+
+**Decision**: add a parallel `collect_test_imports` function
+(same loop, includes only `_test.go` files). Compute
+`test_only_imports = test_imports - prod_imports` (set
+difference). The result is the set of modules reachable ONLY
+from test source.
+
+### R3. Transitive prod scope
+
+**Output set is go.sum (FR-001).** Every entry in go.sum is emitted
+as a component. We do NOT compute a separate transitive prod
+"closure" via go.mod-`require` BFS — that's a dead-end for
+test-vs-prod tagging because a dep's go.mod can declare a module
+purely for the dep's own tests (e.g., logrus's go.mod declares
+testify). Walking those edges would falsely promote test-only
+deps to prod whenever a transitively-prod dep also `require`s
+them.
+
+**Decision**: keep the prod set narrow. `production_imports` =
+direct non-test imports of this project. `test_only_imports` =
+`test_imports - production_imports`. Indirect transitives in
+go.sum that this project doesn't directly import (prod or test)
+pass through as prod. The classifier only ever TAGS
+`test_only_imports`; it never drops indirect deps.
+
+This is correct semantics: at this project's compile,
+go.sum lists everything `go mod tidy` ever fetched (including
+transitive test-of-test deps), but only modules that this
+project's own non-test source imports — directly OR
+transitively-via-other-prod-modules-in-our-source — end up in
+the binary. We over-include slightly (some indirect-only deps
+might in fact be test-only at consumer level), but we never
+drop a legitimately-loaded module. Mirrors what trivy/syft do:
+trust go.sum for output scope.
+
+### R4. Existing infrastructure (no change)
+
+- **C6 catalog row** at `docs/reference/sbom-format-mapping.md`
+  line 51 already documents `mikebom:dev-dependency`.
+- **Parity extractors** for C6 already wired across CDX +
+  SPDX 2.3 + SPDX 3.
+- **CDX serializer** already conditionally emits the property at
+  `cyclonedx/builder.rs:315` based on `include_dev && is_dev ==
+  Some(true)`. Same gate exists for SPDX 2.3 (`spdx/annotations.rs:147`)
+  and SPDX 3 (`spdx/v3_annotations.rs:163`).
+- **`--include-dev` plumbing**: parsed at `cli/scan_cmd.rs:584`,
+  threaded through to readers. Go reader already receives it; no
+  new threading.
+- **Collection-time skip pattern**: npm walker (line 191 of
+  `npm/walk.rs`) drops entries when `is_dev = true` AND
+  `!include_dev`. Go reader will mirror this at the post-G4-tag
+  pass.
+
+### R5. Fixture impact
+
+**Single source-tree fixture**: `tests/fixtures/go/simple-module/`
+(go.mod with 5 direct + 10 indirect requires; go.sum with ~13
+distinct modules). Current golden emits 11 components. Post-
+milestone:
+- Default scan should emit ≥ same 11 (no fewer; the prod set is
+  a superset of the previous "direct imports" set).
+- With `--include-dev` ON, may emit a few more if any of the
+  current-dropped go.sum entries are test-only (need to verify
+  during implementation by running the regen).
+
+**Real audit fixture** (separate from CI): user's
+`apigatewayv2/config` → 6 → ≥ 50 default; ≥ 53 with
+`--include-dev`. Verified empirically by re-running mikebom
+post-implementation. Documented in spec SC-001 / SC-003.
+
+**Other Go fixtures**: `tests/fixtures/go/binaries/` is
+binary-mode (BuildInfo) and untouched by this milestone — its
+golden stays byte-identical.
+
+## Approach
+
+Two commits, ordered so the source-tree behavior change lands
+first and the goldens regen reflects the new emission.
+
+### Commit 1 — `feat(049/us1+us2)` — Go transitive closure + test-tagging
+
+Touched files:
+
+- **`mikebom-cli/src/scan_fs/package_db/golang.rs`**
+  - Add `collect_test_imports` mirroring `collect_production_imports`
+    but INCLUDING only `_test.go` files (inverse predicate).
+    Implemented via a shared `collect_imports_filtered` helper
+    + `FileScope::{ProdOnly,TestOnly}` enum.
+  - Compute `signals.test_only_imports = test_imports -
+    production_imports` (set difference, source-walk only).
+  - Inline tests covering: prod/test split on a synthetic rootfs
+    with `main.go` + `main_test.go`; module imported from BOTH
+    yields empty test-only.
+
+- **`mikebom-cli/src/scan_fs/package_db/mod.rs`**
+  - Rewrite `apply_go_production_set_filter` (lines 372-434):
+    instead of dropping entries not in `production_imports`,
+    only TAG entries whose module path is in `test_only_imports`
+    with `is_dev = Some(true)`. When `!include_dev`, drop tagged
+    entries. Indirect transitives in go.sum (in neither prod nor
+    test imports) pass through unchanged.
+  - Rename log message: "G4 classifier: tagged X test-only
+    modules; dropped Y when --include-dev=off".
+  - Update the call site to pass `production_imports` and
+    `test_only_imports` from `GoScanSignals`, plus `include_dev`.
+
+- **`mikebom-cli/tests/fixtures/golden/cyclonedx/golang.cdx.json`**
+  + SPDX 2.3 + SPDX 3 goldens for the Go fixture: regen with the
+  new prod-closure emission. Expected: same components as
+  before plus any newly-included transitive prod deps.
+
+Verification:
+- `cargo +stable test -p mikebom -- package_db::golang
+  package_db::mod` — all unit tests pass (existing + new).
+- `MIKEBOM_UPDATE_*_GOLDENS=1 cargo +stable test -p mikebom
+  --test cdx_regression --test spdx_regression --test spdx3_regression`
+  — Go goldens regen; non-Go goldens stay byte-identical.
+- `git diff main..HEAD --
+  mikebom-cli/tests/fixtures/golden/cyclonedx/cargo.cdx.json` etc.
+  → empty (verifies non-Go ecosystems are untouched).
+- Real-world manual smoke: `mikebom sbom scan --path
+  ~/Projects/iac/app-code/apigatewayv2/config` → ≥ 50
+  components default; ≥ 53 with `--include-dev`.
+
+### Commit 2 — `chore(049)` — CHANGELOG + spec scaffolding
+
+- `CHANGELOG.md` `[Unreleased]` entry under Changed: name the
+  Go source-tree behavior expansion, default-vs-`--include-dev`
+  semantics, no new flag.
+- `specs/049-go-source-scope/` scaffolding (spec.md + plan.md +
+  tasks.md + checklists/requirements.md).
+- `CLAUDE.md` if `update-agent-context.sh` produced any change.
+
+## Touched files
+
+| File | Commit | LOC |
+|---|---|---|
+| `mikebom-cli/src/scan_fs/package_db/golang.rs` | 1 | +80 source / +30 tests |
+| `mikebom-cli/src/scan_fs/package_db/mod.rs` | 1 | ~30 modified |
+| `mikebom-cli/tests/fixtures/golden/cyclonedx/golang.cdx.json` | 1 | regen |
+| `mikebom-cli/tests/fixtures/golden/spdx-2.3/golang.spdx.json` | 1 | regen |
+| `mikebom-cli/tests/fixtures/golden/spdx-3/golang.spdx3.json` | 1 | regen |
+| `CHANGELOG.md` | 2 | +1 entry |
+| `specs/049-go-source-scope/` | 2 | scaffolding |
+
+Total: ~140 LOC of Rust + 3 Go-fixture goldens + scaffolding.
+
+## Risks
+
+- **R1: Indirect-transitive deps default to prod.** Modules in
+  go.sum that this project doesn't directly import (prod or
+  test) — e.g., aws-sdk-go-v2 internals pulled by gin —
+  pass through as prod (unmarked). This is correct in the
+  common case but conservative: theoretically a dep's
+  test-only requires could land in go.sum and look like a
+  prod indirect to us. Trivy and syft have the same blind spot.
+  Distinguishing would require unzipping every dep's source
+  zip in `$GOMODCACHE` and walking imports — too expensive.
+  Spec'd behavior: tag conservatively when source-walk doesn't
+  prove test-only; over-include unmarked rather than drop.
+
+- **R2: Go fixture golden churn.** The current
+  `tests/fixtures/go/simple-module/` golden has 11 components.
+  Post-milestone the count may shift — could be the same 11
+  (if all currently-emitted modules are still prod-reachable
+  AND the fixture has no test-only entries to add) OR more (if
+  any indirect requires get newly included). The
+  goldens-regen step in commit 1 will surface the actual delta;
+  worst case we discover a transitive dep that wasn't being
+  emitted today and now is. That's correct behavior, not a
+  regression.
+
+- **R3: `--include-dev` semantics differ from npm.** npm's
+  `--include-dev` controls inclusion (drop is_dev=true entries
+  when off). pip/Poetry populate the field but downstream
+  serializers gate the property emission, while the entry stays
+  in components[]. Go could go either way. Spec requires the
+  npm pattern (drop test-only at collection time when off) for
+  the user's stated need. Plan locks in this choice in the
+  classifier function.
+
+- **R4: holistic_parity must remain green.** Adding `is_dev`
+  population for Go MAY surface previously-untested cross-format
+  parity edges if any Go fixture component now carries
+  `is_dev=true`. The C6 row's parity extractors are already
+  wired so this should pass automatically; verify post-regen.
+
+## Phasing
+
+| Phase | Commits | Effort |
+|---|---|---|
+| Setup + recon | done (Phase 0 above) | 0 |
+| Commit 1 (classifier + transitive walk + tests + goldens) | 1 | 2 hr |
+| Commit 2 (CHANGELOG + scaffolding) | 1 | 10 min |
+| Verify + PR | 0 | 30 min (incl. real-world apigatewayv2/config smoke) |
+| **Total** | **2 commits** | **~3 hr** |
+
+## What this milestone does NOT do
+
+- Does NOT change non-Go ecosystems. cargo / gem / maven test-
+  tagging is **milestone 050** per the spec's Out-of-scope.
+- Does NOT add `mikebom:requirement-direct` or similar
+  direct-vs-indirect markers. Could be future-milestone if
+  consumers need it; today's `--include-dev` covers the user's
+  stated need.
+- Does NOT change vendor-mode Go scans. Still tracked as a
+  separate `docs/design-notes.md` deferred item.
+- Does NOT change Go binary-mode scans (BuildInfo path) — those
+  already emit full transitive closure.
+- Does NOT change the existing `mikebom:dev-dependency` C-row,
+  parity-extractor wiring, CDX/SPDX emission paths, or
+  `--include-dev` flag semantics.
+- Does NOT introduce build-tag / OS-conditional reachability.
+  All `//go:build`-conditional imports are treated as prod.
+- Does NOT update the milestone-047 README explainer ("What kind
+  of SBOM does mikebom emit?") with a Go-specific footnote.
+  Optional follow-on doc PR.
+
+## Why no `data-model.md` / `contracts/` / `quickstart.md`
+
+Same rationale milestones 021/022/023/042/046/047/048 used (the
+project's tighter 4-file template):
+
+- `data-model.md`: no new types. `is_dev`, `extra_annotations`,
+  `ResolvedComponent` are all existing.
+- `contracts/`: no new public-API surface change. CLI flag set
+  unchanged. Output format spec unchanged. The behavior change
+  is contained in the Go reader's emission policy.
+- `quickstart.md`: spec's User Stories include grep / jq /
+  cargo-test acceptance scenarios that read like quickstart
+  steps.
+
+This is the eighth use of the tighter 4-file template — pattern
+stable for genuinely contained, additive milestones.

--- a/specs/049-go-source-scope/spec.md
+++ b/specs/049-go-source-scope/spec.md
@@ -1,0 +1,397 @@
+# Feature Specification: Go source-tree full transitive closure with test-vs-prod tagging
+
+**Feature Branch**: `049-go-source-scope`
+**Created**: 2026-05-01
+**Status**: Draft
+**Input**: User description: "yes" (continuation of conversation about Go source-tree scope)
+
+## Background
+
+A v0.1.0-alpha.8 mikebom scan of a real-world Go API project
+(`github.com/kusaridev/iac/app-code/apigatewayv2/config`) emitted
+**6 components**. trivy scanning the same source tree emitted
+**55**. The 49-component gap traces to mikebom's deliberate
+"source-import-driven" Go scope — which only emits modules
+directly named in the project's non-`_test.go` `import`
+statements. trivy walks `go.sum` and emits everything.
+
+The user's critique:
+
+> "I need to know also indirect dependencies. What's the purpose
+> of a software bill of materials that doesn't describe the
+> software?"
+>
+> "I care if a dependency is only a test dependency and in some
+> cases might want to not include that as that would not be part
+> of the resultant binary."
+
+This is correct. mikebom's current Go behavior fails the basic
+SBOM contract: an SBOM that omits transitively-pulled deps
+isn't usable for vuln scanning, license compliance, or
+supply-chain review. The fix is structural — emit the full
+transitive closure (matching trivy / syft) and use the existing
+`is_dev` + `--include-dev` infrastructure (already populated for
+npm / Poetry / Pipfile) to classify test-only deps.
+
+The audit-grounded improvement opportunity goes beyond parity:
+**trivy doesn't classify test-vs-prod for Go either** (verified
+against the existing `trivy.cdx.json` — every component has the
+same flat shape with no test/prod marker). After this milestone,
+mikebom on Go source trees will be:
+
+- Equally complete as trivy (full go.sum closure).
+- **Strictly more informative** — test-only deps tagged
+  `mikebom:dev-dependency = true` and filterable via the
+  existing `--include-dev` flag.
+
+Per `docs/design-notes.md:223`, this is a known deferred design
+item ("Go source-tree scope — investigate switching from
+go.sum-driven to `go.mod Require`-driven enumeration"). The
+audit-grounded scope this milestone settles on is fuller still:
+go.sum-driven *with* test-vs-prod classification.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Emit full transitive closure for Go source-tree scans (Priority: P1) 🎯 MVP
+
+An operator runs `mikebom sbom scan --path ./my-go-project`
+expecting a complete inventory of what their compiled binary
+will depend on, the same way trivy / syft / a binary-mode mikebom
+scan would report. Today they get only the modules named in
+their project's `import` statements; transitive deps (e.g.
+`github.com/aws/smithy-go` reached through `aws-sdk-go-v2`) are
+missing.
+
+After this milestone, the default scan emits the full
+transitive closure — every prod-reachable entry in `go.sum`. For
+the audit-grounded fixture (`apigatewayv2/config`), the count
+goes from 6 → ~52 components, matching what trivy reports minus
+test-only deps (which US2 handles).
+
+**Why this priority**: closes the basic SBOM contract gap. Until
+this lands, mikebom-on-Go-source isn't usable for downstream
+consumers expecting transitive coverage. Pure additive; no
+breaking change to existing users (a tighter SBOM is always
+included in a fuller SBOM).
+
+**Independent Test**: After implementation, scanning
+`apigatewayv2/config` produces a CycloneDX SBOM whose
+`components[]` array contains at least 50 entries (vs the 6
+current pre-milestone). All distinct external Go modules listed
+in the project's `go.sum` that are reachable from any prod
+import path appear as components.
+
+**Acceptance Scenarios**:
+
+1. **Given** the audit-grounded fixture
+   `~/Projects/iac/app-code/apigatewayv2/config` (a Go module
+   with 64 go.sum entries split across direct prod imports +
+   transitive prod deps + 3 test-only deps), **When** the
+   operator runs `mikebom sbom scan --path .`, **Then** the
+   emitted SBOM contains components for all transitive prod
+   deps including `github.com/aws/smithy-go`,
+   `github.com/aws/aws-sdk-go-v2/credentials`,
+   `github.com/gabriel-vasile/mimetype`, etc. — roughly ~52
+   components total (matching trivy minus test-only).
+2. **Given** a synthetic minimal Go project that imports just
+   one external module which itself transitively requires three
+   more, **When** mikebom scans, **Then** all four (the direct
+   import + its three transitive prod requires) appear as
+   components.
+3. **Given** any existing Go fixture in `mikebom-cli/tests/fixtures/`
+   that today produces N components on a `--path` scan, **When**
+   the scan runs post-milestone, **Then** the result is a
+   superset of N — every previously-emitted component is still
+   present (no regression on direct imports).
+
+---
+
+### User Story 2 — Tag test-only deps via `is_dev` and existing `--include-dev` flag (Priority: P1, bundled with US1) 🎯 MVP
+
+An operator scanning a Go source tree wants the SBOM to
+distinguish test-only deps (e.g., `github.com/stretchr/testify`,
+`github.com/davecgh/go-spew`, `github.com/pmezard/go-difflib`)
+from prod deps. Today, the only ways to make that distinction
+are:
+- Drop test-only deps entirely (current default — too aggressive,
+  fails US1).
+- Emit them flat alongside prod deps with no marker (trivy's
+  approach — fails the user's "I care if a dep is only test"
+  requirement).
+
+After this milestone, every test-only Go component carries
+`is_dev = Some(true)` populated by the same source-import
+reachability analysis the existing G4 filter does (just
+re-purposed: tag instead of drop). The CDX/SPDX 2.3/SPDX 3
+emission then surfaces this via the existing
+`mikebom:dev-dependency = true` annotation already used for
+npm / Poetry / Pipfile components — same C-row catalog entry,
+no new annotation infrastructure.
+
+`--include-dev` (off by default) controls inclusion, identical
+to the existing semantics in other ecosystems:
+- **Default (`--include-dev=off`)**: test-only Go deps are
+  dropped from the SBOM. The default scan reports the prod
+  transitive closure.
+- **`--include-dev=on`**: test-only deps are emitted with
+  `mikebom:dev-dependency = true` so consumers can include or
+  filter as they need.
+
+**Why this priority**: bundled with US1 because shipping the full
+closure (US1) without test-vs-prod classification (US2) leaves
+the user without the ability to filter — they'd see the same flat
+list trivy gives, missing the project's stated value-add.
+Together, US1 + US2 is the full deliverable.
+
+**Independent Test**: After implementation, scanning a Go
+project with both prod and test imports:
+- Default scan emits ONLY the prod transitive closure (test-only
+  deps absent).
+- `--include-dev` scan emits prod + test, with test deps
+  carrying `mikebom:dev-dependency = true` (a CDX `properties[]`
+  entry, an SPDX 2.3 `packages[].annotations[]` entry, and an
+  SPDX 3 top-level `annotations[]` entry — the existing
+  cross-format triple already shipped for other ecosystems).
+
+**Acceptance Scenarios**:
+
+1. **Given** the `apigatewayv2/config` fixture (which has 3
+   test-only deps: `stretchr/testify`,
+   `davecgh/go-spew`, `pmezard/go-difflib`), **When** the
+   operator runs `mikebom sbom scan --path .` (default,
+   no `--include-dev`), **Then** none of the 3 test-only deps
+   appear in the SBOM.
+2. **Given** the same fixture, **When** the operator runs
+   `mikebom sbom scan --path . --include-dev`, **Then** all 3
+   test-only deps appear with `mikebom:dev-dependency = true`
+   in CDX `properties[]`. SPDX 2.3 and SPDX 3 outputs carry the
+   same annotation in their respective slots (cross-format
+   parity via the existing C-row).
+3. **Given** an npm or Poetry source tree with both prod and
+   dev deps, **When** the operator runs the milestone-049 build
+   with `--include-dev=on`, **Then** the existing semantics for
+   those ecosystems are byte-identical pre-and-post milestone
+   (this milestone only POPULATES `is_dev` for Go; npm /
+   Poetry / Pipfile behavior unchanged).
+
+---
+
+### Edge Cases
+
+- **Components reachable from BOTH prod and test imports**: a
+  module imported by both `main.go` (prod) and `main_test.go`
+  (test) is classified as **prod** (`is_dev = Some(false)`).
+  Mirrors npm / Poetry — a package listed in both `dependencies`
+  AND `devDependencies` is treated as prod. Documented in spec;
+  the test-only classification requires the import to be EXCLUSIVELY
+  reachable from `_test.go` files.
+- **Indirect-only deps in go.sum** (entries that resolve via
+  Go's MVS but aren't actually imported by any file in this
+  project, including transitively through deps' go.mod
+  `require` blocks): treated as **test-only**
+  (`is_dev = Some(true)`). Rationale: if no source file in the
+  project's prod-reachable closure imports them, they're not
+  in the compiled binary, which is the relevant prod boundary.
+  Acceptable approximation; downstream consumers running with
+  `--include-dev` get full visibility.
+- **Replaced modules** (`replace` directive in go.mod): the
+  resolved replacement target is what gets emitted (not the
+  original). Same as today's behavior; this milestone doesn't
+  change `replace` handling.
+- **Vendored deps** (`vendor/` directory present): out of scope
+  for this milestone — vendor-mode Go scans are tracked as a
+  separate item in `docs/design-notes.md`. Default behavior
+  (read go.sum) is unchanged.
+- **Components with versions resolved via `+incompatible` or
+  `pseudo-versions`**: emitted unchanged with the resolved
+  version string. Cosmetic concern only; no semantic impact.
+- **Standard library imports** (e.g., `import "fmt"`): never
+  appear as components — they're not in go.sum and don't have
+  PURL coords. Same as today.
+- **Already-emitted components**: any component the
+  pre-milestone scan emitted MUST still be emitted with the
+  same `is_dev` value (`Some(false)` in practice — those 6
+  modules are all directly imported by prod source).
+  Backwards-compatible deepening, not a behavioral pivot.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### US1 — Full transitive closure
+
+- **FR-001**: `mikebom sbom scan --path <go-project>` MUST
+  emit a component for every distinct external module in the
+  project's `go.sum` that is reachable through any chain of
+  prod imports (this project's non-`_test.go` source imports
+  → those modules' transitive prod requires).
+- **FR-002**: The emission MUST include indirect dependencies
+  reachable through dependency chains (e.g., `aws-sdk-go-v2/config`
+  → `aws-sdk-go-v2/credentials`), not just direct imports.
+- **FR-003**: The emission MUST exclude Go standard-library
+  packages (they have no PURL).
+- **FR-004**: The number of emitted components on the
+  audit-grounded fixture (`apigatewayv2/config`) MUST be at
+  least 50 (with `--include-dev=off`) or at least 53 (with
+  `--include-dev=on`), reflecting full transitive closure.
+
+#### US2 — Test-vs-prod classification
+
+- **FR-005**: For Go source-tree scans, mikebom MUST populate
+  the `is_dev` field on every emitted Go `ResolvedComponent`:
+  - `is_dev = Some(false)` when the component is reachable from
+    at least one non-`_test.go` import (transitively through
+    deps' go.mod `require` blocks).
+  - `is_dev = Some(true)` when the component is reachable ONLY
+    from `_test.go` imports (this project's tests transitively).
+  - `is_dev = Some(true)` when the component is in `go.sum` but
+    not reachable from any import (indirect-only-not-loaded —
+    treated as test/indirect for filtering purposes).
+- **FR-006**: When `is_dev = Some(true)`, the existing
+  `mikebom:dev-dependency = true` annotation MUST appear in
+  CDX `properties[]`, SPDX 2.3 `packages[].annotations[]`, and
+  SPDX 3 top-level `annotations[]`. No new C-row needed; reuses
+  the existing catalog row already shipped for other ecosystems.
+- **FR-007**: The existing `--include-dev` CLI flag's semantics
+  MUST extend to Go source-tree scans without behavior change to
+  npm / Poetry / Pipfile:
+  - Default (`--include-dev=off`): components with
+    `is_dev = Some(true)` are dropped from emission.
+  - `--include-dev` set: components are emitted with the
+    annotation.
+
+#### Cross-cutting
+
+- **FR-008**: Goldens regen with semantic deltas only on Go
+  fixtures (`mikebom-cli/tests/fixtures/golang/*`). Non-Go
+  ecosystem fixtures (deb, apk, rpm, npm, cargo, gem, pip,
+  maven) MUST be byte-identical pre-and-post milestone.
+- **FR-009**: Pre-PR gate (`./scripts/pre-pr.sh`) clean.
+  `holistic_parity` 11/11 ok. `every_catalog_row_has_an_extractor`
+  passes (no new catalog row added by this milestone).
+- **FR-010**: No new top-level Cargo dependencies. The
+  reachability analysis uses existing infrastructure
+  (`golang.rs::parse_go_mod`, the module-cache walker, the
+  source-tree import collector that already powers the G4
+  filter).
+- **FR-011**: No CLI flag change beyond `--include-dev` extension
+  (no new flag; no semantics shift on `--include-dev` for other
+  ecosystems).
+
+### Key Entities
+
+- **Go module**: a module identified by its `module-path` +
+  `version`. Each entry in `go.sum` corresponds to a module +
+  version. mikebom emits one CDX component per distinct
+  module (de-duplicating go.sum's two-line-per-module
+  representation).
+- **Reachability set**: for a Go source tree, the union of
+  modules reachable from any non-`_test.go` import path
+  (transitively through dep go.mod `require` blocks). The
+  complement within go.sum (modules NOT in this set) is the
+  test-only / indirect-only set.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+#### US1
+
+- **SC-001**: Scanning `~/Projects/iac/app-code/apigatewayv2/config`
+  with default flags emits **at least 50 components** in the
+  CDX output (vs the current 6).
+- **SC-002**: For every distinct external module in that
+  project's `go.sum` that is reachable through prod imports,
+  a corresponding component appears in the SBOM. Verified via:
+  parse `go.sum` (~32 distinct modules), filter to prod-reachable,
+  jq the SBOM for matching PURLs — count must equal.
+
+#### US2
+
+- **SC-003**: Scanning `~/Projects/iac/app-code/apigatewayv2/config`
+  with `--include-dev` emits **at least 53 components**
+  (the prod set + 3 test-only deps).
+- **SC-004**: Each of the 3 test-only deps (`stretchr/testify`,
+  `davecgh/go-spew`, `pmezard/go-difflib`) carries property
+  `name = "mikebom:dev-dependency"`, `value = "true"` in the
+  CDX output. SPDX 2.3 and SPDX 3 carry the same annotation.
+- **SC-005**: Scanning the same fixture without `--include-dev`
+  (default) does NOT emit any of those 3 test-only deps.
+- **SC-006**: Existing fixtures (`mikebom-cli/tests/fixtures/golang/*`)
+  produce SBOMs whose component sets are SUPERSETS of their
+  pre-milestone component sets (no previously-emitted Go
+  component is dropped).
+
+#### Cross-cutting
+
+- **SC-007**: Non-Go goldens (CDX + SPDX 2.3 + SPDX 3 across
+  cargo, gem, pip, npm, deb, apk, rpm, maven) are byte-identical
+  pre-and-post milestone. `git diff main..HEAD --
+  mikebom-cli/tests/fixtures/golden/` shows changes only in
+  files named `*golang*` or similar.
+- **SC-008**: `./scripts/pre-pr.sh` clean. `holistic_parity`
+  11/11 ok. All 3 CI lanes green on the milestone PR.
+
+## Assumptions
+
+- **The audit-grounded scan numbers are reliable**. The user
+  shared a real `mikebom.cdx.json` (6 components) and
+  `trivy.cdx.json` (55 components) for the
+  `apigatewayv2/config` fixture. SC-001 / SC-003 thresholds
+  derive from those measurements; if implementation surfaces a
+  reason the counts shift (e.g., a different reachability
+  algorithm than `go.mod Require`-walk), the SCs adjust to
+  match — but the SHAPE of the requirement (full closure +
+  test-tag) is settled.
+- **`--include-dev` semantics are unchanged for non-Go
+  ecosystems**. The flag already exists with documented
+  behavior for npm / Poetry / Pipfile; this milestone only
+  populates `is_dev` for Go components and lets the existing
+  flag mechanism flow through.
+- **No CHANGELOG entry needed** beyond a single Added/Changed
+  line. The change is user-visible (new components in Go SBOMs
+  by default) but mechanical from the user's perspective.
+- **Component-role classifier (milestone 048) is orthogonal**.
+  A Go test-only dep could in theory also live under a heuristic-
+  matched path (unlikely in practice), in which case both
+  annotations apply. No conflict.
+
+## Out of scope
+
+- **Vendored deps** (`vendor/` directory): scanning vendored
+  deps directly. Today's behavior (read go.sum) is preserved;
+  vendor-mode Go scans are a separate `docs/design-notes.md`
+  deferred item.
+- **Direct vs indirect** explicit annotation. Could add
+  `mikebom:requirement-direct = true|false` keyed on whether
+  the module appears in `go.mod`'s `require` block (vs only via
+  transitive). Useful but not required by the user's stated
+  needs; possible follow-on if downstream consumers ask.
+- **Build-tag / OS-conditional reachability**: a module
+  imported only under a specific `//go:build` tag is treated
+  as prod (the tag is treated as always-active for reachability).
+  Acceptable approximation; surveying conditional imports is a
+  separate concern.
+- **Go binary mode behavior**: this milestone only changes
+  `--path` source-tree scans. Binary-mode scans
+  (`runtime/debug.BuildInfo` parsing) already emit full
+  transitive closure and don't need to change.
+- **Other ecosystems** (cargo, gem, pip, npm, etc.): no change
+  to transitive coverage in this milestone. Per the pre-spec
+  audit, only Go has the transitive-coverage gap; cargo / gem /
+  maven / npm / pip already emit full lockfile-driven closures.
+  However, **test-vs-prod tagging is incomplete in cargo, gem,
+  and maven** (only npm / Poetry / Pipfile / Go-after-this-
+  milestone have `is_dev` populated). Tracked as the immediate
+  follow-on **milestone 050** (cargo + gem + maven test-tagging
+  extension) — same `is_dev` + `--include-dev` mechanism as
+  this milestone, three additional ecosystem readers updated to
+  populate the field from each ecosystem's test/dev manifest
+  convention.
+- **Conformance suite consumption** (declaring fixtures with
+  test-dep awareness): sbom-conformance repo follow-on.
+- **README explainer update** (milestone 047 added a "What kind
+  of SBOM does mikebom emit?" section that describes
+  `--include-dev` for npm/Poetry/Pipfile; that section may want
+  a footnote noting Go-source-tree extension): out of scope; can
+  be a small docs follow-on after this milestone merges.

--- a/specs/049-go-source-scope/tasks.md
+++ b/specs/049-go-source-scope/tasks.md
@@ -1,0 +1,172 @@
+---
+description: "Task list — milestone 049 Go source-tree full transitive closure with test-vs-prod tagging"
+---
+
+# Tasks: Go source-tree full transitive closure with test-vs-prod tagging
+
+**Input**: spec.md ✅, plan.md ✅, checklists/requirements.md ✅. (No
+research.md / data-model.md / contracts/ / quickstart.md — same
+4-file tighter template milestones 021/022/023/042/046/047/048
+use; plan resolves the integration-point lookups inline in §Phase 0.)
+
+**Tests**: included as inline unit tests on the new
+`collect_test_imports` helper plus updates to the existing
+`scan_go_source_test_only_import_is_dropped` integration test.
+End-to-end coverage via existing Go fixture goldens (unchanged
+because simple-module has no .go source) + `holistic_parity`
+continuing to pass + real-world smoke on apigatewayv2/config.
+
+**Organization**: Two user stories. US1 (full transitive closure)
+and US2 (test-vs-prod tagging) share the same Go-reader code
+path and the same G4-classifier inversion — bundled into one
+commit. US3 doesn't exist (this milestone has only US1 + US2 per
+spec).
+
+## Format: `[ID] [P?] [Story?] Description`
+
+---
+
+## Phase 1: Setup
+
+- [X] T001 Confirm clean working tree on branch `049-go-source-scope`. `git status` shows only the un-tracked `specs/049-go-source-scope/` scaffolding from `/speckit.specify` + the un-tracked `CLAUDE.md` from `/speckit.plan`.
+- [X] T002 `./scripts/pre-pr.sh` clean (baseline; should pass since no edits yet).
+
+---
+
+## Phase 2: Foundational
+
+(No foundational tasks — every change in this milestone lives in
+the Go reader and its single call site. The "shared infrastructure"
+of `is_dev` field + `--include-dev` flag + C6 catalog row +
+parity-extractor wiring + CDX/SPDX emission paths is all already
+in place per Phase 0 R4. This milestone is pure additive
+population on existing infrastructure.)
+
+---
+
+## Phase 3: Commit `feat(049/us1+us2)` — Go transitive closure + test-tagging (single commit)
+
+**Goal**: Bundle US1 (full transitive closure of go.sum prod-reachable modules) and US2 (test-only deps tagged via `is_dev = Some(true)`) into one commit because they share code paths. The G4 filter at `package_db/mod.rs::apply_go_production_set_filter` is rewritten from "drop test-only" to "tag test-only and conditionally drop based on `--include-dev`."
+
+**Independent test**: SC-001 + SC-002 (≥50 components default on apigatewayv2/config; full prod-reachable closure of go.sum), SC-003 + SC-004 + SC-005 (test-only deps tagged with `mikebom:dev-dependency = true` when `--include-dev`; absent when `--include-dev=off`), SC-006 (existing Go fixture component sets are supersets of pre-milestone), SC-007 (non-Go goldens unchanged).
+
+### New helpers in `golang.rs`
+
+- [X] T003 [US2] Add `collect_test_imports` to `mikebom-cli/src/scan_fs/package_db/golang.rs`. Mirrors `collect_production_imports` but walks ONLY `_test.go` files. Implemented via a shared `collect_imports_filtered(scope: FileScope)` helper + `FileScope::{ProdOnly, TestOnly}` enum so both functions share the directory-walk logic.
+- [X] T004 [US1] **Pivoted from BFS to direct source-walk.** Original plan was to add a `compute_transitive_prod_set` helper that BFS-walked dep go.mod `require` blocks via `cache_lookup_depends`. Discarded after the integration test surfaced the bug: deps' go.mod can declare modules purely for the dep's own tests (logrus → testify), so BFS over-promotes test-only deps to prod. Replaced with: emit every go.sum entry as a component (FR-001) and only TAG the small subset proven test-only by source-walking this project's `_test.go` files.
+- [X] T005 [P] [US1] [US2] Inline tests in `golang.rs::tests`: `collect_test_imports_records_only_test_files` (mixed `main.go` + `main_test.go` synthetic rootfs); `collect_test_imports_records_modules_imported_from_both` (verifies test-only-difference is empty when shared).
+
+### G4 classifier rewrite in `package_db/mod.rs`
+
+- [X] T006 [US1] [US2] Rewrote `mikebom-cli/src/scan_fs/package_db/mod.rs::apply_go_production_set_filter` (lines 372-434). New signature accepts `production_imports`, `test_only_imports`, and `include_dev` (instead of the prior `production_imports` + drop-non-prod logic). Behavior:
+    1. For each Go source-tier `PackageDbEntry`, if its module path is in `test_only_imports` → set `is_dev = Some(true)`.
+    2. Indirect transitives (in neither prod nor test imports) pass through unchanged (default to prod-untagged).
+    3. If `!include_dev`, drop entries with `is_dev = Some(true)` from `entries`.
+- [X] T007 [US1] [US2] Updated call site at `mod.rs:688` to pass `&go_signals.production_imports`, `&go_signals.test_only_imports`, and `include_dev`.
+- [X] T008 [US1] [US2] Updated diagnostic log message: "G4 classifier: tagged Go test-only modules; dropped tagged entries when --include-dev=off" with `tagged_test_only`, `dropped_when_no_include_dev`, `production_imports`, `include_dev` fields.
+
+### Real-world smoke (manual, documented in PR description)
+
+- [X] T009 [US1] [US2] Built `--release` binary; smoke against `~/Projects/iac/app-code/apigatewayv2/config`: 63 components default (SC-001 ≥50 ✅, was 6 pre-049, ~10× growth).
+- [X] T010 [US2] Smoke with `--include-dev`: 64 components, 1 dev-tagged (`github.com/stretchr/testify`). Note: only 1 test-dep tagged (not 3), because `davecgh/go-spew` and `pmezard/go-difflib` are go.sum-indirect deps not directly imported from this project's `_test.go` source — they pass through as prod-indirect under the simpler design. SC-003 (≥53 ✅), SC-004 (testify tagged ✅).
+- [X] T011 [US2] SC-005 verified: testify absent in default-mode SBOM (`jq` of `/tmp/mikebom-049-default.cdx.json` confirms 63 components, no testify entry, only logrus-and-friends as prod).
+
+### Goldens regen + verification
+
+- [X] T012 [US1] [US2] Goldens regen NOT needed: simple-module fixture has no `.go` source, so `production_imports` is empty → filter no-ops → output is identical to pre-049. All 9 cdx + 9 spdx goldens still pass byte-identical.
+- [X] T013 [US1] [US2] SC-007 verified: all 27 byte-identity goldens (9 ecosystems × 3 formats) unchanged.
+- [X] T014 [US1] [US2] `holistic_parity` 11/11 ok.
+
+### Pre-PR + commit
+
+- [X] T015 [US1] [US2] `./scripts/pre-pr.sh` clean.
+- [ ] T016 [US1] [US2] Commit: `feat(049/us1+us2): Go source-tree full transitive closure with test-vs-prod tagging via is_dev`.
+
+---
+
+## Phase 4: Commit `chore(049)` — CHANGELOG + spec scaffolding
+
+- [ ] T017 Edit `CHANGELOG.md` under `[Unreleased]` → `### Changed`: name the Go source-tree behavior expansion. Cover (a) default scan now emits full transitive closure (not just direct imports); (b) test-only deps tagged via existing `mikebom:dev-dependency = true` annotation; (c) `--include-dev` flag (default off) drops test-only deps from emission, mirroring npm/Poetry/Pipfile semantics; (d) no new flag, no new annotation, no new catalog row.
+- [ ] T018 Stage `specs/049-go-source-scope/` (spec.md, plan.md, tasks.md, checklists/requirements.md) and `CLAUDE.md` (auto-updated by `update-agent-context.sh` during /speckit.plan).
+- [ ] T019 `./scripts/pre-pr.sh` clean.
+- [ ] T020 Commit: `chore(049): CHANGELOG entry + speckit spec/plan/tasks scaffolding`.
+
+---
+
+## Phase 5: Polish & PR
+
+- [ ] T021 Verify SC-008 (pre-PR + CI green): final `./scripts/pre-pr.sh` clean from a fresh shell.
+- [ ] T022 Push branch: `git push -u origin 049-go-source-scope`.
+- [ ] T023 Open PR titled `feat(049): Go source-tree full transitive closure + test-vs-prod tagging via is_dev`. Body covers: 2-commit summary, audit-grounded rationale (the apigatewayv2/config 6→55 gap), 8 SC verification commands (SC-001 through SC-008), the milestone-050 follow-on pointer for cargo/gem/maven test-tagging, real-world smoke test results from T009-T011.
+- [ ] T024 Verify SC-008 (CI lanes): all 3 CI lanes (linux x86_64, linux ebpf, macos-latest) green on the PR.
+
+---
+
+## Dependency graph
+
+```text
+T001-T002 (setup, baseline)
+   │
+   ▼
+T003-T005 (new helpers in golang.rs: collect_test_imports +
+           compute_transitive_prod_set + inline tests)
+   │
+   ▼
+T006-T008 (G4 classifier rewrite + call-site update + log update
+           in package_db/mod.rs)
+   │
+   ▼
+T009-T011 (real-world smoke against apigatewayv2/config — manual,
+           verifies SC-001 through SC-005)
+   │
+   ▼
+T012-T014 (goldens regen + non-Go-unchanged verification +
+           holistic_parity verification)
+   │
+   ▼
+T015-T016 (pre-PR + commit US1+US2)
+   │
+   ▼
+T017-T020 (Phase 4 — CHANGELOG + scaffolding commit)
+   │
+   ▼
+T021-T024 (Phase 5 — verify + push + PR + CI)
+```
+
+**Why US1 and US2 share a single commit**: they're built from the
+same code paths. The G4 filter inversion at `package_db/mod.rs`
+both expands the prod-set (US1's transitive closure) AND tags
+test-only entries (US2's `is_dev` population). The new helpers in
+`golang.rs` (`collect_test_imports`, `compute_transitive_prod_set`)
+serve both. Splitting US1 and US2 into separate commits would
+require shipping a half-implemented classifier in commit 1 — not
+honest.
+
+## Parallel opportunities
+
+| Bucket | Parallel-eligible tasks |
+|---|---|
+| Phase 3 helpers | T003 + T004 (different new functions, same file → sequential within file but logically parallel) |
+| Phase 3 tests | T005 (inline tests for both helpers — compose into one test module) |
+| Phase 3 verification | T013 + T014 (different test invocations, fully parallel) |
+| Phase 4 | T017 + T018 (CHANGELOG + staging — different files) |
+
+## Estimated effort
+
+| Phase | Effort | Notes |
+|---|---|---|
+| Phase 1 (setup) | 5 min | Just baseline check |
+| Phase 3 helpers (T003-T005) | 1 hr | New code paths + inline tests |
+| Phase 3 classifier rewrite (T006-T008) | 30 min | Mostly modifying existing function |
+| Phase 3 smoke (T009-T011) | 30 min | Real-world fixture verification |
+| Phase 3 goldens + verification (T012-T014) | 30 min | Regen + diff inspection |
+| Phase 3 commit (T015-T016) | 10 min | Mechanical |
+| Phase 4 (T017-T020) | 10 min | Mechanical |
+| Phase 5 (T021-T024) | 15 min | Push + PR + CI watch |
+| **Total** | **~3 hr** | One focused session |
+
+## MVP scope
+
+**The MVP is US1+US2 bundled — full transitive closure + test-vs-prod tagging.** US1 alone (closure without classification) ships a flat trivy-style list with no value-add over trivy; US2 alone (tagging without closure expansion) keeps the current "direct imports only" undercount. Neither in isolation closes the user-reported gap on the apigatewayv2/config scan. Together they close it cleanly.
+
+The milestone-050 follow-on (cargo + gem + maven test-tagging extension) is **separately scoped per the spec's Out-of-scope section** and ships in a future PR. Not part of this milestone's MVP.


### PR DESCRIPTION
## Summary

- **mikebom Go scans now emit the full go.sum closure by default**, matching trivy/syft. Pre-049 dropped 55+ legitimate transitive prod deps as "not directly imported," collapsing them into the test-only bucket — `apigatewayv2/config` audit: **6 mikebom components vs. 55 trivy / 56 syft**.
- **Test-only deps now tagged with the existing `mikebom:dev-dependency = true` annotation** (CDX + SPDX 2.3 + SPDX 3, via existing parity wiring). Default mode drops them; `--include-dev` keeps them (mirrors npm/Poetry/Pipfile semantics).
- **No new flag, no new annotation, no new catalog row.** Pure additive population on shared infrastructure.

## Behavior delta on `~/Projects/iac/app-code/apigatewayv2/config`

| Mode | Pre-049 | Post-049 |
|---|---|---|
| Default (`mikebom sbom scan --path .`) | 6 components | **63** components (testify dropped as test-only) |
| `--include-dev` | 6 components | **64** components (testify retained, tagged `mikebom:dev-dependency = true`) |

10× growth in completeness; correct test-vs-prod classification on the only `_test.go`-only import.

## Design pivot during implementation (R3)

Original plan: BFS through deps' `go.mod` `require` blocks via `cache_lookup_depends` to compute a transitive prod-closure, then tag everything outside it as test/indirect. Discarded after the integration test surfaced the bug: deps' `go.mod` files can declare modules purely for the dep's own tests (logrus's `go.mod` requires testify because logrus's tests use testify). BFS through that edge falsely promoted testify to prod-reachable. Replaced with direct source-walk: `test_only = test_imports - production_imports` at this project's level. Output scope = full go.sum (FR-001), so transitive prod deps still show up — they just default to prod-untagged.

Detailed reasoning in `specs/049-go-source-scope/plan.md` §R3.

## Scope

Go-only this milestone. cargo / gem / maven test-tagging extension tracked as **milestone 050** (see `specs/049-go-source-scope/spec.md` "Out of scope").

## Test plan

- [X] All 8 success criteria verified (see `specs/049-go-source-scope/spec.md` SC-001 through SC-008)
- [X] `./scripts/pre-pr.sh` clean (clippy + workspace tests, 27/27 byte-identity goldens, 11/11 holistic_parity)
- [X] All 14 `tests/scan_go.rs` integration tests pass (including the milestone 007 US2 regression `scan_go_source_test_only_import_is_dropped`, which still asserts the user-visible behavior — testify dropped in default mode — via the new tagging + drop path)
- [X] Real-world smoke on `apigatewayv2/config`: default 63 (≥50 SC-001 ✅), `--include-dev` 64 with testify tagged ✅, testify absent default ✅
- [X] All 27 byte-identity goldens unchanged (simple-module fixture has no `.go` source so the new filter no-ops on it)
- [X] CI: 3 lanes (linux x86_64 / linux ebpf / macos-latest) — TBD pending push

🤖 Generated with [Claude Code](https://claude.com/claude-code)