### PR TITLE
feat(051): polyglot dev/test tagging — cargo + gem dev-dep tagging via mikebom:dev-dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,46 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
   41 components pre-050 → 65 components post-050, with 24
   carrying `mikebom:not-linked`. README ecosystem section
   documents the workflow with audit numbers.
+- **Cargo dev/build deps now tagged via
+  `mikebom:dev-dependency`** (milestone 051 US1). Previously
+  `mikebom sbom scan --path <rust-project>` emitted every
+  `Cargo.lock` entry as a runtime dep — `[dev-dependencies]`
+  (criterion, proptest, etc.) and `[build-dependencies]` (cc,
+  bindgen, etc.) showed up unmarked. The cargo reader now
+  parses every `Cargo.toml` reachable from the lockfile
+  (workspace root + members, including `members =
+  ["crates/*"]` glob expansion) and BFS-walks the resolved dep
+  graph from the union of all `[dependencies]` entries to
+  identify the prod closure. Crates outside that closure are
+  tagged + dropped on `--include-dev=off`. Production-wins-
+  over-dev: a crate reachable via both prod and dev edges is
+  retained as production. Smoke on the mikebom workspace:
+  524 → 505 components default (19 dropped); `--include-dev`
+  recovers all 524 with the dev set carrying the annotation.
+- **Gem development/test groups now tagged via
+  `mikebom:dev-dependency`** (milestone 051 US2). The gem
+  reader now reads three sources of grouping metadata: the
+  `Gemfile.lock` `DEPENDENCIES` block, the project's `Gemfile`
+  (`group :name do ... end` blocks plus inline `gem "...",
+  group: :foo` syntax), and any project-root `*.gemspec` files
+  (`add_development_dependency` calls). Sources are unioned
+  with production-wins semantics. BFS through the lockfile's
+  transitive edges from prod-direct roots produces the prod
+  closure; gems outside it are tagged + dropped on
+  `--include-dev=off`.
+- **Maven test-scope tagging now has explicit regression
+  coverage** (milestone 051 US3). `maven.rs:1786-1823` already
+  drops `<scope>test</scope>` deps in default mode and tags
+  them under `--include-dev`; the new
+  `scan_maven_test_scope_is_tagged_with_include_dev`
+  integration test asserts the contract against future
+  refactors. Zero behavior change.
+
+After milestone 051, every ecosystem mikebom supports
+(cargo, gem, maven, npm, Poetry, Pipfile, Go) honors
+`--include-dev` consistently via the shared C6
+`mikebom:dev-dependency` parity wiring. No new flag, no new
+annotation, no new catalog row.
 
 ## [0.1.0-alpha.9] — 2026-05-01
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,6 @@ Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard
 ## Recent Changes
 - 049-go-source-scope: Added Rust stable. + existing only — `std::collections`,
 - 048-component-role: Added Rust stable. + existing only — `std::path`,
-- 047-scope-self-description: Added Rust stable (workspace toolchain inherited). + existing only — `serde`, `serde_json`,
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/scan_fs/package_db/cargo.rs
+++ b/mikebom-cli/src/scan_fs/package_db/cargo.rs
@@ -26,7 +26,7 @@
 //!   "workspace"` (no component emitted at read time; left to the
 //!   caller to decide whether to publish).
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use mikebom_common::types::hash::ContentHash;
@@ -237,12 +237,258 @@ fn parse_authors_from_cargo_toml(text: &str) -> Option<String> {
 }
 
 // ---------------------------------------------------------------------------
+// Milestone 051 — Cargo.toml dev/build-dep classification (T004-T008)
+// ---------------------------------------------------------------------------
+
+/// Crate names declared in a single `Cargo.toml`'s three dependency
+/// sections (plus the `target.<cfg>.*` variants of each). Drives the
+/// milestone-051 dev-vs-prod classification: a crate appearing ONLY in
+/// `dev_deps` or `build_deps` (and not in `prod_deps`) is tagged
+/// `mikebom:dev-dependency = true` after BFS expansion through the
+/// resolved Cargo.lock graph.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct CargoTomlSections {
+    pub prod_deps: HashSet<String>,
+    pub dev_deps: HashSet<String>,
+    pub build_deps: HashSet<String>,
+}
+
+impl CargoTomlSections {
+    /// Union with another sections set — used to merge the workspace
+    /// root + every member crate into a single workspace-wide
+    /// classification view.
+    fn union(&mut self, other: &CargoTomlSections) {
+        self.prod_deps.extend(other.prod_deps.iter().cloned());
+        self.dev_deps.extend(other.dev_deps.iter().cloned());
+        self.build_deps.extend(other.build_deps.iter().cloned());
+    }
+}
+
+/// Parse a `Cargo.toml` file and extract the three dependency sections
+/// (plus their `target.<cfg>.*` counterparts). Returns `None` on parse
+/// failure (warn-and-skip per plan R3 — a malformed Cargo.toml in some
+/// workspace member shouldn't abort the whole scan).
+pub(crate) fn parse_cargo_toml(path: &Path) -> Option<CargoTomlSections> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let parsed: toml::Value = match toml::from_str(&text) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "Cargo.toml parse failed — skipping dev/build classification \
+                 for this manifest",
+            );
+            return None;
+        }
+    };
+    let mut out = CargoTomlSections::default();
+    collect_section_keys(&parsed, "dependencies", &mut out.prod_deps);
+    collect_section_keys(&parsed, "dev-dependencies", &mut out.dev_deps);
+    collect_section_keys(&parsed, "build-dependencies", &mut out.build_deps);
+    // Walk every `target.<cfg>` table for its three section variants.
+    if let Some(target_table) = parsed.get("target").and_then(|v| v.as_table()) {
+        for (_cfg, target_value) in target_table {
+            collect_section_keys(target_value, "dependencies", &mut out.prod_deps);
+            collect_section_keys(target_value, "dev-dependencies", &mut out.dev_deps);
+            collect_section_keys(target_value, "build-dependencies", &mut out.build_deps);
+        }
+    }
+    Some(out)
+}
+
+fn collect_section_keys(parsed: &toml::Value, section: &str, out: &mut HashSet<String>) {
+    let Some(table) = parsed.get(section).and_then(|v| v.as_table()) else {
+        return;
+    };
+    for (key, value) in table {
+        // Cargo allows `foo = { package = "real-name", version = "1" }`.
+        // The renamed key in the TOML doesn't match the resolved
+        // `[[package]] name` in Cargo.lock; the inline `package = "..."`
+        // override does. Honor it when present.
+        let resolved_name = value
+            .as_table()
+            .and_then(|t| t.get("package"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| key.clone());
+        out.insert(resolved_name);
+    }
+}
+
+/// Discover every `Cargo.toml` reachable from the lockfile's project
+/// root: the immediate sibling, plus any workspace members declared
+/// via `[workspace] members = [...]` (with simple glob expansion for
+/// `crate-*` / `crates/*` patterns). Returns absolute paths in
+/// deterministic insertion order.
+///
+/// Per plan R1 fallback: if a glob escalates beyond simple star
+/// matching, we just include every directory under the matched parent
+/// — same effective semantic for typical layouts.
+pub(crate) fn discover_workspace_manifests(lockfile: &Path) -> Vec<PathBuf> {
+    let Some(project_root) = lockfile.parent() else {
+        return Vec::new();
+    };
+    let root_manifest = project_root.join("Cargo.toml");
+    if !root_manifest.is_file() {
+        return Vec::new();
+    }
+    let mut out = vec![root_manifest.clone()];
+    // Read the root manifest's `[workspace] members = [...]` array.
+    let Ok(text) = std::fs::read_to_string(&root_manifest) else {
+        return out;
+    };
+    let Ok(parsed) = toml::from_str::<toml::Value>(&text) else {
+        return out;
+    };
+    let Some(members) = parsed
+        .get("workspace")
+        .and_then(|w| w.get("members"))
+        .and_then(|m| m.as_array())
+    else {
+        return out;
+    };
+    for member in members {
+        let Some(pattern) = member.as_str() else {
+            continue;
+        };
+        expand_workspace_member(project_root, pattern, &mut out);
+    }
+    out
+}
+
+fn expand_workspace_member(project_root: &Path, pattern: &str, out: &mut Vec<PathBuf>) {
+    if let Some(prefix) = pattern.strip_suffix("/*") {
+        // Glob `<prefix>/*`: include every immediate subdirectory of
+        // `<project_root>/<prefix>` whose Cargo.toml exists.
+        let parent = project_root.join(prefix);
+        let Ok(read_dir) = std::fs::read_dir(&parent) else {
+            return;
+        };
+        for entry in read_dir.flatten() {
+            let dir = entry.path();
+            if dir.is_dir() {
+                let manifest = dir.join("Cargo.toml");
+                if manifest.is_file() {
+                    out.push(manifest);
+                }
+            }
+        }
+    } else if pattern.contains('*') {
+        // Plan R1 fallback: more complex glob → include every
+        // descendant Cargo.toml under the pattern's leading literal
+        // prefix. Conservative; over-includes but never misses.
+        let leading = pattern.split('*').next().unwrap_or("");
+        let parent = project_root.join(leading);
+        find_descendant_manifests(&parent, 0, out);
+    } else {
+        // Literal path.
+        let manifest = project_root.join(pattern).join("Cargo.toml");
+        if manifest.is_file() {
+            out.push(manifest);
+        }
+    }
+}
+
+fn find_descendant_manifests(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) {
+    if depth >= MAX_PROJECT_ROOT_DEPTH {
+        return;
+    }
+    let manifest = dir.join("Cargo.toml");
+    if manifest.is_file() {
+        out.push(manifest);
+    }
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if should_skip_descent(name) {
+            continue;
+        }
+        find_descendant_manifests(&path, depth + 1, out);
+    }
+}
+
+/// Compute the prod-reachable closure of `(name, version)` tuples by
+/// BFS-walking `Cargo.lock`'s resolved dep graph from the direct-prod
+/// crate names of the workspace.
+///
+/// Cargo.lock encodes per-package dep edges as
+/// `dependencies = ["bar 1.0.0 (registry+https://...)"]`. Each string
+/// is `<name> [<version>] [(<source>)]`; we extract the name +
+/// (when present) version to look up the next package node.
+///
+/// Production-wins-over-dev (FR-003): a crate reachable from BOTH a
+/// prod and a dev edge lands in this set, so the classifier correctly
+/// retains it as production. Same precedence rule as Go US2 / npm.
+fn compute_cargo_prod_set(
+    lock: &CargoLock,
+    direct_prod: &HashSet<String>,
+) -> HashSet<(String, String)> {
+    // Build a quick (name, version) → CargoPackage index for BFS
+    // traversal. When multiple `[[package]]` rows share a name (rare
+    // but legal — workspace members + transitive multi-version
+    // resolutions), keep them all.
+    let mut by_name: HashMap<&str, Vec<&CargoPackage>> = HashMap::new();
+    for pkg in &lock.package {
+        by_name.entry(pkg.name.as_str()).or_default().push(pkg);
+    }
+    let mut visited: HashSet<(String, String)> = HashSet::new();
+    let mut frontier: Vec<(&str, Option<&str>)> = direct_prod
+        .iter()
+        .map(|name| (name.as_str(), None::<&str>))
+        .collect();
+    while let Some((name, version)) = frontier.pop() {
+        // Resolve to one or more concrete package nodes.
+        let Some(candidates) = by_name.get(name) else {
+            continue;
+        };
+        for pkg in candidates {
+            if let Some(target_version) = version {
+                if pkg.version != target_version {
+                    continue;
+                }
+            }
+            let key = (pkg.name.clone(), pkg.version.clone());
+            if !visited.insert(key) {
+                continue;
+            }
+            for dep in &pkg.dependencies {
+                let mut parts = dep.split_whitespace();
+                let dep_name = match parts.next() {
+                    Some(n) => n,
+                    None => continue,
+                };
+                let dep_version = parts.next().filter(|p| !p.starts_with('('));
+                frontier.push((dep_name, dep_version));
+            }
+        }
+    }
+    visited
+}
+
+// ---------------------------------------------------------------------------
 // Reader
 // ---------------------------------------------------------------------------
 
 /// Parse one `Cargo.lock` file. Emits typed error for v1/v2; otherwise
-/// returns the flattened entry list for v3/v4.
-fn parse_lockfile(path: &Path) -> Result<Vec<PackageDbEntry>, CargoError> {
+/// returns the flattened entry list for v3/v4. When `prod_set` is
+/// non-empty (a Cargo.toml was found alongside the lockfile), entries
+/// whose `(name, version)` is NOT in the set are tagged
+/// `is_dev = Some(true)` per milestone 051. When `prod_set` is empty
+/// (lockfile-only, no Cargo.toml beside it) entries pass through with
+/// `is_dev = None` — we can't classify without dep-section info.
+fn parse_lockfile(
+    path: &Path,
+    prod_set: &HashSet<(String, String)>,
+) -> Result<Vec<PackageDbEntry>, CargoError> {
     let text = match std::fs::read_to_string(path) {
         Ok(t) => t,
         Err(_) => return Ok(Vec::new()),
@@ -311,6 +557,15 @@ fn parse_lockfile(path: &Path) -> Result<Vec<PackageDbEntry>, CargoError> {
                 }
             }
             entry.source_path = source_path.clone();
+            // Milestone 051: tag entries outside the prod-reachable
+            // set. When `prod_set` is empty (no Cargo.toml found
+            // alongside the lockfile) leave is_dev = None — we can't
+            // classify without dep-section info.
+            if !prod_set.is_empty()
+                && !prod_set.contains(&(pkg.name.clone(), pkg.version.clone()))
+            {
+                entry.is_dev = Some(true);
+            }
             out.push(entry);
         }
     }
@@ -320,13 +575,45 @@ fn parse_lockfile(path: &Path) -> Result<Vec<PackageDbEntry>, CargoError> {
 /// Public entry point — walks `rootfs` for `Cargo.lock` files, parses
 /// each, and returns the flattened entry list. v1/v2 at any root
 /// short-circuits with the typed error.
-pub fn read(rootfs: &Path, _include_dev: bool) -> Result<Vec<PackageDbEntry>, CargoError> {
+///
+/// Milestone 051: per-lockfile, parses sibling/workspace `Cargo.toml`
+/// files to identify dev/build deps, BFS-expands the prod closure
+/// against the lockfile, and tags entries outside that closure with
+/// `is_dev = Some(true)`. When `include_dev = false`, tagged entries
+/// are dropped (mirrors maven.rs:1786 + go-source-set filter).
+pub fn read(rootfs: &Path, include_dev: bool) -> Result<Vec<PackageDbEntry>, CargoError> {
     let mut out: Vec<PackageDbEntry> = Vec::new();
     let mut seen_purls: HashSet<String> = HashSet::new();
+    let mut tagged_dev = 0usize;
+    let mut dropped = 0usize;
     for lock_path in find_cargo_lockfiles(rootfs) {
-        let entries = parse_lockfile(&lock_path)?;
+        // Per-lockfile: build the workspace-wide CargoTomlSections by
+        // unioning the root manifest + every workspace member.
+        let mut workspace_sections = CargoTomlSections::default();
+        for manifest_path in discover_workspace_manifests(&lock_path) {
+            if let Some(sections) = parse_cargo_toml(&manifest_path) {
+                workspace_sections.union(&sections);
+            }
+        }
+        // Re-read the lockfile structurally to drive the BFS prod-set
+        // computation. parse_lockfile_doc returns the typed CargoLock
+        // (lighter than re-running parse_lockfile, which already
+        // converts to PackageDbEntry).
+        let prod_set = match parse_lockfile_doc(&lock_path) {
+            Ok(Some(doc)) => compute_cargo_prod_set(&doc, &workspace_sections.prod_deps),
+            _ => HashSet::new(),
+        };
+        let entries = parse_lockfile(&lock_path, &prod_set)?;
         for entry in entries {
             let purl_key = entry.purl.as_str().to_string();
+            // Drop dev entries when --include-dev is off.
+            if entry.is_dev == Some(true) {
+                tagged_dev += 1;
+                if !include_dev {
+                    dropped += 1;
+                    continue;
+                }
+            }
             if seen_purls.insert(purl_key) {
                 out.push(entry);
             }
@@ -336,10 +623,45 @@ pub fn read(rootfs: &Path, _include_dev: bool) -> Result<Vec<PackageDbEntry>, Ca
         tracing::info!(
             rootfs = %rootfs.display(),
             entries = out.len(),
+            tagged_dev,
+            dropped_when_no_include_dev = dropped,
+            include_dev,
             "parsed Cargo lockfiles",
         );
     }
     Ok(out)
+}
+
+/// Parse a `Cargo.lock` file into the typed `CargoLock` document
+/// without converting to `PackageDbEntry`. Used by the milestone-051
+/// prod-set BFS — needs raw `[[package]] dependencies = [...]` edges
+/// before the per-entry classification + drop logic runs.
+///
+/// Returns `Ok(None)` on read/parse failure (warn-and-skip), `Err` on
+/// fatal v1/v2 lockfile-version refusal.
+fn parse_lockfile_doc(path: &Path) -> Result<Option<CargoLock>, CargoError> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let doc: CargoLock = match toml::from_str(&text) {
+        Ok(d) => d,
+        Err(_) => return Ok(None),
+    };
+    match doc.version {
+        None => {
+            let version_hint = if text.contains("[root]") { 1 } else { 2 };
+            Err(CargoError::LockfileUnsupportedVersion {
+                path: path.to_path_buf(),
+                version: version_hint,
+            })
+        }
+        Some(v) if v < 3 => Err(CargoError::LockfileUnsupportedVersion {
+            path: path.to_path_buf(),
+            version: v,
+        }),
+        _ => Ok(Some(doc)),
+    }
 }
 
 fn find_cargo_lockfiles(rootfs: &Path) -> Vec<PathBuf> {
@@ -481,7 +803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0000000000000000000000000000000000000000000000000000000000000001"
 "#;
         let path = write_lockfile(dir.path(), body);
-        let entries = parse_lockfile(&path).unwrap();
+        let entries = parse_lockfile(&path, &HashSet::new()).unwrap();
         assert_eq!(entries.len(), 2);
         assert!(entries.iter().any(|e| e.name == "serde"));
         let serde = entries.iter().find(|e| e.name == "serde").unwrap();
@@ -503,7 +825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 "#;
         let path = write_lockfile(dir.path(), body);
-        let entries = parse_lockfile(&path).unwrap();
+        let entries = parse_lockfile(&path, &HashSet::new()).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "anyhow");
     }
@@ -520,7 +842,7 @@ version = "0.1.0"
 source = "git+https://github.com/me/my-fork?branch=main#abc123"
 "#;
         let path = write_lockfile(dir.path(), body);
-        let entries = parse_lockfile(&path).unwrap();
+        let entries = parse_lockfile(&path, &HashSet::new()).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].source_type.as_deref(), Some("git"));
     }
@@ -536,7 +858,7 @@ version = "0.1.0"
 dependencies = []
 "#;
         let path = write_lockfile(dir.path(), body);
-        match parse_lockfile(&path) {
+        match parse_lockfile(&path, &HashSet::new()) {
             Err(CargoError::LockfileUnsupportedVersion { version, .. }) => {
                 assert_eq!(version, 1);
             }
@@ -556,7 +878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0000000000000000000000000000000000000000000000000000000000000000"
 "#;
         let path = write_lockfile(dir.path(), body);
-        match parse_lockfile(&path) {
+        match parse_lockfile(&path, &HashSet::new()) {
             Err(CargoError::LockfileUnsupportedVersion { version, .. }) => {
                 assert_eq!(version, 2);
             }
@@ -688,5 +1010,227 @@ checksum = "0a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393"
             read(dir.path(), false),
             Err(CargoError::LockfileUnsupportedVersion { version: 1, .. })
         ));
+    }
+
+    // ---- Milestone 051 — Cargo.toml dev/build classification ----
+
+    #[test]
+    fn parse_cargo_toml_extracts_three_sections() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(
+            &path,
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[dependencies]
+serde = "1"
+tokio = { version = "1", features = ["full"] }
+
+[dev-dependencies]
+criterion = "0.5"
+proptest = "1"
+
+[build-dependencies]
+cc = "1"
+"#,
+        )
+        .unwrap();
+        let sections = parse_cargo_toml(&path).expect("parsed");
+        assert!(sections.prod_deps.contains("serde"));
+        assert!(sections.prod_deps.contains("tokio"));
+        assert!(sections.dev_deps.contains("criterion"));
+        assert!(sections.dev_deps.contains("proptest"));
+        assert!(sections.build_deps.contains("cc"));
+        assert_eq!(sections.prod_deps.len(), 2);
+        assert_eq!(sections.dev_deps.len(), 2);
+        assert_eq!(sections.build_deps.len(), 1);
+    }
+
+    #[test]
+    fn parse_cargo_toml_walks_target_cfg_tables() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(
+            &path,
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[target."cfg(unix)".dev-dependencies]
+nix = "0.27"
+
+[target."cfg(windows)".build-dependencies]
+winres = "0.1"
+"#,
+        )
+        .unwrap();
+        let sections = parse_cargo_toml(&path).expect("parsed");
+        assert!(sections.dev_deps.contains("nix"));
+        assert!(sections.build_deps.contains("winres"));
+        assert!(sections.prod_deps.is_empty());
+    }
+
+    #[test]
+    fn parse_cargo_toml_returns_none_on_malformed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(&path, "this is = not valid [[ toml\n").unwrap();
+        assert!(parse_cargo_toml(&path).is_none());
+    }
+
+    #[test]
+    fn parse_cargo_toml_absent_sections_yield_empty_sets() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(
+            &path,
+            "[package]\nname = \"x\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let sections = parse_cargo_toml(&path).expect("parsed");
+        assert!(sections.prod_deps.is_empty());
+        assert!(sections.dev_deps.is_empty());
+        assert!(sections.build_deps.is_empty());
+    }
+
+    #[test]
+    fn parse_cargo_toml_honors_package_rename() {
+        // `foo = { package = "real-name", version = "1" }` resolves
+        // to crate `real-name` in Cargo.lock, not `foo`.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Cargo.toml");
+        std::fs::write(
+            &path,
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[dependencies]
+foo = { package = "real-name", version = "1" }
+"#,
+        )
+        .unwrap();
+        let sections = parse_cargo_toml(&path).expect("parsed");
+        assert!(sections.prod_deps.contains("real-name"));
+        assert!(!sections.prod_deps.contains("foo"));
+    }
+
+    fn lock_pkg(name: &str, version: &str, deps: &[&str]) -> CargoPackage {
+        CargoPackage {
+            name: name.to_string(),
+            version: version.to_string(),
+            source: Some("registry+https://github.com/rust-lang/crates.io-index".to_string()),
+            checksum: None,
+            dependencies: deps.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn compute_prod_set_returns_just_direct_when_no_transitives() {
+        let lock = CargoLock {
+            version: Some(3),
+            package: vec![lock_pkg("foo", "1.0.0", &[])],
+        };
+        let mut direct = HashSet::new();
+        direct.insert("foo".to_string());
+        let prod = compute_cargo_prod_set(&lock, &direct);
+        assert_eq!(prod.len(), 1);
+        assert!(prod.contains(&("foo".to_string(), "1.0.0".to_string())));
+    }
+
+    #[test]
+    fn compute_prod_set_walks_three_level_chain() {
+        let lock = CargoLock {
+            version: Some(3),
+            package: vec![
+                lock_pkg("a", "1.0.0", &["b 2.0.0"]),
+                lock_pkg("b", "2.0.0", &["c 3.0.0"]),
+                lock_pkg("c", "3.0.0", &[]),
+            ],
+        };
+        let mut direct = HashSet::new();
+        direct.insert("a".to_string());
+        let prod = compute_cargo_prod_set(&lock, &direct);
+        assert_eq!(prod.len(), 3);
+        assert!(prod.contains(&("a".to_string(), "1.0.0".to_string())));
+        assert!(prod.contains(&("b".to_string(), "2.0.0".to_string())));
+        assert!(prod.contains(&("c".to_string(), "3.0.0".to_string())));
+    }
+
+    #[test]
+    fn compute_prod_set_production_wins_over_dev() {
+        // `shared` is reachable from BOTH the prod root `a` and (in
+        // a real workspace) a dev root. From the BFS perspective —
+        // which is seeded from prod-direct only — `shared` lands
+        // in the prod set when reachable through prod chain.
+        let lock = CargoLock {
+            version: Some(3),
+            package: vec![
+                lock_pkg("a", "1.0.0", &["shared 1.0.0"]),
+                lock_pkg("dev-only", "1.0.0", &["shared 1.0.0"]),
+                lock_pkg("shared", "1.0.0", &[]),
+            ],
+        };
+        let mut direct = HashSet::new();
+        direct.insert("a".to_string());
+        let prod = compute_cargo_prod_set(&lock, &direct);
+        assert!(prod.contains(&("shared".to_string(), "1.0.0".to_string())));
+        // dev-only is NOT in the prod set — exactly what we want.
+        assert!(!prod.contains(&("dev-only".to_string(), "1.0.0".to_string())));
+    }
+
+    #[test]
+    fn compute_prod_set_empty_seed_returns_empty() {
+        let lock = CargoLock {
+            version: Some(3),
+            package: vec![lock_pkg("foo", "1.0.0", &[])],
+        };
+        let prod = compute_cargo_prod_set(&lock, &HashSet::new());
+        assert!(prod.is_empty());
+    }
+
+    #[test]
+    fn discover_workspace_manifests_includes_root_only_when_no_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"solo\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("Cargo.lock"), "version = 3\n").unwrap();
+        let manifests = discover_workspace_manifests(&dir.path().join("Cargo.lock"));
+        assert_eq!(manifests.len(), 1);
+        assert!(manifests[0].ends_with("Cargo.toml"));
+    }
+
+    #[test]
+    fn discover_workspace_manifests_expands_glob_members() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"crates/*\"]\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("Cargo.lock"), "version = 3\n").unwrap();
+        std::fs::create_dir_all(dir.path().join("crates/foo")).unwrap();
+        std::fs::create_dir_all(dir.path().join("crates/bar")).unwrap();
+        std::fs::write(
+            dir.path().join("crates/foo/Cargo.toml"),
+            "[package]\nname = \"foo\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("crates/bar/Cargo.toml"),
+            "[package]\nname = \"bar\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let manifests = discover_workspace_manifests(&dir.path().join("Cargo.lock"));
+        // Root + 2 members.
+        assert_eq!(manifests.len(), 3);
     }
 }

--- a/mikebom-cli/src/scan_fs/package_db/gem.rs
+++ b/mikebom-cli/src/scan_fs/package_db/gem.rs
@@ -42,7 +42,7 @@
 //! we handle both via indent counting (≥2 for section body, ≥4 for
 //! specs) rather than fixed counts.
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use mikebom_common::types::purl::{encode_purl_segment, Purl};
@@ -328,13 +328,278 @@ fn gemspec_to_entry(
     })
 }
 
+// ---------------------------------------------------------------------------
+// Milestone 051 — Gem dev/test group classification (T022-T026)
+// ---------------------------------------------------------------------------
+
+/// Parse a `Gemfile` for `group :name [, :name2] do ... end` blocks
+/// and inline `gem "name", group(s): ...` syntax. Returns a map from
+/// gem name to the set of groups it appears in. The default group
+/// (no enclosing block, no inline keyword) maps to an empty set —
+/// production semantic.
+///
+/// Best-effort line scanner per plan R2: warn-and-skip lines that
+/// don't fit the canonical idioms (interpolation, conditional
+/// loading, eval_gemfile). Bundler accepts a wider Ruby DSL surface
+/// than this matches; consumers wanting full coverage rely on the
+/// gemspec source as a fallback.
+pub(crate) fn parse_gemfile(path: &Path) -> HashMap<String, BTreeSet<String>> {
+    let mut out: HashMap<String, BTreeSet<String>> = HashMap::new();
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return out;
+    };
+    let mut block_stack: Vec<BTreeSet<String>> = Vec::new();
+    for raw_line in text.lines() {
+        let line = strip_ruby_comment(raw_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+        // `end` closes the most recent block (group or otherwise).
+        if line == "end" {
+            block_stack.pop();
+            continue;
+        }
+        // Block opener: `group :foo[, :bar] do`. Other `do` blocks
+        // (source, platforms, ruby) push an empty set so `end`
+        // unwinds correctly.
+        if line.ends_with(" do") || line.ends_with("do") {
+            if let Some(rest) = line.strip_prefix("group ") {
+                let groups = parse_group_idents(rest);
+                block_stack.push(groups);
+                continue;
+            }
+            if line.starts_with("source ")
+                || line.starts_with("platforms ")
+                || line.starts_with("group ")
+                || line == "do"
+            {
+                block_stack.push(BTreeSet::new());
+                continue;
+            }
+            // Unknown block — push empty so the matching end pops.
+            block_stack.push(BTreeSet::new());
+            continue;
+        }
+        // `gem "name"[, options...]`
+        if let Some(rest) = line.strip_prefix("gem ") {
+            let Some((name, inline_groups)) = parse_gem_call(rest) else {
+                continue;
+            };
+            let mut groups = BTreeSet::new();
+            for g in block_stack.iter().flatten() {
+                groups.insert(g.clone());
+            }
+            for g in inline_groups {
+                groups.insert(g);
+            }
+            merge_groups(&mut out, name, groups);
+        }
+    }
+    out
+}
+
+fn strip_ruby_comment(line: &str) -> &str {
+    // Naive: `#` starts a comment unless inside a string. The
+    // canonical Gemfile rarely uses `#` inside strings, so this
+    // suffices for line-oriented scanning.
+    line.find('#').map(|i| &line[..i]).unwrap_or(line)
+}
+
+fn parse_group_idents(rest: &str) -> BTreeSet<String> {
+    // Input shape: `:test do` or `:development, :test do`.
+    let mut out = BTreeSet::new();
+    let payload = rest.trim_end_matches("do").trim().trim_end_matches(',');
+    for piece in payload.split(',') {
+        let s = piece.trim();
+        if let Some(name) = s.strip_prefix(':') {
+            let trimmed = name.trim().trim_end_matches('"').trim_end_matches('\'');
+            if !trimmed.is_empty() {
+                out.insert(trimmed.to_string());
+            }
+        }
+    }
+    out
+}
+
+fn parse_gem_call(rest: &str) -> Option<(String, BTreeSet<String>)> {
+    // `"rspec"` or `"rspec", "~> 3.0"` or
+    // `"pry", group: :development` or `"foo", groups: [:dev, :test]`.
+    let s = rest.trim();
+    let (name_quote, name) = if let Some(s) = s.strip_prefix('"') {
+        ('"', s)
+    } else if let Some(s) = s.strip_prefix('\'') {
+        ('\'', s)
+    } else {
+        return None;
+    };
+    let close = name.find(name_quote)?;
+    let gem_name = name[..close].to_string();
+    let after = &name[close + 1..];
+    let inline_groups = extract_inline_groups(after);
+    Some((gem_name, inline_groups))
+}
+
+fn extract_inline_groups(after: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    // Look for `group: :foo` or `groups: [:foo, :bar]`.
+    if let Some(idx) = after.find("group:") {
+        let payload = &after[idx + "group:".len()..];
+        let payload = payload.trim_start();
+        if let Some(rest) = payload.strip_prefix(':') {
+            let name: String = rest
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if !name.is_empty() {
+                out.insert(name);
+            }
+        }
+    }
+    if let Some(idx) = after.find("groups:") {
+        let payload = &after[idx + "groups:".len()..];
+        // Match `[:foo, :bar]`.
+        if let Some(open) = payload.find('[') {
+            if let Some(close) = payload[open..].find(']') {
+                let inner = &payload[open + 1..open + close];
+                for piece in inner.split(',') {
+                    let s = piece.trim();
+                    if let Some(name) = s.strip_prefix(':') {
+                        let trimmed: String = name
+                            .chars()
+                            .take_while(|c| c.is_alphanumeric() || *c == '_')
+                            .collect();
+                        if !trimmed.is_empty() {
+                            out.insert(trimmed);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Parse a `*.gemspec` file for `s.add_dependency` (prod),
+/// `s.add_runtime_dependency` (prod), and
+/// `s.add_development_dependency` (dev) calls.
+/// Returns gem name → groups map (empty set for prod, single
+/// `"development"` for dev).
+pub(crate) fn parse_gemspec_groups(path: &Path) -> HashMap<String, BTreeSet<String>> {
+    let mut out: HashMap<String, BTreeSet<String>> = HashMap::new();
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return out;
+    };
+    for raw_line in text.lines() {
+        let line = strip_ruby_comment(raw_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+        let (rest, groups): (&str, BTreeSet<String>) = if let Some(r) =
+            line.strip_prefix(".add_development_dependency")
+                .or_else(|| line.split('.').nth(1).and_then(|after_dot| {
+                    after_dot.strip_prefix("add_development_dependency")
+                }))
+        {
+            let mut g = BTreeSet::new();
+            g.insert("development".to_string());
+            (r, g)
+        } else if let Some(r) = line.strip_prefix(".add_dependency").or_else(|| {
+            line.split('.').nth(1).and_then(|after_dot| {
+                after_dot
+                    .strip_prefix("add_dependency")
+                    .or_else(|| after_dot.strip_prefix("add_runtime_dependency"))
+            })
+        }) {
+            (r, BTreeSet::new())
+        } else {
+            continue;
+        };
+        // Now `rest` looks like ` "rspec", "~> 3.0"`. Pull the first
+        // string literal.
+        let s = rest.trim_start_matches(|c: char| c == '(' || c.is_whitespace());
+        let Some((quote_char, body)) = s
+            .strip_prefix('"')
+            .map(|b| ('"', b))
+            .or_else(|| s.strip_prefix('\'').map(|b| ('\'', b)))
+        else {
+            continue;
+        };
+        let Some(close) = body.find(quote_char) else {
+            continue;
+        };
+        let name = body[..close].to_string();
+        if name.is_empty() {
+            continue;
+        }
+        out.entry(name).or_default().extend(groups);
+    }
+    out
+}
+
+/// Compute the prod-reachable gem name set by BFS-walking the lock's
+/// `specs:` indent-6 transitive edges starting from `direct_prod`.
+pub(crate) fn compute_gem_prod_set(
+    direct_prod: &HashSet<String>,
+    lock: &GemfileLockDocument,
+) -> HashSet<String> {
+    let mut by_name: HashMap<&str, &GemSpec> = HashMap::new();
+    for spec in &lock.specs {
+        by_name.insert(spec.name.as_str(), spec);
+    }
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut frontier: Vec<String> = direct_prod.iter().cloned().collect();
+    while let Some(name) = frontier.pop() {
+        if !visited.insert(name.clone()) {
+            continue;
+        }
+        if let Some(spec) = by_name.get(name.as_str()) {
+            for dep in &spec.depends {
+                if !visited.contains(dep) {
+                    frontier.push(dep.clone());
+                }
+            }
+        }
+    }
+    visited
+}
+
+/// Find sibling Gemfile + `*.gemspec` files alongside a Gemfile.lock.
+fn find_grouping_sources(lock_path: &Path) -> (Option<PathBuf>, Vec<PathBuf>) {
+    let Some(project_root) = lock_path.parent() else {
+        return (None, Vec::new());
+    };
+    let gemfile = project_root.join("Gemfile");
+    let gemfile = if gemfile.is_file() { Some(gemfile) } else { None };
+    let mut gemspecs = Vec::new();
+    if let Ok(read_dir) = std::fs::read_dir(project_root) {
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            if path.extension().and_then(|s| s.to_str()) == Some("gemspec") {
+                gemspecs.push(path);
+            }
+        }
+    }
+    (gemfile, gemspecs)
+}
+
 /// Public entry point — walks `rootfs` for `Gemfile.lock` files AND
 /// for `specifications/*.gemspec` files (Ruby's stdlib/default gems +
 /// system-installed gems not pinned by a Gemfile). Dedupes on PURL so
 /// Gemfile.lock entries win if both sources see the same gem.
-pub fn read(rootfs: &Path, _include_dev: bool) -> Vec<PackageDbEntry> {
+///
+/// Milestone 051: per-Gemfile.lock, parse co-located Gemfile +
+/// `*.gemspec` files; build a union grouping map (per FR-006:
+/// production wins when sources disagree); compute prod-reachable
+/// closure; tag entries OUTSIDE the prod set with `is_dev = Some(true)`;
+/// drop tagged entries when `!include_dev`.
+pub fn read(rootfs: &Path, include_dev: bool) -> Vec<PackageDbEntry> {
     let mut out: Vec<PackageDbEntry> = Vec::new();
     let mut seen_purls: HashSet<String> = HashSet::new();
+    let mut tagged_dev = 0usize;
+    let mut dropped = 0usize;
     for lock_path in find_gemfile_locks(rootfs) {
         let Ok(text) = std::fs::read_to_string(&lock_path) else {
             continue;
@@ -342,10 +607,50 @@ pub fn read(rootfs: &Path, _include_dev: bool) -> Vec<PackageDbEntry> {
         let doc = parse_gemfile_lock(&text);
         let direct: HashSet<String> = doc.dependencies.iter().cloned().collect();
         let source_path = lock_path.to_string_lossy().into_owned();
+
+        // Build the merged grouping signal from Gemfile + gemspec
+        // sources. Production-wins union (FR-006): a gem with empty
+        // group set in ANY source counts as prod.
+        let (gemfile_path, gemspec_paths) = find_grouping_sources(&lock_path);
+        let mut grouping: HashMap<String, BTreeSet<String>> = HashMap::new();
+        if let Some(p) = gemfile_path {
+            for (name, groups) in parse_gemfile(&p) {
+                merge_groups(&mut grouping, name, groups);
+            }
+        }
+        for p in &gemspec_paths {
+            for (name, groups) in parse_gemspec_groups(p) {
+                merge_groups(&mut grouping, name, groups);
+            }
+        }
+
+        // Direct prod-roots = direct deps that EITHER aren't in
+        // grouping OR carry an empty group set in grouping (default
+        // group = production).
+        let direct_prod: HashSet<String> = direct
+            .iter()
+            .filter(|name| {
+                grouping
+                    .get(name.as_str())
+                    .is_none_or(|groups| groups.is_empty())
+            })
+            .cloned()
+            .collect();
+        let prod_set = compute_gem_prod_set(&direct_prod, &doc);
+
         for spec in &doc.specs {
-            let Some(entry) = spec_to_entry(spec, &source_path, &direct) else {
+            let Some(mut entry) = spec_to_entry(spec, &source_path, &direct) else {
                 continue;
             };
+            // Tag dev: not in prod-reachable set.
+            if !prod_set.contains(&spec.name) {
+                entry.is_dev = Some(true);
+                tagged_dev += 1;
+                if !include_dev {
+                    dropped += 1;
+                    continue;
+                }
+            }
             let purl_key = entry.purl.as_str().to_string();
             if seen_purls.insert(purl_key) {
                 out.push(entry);
@@ -382,10 +687,38 @@ pub fn read(rootfs: &Path, _include_dev: bool) -> Vec<PackageDbEntry> {
         tracing::info!(
             rootfs = %rootfs.display(),
             entries = out.len(),
+            tagged_dev,
+            dropped_when_no_include_dev = dropped,
+            include_dev,
             "parsed Gemfile.lock + gemspec entries",
         );
     }
     out
+}
+
+/// Production-wins union: a gem with empty group set in ANY source
+/// counts as production (mirrors FR-006). When the existing entry
+/// already represents prod (empty groups), keep it; otherwise the
+/// union of groups is the new value.
+fn merge_groups(
+    out: &mut HashMap<String, BTreeSet<String>>,
+    name: String,
+    new_groups: BTreeSet<String>,
+) {
+    match out.get_mut(&name) {
+        Some(existing) if existing.is_empty() => {
+            // Already classified as prod by another source — keep.
+        }
+        Some(existing) if new_groups.is_empty() => {
+            existing.clear();
+        }
+        Some(existing) => {
+            existing.extend(new_groups);
+        }
+        None => {
+            out.insert(name, new_groups);
+        }
+    }
 }
 
 fn find_gemfile_locks(rootfs: &Path) -> Vec<PathBuf> {
@@ -1043,5 +1376,130 @@ end
         let json_entries: Vec<_> =
             entries.iter().filter(|e| e.name == "json").collect();
         assert_eq!(json_entries.len(), 2);
+    }
+
+    // ---- Milestone 051 — gem dev/test group classification ----
+
+    #[test]
+    fn parse_gemfile_extracts_group_block() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Gemfile");
+        std::fs::write(
+            &path,
+            r#"
+source "https://rubygems.org"
+
+gem "rack"
+
+group :test do
+  gem "rspec"
+  gem "factory_bot"
+end
+
+group :development, :test do
+  gem "pry"
+end
+"#,
+        )
+        .unwrap();
+        let groups = parse_gemfile(&path);
+        assert!(groups.get("rack").map(|g| g.is_empty()).unwrap_or(false));
+        assert!(groups.get("rspec").unwrap().contains("test"));
+        assert!(groups.get("factory_bot").unwrap().contains("test"));
+        let pry_groups = groups.get("pry").unwrap();
+        assert!(pry_groups.contains("development"));
+        assert!(pry_groups.contains("test"));
+    }
+
+    #[test]
+    fn parse_gemfile_extracts_inline_group_keyword() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Gemfile");
+        std::fs::write(
+            &path,
+            r#"
+gem "rack"
+gem "byebug", group: :development
+gem "minitest", groups: [:test, :ci]
+"#,
+        )
+        .unwrap();
+        let groups = parse_gemfile(&path);
+        assert!(groups.get("byebug").unwrap().contains("development"));
+        let minitest = groups.get("minitest").unwrap();
+        assert!(minitest.contains("test"));
+        assert!(minitest.contains("ci"));
+    }
+
+    #[test]
+    fn parse_gemspec_groups_extracts_dev_deps() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("foo.gemspec");
+        std::fs::write(
+            &path,
+            r#"
+Gem::Specification.new do |s|
+  s.name = "foo"
+  s.version = "0.1.0"
+  s.add_dependency "activesupport", "~> 7.0"
+  s.add_runtime_dependency "json"
+  s.add_development_dependency "rspec", "~> 3.0"
+  s.add_development_dependency("factory_bot")
+end
+"#,
+        )
+        .unwrap();
+        let groups = parse_gemspec_groups(&path);
+        assert!(groups.get("activesupport").map(|g| g.is_empty()).unwrap_or(false));
+        assert!(groups.get("json").map(|g| g.is_empty()).unwrap_or(false));
+        assert!(groups.get("rspec").unwrap().contains("development"));
+        assert!(groups.get("factory_bot").unwrap().contains("development"));
+    }
+
+    #[test]
+    fn parse_gemfile_returns_empty_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let groups = parse_gemfile(&dir.path().join("NoSuchFile"));
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn parse_gemspec_groups_returns_empty_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let groups = parse_gemspec_groups(&dir.path().join("nope.gemspec"));
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn compute_gem_prod_set_walks_three_level_chain() {
+        let lock = GemfileLockDocument {
+            specs: vec![
+                GemSpec {
+                    name: "a".to_string(),
+                    version: "1".to_string(),
+                    kind: GemSection::Gem,
+                    depends: vec!["b".to_string()],
+                },
+                GemSpec {
+                    name: "b".to_string(),
+                    version: "1".to_string(),
+                    kind: GemSection::Gem,
+                    depends: vec!["c".to_string()],
+                },
+                GemSpec {
+                    name: "c".to_string(),
+                    version: "1".to_string(),
+                    kind: GemSection::Gem,
+                    depends: vec![],
+                },
+            ],
+            dependencies: vec!["a".to_string()],
+        };
+        let mut direct = HashSet::new();
+        direct.insert("a".to_string());
+        let prod = compute_gem_prod_set(&direct, &lock);
+        assert!(prod.contains("a"));
+        assert!(prod.contains("b"));
+        assert!(prod.contains("c"));
     }
 }

--- a/mikebom-cli/tests/scan_cargo.rs
+++ b/mikebom-cli/tests/scan_cargo.rs
@@ -164,3 +164,291 @@ fn scan_cargo_v2_lockfile_refuses_with_actionable_error() {
         "stderr missing refusal message: {stderr}",
     );
 }
+
+// ---------------------------------------------------------------------------
+// Milestone 051 — cargo dev/build dep tagging
+// ---------------------------------------------------------------------------
+
+/// Run mikebom against `path` with optional extra args (e.g.
+/// `--include-dev`). Returns the parsed SBOM JSON.
+fn run_scan_args(path: &Path, extra_args: &[&str]) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("sbom.cdx.json");
+    let mut cmd = Command::new(bin);
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(path)
+        .arg("--output")
+        .arg(&out_path)
+        .arg("--no-deep-hash");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let output = cmd.output().expect("mikebom should run");
+    assert!(
+        output.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let raw = std::fs::read_to_string(&out_path).expect("read sbom");
+    serde_json::from_str(&raw).expect("valid JSON")
+}
+
+fn cargo_component_named<'a>(sbom: &'a serde_json::Value, name: &str) -> Option<&'a serde_json::Value> {
+    sbom["components"]
+        .as_array()?
+        .iter()
+        .find(|c| c["name"].as_str() == Some(name))
+}
+
+fn has_dev_property(component: &serde_json::Value) -> bool {
+    component["properties"]
+        .as_array()
+        .map(|props| {
+            props.iter().any(|p| {
+                p["name"].as_str() == Some("mikebom:dev-dependency")
+                    && (p["value"].as_str() == Some("true")
+                        || p["value"].as_bool() == Some(true))
+            })
+        })
+        .unwrap_or(false)
+}
+
+#[test]
+fn scan_cargo_dev_dependency_is_tagged_and_droppable() {
+    // FR-001 / FR-002: a crate declared in [dev-dependencies] is
+    // dropped from the default-mode SBOM and tagged with
+    // mikebom:dev-dependency = true under --include-dev.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[dependencies]
+serde = "1.0.197"
+
+[dev-dependencies]
+criterion = "0.5.1"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.lock"),
+        r#"
+version = 3
+
+[[package]]
+name = "demo"
+version = "0.1.0"
+dependencies = ["serde"]
+
+[[package]]
+name = "serde"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb1c753"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d09"
+"#,
+    )
+    .unwrap();
+
+    // Default scan: criterion absent.
+    let sbom = run_scan_args(dir.path(), &[]);
+    assert!(
+        cargo_component_named(&sbom, "criterion").is_none(),
+        "criterion (dev-dep) must be dropped in default mode",
+    );
+    assert!(
+        cargo_component_named(&sbom, "serde").is_some(),
+        "serde (prod-dep) must be retained",
+    );
+
+    // --include-dev: criterion present + tagged.
+    let sbom_dev = run_scan_args(dir.path(), &["--include-dev"]);
+    let criterion =
+        cargo_component_named(&sbom_dev, "criterion").expect("criterion present with --include-dev");
+    assert!(
+        has_dev_property(criterion),
+        "criterion must carry mikebom:dev-dependency = true: {criterion:?}",
+    );
+}
+
+#[test]
+fn scan_cargo_build_dependency_is_treated_as_dev() {
+    // FR-001 (build-deps): per the cargo book, build-deps don't
+    // ship in the runtime artifact — same SBOM-filter semantic
+    // as dev-deps.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[dependencies]
+serde = "1.0.197"
+
+[build-dependencies]
+cc = "1.0.83"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.lock"),
+        r#"
+version = 3
+
+[[package]]
+name = "demo"
+version = "0.1.0"
+dependencies = ["serde"]
+
+[[package]]
+name = "serde"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb1c753"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deadbeef"
+"#,
+    )
+    .unwrap();
+
+    let sbom = run_scan_args(dir.path(), &[]);
+    assert!(
+        cargo_component_named(&sbom, "cc").is_none(),
+        "cc (build-dep) must be dropped in default mode",
+    );
+    let sbom_dev = run_scan_args(dir.path(), &["--include-dev"]);
+    let cc = cargo_component_named(&sbom_dev, "cc").expect("cc present with --include-dev");
+    assert!(has_dev_property(cc), "cc must be tagged dev: {cc:?}");
+}
+
+#[test]
+fn scan_cargo_production_wins_over_dev() {
+    // FR-003: a crate listed in BOTH [dependencies] and
+    // [dev-dependencies] is treated as production.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[dependencies]
+serde = "1.0.197"
+
+[dev-dependencies]
+serde = "1.0.197"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.lock"),
+        r#"
+version = 3
+
+[[package]]
+name = "demo"
+version = "0.1.0"
+dependencies = ["serde"]
+
+[[package]]
+name = "serde"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb1c753"
+"#,
+    )
+    .unwrap();
+
+    let sbom = run_scan_args(dir.path(), &[]);
+    let serde =
+        cargo_component_named(&sbom, "serde").expect("serde must be retained (prod wins)");
+    assert!(
+        !has_dev_property(serde),
+        "serde must NOT be tagged dev when also present in [dependencies]: {serde:?}",
+    );
+}
+
+#[test]
+fn scan_cargo_workspace_member_dev_dep_is_tagged() {
+    // FR-001 + workspace traversal: a dev-dep declared by a
+    // workspace member crate gets correctly classified.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"
+[workspace]
+members = ["member-a"]
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.path().join("member-a")).unwrap();
+    std::fs::write(
+        dir.path().join("member-a/Cargo.toml"),
+        r#"
+[package]
+name = "member-a"
+version = "0.1.0"
+
+[dependencies]
+serde = "1.0.197"
+
+[dev-dependencies]
+proptest = "1.4.0"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.lock"),
+        r#"
+version = 3
+
+[[package]]
+name = "member-a"
+version = "0.1.0"
+dependencies = ["serde"]
+
+[[package]]
+name = "serde"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb1c753"
+
+[[package]]
+name = "proptest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abcd1234"
+"#,
+    )
+    .unwrap();
+
+    let sbom = run_scan_args(dir.path(), &[]);
+    assert!(
+        cargo_component_named(&sbom, "proptest").is_none(),
+        "workspace member's dev-dep must be dropped",
+    );
+    let sbom_dev = run_scan_args(dir.path(), &["--include-dev"]);
+    let proptest =
+        cargo_component_named(&sbom_dev, "proptest").expect("proptest present with --include-dev");
+    assert!(has_dev_property(proptest), "proptest must be tagged dev");
+}

--- a/mikebom-cli/tests/scan_gem.rs
+++ b/mikebom-cli/tests/scan_gem.rs
@@ -170,3 +170,232 @@ fn scan_gem_git_and_path_entries_tagged_with_source_type() {
     assert_eq!(rails_src, "git");
     assert_eq!(my_gem_src, "path");
 }
+
+// ---------------------------------------------------------------------------
+// Milestone 051 — gem dev/test group classification
+// ---------------------------------------------------------------------------
+
+fn scan_args(path: &Path, extra: &[&str]) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("sbom.cdx.json");
+    let mut cmd = Command::new(bin);
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(path)
+        .arg("--output")
+        .arg(&out_path)
+        .arg("--no-deep-hash");
+    for a in extra {
+        cmd.arg(a);
+    }
+    let output = cmd.output().expect("mikebom should run");
+    assert!(
+        output.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let raw = std::fs::read_to_string(&out_path).expect("read sbom");
+    serde_json::from_str(&raw).expect("valid JSON")
+}
+
+fn gem_named<'a>(sbom: &'a serde_json::Value, name: &str) -> Option<&'a serde_json::Value> {
+    sbom["components"]
+        .as_array()?
+        .iter()
+        .find(|c| c["name"].as_str() == Some(name))
+}
+
+fn has_dev_property(component: &serde_json::Value) -> bool {
+    component["properties"]
+        .as_array()
+        .map(|props| {
+            props.iter().any(|p| {
+                p["name"].as_str() == Some("mikebom:dev-dependency")
+                    && (p["value"].as_str() == Some("true")
+                        || p["value"].as_bool() == Some(true))
+            })
+        })
+        .unwrap_or(false)
+}
+
+#[test]
+fn scan_gem_gemfile_groups_are_tagged() {
+    // FR-004 / FR-005: Gemfile groups drive dev classification when
+    // the lockfile has no group annotations (canonical Bundler).
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("Gemfile"),
+        r#"
+source "https://rubygems.org"
+gem "rack", "~> 3.0"
+
+group :development do
+  gem "pry", "0.14.2"
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Gemfile.lock"),
+        r#"GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (3.0.8)
+    pry (0.14.2)
+
+DEPENDENCIES
+  rack (~> 3.0)
+  pry
+
+BUNDLED WITH
+   2.4.10
+"#,
+    )
+    .unwrap();
+    // Default: pry absent.
+    let sbom = scan_args(dir.path(), &[]);
+    assert!(
+        gem_named(&sbom, "pry").is_none(),
+        "pry (development group) must be dropped in default mode",
+    );
+    assert!(
+        gem_named(&sbom, "rack").is_some(),
+        "rack (default group) must be retained",
+    );
+    // --include-dev: pry tagged.
+    let sbom_dev = scan_args(dir.path(), &["--include-dev"]);
+    let pry = gem_named(&sbom_dev, "pry").expect("pry present with --include-dev");
+    assert!(
+        has_dev_property(pry),
+        "pry must carry mikebom:dev-dependency = true: {pry:?}",
+    );
+}
+
+#[test]
+fn scan_gem_gemspec_dev_deps_are_tagged() {
+    // FR-004 (gemspec source): library projects with `*.gemspec`
+    // declaring `add_development_dependency` get correct
+    // classification even when no Gemfile groups are present.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("foo.gemspec"),
+        r#"
+Gem::Specification.new do |s|
+  s.name = "foo"
+  s.version = "0.1.0"
+  s.add_dependency "activesupport", "~> 7.0"
+  s.add_development_dependency "rspec", "~> 3.0"
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Gemfile"),
+        "source \"https://rubygems.org\"\ngemspec\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Gemfile.lock"),
+        r#"GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.1.3)
+    rspec (3.13.0)
+
+DEPENDENCIES
+  activesupport
+  rspec
+
+BUNDLED WITH
+   2.4.10
+"#,
+    )
+    .unwrap();
+    let sbom = scan_args(dir.path(), &[]);
+    assert!(
+        gem_named(&sbom, "rspec").is_none(),
+        "rspec (gemspec dev-dep) must be dropped in default mode",
+    );
+    assert!(
+        gem_named(&sbom, "activesupport").is_some(),
+        "activesupport (gemspec runtime-dep) must be retained",
+    );
+    let sbom_dev = scan_args(dir.path(), &["--include-dev"]);
+    let rspec = gem_named(&sbom_dev, "rspec").expect("rspec present with --include-dev");
+    assert!(has_dev_property(rspec), "rspec must be tagged dev");
+}
+
+#[test]
+fn scan_gem_production_wins_over_dev() {
+    // FR-006: a gem listed as prod by ANY source (Gemfile default
+    // group, gemspec add_dependency, or anywhere with empty groups)
+    // is treated as production, even if another source classifies
+    // it as dev.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("Gemfile"),
+        r#"
+source "https://rubygems.org"
+gem "json", "2.7.1"
+group :test do
+  gem "json"
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Gemfile.lock"),
+        r#"GEM
+  remote: https://rubygems.org/
+  specs:
+    json (2.7.1)
+
+DEPENDENCIES
+  json
+
+BUNDLED WITH
+   2.4.10
+"#,
+    )
+    .unwrap();
+    let sbom = scan_args(dir.path(), &[]);
+    let json = gem_named(&sbom, "json").expect("json must be retained (prod wins)");
+    assert!(
+        !has_dev_property(json),
+        "json must NOT be tagged dev when present in default group: {json:?}",
+    );
+}
+
+#[test]
+fn scan_gem_default_group_is_production_unmarked() {
+    // No Gemfile groups, no gemspec — every gem in the lock is
+    // production by default. Default scan emits all of them
+    // unmarked.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("Gemfile"),
+        "source \"https://rubygems.org\"\ngem \"rack\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Gemfile.lock"),
+        r#"GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (3.0.8)
+
+DEPENDENCIES
+  rack
+
+BUNDLED WITH
+   2.4.10
+"#,
+    )
+    .unwrap();
+    let sbom = scan_args(dir.path(), &[]);
+    let rack = gem_named(&sbom, "rack").expect("rack must emit");
+    assert!(!has_dev_property(rack), "rack must not be tagged dev");
+}

--- a/mikebom-cli/tests/scan_maven.rs
+++ b/mikebom-cli/tests/scan_maven.rs
@@ -704,3 +704,94 @@ fn scan_maven_placeholder_version_becomes_design_tier() {
     let range = prop_value(sibling, "mikebom:requirement-range").unwrap_or("");
     assert_eq!(range, "${sibling.version}");
 }
+
+// ---------------------------------------------------------------------------
+// Milestone 051 US3 — maven test-scope tagging regression guard
+// ---------------------------------------------------------------------------
+
+fn scan_path_args(path: &Path, extra: &[&str]) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("sbom.cdx.json");
+    let mut cmd = Command::new(bin);
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(path)
+        .arg("--output")
+        .arg(&out_path)
+        .arg("--no-deep-hash");
+    for a in extra {
+        cmd.arg(a);
+    }
+    let output = cmd.output().expect("mikebom should run");
+    assert!(
+        output.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let raw = std::fs::read_to_string(&out_path).expect("read sbom");
+    serde_json::from_str(&raw).expect("valid JSON")
+}
+
+#[test]
+fn scan_maven_test_scope_is_tagged_with_include_dev() {
+    // Milestone 051 US3 / FR-007: maven.rs:1786-1823 already drops
+    // <scope>test</scope> deps in default mode and tags them with
+    // mikebom:dev-dependency = true under --include-dev. This test
+    // is a regression guard against future refactors.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("pom.xml"),
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>demo</artifactId>
+  <version>0.1.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.13</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>
+"#,
+    )
+    .unwrap();
+
+    // Default: junit absent.
+    let sbom = scan_path_args(dir.path(), &[]);
+    let maven = maven_components(&sbom);
+    let junit = maven.iter().find(|c| c["name"].as_str() == Some("junit"));
+    assert!(
+        junit.is_none(),
+        "junit (test-scope) must be dropped in default mode. components: {maven:?}",
+    );
+    // slf4j-api stays.
+    assert!(
+        maven.iter().any(|c| c["name"].as_str() == Some("slf4j-api")),
+        "slf4j-api (compile-scope) must be retained",
+    );
+
+    // --include-dev: junit emits with mikebom:dev-dependency = true.
+    let sbom_dev = scan_path_args(dir.path(), &["--include-dev"]);
+    let maven_dev = maven_components(&sbom_dev);
+    let junit_dev = maven_dev
+        .iter()
+        .find(|c| c["name"].as_str() == Some("junit"))
+        .expect("junit must emit under --include-dev");
+    let is_dev = prop_value(junit_dev, "mikebom:dev-dependency").unwrap_or("");
+    assert_eq!(
+        is_dev, "true",
+        "junit must carry mikebom:dev-dependency = true under --include-dev: {junit_dev:?}",
+    );
+}

--- a/specs/051-polyglot-dev-tagging/checklists/requirements.md
+++ b/specs/051-polyglot-dev-tagging/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Specification Quality Checklist: Polyglot dev/test tagging — cargo + gem + maven regression
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- 3 user stories: US1 cargo (P1), US2 gem (P1), US3 maven regression (P2).
+- Audit-grounded against alpha.9 reader state: cargo + gem currently have
+  `_include_dev` parameters underscore-prefixed (unused); `is_dev: None` always.
+  Maven already correctly tags + drops via `<scope>test</scope>` at maven.rs:1786-1823.
+- 10 FRs, 10 SCs. No NEEDS CLARIFICATION markers — informed defaults used
+  throughout (e.g., production-wins-over-dev mirrors milestone 049 US2).
+- Reuses existing C6 parity infrastructure — no new annotation, no new flag,
+  no new catalog row. Pure additive population.
+- Out of scope (called out explicitly): maven `<scope>provided/runtime>`
+  scopes (future milestone, possibly `mikebom:not-linked`-style annotation),
+  rpm soft-deps, npm/Poetry/Pipfile (already done).

--- a/specs/051-polyglot-dev-tagging/plan.md
+++ b/specs/051-polyglot-dev-tagging/plan.md
@@ -1,0 +1,361 @@
+---
+description: "Plan — milestone 051 polyglot dev/test tagging (cargo + gem + maven regression)"
+---
+
+# Plan: Polyglot dev/test tagging — `mikebom:dev-dependency` for cargo and gem
+
+**Branch**: `051-polyglot-dev-tagging` | **Spec**: spec.md ✅
+**Output**: 4-file tighter template (no research.md / data-model.md /
+contracts/ / quickstart.md — pattern from
+021/022/023/042/046/047/048/049/050).
+
+## Constitution Check
+
+Reviewed against `.specify/memory/constitution.md`. No violations:
+
+- **I. Pure Rust, Zero C**: parsing TOML (`Cargo.toml`) uses
+  existing `toml` crate (already in deps via `cargo.rs`). Parsing
+  `Gemfile` and `*.gemspec` via hand-rolled byte/regex scanners
+  (mikebom's house style for non-TOML/non-JSON formats — see
+  `gem.rs`'s existing parser). No new C deps.
+- **III. Fail Closed**: existing cargo.rs already fails closed on
+  v1/v2 lockfiles. New Cargo.toml parser should warn-and-skip on
+  unparseable files (preserving the "broken project shouldn't
+  abort the whole scan" precedent set by gem.rs / pip.rs).
+  Confirmed safe — see Phase 0 R3.
+- **IV. Type-Driven Correctness**: reuse existing
+  `is_dev: Option<bool>` field on `PackageDbEntry`.
+  Three-state (`Some(true)` / `Some(false)` / `None`) preserved.
+- **VIII. Completeness / IX. Accuracy**: this milestone directly
+  improves both — no deps silently miscategorized as runtime when
+  they're dev-only.
+- **No new annotation, no new flag, no new catalog row**.
+
+## Phase 0: Recon (resolved inline; no `research.md`)
+
+### R1. Cargo: Cargo.lock has resolved dep edges; no Cargo.toml parsing today
+
+**Finding**: `mikebom-cli/src/scan_fs/package_db/cargo.rs:323`
+(`pub fn read(rootfs: &Path, _include_dev: bool)`) parses
+`Cargo.lock` only. The `_include_dev` parameter is unused
+(underscore-prefixed). Cargo.lock contains the full resolved
+graph via `[[package]] dependencies = [...]` arrays — but
+NOT the dev/build/runtime classification (the lockfile
+flattens all three into a single `dependencies` list per
+package).
+
+**Decision**: add Cargo.toml parsing alongside Cargo.lock
+parsing. For each scanned `Cargo.lock`, walk the same
+directory + workspace-member directories for `Cargo.toml`
+files; extract `[dev-dependencies]`, `[build-dependencies]`,
+`[dependencies]` sections; build the dev-roots set; BFS
+through lockfile dep edges to compute prod-reachable closure;
+tag entries OUTSIDE the prod closure with `is_dev=Some(true)`.
+
+**Workspace traversal**: a workspace's root `Cargo.toml` may
+declare `[workspace] members = ["crate-a", "crate-b/*"]` with
+glob patterns. Implement glob resolution via existing path
+walk (no `glob` crate needed; the patterns are simple `*` /
+`**` cases). For each member crate, parse its own
+`Cargo.toml`'s sections.
+
+**Target-conditional sections** (`target."cfg(unix)".dev-dependencies`):
+spec FR-001 says treat as dev. Implementation: walk all
+top-level `target.<cfg>.{dev,build}-dependencies` keys via
+TOML `Table` iteration; classify same as unconditional
+sections.
+
+### R2. Gem: three-source classification (lock + Gemfile + gemspec)
+
+Per Q1 / FR-004 (clarified 2026-05-01):
+
+**Gemfile.lock** (existing parse): newer Bundler emits group
+annotations under `DEPENDENCIES` like:
+
+```
+DEPENDENCIES
+  rspec (~> 3.0)
+    group: test
+```
+
+Older locks omit the group line. Existing parser at
+`gem.rs:114-145` reads the gem name; needs extension to read
+the optional `group:` continuation line.
+
+**Gemfile** (NEW parser): handles the canonical app shape:
+
+```ruby
+group :development, :test do
+  gem "rspec"
+  gem "factory_bot"
+end
+gem "pry", group: :development
+gem "rack"  # default group → production
+```
+
+Hand-rolled scanner — patterns are line-oriented and small.
+No need for a Ruby parser; we only extract `gem "name"` calls
+and their group context. Bundler doesn't enforce strict syntax
+beyond the keyword form, so we treat the Gemfile parser as
+best-effort: warn-and-skip on unparseable lines (mirrors
+gem.rs's existing tolerance for malformed `Gemfile.lock`
+specs).
+
+**`*.gemspec`** (NEW parser): handles the canonical library
+shape:
+
+```ruby
+Gem::Specification.new do |s|
+  s.add_dependency "activesupport"
+  s.add_development_dependency "rspec"
+end
+```
+
+Same line-oriented hand-rolled scanner. Match
+`s.add_dependency "..."` (or `add_runtime_dependency`) for
+prod, `s.add_development_dependency "..."` for dev.
+
+**Union semantics** per FR-006: gem is prod IFF ANY source
+classifies it as prod (default group, `add_dependency`, or
+prod transitively via lockfile spec edges). Otherwise dev.
+
+### R3. Cargo.toml parse failure handling
+
+**Decision**: warn-and-skip on unparseable Cargo.toml files
+(don't fail the whole scan). Mirrors the existing pattern at
+`cargo.rs:252-258` for unparseable `Cargo.lock`. Constitution
+III's "fail closed" applies to invariant violations
+(unsupported lockfile versions); a malformed `Cargo.toml`
+in some workspace member is recoverable degradation — emit
+the entries WITHOUT dev classification rather than abort.
+
+### R4. Maven: existing test-scope handling at `maven.rs:1786-1823`
+
+**Existing primitives** verified:
+
+```rust
+// mikebom-cli/src/scan_fs/package_db/maven.rs:1786
+if !include_dev && matches!(dep.scope.as_deref(), Some("test")) {
+    continue;
+}
+// mikebom-cli/src/scan_fs/package_db/maven.rs:1823
+is_dev: matches!(dep.scope.as_deref(), Some("test")).then_some(true),
+```
+
+**Decision**: zero code change. US3 (P2) requires only a new
+explicit integration test in `tests/scan_maven.rs` asserting
+`mikebom:dev-dependency = true` appears on test-scope deps
+when `--include-dev` is set. Regression guard against future
+refactors.
+
+### R5. Existing infrastructure (no change)
+
+- **C6 catalog row** (`docs/reference/sbom-format-mapping.md:51`):
+  documents `mikebom:dev-dependency` parity contract. Already
+  applies to cargo and gem outputs (no per-ecosystem clauses).
+- **CDX/SPDX 2.3/SPDX 3 serializers**: gate emission on
+  `is_dev == Some(true)` (`cyclonedx/builder.rs:317`,
+  `spdx/annotations.rs:148`, `spdx/v3_annotations.rs:164`).
+- **Parity extractors**: existing `cdx_dev_deps`,
+  `spdx23_dev_deps`, `spdx3_dev_deps` already wire C6 across
+  formats.
+- **`--include-dev` plumbing** at `cli/scan_cmd.rs:584`
+  threads through to `read_all` → individual readers.
+- **`apply_go_production_set_filter` precedent** (milestone
+  049): drop-on-`!include_dev` pattern lifted directly into
+  cargo/gem.
+
+## Phase 1: Implementation strategy
+
+Single PR, three commits (one per ecosystem) for clean review:
+
+### Commit 1 — `feat(051/us1): cargo dev/build dep tagging`
+
+**Touched files**:
+
+- **`mikebom-cli/src/scan_fs/package_db/cargo.rs`** (~120 LOC)
+  - Add a `CargoTomlSections` struct holding three
+    `HashSet<String>`: `prod_deps`, `dev_deps`, `build_deps`.
+  - Add `parse_cargo_toml(path: &Path) -> Option<CargoTomlSections>`
+    — TOML parse; iterate `[dependencies]`, `[dev-dependencies]`,
+    `[build-dependencies]`, `target.*.{dev,build}-dependencies`,
+    extract crate names. Warn-and-skip on parse error per R3.
+  - Add `discover_workspace_manifests(rootfs: &Path) ->
+    Vec<PathBuf>` — find every `Cargo.toml` in workspace
+    (root + members); resolve glob patterns inline
+    (no new crate dep).
+  - Add `compute_cargo_prod_set(lock: &CargoLock,
+    direct_prod: HashSet<String>) -> HashSet<(String, String)>`
+    — BFS through `[[package]] dependencies = [...]` edges
+    starting from direct prod crate names, collecting
+    `(name, version)` tuples reachable through prod chains.
+    Returns the prod-reachable closure.
+  - Modify `parse_lockfile` to also accept the prod-set
+    parameter and tag `is_dev = Some(true)` on entries OUTSIDE
+    the prod set.
+  - Modify `read` to: (1) drop `_` from `include_dev`
+    parameter, (2) discover workspace manifests, (3) compute
+    prod set per workspace, (4) pass to lockfile parsing,
+    (5) drop tagged entries when `!include_dev`.
+
+- **`mikebom-cli/tests/scan_cargo.rs`** (~80 LOC)
+  - New integration test
+    `scan_cargo_dev_dependency_is_tagged_and_droppable` —
+    synthetic workspace with root `Cargo.toml` + dev-dep
+    + `Cargo.lock`. Default scan: dev-dep absent. With
+    `--include-dev`: dev-dep present + tagged.
+  - New integration test
+    `scan_cargo_build_dependency_is_treated_as_dev` —
+    `[build-dependencies]`-only crate gets tagged.
+  - New integration test
+    `scan_cargo_production_wins_over_dev` — crate reachable
+    via both prod and dev edges retained as prod.
+
+**Verification** (Commit 1):
+
+- New unit tests in `cargo.rs::tests` for `parse_cargo_toml`
+  and `compute_cargo_prod_set`.
+- 3 new integration tests pass.
+- Existing 8 cargo tests pass.
+- `cdx/spdx/spdx3` regression: simple-cargo fixture's golden
+  may shift if it has a dev-dep (audit during impl); regen if
+  needed.
+- Real-world smoke on the mikebom workspace:
+  `mikebom sbom scan --path /Users/mlieberman/Projects/mikebom`
+  default emits ≥ 5 fewer cargo components vs alpha.9 (per
+  SC-001).
+
+### Commit 2 — `feat(051/us2): gem development/test group tagging`
+
+**Touched files**:
+
+- **`mikebom-cli/src/scan_fs/package_db/gem.rs`** (~150 LOC)
+  - Extend `parse_gemfile_lock` to read group annotations
+    when present in the lock's `DEPENDENCIES` block (lines
+    133+). Add a `groups: HashMap<String, Vec<String>>`
+    field on `GemfileLockDocument` (gem name → groups).
+  - Add `parse_gemfile(path: &Path) -> HashMap<String, Vec<String>>`
+    — line-oriented scanner for `group :name do ... end`
+    blocks and inline `gem "...", group: :name`.
+    Best-effort; warn-and-skip on syntax outside the
+    canonical idioms.
+  - Add `parse_gemspec(path: &Path) -> HashMap<String, Vec<String>>`
+    — same scanner shape; matches
+    `s.add_dependency "..."` / `s.add_runtime_dependency
+    "..."` (prod) and `s.add_development_dependency "..."`
+    (dev).
+  - Add `compute_gem_prod_set(direct_prod: HashSet<String>,
+    lock: &GemfileLockDocument) -> HashSet<String>` — BFS
+    through `lock.specs` indent-6 transitive edges from
+    prod roots. Returns prod-reachable gem names.
+  - Modify `read` to: (1) drop `_` from `include_dev`,
+    (2) parse Gemfile.lock as today, (3) parse co-located
+    Gemfile + `*.gemspec`, (4) compute union prod set per
+    FR-006, (5) tag non-prod entries, (6) drop tagged when
+    `!include_dev`.
+
+- **`mikebom-cli/tests/scan_gem.rs`** (~80 LOC)
+  - New integration tests covering: lockfile group
+    annotations, Gemfile groups, gemspec dev deps, union
+    semantics with conflicting sources.
+
+**Verification** (Commit 2):
+
+- 4+ new integration tests pass.
+- Existing 3 gem tests pass.
+- Real-world smoke: synthetic Ruby fixture with mixed
+  Gemfile groups + gemspec dev deps emits ≥ 3 fewer
+  components in default mode.
+
+### Commit 3 — `feat(051/us3): maven dev-dep regression test + chore scaffolding`
+
+**Touched files**:
+
+- **`mikebom-cli/tests/scan_maven.rs`** (~30 LOC)
+  - New integration test
+    `scan_maven_test_scope_is_tagged_with_include_dev` —
+    synthetic Maven project with `<scope>test</scope>` dep.
+    With `--include-dev`: junit emits with
+    `mikebom:dev-dependency = true`. Without: junit absent.
+  - Regression guard against future refactors that might
+    inadvertently break the existing maven.rs:1823 wiring.
+
+- **`CHANGELOG.md`** (~10 LOC)
+  - `[Unreleased]` → `### Changed`: name the cargo + gem dev-
+    tagging, no behavior change for npm/Poetry/Pipfile/Maven,
+    no new flag/annotation/catalog-row.
+
+- **`specs/051-polyglot-dev-tagging/`** scaffolding
+  (spec/plan/tasks/checklists already authored; bundle
+  into this commit per the established 4-file pattern).
+
+**Verification** (Commit 3):
+
+- `pre-pr.sh` clean from a fresh shell.
+- 11/11 holistic_parity ok (existing C6 wiring picks up new
+  is_dev population automatically).
+- 27/27 byte-identity goldens pass after any audit-driven
+  regen.
+
+## Touched files
+
+| File | Commit | LOC |
+|---|---|---|
+| `mikebom-cli/src/scan_fs/package_db/cargo.rs` | 1 | +120 |
+| `mikebom-cli/tests/scan_cargo.rs` | 1 | +80 |
+| `mikebom-cli/src/scan_fs/package_db/gem.rs` | 2 | +150 |
+| `mikebom-cli/tests/scan_gem.rs` | 2 | +80 |
+| `mikebom-cli/tests/scan_maven.rs` | 3 | +30 |
+| `CHANGELOG.md` | 3 | +10 |
+| `specs/051-polyglot-dev-tagging/` | 3 | scaffolding |
+
+Total: ~470 LOC of Rust + scaffolding. Single PR, three
+commits ordered for review clarity.
+
+## Risks
+
+- **R1: Cargo workspace member traversal complexity.** Some
+  workspaces declare members via glob patterns
+  (`members = ["crates/*"]`). Implementation must resolve
+  these without a new crate dep (the existing path-walk
+  primitives suffice — see `cargo.rs::find_cargo_lockfiles`).
+  If glob complexity escalates, fall back to "scan every
+  `Cargo.toml` reachable under rootfs" — same effective
+  semantics for typical layouts.
+
+- **R2: Gemfile syntax edge cases.** Bundler accepts a wide
+  range of Ruby DSL forms (interpolation, conditional
+  loading, `eval_gemfile`). Spec-grade compliance would need
+  a Ruby parser. Decision per R2: best-effort line-scanner
+  matching the canonical idioms; warn-and-skip the rest.
+  If a downstream consumer reports a missed group, the lock
+  + gemspec sources usually catch it via the union semantics.
+
+- **R3: Golden churn on simple-cargo and simple-gem
+  fixtures.** Both fixtures may have dev/test deps — audit
+  during impl. If goldens shift, regen is mechanical (same
+  `MIKEBOM_UPDATE_*_GOLDENS=1` flow as milestone 049).
+
+- **R4: `--include-dev` flag interaction with the
+  milestone-049 Go path and milestone-050 not-linked
+  annotation**. The flag is shared across all ecosystems.
+  Verify during impl that toggling it doesn't disturb the
+  Go test-only / cache-zip / not-linked flows. The
+  `apply_go_production_set_filter` and
+  `apply_go_linked_filter` chains are independent of the
+  cargo/gem readers — confirmed via code inspection.
+
+## Out of scope
+
+- **Maven `<scope>provided</scope>` / `<scope>runtime</scope>`
+  tagging**: separate future milestone (potentially via a
+  new annotation parallel to `mikebom:not-linked`).
+- **Cargo `[features]` flag-gated deps**: a crate may be in
+  `[dependencies]` but conditional on a feature. Today's
+  Cargo.lock resolves features at lock-time and emits the
+  unioned closure — that's what mikebom reads. Per-feature
+  conditional tagging is out of scope.
+- **rpm `Recommends:` / `Suggests:` soft-dep tagging**:
+  semantically different from dev/test; no work.
+- **npm / Poetry / Pipfile**: already correctly tagged per
+  alpha.9 audit; no work.

--- a/specs/051-polyglot-dev-tagging/spec.md
+++ b/specs/051-polyglot-dev-tagging/spec.md
@@ -1,0 +1,321 @@
+# Feature Specification: Polyglot dev/test tagging — extend `mikebom:dev-dependency` to cargo and gem
+
+**Feature Branch**: `051-polyglot-dev-tagging`
+**Created**: 2026-05-01
+**Status**: Draft
+
+## Summary
+
+Milestone 049 established the polyglot pattern for Go: emit every
+lockfile entry as a component, tag test-only deps with
+`mikebom:dev-dependency = true`, drop them when `--include-dev=off`.
+Audit shows the pattern is already in place for several ecosystems:
+
+| Ecosystem | Status (alpha.9) |
+|---|---|
+| **npm** | ✅ devDependencies tagged + dropped on `--include-dev=off` |
+| **Poetry / Pipfile** | ✅ dev-dependencies tagged + dropped |
+| **Maven** | ✅ `<scope>test</scope>` tagged + dropped (`maven.rs:1786-1823`) |
+| **Go** | ✅ Milestone 049 (`_test.go` import-walk → tag + drop) |
+| **Cargo** | ❌ `_include_dev: bool` parameter is **unused**; `is_dev: None` always |
+| **Gem** | ❌ `_include_dev: bool` parameter is **unused**; `is_dev: None` always |
+
+This milestone closes the gap for **cargo** and **gem**. After it
+ships, every ecosystem mikebom supports will honor `--include-dev`
+consistently, and SBOM consumers will see the same
+`mikebom:dev-dependency = true` annotation everywhere a test/dev
+dep is present.
+
+## Clarifications
+
+### Session 2026-05-01
+
+- Q: Gem source of truth for group classification (lock-only vs.
+  lock+Gemfile vs. lock+Gemfile+gemspec)? → A: Lock + Gemfile +
+  `*.gemspec` (Option C — full coverage). Rationale: Ruby projects
+  vary across formats (apps use `Gemfile` groups; libraries use
+  `*.gemspec` `add_development_dependency`; older lockfiles don't
+  carry group annotations). Reading all three sources gives the
+  best classification accuracy. Production-wins-over-dev (FR-006)
+  resolves any conflicts when sources disagree.
+
+## User Scenarios & Testing
+
+### User Story 1 - Cargo dev/build deps tagged (Priority: P1)
+
+**As a developer scanning a Rust workspace**, when I run
+`mikebom sbom scan --path ./my-rust-project`, I want crates
+declared in `[dev-dependencies]` or `[build-dependencies]` of any
+`Cargo.toml` to carry `mikebom:dev-dependency = true` in the SBOM
+(or be dropped by default per the existing `--include-dev=off`
+semantics) — same as how npm devDependencies and Maven
+test-scope already work.
+
+**Why this priority**: Cargo is the most-impactful gap. Every
+non-trivial Rust project has dev-dependencies (criterion,
+proptest, mockall, tempfile-as-test-helper, etc.) plus build-
+dependencies (anything in `build.rs`'s build chain). Today they
+all show up as runtime deps in the SBOM. Audit-grounded:
+mikebom's own workspace lockfile has 12+ dev-dependencies that
+currently emit unmarked.
+
+**Independent Test**: Run `mikebom sbom scan --path
+<rust-project-with-dev-deps> --output sbom.cdx.json` (default
+mode). Assert: zero components carry the dev-dep crate names.
+Run again with `--include-dev`. Assert: those names appear AND
+each carries `mikebom:dev-dependency = true`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Rust project whose root `Cargo.toml` has
+   `[dev-dependencies] criterion = "0.5"` and a `Cargo.lock`
+   resolving criterion + its transitive closure,
+   **When** I run `mikebom sbom scan --path .` (default),
+   **Then** criterion and its dev-only transitives are absent
+   from the SBOM.
+
+2. **Given** the same project,
+   **When** I run `mikebom sbom scan --path . --include-dev`,
+   **Then** criterion and dev-only transitives appear AND each
+   carries `mikebom:dev-dependency = true`.
+
+3. **Given** a Rust workspace with a crate that's both a normal
+   dep AND a dev-dep transitively,
+   **When** I run any scan,
+   **Then** the crate is treated as a normal dep (production wins
+   over dev — same precedence rule as Go US2).
+
+4. **Given** a `[build-dependencies]`-only crate (e.g., a
+   build-script-only `cc` or `bindgen` use),
+   **When** I run any scan,
+   **Then** the crate is tagged `mikebom:dev-dependency = true`
+   (build-deps don't ship in the runtime artifact, so they belong
+   in the dev category for filtering purposes; same as how
+   `[dev-dependencies]` aren't shipped).
+
+---
+
+### User Story 2 - Gem development/test group tagged (Priority: P1)
+
+**As a developer scanning a Ruby project**, when I run
+`mikebom sbom scan --path ./my-ruby-app`, I want gems declared
+under `group :development` or `group :test` (or any non-default
+group like `:doc`, `:lint`) in the `Gemfile`/`Gemfile.lock` to
+carry `mikebom:dev-dependency = true` (or be dropped by default).
+
+**Why this priority**: Same impact shape as cargo. Every Rails/
+Sinatra/Hanami app has a substantial `:development` and `:test`
+group (rspec, factory_bot, pry, byebug, capybara, etc.).
+Currently these emit as runtime deps.
+
+**Independent Test**: Run `mikebom sbom scan --path
+<ruby-project>` (default). Assert: rspec / factory_bot / etc.
+are absent. Run with `--include-dev`. Assert: they appear with
+the dev-dep annotation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Ruby project with `Gemfile.lock` whose
+   `DEPENDENCIES` block includes `rspec` after `group :test do`
+   in the source `Gemfile`,
+   **When** I run `mikebom sbom scan --path .` (default),
+   **Then** rspec and its test-group-only transitives are absent.
+
+2. **Given** the same project,
+   **When** I run `mikebom sbom scan --path . --include-dev`,
+   **Then** rspec emits with `mikebom:dev-dependency = true`.
+
+3. **Given** a gem in BOTH a default group AND `:test`,
+   **When** I run any scan,
+   **Then** the gem is treated as a runtime dep (production wins).
+
+---
+
+### User Story 3 - Maven existing behavior is regression-tested (Priority: P2)
+
+**As an existing mikebom user scanning Java/Maven projects**,
+when this milestone ships, I want the existing
+`<scope>test</scope>` handling at `maven.rs:1786-1823` to be
+unchanged: test-scope deps are dropped on default, tagged on
+`--include-dev`. No regression.
+
+**Why this priority**: Maven already works correctly per
+audit; adding regression coverage just guards the contract.
+
+**Independent Test**: Existing maven integration tests pass
+unchanged. Add one new explicit assertion that
+`<scope>test</scope>` deps carry `mikebom:dev-dependency = true`
+when `--include-dev` is set.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Maven project with a test-scope dep (junit),
+   **When** I run `mikebom sbom scan --path . --include-dev`,
+   **Then** junit emits with `mikebom:dev-dependency = true`
+   AND its component count is unchanged from alpha.9 baseline.
+
+---
+
+### Edge Cases
+
+- **Cargo workspace with mixed dev/non-dev usage across
+  member crates**: a crate that's a dev-dep of crate A but a
+  normal dep of crate B should be PRODUCTION (production wins,
+  same as Go US2). This requires a workspace-wide BFS, not
+  per-Cargo.toml local analysis.
+- **Cargo `target."cfg(...)".dev-dependencies`** (target-
+  conditional dev deps): tag as dev (same semantic as
+  unconditional `[dev-dependencies]`).
+- **Gem `gemspec` development_dependencies vs Gemfile groups
+  vs lock annotations**: per Q1 / FR-004, all three sources are
+  read and unioned (with production winning conflicts). Library
+  gems shipping only a `*.gemspec` get tagged via
+  `add_development_dependency` calls; apps using `Gemfile` get
+  tagged via `group :foo do ... end` blocks; modern Bundler
+  apps additionally benefit from lock-side group annotations.
+- **Gem with no group annotation anywhere**: default group =
+  production. Untagged. Same default semantic as before.
+- **Maven `<scope>provided</scope>`**: out of scope — these
+  are present at compile time but not bundled at runtime.
+  They're conceptually similar to Go's `mikebom:not-linked`
+  (milestone 050). Tracked as a separate future milestone.
+- **Maven `<optional>true</optional>`**: out of scope — already
+  handled correctly per current maven.rs; no behavior change.
+- **rpm `Recommends:` / `Suggests:`**: out of scope — soft
+  runtime deps, not dev-deps in this sense.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001 (Cargo)**: When the cargo reader walks a Rust
+  project, every crate reachable ONLY through
+  `[dev-dependencies]` or `[build-dependencies]` edges (across
+  all `Cargo.toml` files in the workspace) MUST be tagged
+  `is_dev = Some(true)` in its `PackageDbEntry`.
+- **FR-002 (Cargo)**: When `include_dev = false`, tagged
+  cargo entries MUST be dropped (mirrors maven.rs's existing
+  pattern at lines 1786-1823).
+- **FR-003 (Cargo)**: A crate reachable from BOTH a normal-dep
+  edge AND a dev/build-dep edge MUST be tagged production
+  (production wins). This requires the same set-union semantics
+  as Go US2 / npm prod-vs-dev.
+- **FR-004 (Gem)**: When the gem reader walks a Ruby project,
+  every gem the union of three sources classifies as
+  development/test MUST be tagged `is_dev = Some(true)`. The
+  three sources, in priority order:
+    1. **`Gemfile.lock`** `DEPENDENCIES` block — newer Bundler
+       versions emit group annotations directly; honor them when
+       present.
+    2. **`Gemfile`** — parse `group :name do ... end` blocks
+       and inline `gem "...", group: :name` syntax. Authoritative
+       when the lockfile is too old to carry group metadata.
+    3. **`*.gemspec`** at the project root — parse
+       `s.add_development_dependency "..."` invocations.
+       Authoritative for library-style gems that don't ship a
+       `Gemfile`.
+  Transitive gems reachable ONLY from grouped roots MUST also be
+  tagged. Group names other than the default (`:default`) all
+  count as dev for filtering purposes (`:development`, `:test`,
+  `:doc`, `:lint`, custom groups, etc.).
+- **FR-005 (Gem)**: When `include_dev = false`, tagged gem
+  entries MUST be dropped.
+- **FR-006 (Gem)**: A gem classified as production by ANY of
+  the three sources MUST be tagged production, even if another
+  source classifies it as dev (production wins, mirroring the
+  Go US2 / npm rule). Sources are unioned for prod evidence,
+  intersected for dev evidence.
+- **FR-007 (Maven)**: Existing test-scope behavior at
+  `maven.rs:1786-1823` MUST be unchanged. The new milestone
+  test in `tests/scan_maven.rs` MUST explicitly assert
+  `mikebom:dev-dependency = true` appears when `--include-dev`
+  is set.
+- **FR-008**: Existing 27 byte-identity goldens MUST stay
+  byte-identical UNLESS the underlying fixture exercises
+  dev/test deps. Audit during implementation: regenerate ONLY
+  fixtures with dev/test signals, leave others untouched.
+- **FR-009**: All 11 holistic_parity tests MUST continue to
+  pass — the existing C6 (`mikebom:dev-dependency`) parity
+  wiring picks up the new cargo/gem tagging automatically.
+- **FR-010**: No new flag, no new annotation, no new catalog
+  row. This milestone is pure additive population on the
+  existing C6 infrastructure.
+
+### Key Entities
+
+- **`PackageDbEntry.is_dev: Option<bool>`** (existing): set to
+  `Some(true)` on tagged cargo / gem entries.
+- **Cargo workspace dep graph**: built from all `Cargo.toml`
+  files (root + workspace members) + `Cargo.lock` resolved
+  package list. BFS produces the prod-reachable set; cargo
+  entries NOT in that set are dev/build.
+- **Gem grouping signals** (multi-source per FR-004):
+  - **`Gemfile.lock` `DEPENDENCIES`**: newer Bundler emits
+    group annotations inline.
+  - **`Gemfile`**: `group :name do ... end` blocks and inline
+    `gem "...", group: :name` syntax.
+  - **`*.gemspec`** at project root:
+    `s.add_development_dependency` invocations.
+  Direct-dep grouping flows transitively through the lockfile's
+  `specs:` indent-6 edges (existing parser).
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001 (Cargo)**: Scanning the mikebom-self workspace
+  (`/Users/mlieberman/Projects/mikebom`) in default mode emits
+  ≥ 5 fewer components than alpha.9 (the existing
+  `[dev-dependencies]` get dropped).
+- **SC-002 (Cargo)**: Scanning the same workspace with
+  `--include-dev` emits the same component count as alpha.9
+  AND ≥ 5 components carry `mikebom:dev-dependency = true`.
+- **SC-003 (Gem)**: Scanning a typical Ruby project with
+  `group :development` and `group :test` emits ≥ 3 fewer
+  components in default mode vs alpha.9.
+- **SC-004 (Gem)**: Same project with `--include-dev` emits
+  the alpha.9 count with the new components tagged.
+- **SC-005 (Maven)**: All existing maven integration tests
+  pass unchanged.
+- **SC-006**: 27 byte-identity goldens pass after regen (any
+  cargo/gem fixture with dev-deps will see component count
+  drop in default-mode goldens; non-dev-affected ecosystems
+  unchanged).
+- **SC-007**: 11/11 holistic_parity passes — the C6 row's
+  existing parity wiring picks up cargo/gem `is_dev`
+  population automatically.
+- **SC-008**: At least one new integration test per ecosystem
+  (cargo, gem, maven regression) covers the dev-tagging path.
+- **SC-009**: `pre-pr.sh` clean.
+- **SC-010**: 3 CI lanes green.
+
+## Assumptions
+
+- The milestone-049 `--include-dev` pattern is the right shape
+  for cargo and gem (same as it was for Go and the others).
+  Validated by the user's verbatim ask to extend the pattern
+  ("cargo, maven, gem, etc.") and the existing parallel wiring
+  for npm/Poetry/Pipfile/Maven.
+- "Production wins over dev" is the correct precedence when a
+  module is reachable from both — same rule as milestone 049
+  US2 (`scan_go_source_production_and_test_import_dominates`).
+  An SBOM consumer trying to filter dev-deps wants conservative
+  retention; a transitively-prod dep should never be silently
+  dropped just because it's also reachable through a dev edge.
+- `[build-dependencies]` are tagged dev (not in shipped
+  binary). Per the cargo book, build-deps are only present at
+  compile time, not in the resulting binary — same semantic as
+  dev-deps for SBOM filtering.
+- Cargo workspace dep-graph traversal stays in-process
+  (parsing `Cargo.toml` files directly + `Cargo.lock`'s
+  resolved list); no `cargo metadata` shell-out. Mikebom
+  is a Rust binary that doesn't depend on a host cargo install.
+- Maven `<scope>provided</scope>` and `<scope>runtime</scope>`
+  enhancements are out of scope — separate future milestone
+  (potentially via a new annotation parallel to milestone 050's
+  `mikebom:not-linked`).
+- npm / Poetry / Pipfile dev-dep handling is already correct
+  (alpha.9 audit: `--include-dev` flag is honored, dev-deps
+  carry C6 annotation when emitted). No work needed here.
+- rpm `Recommends:` / `Suggests:` are NOT dev-deps in the
+  same sense — they're soft runtime deps. Out of scope.

--- a/specs/051-polyglot-dev-tagging/tasks.md
+++ b/specs/051-polyglot-dev-tagging/tasks.md
@@ -1,0 +1,187 @@
+---
+description: "Task list — milestone 051 polyglot dev/test tagging (cargo + gem + maven regression)"
+---
+
+# Tasks: Polyglot dev/test tagging — `mikebom:dev-dependency` for cargo and gem
+
+**Input**: spec.md ✅, plan.md ✅, checklists/requirements.md ✅. (No
+research.md / data-model.md / contracts/ / quickstart.md — same
+4-file tighter template milestones 047/048/049/050 use; plan
+resolves the integration-point lookups inline in §Phase 0.)
+
+**Tests**: explicitly requested in the spec (SC-008 — at least one
+integration test per ecosystem). Inline unit tests for the new
+helpers; integration tests in `tests/scan_cargo.rs`,
+`tests/scan_gem.rs`, `tests/scan_maven.rs`.
+
+**Organization**: Three user stories, three commits (one per
+ecosystem). US1 cargo (P1) and US2 gem (P1) ship behavior change;
+US3 maven (P2) ships a regression-guard test only.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+---
+
+## Phase 1: Setup
+
+- [X] T001 Branch `051-polyglot-dev-tagging` created (via /speckit.specify auto-allocation; rebased onto main `9f8302c` after milestone 050 merge).
+- [X] T002 Spec.md + plan.md authored, /speckit.clarify resolved gem source-of-truth (Q1 → Option C, lock + Gemfile + gemspec).
+- [X] T003 Baseline `./scripts/pre-pr.sh` clean from a fresh shell (should pass since no edits yet).
+
+---
+
+## Phase 2: Foundational
+
+(No foundational tasks — every change in this milestone lives in
+the per-ecosystem readers and their integration tests. The shared
+infrastructure — `is_dev: Option<bool>` field + `--include-dev`
+flag + C6 catalog row + parity-extractor wiring + CDX/SPDX
+emission paths — is already in place per Phase 0 R5. This
+milestone is pure additive population on existing infrastructure.)
+
+---
+
+## Phase 3: Commit `feat(051/us1)` — Cargo dev/build dep tagging
+
+**Goal**: Crates declared in `[dev-dependencies]` or
+`[build-dependencies]` of any `Cargo.toml` in the workspace get
+tagged `is_dev = Some(true)`. When `--include-dev=off`, tagged
+entries are dropped (mirrors maven.rs:1786-1823 + milestone 049
+Go pattern).
+
+**Independent test**: SC-001 (≥5 fewer cargo components on the
+mikebom workspace default scan), SC-002 (≥5 carrying
+`mikebom:dev-dependency = true` with `--include-dev`).
+
+### Cargo reader extensions
+
+- [X] T004 [US1] Add a `CargoTomlSections` struct to `mikebom-cli/src/scan_fs/package_db/cargo.rs` holding three fields: `prod_deps: HashSet<String>`, `dev_deps: HashSet<String>`, `build_deps: HashSet<String>`. Each set holds the crate names declared in the corresponding `Cargo.toml` section.
+- [X] T005 [US1] Add `parse_cargo_toml(path: &Path) -> Option<CargoTomlSections>` to `cargo.rs`. Use the existing `toml` crate (already in deps) to parse the file. Iterate the `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]` tables AND every `target.<cfg>.{dependencies,dev-dependencies,build-dependencies}` table by walking the parsed `toml::Table`. Per R3: warn-and-skip on parse error (return `None` rather than abort the scan).
+- [X] T006 [P] [US- [ ] T006 [P] [US1]1] Add inline unit tests in `cargo.rs::tests` for `parse_cargo_toml`: (a) basic three-section split correctly populates the three HashSets; (b) `target."cfg(unix)".dev-dependencies` entries land in `dev_deps`; (c) malformed TOML returns `None`; (d) absent sections produce empty sets, not failure.
+- [X] T007 [US1] Add `discover_workspace_manifests(rootfs: &Path) -> Vec<PathBuf>` to `cargo.rs`. For each `Cargo.lock` already discovered by `find_cargo_lockfiles`, find its sibling `Cargo.toml`. If the root `Cargo.toml` declares `[workspace] members = [...]`, resolve each member entry (handle simple glob patterns like `crates/*` via the existing path-walk; no new crate dep) and include each member's `Cargo.toml`. Per R1: fallback to "scan every `Cargo.toml` reachable under rootfs" if glob handling escalates.
+- [X] T008 [US1] Add `compute_cargo_prod_set(lock: &CargoLock, direct_prod: HashSet<String>) -> HashSet<(String, String)>` to `cargo.rs`. BFS-walk: seed = the resolved `(name, version)` tuples of every package whose name is in `direct_prod`. Frontier expansion: each visited package's `dependencies = ["bar 1.0 (registry+...)"]` array; parse each dep string to extract the name, look it up in the lockfile's package list, push to frontier. Returns the closed prod-reachable set of `(name, version)` tuples.
+- [X] T009 [P] [US- [ ] T009 [P] [US1]1] Inline unit tests for `compute_cargo_prod_set`: (a) single-level prod chain returns just direct deps; (b) 3-level chain returns full closure; (c) production-wins-over-dev — a crate reachable from both prod and dev edges is in prod set; (d) empty seed returns empty.
+- [X] T010 [US1] Modify `parse_lockfile` in `cargo.rs` to accept a `prod_set: &HashSet<(String, String)>` parameter. For each `[[package]]` entry, when emitting the `PackageDbEntry`, set `is_dev: prod_set.contains(&(name, version)).not().then_some(true)`. Lockfile-only path (when no Cargo.toml is found alongside) keeps the existing `is_dev: None` (can't classify without dep-section info).
+- [X] T011 [US1] Modify `pub fn read` in `cargo.rs`: drop the `_` from `_include_dev`, threading the real flag through. Steps: (1) discover workspace manifests via T007; (2) for each lockfile, parse the corresponding manifest set via T005, union all sections to get this workspace's direct-prod and direct-dev/build sets; (3) call T008 to compute the prod-reachable closure; (4) pass to T010's modified `parse_lockfile`; (5) when `!include_dev`, drop entries with `is_dev == Some(true)`. Mirrors the milestone 049 pattern at `package_db/mod.rs::apply_go_production_set_filter`.
+
+### Cargo integration tests
+
+- [X] T012 [P] [US- [ ] T012 [P] [US1]1] Add `scan_cargo_dev_dependency_is_tagged_and_droppable` to `mikebom-cli/tests/scan_cargo.rs`. Synthetic workspace with root `Cargo.toml` declaring `[dev-dependencies] criterion = "0.5"`, plus a `Cargo.lock` listing criterion + at least one of its transitive deps. Default scan: assert criterion absent. With `--include-dev`: assert criterion present AND its `properties[]` carry `mikebom:dev-dependency = "true"`.
+- [X] T013 [P] [US- [ ] T013 [P] [US1]1] Add `scan_cargo_build_dependency_is_treated_as_dev` to `tests/scan_cargo.rs`. Synthetic crate with `[build-dependencies] cc = "1"` only (no normal/dev section for cc). Default scan: cc absent. With `--include-dev`: cc tagged.
+- [X] T014 [P] [US- [ ] T014 [P] [US1]1] Add `scan_cargo_production_wins_over_dev` to `tests/scan_cargo.rs`. Synthetic project where crate `foo` appears in BOTH `[dependencies]` and `[dev-dependencies]`. Either-mode scan: foo present, NOT tagged (production wins per FR-003).
+- [X] T015 [P] [US- [ ] T015 [P] [US1]1] Add `scan_cargo_workspace_member_dev_dep_is_tagged` to `tests/scan_cargo.rs`. Synthetic 2-crate workspace where only the workspace member crate has a dev-dep. Default scan: dev-dep absent. With `--include-dev`: tagged.
+
+### Verify + commit
+
+- [X] T016 [US1] `cargo +stable test -p mikebom --test scan_cargo` — all 4 new + existing 8 tests pass.
+- [X] T017 [US1] `cargo +stable test -p mikebom --bin mikebom -- package_db::cargo` — new unit tests for `parse_cargo_toml` + `compute_cargo_prod_set` pass.
+- [X] T018 [US1] Real-world smoke: `cargo +stable build -p mikebom && ~/Projects/mikebom/target/debug/mikebom sbom scan --path /Users/mlieberman/Projects/mikebom --output /tmp/mb051-cargo-default.cdx.json`. Default scan: `jq '[.components[] | select(.purl | startswith("pkg:cargo"))] | length'` returns ≥ 5 fewer cargo components than alpha.9 baseline (per SC-001). Repeat with `--include-dev`: count back to alpha.9 level AND ≥ 5 components carry `mikebom:dev-dependency = "true"` (per SC-002).
+- [X] T019 [US1] Audit goldens: if `mikebom-cli/tests/fixtures/cargo/`'s fixture has dev-deps, run `MIKEBOM_UPDATE_*_GOLDENS=1 cargo +stable test -p mikebom --test cdx_regression cargo_byte_identity --test spdx_regression cargo_byte_identity --test spdx3_regression cargo_byte_identity` and inspect the diff. Otherwise no regen needed.
+- [X] T020 [US1] `cargo +stable test -p mikebom --test holistic_parity` — 11/11 ok (existing C6 wiring picks up new cargo `is_dev` population automatically).
+- [X] T021 [US1] Commit: `feat(051/us1): cargo dev/build dep tagging via Cargo.toml [dev-dependencies] + [build-dependencies]`.
+
+---
+
+## Phase 4: Commit `feat(051/us2)` — Gem development/test group tagging
+
+**Goal**: Gems classified as development/test by Gemfile.lock,
+Gemfile, OR `*.gemspec` (union semantics per FR-006) get tagged
+`is_dev = Some(true)`. Drop on `--include-dev=off`.
+
+**Independent test**: SC-003 (≥3 fewer gem components on a typical
+Ruby project default scan), SC-004 (alpha.9 count back with
+`--include-dev` AND tagged components).
+
+### Gem reader extensions
+
+- [X] T022 [US2] Extend `GemfileLockDocument` in `mikebom-cli/src/scan_fs/package_db/gem.rs` with `groups: HashMap<String, Vec<String>>` (gem name → group names). Extend `parse_gemfile_lock` (lines 82-200ish) to read optional `group:` continuation lines under `DEPENDENCIES` entries (newer Bundler emits them; older locks omit). When absent, the gem maps to no groups (default = production).
+- [X] T023 [US2] Add `parse_gemfile(path: &Path) -> HashMap<String, Vec<String>>` to `gem.rs`. Line-oriented scanner per R2. Track `group :name [, :name2] do` block context; emit each `gem "name"` inside the block into all listed groups. Handle inline `gem "name", group: :foo` and `gem "name", groups: [:foo, :bar]`. Best-effort — warn-and-skip lines outside the canonical idioms (interpolation, `eval_gemfile`, conditional loading). Default group (no enclosing block, no inline keyword) = empty group list = production.
+- [X] T024 [US2] Add `parse_gemspec(path: &Path) -> HashMap<String, Vec<String>>` to `gem.rs`. Line-oriented scanner. Match `s.add_dependency "..."` and `s.add_runtime_dependency "..."` (emit gem name with empty group list = production); match `s.add_development_dependency "..."` (emit gem name with `["development"]`). Other DSL forms warn-and-skip per R2.
+- [X] T025 [P] [US- [ ] T025 [P] [US2]1] Inline unit tests in `gem.rs::tests` for: (a) lockfile group annotations parsed correctly when present, gracefully ignored when absent; (b) `parse_gemfile` extracts `group :test do; gem "rspec"; end` and `gem "pry", group: :development`; (c) `parse_gemspec` extracts `add_development_dependency` calls; (d) all three return empty maps for nonexistent / unparseable input.
+- [X] T026 [US2] Add `compute_gem_prod_set(direct_prod: &HashSet<String>, lock: &GemfileLockDocument) -> HashSet<String>` to `gem.rs`. BFS through `lock.specs`'s indent-6 transitive edges starting from `direct_prod` gem names. Returns prod-reachable gem name set. Inline test: 3-level chain produces full closure.
+- [X] T027 [US2] Modify `pub fn read` in `gem.rs`: drop the `_` from `_include_dev`. Per FR-006 (production-wins union): for each Gemfile.lock found, locate co-located Gemfile + `*.gemspec` files; parse all three; compute the merged grouping map (a gem listed as prod in ANY source counts as prod); seed `direct_prod` from gems with empty / no-group classification; compute prod-reachable closure via T026; tag entries NOT in prod set with `is_dev = Some(true)`; drop tagged entries when `!include_dev`.
+
+### Gem integration tests
+
+- [X] T028 [P] [US- [ ] T028 [P] [US2]1] Add `scan_gem_lockfile_group_annotation_is_tagged` to `mikebom-cli/tests/scan_gem.rs`. Synthetic Ruby project with newer-Bundler-style Gemfile.lock carrying `group: test` on rspec. Default: rspec absent. `--include-dev`: tagged.
+- [X] T029 [P] [US- [ ] T029 [P] [US2]1] Add `scan_gem_gemfile_groups_are_tagged` to `tests/scan_gem.rs`. Synthetic project with older Gemfile.lock (no group annotations) + Gemfile declaring `group :development do; gem "pry"; end`. Default: pry absent. `--include-dev`: tagged.
+- [X] T030 [P] [US- [ ] T030 [P] [US2]1] Add `scan_gem_gemspec_dev_deps_are_tagged` to `tests/scan_gem.rs`. Synthetic library project with `*.gemspec` calling `add_development_dependency "rspec"` and Gemfile.lock listing rspec. Default: rspec absent. `--include-dev`: tagged.
+- [X] T031 [P] [US- [ ] T031 [P] [US2]1] Add `scan_gem_production_wins_over_dev` to `tests/scan_gem.rs`. Project where Gemfile says `gem "json", group: :test` AND gemspec says `add_dependency "json"`. Either-mode scan: json present, NOT tagged (FR-006 union semantic).
+
+### Verify + commit
+
+- [X] T032 [US2] `cargo +stable test -p mikebom --test scan_gem` — all 4 new + existing 3 tests pass.
+- [X] T033 [US2] `cargo +stable test -p mikebom --bin mikebom -- package_db::gem` — new unit tests pass.
+- [X] T034 [US2] Audit `mikebom-cli/tests/fixtures/gem/`'s fixture for dev-group entries; if present, regen the gem golden across all 3 formats. Otherwise no regen.
+- [X] T035 [US2] `cargo +stable test -p mikebom --test holistic_parity` — 11/11 ok.
+- [X] T036 [US2] Commit: `feat(051/us2): gem development/test group tagging via Gemfile.lock + Gemfile + gemspec union`.
+
+---
+
+## Phase 5: Commit `feat(051/us3)` — Maven regression guard + chore scaffolding
+
+**Goal**: Add an explicit integration test asserting maven's
+existing test-scope tagging behavior (zero code change). Bundle
+CHANGELOG entry + speckit scaffolding into the same commit per
+the 4-file pattern.
+
+**Independent test**: SC-005 (existing maven tests pass unchanged
++ new test asserts `mikebom:dev-dependency = true` appears on
+test-scope deps when `--include-dev`).
+
+### Maven regression test
+
+- [X] T037 [US3] Add `scan_maven_test_scope_is_tagged_with_include_dev` to `mikebom-cli/tests/scan_maven.rs`. Synthetic Maven project with a pom.xml declaring `<dependency><groupId>junit</groupId><artifactId>junit</artifactId><version>4.13.2</version><scope>test</scope></dependency>` plus a runtime-scope dep. Default: junit absent. `--include-dev`: junit present AND `properties[]` carry `mikebom:dev-dependency = "true"`. Regression guard against future refactors of `maven.rs:1786-1823`.
+
+### CHANGELOG + scaffolding
+
+- [ ] T038 [US3] Edit `CHANGELOG.md` `[Unreleased]` → `### Changed`: name the cargo + gem dev-dep tagging, the gem 3-source union semantics (lock + Gemfile + gemspec, prod wins), the maven regression-guard test addition, and call out: no behavior change for npm/Poetry/Pipfile/Maven, no new flag/annotation/catalog-row.
+- [ ] T039 [US3] Stage `specs/051-polyglot-dev-tagging/` (spec.md, plan.md, tasks.md, checklists/requirements.md) and `CLAUDE.md` (auto-updated by `update-agent-context.sh` during /speckit.plan).
+- [X] T040 [US3] `cargo +stable test -p mikebom --test scan_maven` — all existing maven tests + new test pass.
+
+### Verify + commit
+
+- [ ] T041 [US3] `./scripts/pre-pr.sh` clean.
+- [ ] T042 [US3] Commit: `feat(051/us3): maven test-scope dev-dep regression test + chore scaffolding`.
+
+---
+
+## Phase 6: PR
+
+- [ ] T043 Verify final `./scripts/pre-pr.sh` clean from a fresh shell.
+- [ ] T044 Push branch: `git push -u origin 051-polyglot-dev-tagging`.
+- [ ] T045 Open PR titled `feat(051): polyglot dev/test tagging — cargo + gem dev-dep tagging via mikebom:dev-dependency`. Body covers: 3-commit summary, the alpha.9 audit gap (cargo + gem `_include_dev` underscore-prefixed unused), gem 3-source union design, audit-grounded numbers (mikebom workspace ≥5 cargo dev-deps; typical Ruby project ≥3 gem dev-deps), 10-SC verification commands, link to the milestone-049 precedent.
+- [ ] T046 Verify SC-010: 3 CI lanes (linux x86_64, linux ebpf, macos-latest) green on the PR.
+
+---
+
+## Dependencies
+
+- **Phase 1 (Setup)** blocks all subsequent phases.
+- **Phase 2 (Foundational)** is a no-op; no blocking work.
+- **Phase 3 (US1 cargo)** independent of US2 / US3 — can be implemented in any order or in parallel by different agents.
+- **Phase 4 (US2 gem)** independent of US1 / US3.
+- **Phase 5 (US3 maven)** independent of US1 / US2 — but the CHANGELOG entry should reference all three so the commit naturally lands last in the PR sequence.
+- **Phase 6 (PR)** blocked on Phases 3 + 4 + 5 all complete.
+
+## Parallel execution opportunities
+
+Within Phase 3:
+
+- T006 (cargo unit tests for `parse_cargo_toml`) ‖ T009 (cargo unit tests for `compute_cargo_prod_set`) ‖ T012-T015 (cargo integration tests) — all touch test files only and have no dependencies on incomplete tasks.
+
+Within Phase 4:
+
+- T025 (gem unit tests) ‖ T028-T031 (gem integration tests) — all parallel.
+
+Cross-phase:
+
+- US1 and US2 are fully independent. Two agents could work T004-T021 (cargo) and T022-T036 (gem) simultaneously without conflict.
+
+## Implementation strategy
+
+**MVP scope**: T004-T011 (cargo reader extensions). Once that lands locally, the user gets the milestone's biggest impact (cargo is the most-touched ecosystem on this codebase). T012-T021 add the test coverage and verification.
+
+**Incremental delivery**: Each user story phase produces a runnable mikebom that improves cargo / gem / maven separately. The commits are structured so any subset can ship as a partial milestone if scope shrinks.
+
+**Format validation**: All 46 tasks follow the strict checklist format — checkbox `- [ ]` (or `- [X]` for completed setup), Task ID `T###`, optional `[P]` for parallelizable, `[US#]` for user-story phases (omitted in setup/polish), description with explicit file paths.


### PR DESCRIPTION
## Summary

Closes the alpha.9 audit gap where cargo and gem readers had `_include_dev: bool` parameters underscore-prefixed (unused) and emitted every lockfile entry as a runtime dep. After this PR, every ecosystem mikebom supports honors `--include-dev` consistently via the shared C6 `mikebom:dev-dependency` parity wiring.

| Ecosystem | Pre-051 | Post-051 |
|---|---|---|
| **npm** | ✅ already correct | ✅ unchanged |
| **Poetry / Pipfile** | ✅ already correct | ✅ unchanged |
| **Maven** | ✅ already correct (`maven.rs:1786-1823`) | ✅ + new regression test |
| **Go** | ✅ milestone 049 | ✅ unchanged |
| **Cargo** | ❌ `is_dev: None` always | ✅ tagged via Cargo.toml workspace BFS |
| **Gem** | ❌ `is_dev: None` always | ✅ tagged via lock + Gemfile + gemspec union |

## Three commits

1. **`feat(051/us1): cargo dev/build dep tagging`** — new `parse_cargo_toml`, `discover_workspace_manifests` (with `members = ["crates/*"]` glob), `compute_cargo_prod_set` BFS. Workspace-wide classification: a crate reachable only via `[dev-dependencies]` or `[build-dependencies]` from any member crate gets tagged + dropped on `--include-dev=off`. Production-wins-over-dev. **Smoke on the mikebom workspace: 524 → 505 components default (19 dropped); `--include-dev` recovers all 524 with the dev set carrying the annotation.**

2. **`feat(051/us2): gem development/test group tagging`** — three-source union (lock + Gemfile + gemspec) per Q1 clarification. New `parse_gemfile` (group blocks + inline `group:` keyword), `parse_gemspec_groups` (`add_development_dependency`), `merge_groups` (prod-wins union). BFS through lockfile transitive edges from prod-direct roots.

3. **`feat(051/us3): maven regression test + chore scaffolding`** — zero behavior change. New `scan_maven_test_scope_is_tagged_with_include_dev` asserts the contract against future refactors. Bundles CHANGELOG entry + speckit scaffolding.

## Verification

- [X] `./scripts/pre-pr.sh` clean (clippy `--all-targets` zero errors; full workspace tests `ok. N passed; 0 failed`)
- [X] **9/9 `tests/scan_cargo.rs`** (5 existing + 4 new)
- [X] **7/7 `tests/scan_gem.rs`** (3 existing + 4 new)
- [X] **8/8 `tests/scan_maven.rs`** (7 existing + 1 new regression guard)
- [X] **28/28 cargo unit tests** + **29/29 gem unit tests**
- [X] **27/27 byte-identity goldens unchanged**
- [X] **11/11 holistic_parity ok** — existing C6 wiring picks up the new is_dev population automatically
- [X] Real-world cargo smoke on the mikebom workspace: 524 → 505 default, 19 dev-tagged with `--include-dev`
- [ ] CI: 3 lanes green

## Out of scope (future milestones)

- Maven `<scope>provided</scope>` / `<scope>runtime</scope>` (parallel to milestone 050's `mikebom:not-linked`)
- Cargo `[features]` flag-gated dep classification
- rpm `Recommends:` / `Suggests:` soft-deps (semantically different)

🤖 Generated with [Claude Code](https://claude.com/claude-code)