### PR TITLE
release: bump workspace to v0.1.0-alpha.10 + regen 27 byte-identity goldens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,254 +7,113 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 
 ## [Unreleased]
 
-### Fixed
+_No unreleased changes since v0.1.0-alpha.10._
 
-- **Filesystem-walker symlink-loop hang on real-world projects**
-  (milestone 054). `mikebom sbom scan --path <project>` would hang
-  at 100% CPU indefinitely on any repo containing intentional
-  symlink-loop test fixtures (e.g., knative/func @
-  `knative-v1.22.0` ships `pkg/oci/testdata/test-links/linkToRoot ->
-  .` plus parent-loop variants). Root cause: `rpm_file::walk_dir`
-  and `binary/discover::walk_dir` followed symlinks via
-  `path.is_dir()` (which dereferences) with no visited-set or
-  depth limit. Closes #102 (the second time — the first close was
-  the milestone 053 main-module-edge fix; this one closes the
-  walker-hang shape that the original repro also exhibited).
 
-  Per-walker hardening: every `fn walk*` in
-  `mikebom-cli/src/scan_fs/` now has either (a) a canonicalize-
-  keyed visited-set + max-depth backstop, or (b) an explicit
-  `// SAFETY:` comment naming an `entry.file_type()` lstat-skip
-  protection. Audit-gate via
-  `grep -rn "fn walk" mikebom-cli/src/scan_fs/`. New
-  `tests/scan_walker_loops.rs` integration test exercises a
-  knative/func-style fixture end-to-end (4 symlink loops in 4
-  different shapes).
 
-  Regression-prevention: new
-  `.github/workflows/realistic-projects.yml` clones knative/func
-  at the pinned tag per CI run (cached via `actions/cache@v4`)
-  and scans it on linux-x86_64 + macos-latest, asserting scan
-  duration is bounded AND the resulting SBOM has ≥ 200 components.
-  Future per-ecosystem expansion (cargo, npm, maven, pip, gem,
-  rpm, deb, apk) tracked in #109.
+## [0.1.0-alpha.10] — 2026-05-02
 
-  Migration to a single shared `safe_walk` helper (vs. the per-
-  walker patches landed here) deferred to #108.
+A larger release covering seven milestones shipped since alpha.9
+(~1 day later): three breaking changes to SBOM output shape PLUS
+a critical hang fix that SBOM consumers should review before
+upgrading.
 
-### Changed (BREAKING — Go SBOM shape, milestone 053)
+### Headline changes
 
-- **Go source-tree scans now emit a synthetic main-module component**
-  representing the workspace root, with direct `dependsOn` edges to
-  every `require` in the project's `go.mod`. Closes issue #102: a
-  fresh-clone Go scan with empty GOMODCACHE, which pre-053 produced
-  an SBOM with **zero `DEPENDS_ON` edges**, now produces ≥ N edges
-  where N is the count of direct requires in `go.mod`. Matches
-  trivy + syft's pattern.
+- **Filesystem-walker symlink-loop hang fixed.** Pre-054
+  `mikebom sbom scan --path <project>` hung at 100% CPU
+  indefinitely on any repo containing intentional symlink-loop
+  test fixtures (e.g., knative/func @ `knative-v1.22.0` ships
+  `pkg/oci/testdata/test-links/linkToRoot -> .` plus parent-loop
+  variants). Root cause: `rpm_file::walk_dir` and
+  `binary/discover::walk_dir` followed symlinks via
+  `path.is_dir()` with no visited-set or depth limit. Per-walker
+  hardening now applies a canonicalize-keyed visited-set + max-
+  depth backstop to every walker in `mikebom-cli/src/scan_fs/`.
+  New `realistic-projects.yml` CI workflow clones knative/func
+  per CI run as a regression gate. (Milestone 054; PR #110.)
 
-  - **Native-field placement** per Constitution Principle V (v1.4.0):
-    - **CycloneDX 1.6**: the main-module is the `metadata.component`
-      with `type: "application"`, NOT a sibling in `components[]`.
-      Edges from the main-module to direct requires use
-      `dependencies[]` keyed by `metadata.component.bom-ref`.
-    - **SPDX 2.3**: the main-module is a regular `packages[]` entry
-      with `primaryPackagePurpose: "APPLICATION"`. The document's
-      `documentDescribes` array and `SPDXRef-DOCUMENT DESCRIBES`
-      relationship target the main-module's SPDXID.
-    - **SPDX 3.0.1**: the main-module element carries
-      `software_primaryPurpose: "application"`.
-  - **Supplementary `mikebom:component-role: main-module`** (catalog
-    row C40) attached to all three formats as backwards-compat /
-    finer-grained signal layered on top of the native fields.
-  - **Version-resolution ladder** (FR-001): main-module's PURL
-    version comes from `git describe --tags --exact-match HEAD`,
-    falling back to `git describe --tags --always`, falling back to
-    the literal placeholder `v0.0.0-unknown` when not in a git
-    repo, when no tags reach HEAD, or when a shallow clone elided
-    all tags. Tarball-style sources (no `.git`) deterministically
-    produce the placeholder, preserving cross-host byte-identity
-    for goldens. Better than trivy + syft, which both use the raw
-    (typically empty) `go.mod` `module` directive version.
-  - **Indirect requires** (`// indirect` in `go.mod`) get root edges
-    too — deliberate divergence from Trivy's tagging approach;
-    simpler implementation that benefits the offline-scan case.
-  - **FR-009 BuildInfo dedup**: when both source-tree + binary
-    readers run, the source-tree main-module wins; binary BuildInfo's
-    redundant main-module emission is dropped.
-  - **FR-010 not-linked exclusion**: the main-module is never tagged
-    `mikebom:not-linked` (it's the linker root by definition).
+- **Go source-tree scans now produce a real dependency graph.**
+  Pre-053, scanning a freshly-cloned Go project with empty
+  `GOMODCACHE` produced an SBOM with **zero `DEPENDS_ON` edges**
+  (issue #102). Post-053 it emits a synthetic main-module
+  component (CDX `metadata.component`, SPDX
+  `primaryPackagePurpose: APPLICATION`) with direct-require edges
+  for every `require` in `go.mod`. Closes the parity gap with
+  trivy / syft. (Milestone 053; PR #105.)
 
-  **Migration**: SBOM consumers reading CDX `metadata.component.purl`
-  now get the real Go module identifier (`pkg:golang/<module>@<ver>`)
-  instead of the synthetic `pkg:generic/<target>@0.0.0` placeholder
-  for Go-only scans. Consumers reading the project's own component
-  in `components[]` need to look at `metadata.component` instead —
-  it's no longer duplicated. `documentDescribes` (SPDX) targets the
+- **Default scan now emits ALL lifecycle scopes, not just
+  Runtime.** Pre-052, the default `mikebom sbom scan` silently
+  dropped Development / Build / Test components. Post-052 they
+  emit by default with native scope tagging (CDX
+  `scope: "excluded"`, SPDX 2.3 `*_DEPENDENCY_OF` typed
+  relationships, SPDX 3 `lifecycleScope` on `dependsOn`).
+  Consumers wanting the strict pre-052 prod-only view use the
+  new `--exclude-scope dev,build,test` flag. (Milestone
+  052/part-3; PR #100.)
+
+- **Lifecycle-scope dependency tagging via standards-native
+  fields.** The legacy `mikebom:dev-dependency` annotation is
+  REMOVED; the dev-vs-build-vs-test distinction now travels via
+  each format's standards-defined construct per Constitution
+  Principle V (v1.4.0). (Milestone 052/part-2; PR #99.)
+
+### Breaking changes for SBOM consumers
+
+- **CDX `metadata.component.purl` for Go-only scans** shifts
+  from synthetic `pkg:generic/<target>@0.0.0` to the real
+  `pkg:golang/<module-path>@<version>`.
+- **SPDX `documentDescribes` for Go-only scans** targets the
   Go main-module's SPDXID instead of a `SPDXRef-DocumentRoot-*`
   placeholder.
+- **CDX `components[]` no longer contains the Go main-module**
+  for Go-only scans (it lives in `metadata.component`).
+- **`mikebom:dev-dependency` annotation** is gone everywhere —
+  consumers filtering on it migrate to CDX
+  `components[].scope = "excluded"` / SPDX 2.3
+  `*_DEPENDENCY_OF` / SPDX 3 `lifecycleScope` on `dependsOn`.
+- **`--include-dev` flag** is now a deprecated parse-and-warn
+  no-op shim (will be removed in a future release per #101).
+  Use `--exclude-scope dev,build,test` for the strict prod-only
+  view.
 
-  **Out of scope** (tracked in follow-up issues):
-  - LICENSE-file detection on the main-module (issue #103). Today
-    main-module emits empty `licenses`; the C40 role tag preserves
-    sbomqs licensing-coverage parity.
-  - Per-ecosystem main-modules for npm / cargo / maven / pip / gem
-    (issue #104). Today only Go gets a synthetic main-module.
+### Milestones in this release
 
-### Changed (BREAKING — default SBOM scope, milestone 052/part-3)
+- **054**: filesystem-walker symlink-loop hang fix +
+  realistic-project regression suite (closes #102 — second time;
+  PR #110).
+- **053**: Go main-module component + direct dependency edges
+  (closes #102 — first time; PR #105).
+- **052/part-3**: `--exclude-scope` flag + default scope flip +
+  `--include-dev` deprecation (PR #100).
+- **052/part-2**: native CDX/SPDX 2.3/SPDX 3 lifecycle-scope
+  emission + edge rewrite (PR #99).
+- **052/part-1**: `LifecycleScope` data model + behavior-
+  preserving rename + Constitution Principle V codification
+  (PR #98).
+- **051**: polyglot dev/test tagging — cargo + gem + maven
+  + python + npm dev-dep classification via
+  `mikebom:dev-dependency` (legacy, removed in 052/part-2;
+  PR #96).
+- **050**: `mikebom:not-linked` annotation on Go source-tier
+  entries not confirmed by binary BuildInfo + scope hint
+  for source-tree-only Go scans (PR #93).
 
-- **Default scan now emits ALL lifecycle scopes, not just Runtime**
-  (milestone 052/part-3, FR-002). Pre-052 the default `mikebom sbom
-  scan` silently dropped Development / Build / Test components; now
-  it emits every component with native scope tagging (CDX
-  `scope: "excluded"` + `mikebom:lifecycle-scope`; SPDX 2.3
-  `*_DEPENDENCY_OF` relationship types; SPDX 3 `lifecycleScope` on
-  `dependsOn`). Consumers wanting the strict pre-052 prod-only view
-  use the new `--exclude-scope dev,build,test` flag.
+### Follow-ups (open issues)
 
-  - **New `--exclude-scope <list>` flag**: comma-separated subset of
-    `dev,build,test`. Drops components whose `lifecycle_scope` is in
-    the set after resolution + dedup, plus every relationship edge
-    referencing them. Centralized post-resolution filter — replaces
-    the per-reader drop logic across cargo/gem/maven/npm/pip/Go/
-    package_db.
-
-  - **`--include-dev` flag deprecated to a parse-and-warn no-op
-    shim**. Pre-052 it was the only way to surface dev/build/test
-    components; now they emit by default, so `--include-dev` does
-    nothing and logs a `tracing::warn!` deprecation notice. Will be
-    removed in a future release.
-
-  - **Migration**: Consumers expecting the pre-052 prod-only set
-    add `--exclude-scope dev,build,test` to their invocation.
-    Consumers reading `mikebom:lifecycle-scope` / native
-    relationship types directly need no changes.
-
-  - **Parity framework**: New `Directionality::CdxOnly` variant on
-    parity extractors lets C42 (`mikebom:lifecycle-scope`) bypass
-    the SPDX-side parity check — the SPDX formats carry the same
-    signal natively via B2 relationship types per Principle V's
-    finer-info carve-out clause. Mirrored in
-    `spdx_annotation_fidelity` test (CDX-only carve-out list).
-
-### Changed (BREAKING — SBOM output shape, milestone 052)
-
-- **Native lifecycle-scope dependency tagging**
-  (milestone 052/part-2). The legacy `mikebom:dev-dependency`
-  annotation is REMOVED; the lifecycle-scope signal now
-  travels via each format's standards-defined construct per
-  Constitution Principle V (v1.4.0):
-  - **CycloneDX 1.6**: `components[].scope = "excluded"` plus
-    new `mikebom:lifecycle-scope` property carrying the
-    finer `development` / `build` / `test` distinction (C42
-    catalog row, finer-info carve-out per Principle V).
-  - **SPDX 2.3**: native `DEV_DEPENDENCY_OF` /
-    `BUILD_DEPENDENCY_OF` / `TEST_DEPENDENCY_OF` relationship
-    types (the mapper had the wiring since milestone 007 —
-    readers now emit the typed variants).
-  - **SPDX 3.0.1**: `scope` field on `dependsOn` relationships
-    carrying `LifecycleScopeType` (`development` / `build` /
-    `test`).
-  Per-ecosystem 4-way classifiers: cargo `[dev-dependencies]`
-  → Development, `[build-dependencies]` → Build; gem `:test`
-  group → Test, other non-default groups → Development;
-  maven `<scope>test</scope>` → Test, `<scope>provided</scope>`
-  → Build; Go test-only imports → Test;
-  npm/Poetry/Pipfile → Development. New
-  `apply_lifecycle_scope_to_edges` helper rewrites generic
-  `DependsOn` edges to typed variants based on target's
-  `lifecycle_scope`. C6 row deleted; new C42 row added; B2
-  updated; parity-extractor wiring swapped.
-
-  **Migration**: SBOM consumers filtering on
-  `mikebom:dev-dependency = true` migrate to:
-  CDX → `components[].scope = "excluded"` or
-  `mikebom:lifecycle-scope` property; SPDX 2.3 → native
-  `DEV/BUILD/TEST_DEPENDENCY_OF` relationship types; SPDX 3
-  → `relationships[].scope` field.
-
-- **LifecycleScope data model + behavior-preserving rename**
-  (milestone 052/part-1, prerequisite for part-2). Replaced
-  `is_dev: Option<bool>` everywhere with
-  `lifecycle_scope: Option<LifecycleScope>` (4-variant enum:
-  Runtime, Development, Build, Test). Added `TestDependsOn`
-  variant to `RelationshipType`. Cross-cutting field rename
-  across 44 files. Constitution v1.4.0 amendment bundled
-  (Principle V "standards-native fields take precedence"
-  clause).
-
-### Added
-
-- **`mikebom:not-linked` annotation on Go source-tier entries
-  not confirmed by binary BuildInfo** (milestone 050). When
-  `mikebom sbom scan` finds both a Go binary and source-tier
-  `pkg:golang` entries (from go.sum) in the same rootfs, every
-  go.sum entry whose `(name, version)` is NOT in the binary's
-  `runtime/debug.BuildInfo` is now annotated with
-  `mikebom:not-linked = true`. Consumers wanting the strict
-  "what shipped" view filter on this property; consumers
-  wanting the full lockfile closure get every go.sum entry
-  with rich classification metadata. CDX, SPDX 2.3, and SPDX 3
-  outputs all carry the annotation via the generic
-  `extra_annotations` serialization wired in milestone 048.
-- **Source-tree Go scan: BuildInfo-scope hint when no binary is
-  present**. When `mikebom sbom scan --path <go-project>` finds
-  a `go.mod` but the rootfs has no built Go binary, mikebom
-  emits a one-line `tracing::info` log naming the SBOM scope
-  (full go.sum closure, no `mikebom:not-linked` data) and the
-  workflow that tightens it: `go build`, then re-scan.
-
-### Changed
-
-- **G3 filter (`apply_go_linked_filter`) inverted from drop to
-  tag** (milestone 050). Pre-050 silently dropped go.sum
-  entries not in BuildInfo, throwing away the data with no
-  recovery path. Now G3 tags those entries with
-  `mikebom:not-linked = true` and retains them. SBOM output
-  is strictly more inclusive; consumers narrow scope via the
-  annotation. On `apigatewayv2/config` (with binary present):
-  41 components pre-050 → 65 components post-050, with 24
-  carrying `mikebom:not-linked`. README ecosystem section
-  documents the workflow with audit numbers.
-- **Cargo dev/build deps now tagged via
-  `mikebom:dev-dependency`** (milestone 051 US1). Previously
-  `mikebom sbom scan --path <rust-project>` emitted every
-  `Cargo.lock` entry as a runtime dep — `[dev-dependencies]`
-  (criterion, proptest, etc.) and `[build-dependencies]` (cc,
-  bindgen, etc.) showed up unmarked. The cargo reader now
-  parses every `Cargo.toml` reachable from the lockfile
-  (workspace root + members, including `members =
-  ["crates/*"]` glob expansion) and BFS-walks the resolved dep
-  graph from the union of all `[dependencies]` entries to
-  identify the prod closure. Crates outside that closure are
-  tagged + dropped on `--include-dev=off`. Production-wins-
-  over-dev: a crate reachable via both prod and dev edges is
-  retained as production. Smoke on the mikebom workspace:
-  524 → 505 components default (19 dropped); `--include-dev`
-  recovers all 524 with the dev set carrying the annotation.
-- **Gem development/test groups now tagged via
-  `mikebom:dev-dependency`** (milestone 051 US2). The gem
-  reader now reads three sources of grouping metadata: the
-  `Gemfile.lock` `DEPENDENCIES` block, the project's `Gemfile`
-  (`group :name do ... end` blocks plus inline `gem "...",
-  group: :foo` syntax), and any project-root `*.gemspec` files
-  (`add_development_dependency` calls). Sources are unioned
-  with production-wins semantics. BFS through the lockfile's
-  transitive edges from prod-direct roots produces the prod
-  closure; gems outside it are tagged + dropped on
-  `--include-dev=off`.
-- **Maven test-scope tagging now has explicit regression
-  coverage** (milestone 051 US3). `maven.rs:1786-1823` already
-  drops `<scope>test</scope>` deps in default mode and tags
-  them under `--include-dev`; the new
-  `scan_maven_test_scope_is_tagged_with_include_dev`
-  integration test asserts the contract against future
-  refactors. Zero behavior change.
-
-After milestone 051, every ecosystem mikebom supports
-(cargo, gem, maven, npm, Poetry, Pipfile, Go) honors
-`--include-dev` consistently via the shared C6
-`mikebom:dev-dependency` parity wiring. No new flag, no new
-annotation, no new catalog row.
+- **#101**: remove the deprecated `--include-dev` parse-and-warn
+  shim once the soak window completes (~3 weeks post-052/part-3).
+- **#103**: LICENSE-file detection on the Go main-module
+  (currently emits empty `licenses`; C40 role tag preserves
+  sbomqs licensing-coverage parity).
+- **#104**: per-ecosystem main-modules for npm / cargo / maven /
+  pip / gem (Go-only in milestone 053).
+- **#108**: migrate every filesystem walker to a single shared
+  `safe_walk` helper (milestone 054 kept per-walker patches to
+  minimize blast radius before this release).
+- **#109**: per-ecosystem expansion of the realistic-project CI
+  matrix beyond knative/func (cargo / npm / maven / pip / gem /
+  rpm / deb / apk).
 
 ## [0.1.0-alpha.9] — 2026-05-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,7 +2118,7 @@ checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "mikebom"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 dependencies = [
  "anyhow",
  "aya",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "mikebom-common"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 dependencies = [
  "aya",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["mikebom-ebpf"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/mikebom-cli/tests/fixtures/golden/cyclonedx/apk.cdx.json
+++ b/mikebom-cli/tests/fixtures/golden/cyclonedx/apk.cdx.json
@@ -174,7 +174,7 @@
           "name": "mikebom",
           "publisher": "mikebom contributors",
           "type": "application",
-          "version": "0.1.0-alpha.9"
+          "version": "0.1.0-alpha.10"
         }
       ]
     }

--- a/mikebom-cli/tests/fixtures/golden/cyclonedx/cargo.cdx.json
+++ b/mikebom-cli/tests/fixtures/golden/cyclonedx/cargo.cdx.json
@@ -417,7 +417,7 @@
           "name": "mikebom",
           "publisher": "mikebom contributors",
           "type": "application",
-          "version": "0.1.0-alpha.9"
+          "version": "0.1.0-alpha.10"
         }
       ]
     }

--- a/mikebom-cli/tests/fixtures/golden/cyclonedx/deb.cdx.json
+++ b/mikebom-cli/tests/fixtures/golden/cyclonedx/deb.cdx.json
@@ -180,7 +180,7 @@
           "name": "mikebom",
           "publisher": "mikebom contributors",
           "type": "application",
-          "version": "0.1.0-alpha.9"
+          "version": "0.1.0-alpha.10"
         }
       ]
     }

--- a/mikebom-cli/tests/fixtures/golden/cyclonedx/gem.cdx.json
+++ b/mikebom-cli/tests/fixtures/golden/cyclonedx/gem.cdx.json
@@ -775,7 +775,7 @@
           "name": "mikebom",
           "publisher": "mikebom contributors",
           "type": "application",
-          "version": "0.1.0-alpha.9"
+          "version": "0.1.0-alpha.10"
         }
       ]
     }

--- a/mikebom-cli/tests/fixtures/golden/cyclonedx/golang.cdx.json
+++ b/mikebom-cli/tests/fixtures/golden/cyclonedx/golang.cdx.json
@@ -675,7 +675,7 @@
           "name": "mikebom",
           "publisher": "mikebom contributors",
           "type": "application",
-          "version": "0.1.0-alpha.9"
+          "version": "0.1.0-alpha.10"
         }
       ]
     }

--- a/mikebom-cli/tests/fixtures/golden/cyclonedx/maven.cdx.json
+++ b/mikebom-cli/tests/fixtures/golden/cyclonedx/maven.cdx.json
@@ -243,7 +243,7 @@
           "name": "mikebom",
           "publisher": "mikebom contributors",
           "type": "application",
-          "version": "0.1.0-alpha.9"
+          "version": "0.1.0-alpha.10"
         }
       ]
     }

--- a/mikebom-cli/tests/fixtures/golden/cyclonedx/npm.cdx.json
+++ b/mikebom-cli/tests/fixtures/golden/cyclonedx/npm.cdx.json
@@ -187,7 +187,7 @@
           "name": "mikebom",
           "publisher": "mikebom contributors",
           "type": "application",
-          "version": "0.1.0-alpha.9"
+          "version": "0.1.0-alpha.10"
         }
       ]
     }

--- a/mikebom-cli/tests/fixtures/golden/cyclonedx/pip.cdx.json
+++ b/mikebom-cli/tests/fixtures/golden/cyclonedx/pip.cdx.json
@@ -450,7 +450,7 @@
           "name": "mikebom",
           "publisher": "mikebom contributors",
           "type": "application",
-          "version": "0.1.0-alpha.9"
+          "version": "0.1.0-alpha.10"
         }
       ]
     }

--- a/mikebom-cli/tests/fixtures/golden/cyclonedx/rpm.cdx.json
+++ b/mikebom-cli/tests/fixtures/golden/cyclonedx/rpm.cdx.json
@@ -72,7 +72,7 @@
           "name": "mikebom",
           "publisher": "mikebom contributors",
           "type": "application",
-          "version": "0.1.0-alpha.9"
+          "version": "0.1.0-alpha.10"
         }
       ]
     }

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/apk.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/apk.spdx.json
@@ -4,37 +4,37 @@
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"apk\"]}}"
     }
   ],
@@ -42,19 +42,19 @@
     "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: operations. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
-      "Tool: mikebom-0.1.0-alpha.9",
+      "Tool: mikebom-0.1.0-alpha.10",
       "Organization: mikebom contributors"
     ]
   },
   "dataLicense": "CC0-1.0",
   "documentDescribes": [
-    "SPDXRef-DocumentRoot-Y6LUB5V5DTXSIWBX"
+    "SPDXRef-DocumentRoot-X6YR6W5UD7VNJ2A6"
   ],
-  "documentNamespace": "https://mikebom.kusari.dev/spdx/YIDPPXIC2SDS3M3JRKT5VML7XUHLVI2V",
+  "documentNamespace": "https://mikebom.kusari.dev/spdx/QG42Y43REMCYX2BEBMLAFMECYOB2K4RA",
   "name": "synthetic",
   "packages": [
     {
-      "SPDXID": "SPDXRef-DocumentRoot-Y6LUB5V5DTXSIWBX",
+      "SPDXID": "SPDXRef-DocumentRoot-X6YR6W5UD7VNJ2A6",
       "downloadLocation": "NOASSERTION",
       "externalRefs": [
         {
@@ -81,25 +81,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/apk/synthetic/lib/apk/db/installed\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:alpinelinux:busybox:1.36.1-r15:*:*:*:*:*:*:*\",\"cpe:2.3:a:busybox:busybox:1.36.1-r15:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -128,25 +128,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/apk/synthetic/lib/apk/db/installed\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:alpinelinux:musl:1.2.4_git20230717-r4:*:*:*:*:*:*:*\",\"cpe:2.3:a:musl:musl:1.2.4_git20230717-r4:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -172,7 +172,7 @@
   ],
   "relationships": [
     {
-      "relatedSpdxElement": "SPDXRef-DocumentRoot-Y6LUB5V5DTXSIWBX",
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-X6YR6W5UD7VNJ2A6",
       "relationshipType": "DESCRIBES",
       "spdxElementId": "SPDXRef-DOCUMENT"
     }

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/cargo.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/cargo.spdx.json
@@ -4,43 +4,43 @@
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"cargo\"]}}"
     }
   ],
@@ -48,19 +48,19 @@
     "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
-      "Tool: mikebom-0.1.0-alpha.9",
+      "Tool: mikebom-0.1.0-alpha.10",
       "Organization: mikebom contributors"
     ]
   },
   "dataLicense": "CC0-1.0",
   "documentDescribes": [
-    "SPDXRef-DocumentRoot-E4UZ4LFKFB5Z5JKL"
+    "SPDXRef-DocumentRoot-WTLLKO6TKU5G5QJM"
   ],
-  "documentNamespace": "https://mikebom.kusari.dev/spdx/5NXNMLTWOEAMCQYJGKRGS2662BN26J7K",
+  "documentNamespace": "https://mikebom.kusari.dev/spdx/JOUFSGNU2VVTOX3FNAYUNOIE3MEF7DAF",
   "name": "lockfile-v3",
   "packages": [
     {
-      "SPDXID": "SPDXRef-DocumentRoot-E4UZ4LFKFB5Z5JKL",
+      "SPDXID": "SPDXRef-DocumentRoot-WTLLKO6TKU5G5QJM",
       "downloadLocation": "NOASSERTION",
       "externalRefs": [
         {
@@ -87,19 +87,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -128,25 +128,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"git\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -175,19 +175,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -216,19 +216,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -257,19 +257,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -298,19 +298,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -339,19 +339,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -380,19 +380,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -418,7 +418,7 @@
   ],
   "relationships": [
     {
-      "relatedSpdxElement": "SPDXRef-DocumentRoot-E4UZ4LFKFB5Z5JKL",
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-WTLLKO6TKU5G5QJM",
       "relationshipType": "DESCRIBES",
       "spdxElementId": "SPDXRef-DOCUMENT"
     },

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/deb.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/deb.spdx.json
@@ -4,37 +4,37 @@
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"deb\"]}}"
     }
   ],
@@ -42,19 +42,19 @@
     "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: operations. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
-      "Tool: mikebom-0.1.0-alpha.9",
+      "Tool: mikebom-0.1.0-alpha.10",
       "Organization: mikebom contributors"
     ]
   },
   "dataLicense": "CC0-1.0",
   "documentDescribes": [
-    "SPDXRef-DocumentRoot-K2N3IX6Q443J4FFO"
+    "SPDXRef-DocumentRoot-F2OXISSR3WVAIQJI"
   ],
-  "documentNamespace": "https://mikebom.kusari.dev/spdx/7AICXQABAEIBNOZGKOKLZXHUXTVRP23H",
+  "documentNamespace": "https://mikebom.kusari.dev/spdx/7EB2JGNGIRXHNECJNBJKAUAWAPZ6DYRF",
   "name": "synthetic",
   "packages": [
     {
-      "SPDXID": "SPDXRef-DocumentRoot-K2N3IX6Q443J4FFO",
+      "SPDXID": "SPDXRef-DocumentRoot-F2OXISSR3WVAIQJI",
       "downloadLocation": "NOASSERTION",
       "externalRefs": [
         {
@@ -81,25 +81,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/deb/synthetic/var/lib/dpkg/status\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:debian:libc6:2.36-9:*:*:*:*:*:*:*\",\"cpe:2.3:a:libc6:libc6:2.36-9:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -129,25 +129,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/deb/synthetic/var/lib/dpkg/status\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:debian:zlib1g:1\\\\:1.2.13.dfsg-1:*:*:*:*:*:*:*\",\"cpe:2.3:a:zlib1g:zlib1g:1\\\\:1.2.13.dfsg-1:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -174,7 +174,7 @@
   ],
   "relationships": [
     {
-      "relatedSpdxElement": "SPDXRef-DocumentRoot-K2N3IX6Q443J4FFO",
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-F2OXISSR3WVAIQJI",
       "relationshipType": "DESCRIBES",
       "spdxElementId": "SPDXRef-DOCUMENT"
     }

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/gem.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/gem.spdx.json
@@ -4,43 +4,43 @@
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"gem\"]}}"
     }
   ],
@@ -48,19 +48,19 @@
     "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
-      "Tool: mikebom-0.1.0-alpha.9",
+      "Tool: mikebom-0.1.0-alpha.10",
       "Organization: mikebom contributors"
     ]
   },
   "dataLicense": "CC0-1.0",
   "documentDescribes": [
-    "SPDXRef-DocumentRoot-TYQLMPTJFRHKRBFO"
+    "SPDXRef-DocumentRoot-3VUV4QI6OKIODNPB"
   ],
-  "documentNamespace": "https://mikebom.kusari.dev/spdx/7KXD6OJBEQ2SRHYXUYVX7NGMUMPZATUP",
+  "documentNamespace": "https://mikebom.kusari.dev/spdx/RDTKJOBKZAQ7PW7SGTV7P5EV6BGHVIYV",
   "name": "simple-bundle",
   "packages": [
     {
-      "SPDXID": "SPDXRef-DocumentRoot-TYQLMPTJFRHKRBFO",
+      "SPDXID": "SPDXRef-DocumentRoot-3VUV4QI6OKIODNPB",
       "downloadLocation": "NOASSERTION",
       "externalRefs": [
         {
@@ -87,19 +87,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -128,19 +128,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -169,19 +169,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -210,19 +210,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -251,19 +251,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -292,19 +292,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -333,19 +333,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -374,19 +374,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -415,19 +415,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -456,25 +456,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"path\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -503,25 +503,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"git\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -550,19 +550,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -591,19 +591,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -632,19 +632,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -673,19 +673,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -714,19 +714,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -755,19 +755,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -793,7 +793,7 @@
   ],
   "relationships": [
     {
-      "relatedSpdxElement": "SPDXRef-DocumentRoot-TYQLMPTJFRHKRBFO",
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-3VUV4QI6OKIODNPB",
       "relationshipType": "DESCRIBES",
       "spdxElementId": "SPDXRef-DOCUMENT"
     },

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/golang.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/golang.spdx.json
@@ -4,43 +4,43 @@
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"golang\"]}}"
     }
   ],
@@ -48,7 +48,7 @@
     "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
-      "Tool: mikebom-0.1.0-alpha.9",
+      "Tool: mikebom-0.1.0-alpha.10",
       "Organization: mikebom contributors"
     ]
   },
@@ -56,7 +56,7 @@
   "documentDescribes": [
     "SPDXRef-Package-4BC3TYO5L6QI7GXM"
   ],
-  "documentNamespace": "https://mikebom.kusari.dev/spdx/3QAHEPWH4UJCAY4VZWMHR4G6VYNGYSTH",
+  "documentNamespace": "https://mikebom.kusari.dev/spdx/XMDPZ6GB4HINXXIITLLHGQQ2NNXLK57B",
   "name": "simple-module",
   "packages": [
     {
@@ -65,37 +65,37 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:detected-go\",\"value\":\"true\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.mod\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:example.com\\\\/simple:example.com\\\\/simple:v0.0.0-unknown:*:*:*:*:*:*:*\",\"cpe:2.3:a:example.com:example.com\\\\/simple:v0.0.0-unknown:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:component-role\",\"value\":\"main-module\"}"
         }
       ],
@@ -126,25 +126,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/davecgh\\\\/go-spew:github.com\\\\/davecgh\\\\/go-spew:v1.1.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/davecgh:github.com\\\\/davecgh\\\\/go-spew:v1.1.1:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -179,25 +179,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/inconshreveable\\\\/mousetrap:github.com\\\\/inconshreveable\\\\/mousetrap:v1.1.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/inconshreveable:github.com\\\\/inconshreveable\\\\/mousetrap:v1.1.0:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -232,25 +232,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/mattn\\\\/go-isatty:github.com\\\\/mattn\\\\/go-isatty:v0.0.21:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/mattn:github.com\\\\/mattn\\\\/go-isatty:v0.0.21:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -285,25 +285,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/pmezard\\\\/go-difflib:github.com\\\\/pmezard\\\\/go-difflib:v1.0.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/pmezard:github.com\\\\/pmezard\\\\/go-difflib:v1.0.0:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -338,25 +338,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/sirupsen\\\\/logrus:github.com\\\\/sirupsen\\\\/logrus:v1.9.4:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/sirupsen:github.com\\\\/sirupsen\\\\/logrus:v1.9.4:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -391,25 +391,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/spf13\\\\/cobra:github.com\\\\/spf13\\\\/cobra:v1.10.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/spf13:github.com\\\\/spf13\\\\/cobra:v1.10.2:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -444,25 +444,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/spf13\\\\/pflag:github.com\\\\/spf13\\\\/pflag:v1.0.9:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/spf13:github.com\\\\/spf13\\\\/pflag:v1.0.9:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -497,25 +497,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/stretchr\\\\/testify:github.com\\\\/stretchr\\\\/testify:v1.11.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/stretchr:github.com\\\\/stretchr\\\\/testify:v1.11.1:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -550,25 +550,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:golang.org\\\\/x\\\\/sys:golang.org\\\\/x\\\\/sys:v0.28.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:golang.org\\\\/x:golang.org\\\\/x\\\\/sys:v0.28.0:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -598,25 +598,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:gopkg.in\\\\/check.v1:gopkg.in\\\\/check.v1:v0.0.0-20161208181325-20d25e280405:*:*:*:*:*:*:*\",\"cpe:2.3:a:gopkg.in:gopkg.in\\\\/check.v1:v0.0.0-20161208181325-20d25e280405:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -646,25 +646,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:gopkg.in\\\\/yaml.v3:gopkg.in\\\\/yaml.v3:v3.0.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:gopkg.in:gopkg.in\\\\/yaml.v3:v3.0.1:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/maven.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/maven.spdx.json
@@ -4,43 +4,43 @@
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"maven\"]}}"
     }
   ],
@@ -48,19 +48,19 @@
     "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
-      "Tool: mikebom-0.1.0-alpha.9",
+      "Tool: mikebom-0.1.0-alpha.10",
       "Organization: mikebom contributors"
     ]
   },
   "dataLicense": "CC0-1.0",
   "documentDescribes": [
-    "SPDXRef-DocumentRoot-MGVQU53L3DI26L2G"
+    "SPDXRef-DocumentRoot-LWOEWMV2XXTHWPSF"
   ],
-  "documentNamespace": "https://mikebom.kusari.dev/spdx/ACSIW3UJMMVTZGX2URHZKPGRL6VB7ZVZ",
+  "documentNamespace": "https://mikebom.kusari.dev/spdx/EQ6IT4M43LERS6J5IXJHU3SVC7NWIDMD",
   "name": "pom-three-deps",
   "packages": [
     {
-      "SPDXID": "SPDXRef-DocumentRoot-MGVQU53L3DI26L2G",
+      "SPDXID": "SPDXRef-DocumentRoot-LWOEWMV2XXTHWPSF",
       "downloadLocation": "NOASSERTION",
       "externalRefs": [
         {
@@ -87,31 +87,31 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"workspace\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/maven/pom-three-deps/pom.xml\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:com.google.guava:guava:32.1.3-jre:*:*:*:*:*:*:*\",\"cpe:2.3:a:guava:guava:32.1.3-jre:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -141,25 +141,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"workspace\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/maven/pom-three-deps/pom.xml\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -189,31 +189,31 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"workspace\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/maven/pom-three-deps/pom.xml\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:org.apache.commons:commons-lang3:3.14.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:commons:commons-lang3:3.14.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:commons-lang3:commons-lang3:3.14.0:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -240,7 +240,7 @@
   ],
   "relationships": [
     {
-      "relatedSpdxElement": "SPDXRef-DocumentRoot-MGVQU53L3DI26L2G",
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-LWOEWMV2XXTHWPSF",
       "relationshipType": "DESCRIBES",
       "spdxElementId": "SPDXRef-DOCUMENT"
     }

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/npm.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/npm.spdx.json
@@ -4,43 +4,43 @@
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"npm\"]}}"
     }
   ],
@@ -48,19 +48,19 @@
     "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: operations. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
-      "Tool: mikebom-0.1.0-alpha.9",
+      "Tool: mikebom-0.1.0-alpha.10",
       "Organization: mikebom contributors"
     ]
   },
   "dataLicense": "CC0-1.0",
   "documentDescribes": [
-    "SPDXRef-DocumentRoot-GAOWSEUVCIQEMMAV"
+    "SPDXRef-DocumentRoot-F7KUXD636I4ZAKOB"
   ],
-  "documentNamespace": "https://mikebom.kusari.dev/spdx/R62GGU626ESUQ3ZLYZVTWJ4LH2JZ54CX",
+  "documentNamespace": "https://mikebom.kusari.dev/spdx/QWPQ6CVO7XRWOUU7MX5TKP53QWG2ZKKO",
   "name": "node-modules-walk",
   "packages": [
     {
-      "SPDXID": "SPDXRef-DocumentRoot-GAOWSEUVCIQEMMAV",
+      "SPDXID": "SPDXRef-DocumentRoot-F7KUXD636I4ZAKOB",
       "downloadLocation": "NOASSERTION",
       "externalRefs": [
         {
@@ -87,19 +87,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/npm/node-modules-walk/node_modules/express/package.json\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -128,19 +128,19 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/npm/node-modules-walk/node_modules/safe-buffer/package.json\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -166,7 +166,7 @@
   ],
   "relationships": [
     {
-      "relatedSpdxElement": "SPDXRef-DocumentRoot-GAOWSEUVCIQEMMAV",
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-F7KUXD636I4ZAKOB",
       "relationshipType": "DESCRIBES",
       "spdxElementId": "SPDXRef-DOCUMENT"
     },

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/pip.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/pip.spdx.json
@@ -4,43 +4,43 @@
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"pypi\"]}}"
     }
   ],
@@ -48,19 +48,19 @@
     "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: operations. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
-      "Tool: mikebom-0.1.0-alpha.9",
+      "Tool: mikebom-0.1.0-alpha.10",
       "Organization: mikebom contributors"
     ]
   },
   "dataLicense": "CC0-1.0",
   "documentDescribes": [
-    "SPDXRef-DocumentRoot-FOGQ2KTZ6GTXG5KE"
+    "SPDXRef-DocumentRoot-DBK7HOXVCHPZIKY2"
   ],
-  "documentNamespace": "https://mikebom.kusari.dev/spdx/2VT3XL7V3T5XYJWRI34CJBFVPKXDPLVH",
+  "documentNamespace": "https://mikebom.kusari.dev/spdx/JWIIGD37JGDG3EWS5TCEVOTJOT7FFALO",
   "name": "simple-venv",
   "packages": [
     {
-      "SPDXID": "SPDXRef-DocumentRoot-FOGQ2KTZ6GTXG5KE",
+      "SPDXID": "SPDXRef-DocumentRoot-DBK7HOXVCHPZIKY2",
       "downloadLocation": "NOASSERTION",
       "externalRefs": [
         {
@@ -87,25 +87,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/certifi-2023.7.22.dist-info/METADATA\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:certifi:certifi:2023.7.22:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-certifi:certifi:2023.7.22:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -134,25 +134,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/charset_normalizer-3.3.2.dist-info/METADATA\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:charset-normalizer:charset-normalizer:3.3.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-charset-normalizer:charset-normalizer:3.3.2:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -181,25 +181,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/flask-3.0.0.dist-info/METADATA\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:flask:flask:3.0.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-flask:flask:3.0.0:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -228,25 +228,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/idna-3.6.dist-info/METADATA\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:idna:idna:3.6:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-idna:idna:3.6:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -275,25 +275,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/jinja2-3.1.2.dist-info/METADATA\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:jinja2:jinja2:3.1.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-jinja2:jinja2:3.1.2:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -322,25 +322,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/requests-2.31.0.dist-info/METADATA\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:requests:requests:2.31.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-requests:requests:2.31.0:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -369,25 +369,25 @@
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/urllib3-2.0.7.dist-info/METADATA\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:urllib3:urllib3:2.0.7:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-urllib3:urllib3:2.0.7:*:*:*:*:*:*:*\"]}"
         },
         {
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
-          "annotator": "Tool: mikebom-0.1.0-alpha.9",
+          "annotator": "Tool: mikebom-0.1.0-alpha.10",
           "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
         }
       ],
@@ -413,7 +413,7 @@
   ],
   "relationships": [
     {
-      "relatedSpdxElement": "SPDXRef-DocumentRoot-FOGQ2KTZ6GTXG5KE",
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-DBK7HOXVCHPZIKY2",
       "relationshipType": "DESCRIBES",
       "spdxElementId": "SPDXRef-DOCUMENT"
     },

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/rpm.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/rpm.spdx.json
@@ -4,37 +4,37 @@
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}"
     },
     {
       "annotationDate": "1970-01-01T00:00:00Z",
       "annotationType": "OTHER",
-      "annotator": "Tool: mikebom-0.1.0-alpha.9",
+      "annotator": "Tool: mikebom-0.1.0-alpha.10",
       "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}"
     }
   ],
@@ -42,19 +42,19 @@
     "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: no lifecycle phases observed. Per-component scope detail in mikebom:sbom-tier annotations.",
     "created": "1970-01-01T00:00:00Z",
     "creators": [
-      "Tool: mikebom-0.1.0-alpha.9",
+      "Tool: mikebom-0.1.0-alpha.10",
       "Organization: mikebom contributors"
     ]
   },
   "dataLicense": "CC0-1.0",
   "documentDescribes": [
-    "SPDXRef-DocumentRoot-DIH5E2MDGFJPCVPF"
+    "SPDXRef-DocumentRoot-ZIVNVQVIANJWLCMM"
   ],
-  "documentNamespace": "https://mikebom.kusari.dev/spdx/GM2HXYJFFXNGQGI6HYNJIWKNSEQHJCFM",
+  "documentNamespace": "https://mikebom.kusari.dev/spdx/IR564UGLENZGHF3X733AC3ZRHR5LZHPE",
   "name": "bdb-only",
   "packages": [
     {
-      "SPDXID": "SPDXRef-DocumentRoot-DIH5E2MDGFJPCVPF",
+      "SPDXID": "SPDXRef-DocumentRoot-ZIVNVQVIANJWLCMM",
       "downloadLocation": "NOASSERTION",
       "externalRefs": [
         {
@@ -78,7 +78,7 @@
   ],
   "relationships": [
     {
-      "relatedSpdxElement": "SPDXRef-DocumentRoot-DIH5E2MDGFJPCVPF",
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-ZIVNVQVIANJWLCMM",
       "relationshipType": "DESCRIBES",
       "spdxElementId": "SPDXRef-DOCUMENT"
     }

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/apk.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/apk.spdx3.json
@@ -5,15 +5,15 @@
       "@id": "_:creation-info",
       "created": "1970-01-01T00:00:00Z",
       "createdBy": [
-        "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/tool/mikebom"
+        "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/tool/mikebom"
       ],
       "specVersion": "3.0.1",
       "type": "CreationInfo"
     },
     {
       "creationInfo": "_:creation-info",
-      "name": "mikebom-0.1.0-alpha.9",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/tool/mikebom",
+      "name": "mikebom-0.1.0-alpha.10",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/tool/mikebom",
       "type": "Tool"
     },
     {
@@ -22,9 +22,9 @@
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "synthetic",
       "rootElement": [
-        "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/pkg-root-PEPQMV5CGEDHQJI2"
+        "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/pkg-root-PEPQMV5CGEDHQJI2"
       ],
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG",
       "type": "SpdxDocument"
     },
     {
@@ -44,7 +44,7 @@
       "name": "synthetic",
       "software_packageUrl": "pkg:generic/synthetic@0.0.0",
       "software_packageVersion": "0.0.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/pkg-root-PEPQMV5CGEDHQJI2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/pkg-root-PEPQMV5CGEDHQJI2",
       "type": "software_Package"
     },
     {
@@ -69,7 +69,7 @@
       "name": "busybox",
       "software_packageUrl": "pkg:apk/alpine/busybox@1.36.1-r15?arch=x86_64&distro=alpine-3.19",
       "software_packageVersion": "1.36.1-r15",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/pkg-DHDBA3PTGCIRJAUV",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/pkg-DHDBA3PTGCIRJAUV",
       "type": "software_Package"
     },
     {
@@ -94,119 +94,119 @@
       "name": "musl",
       "software_packageUrl": "pkg:apk/alpine/musl@1.2.4_git20230717-r4?arch=x86_64&distro=alpine-3.19",
       "software_packageVersion": "1.2.4_git20230717-r4",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/pkg-NJ6CH7QTZDKJ74FQ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/pkg-NJ6CH7QTZDKJ74FQ",
       "type": "software_Package"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-AAX2TEGRN34TVLMD",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-32A6375YL3SAKPKL",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/pkg-DHDBA3PTGCIRJAUV",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/pkg-DHDBA3PTGCIRJAUV",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-EWRJRZ64Q5CBTIT6",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/pkg-NJ6CH7QTZDKJ74FQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-EZBFDZK3DZIKDB2W",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-4VT3RB635ZVJ2PTR",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/apk/synthetic/lib/apk/db/installed\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/pkg-DHDBA3PTGCIRJAUV",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/pkg-DHDBA3PTGCIRJAUV",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-F7QBKU776X4EBF32",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-I2S7KJODK23X3CEB",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/apk/synthetic/lib/apk/db/installed\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/pkg-NJ6CH7QTZDKJ74FQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-IL7MH22J4KEFGUPG",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-JP2C6ZTUHYC3HVKU",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-RVLMUGLVHEVJ5M32",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:alpinelinux:musl:1.2.4_git20230717-r4:*:*:*:*:*:*:*\",\"cpe:2.3:a:musl:musl:1.2.4_git20230717-r4:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/pkg-NJ6CH7QTZDKJ74FQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-S2V2GVVTWL6QQDPV",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-SGNQRMRTPGOXOMT6",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"apk\"]}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-TGK23A24WTHPDG7A",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/pkg-NJ6CH7QTZDKJ74FQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-U6X77FYQNJ75WRXQ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-V2HH22JY3NCSO5AU",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/pkg-DHDBA3PTGCIRJAUV",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/anno-ZVMBWNKRJ6HF4ZFJ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-FMGUK72MCQCWTF66",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:alpinelinux:busybox:1.36.1-r15:*:*:*:*:*:*:*\",\"cpe:2.3:a:busybox:busybox:1.36.1-r15:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-BHTO675LDADVGIRWLRFE24O2/pkg-DHDBA3PTGCIRJAUV",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/pkg-DHDBA3PTGCIRJAUV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-FXN5TTJBJOSO5TV2",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/apk/synthetic/lib/apk/db/installed\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/pkg-NJ6CH7QTZDKJ74FQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-HBMGAQSKPCMNSBLI",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-JMNJ22S5KQFCK57Y",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/pkg-DHDBA3PTGCIRJAUV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-KCR6IUT2OBFUPYRH",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/pkg-NJ6CH7QTZDKJ74FQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-NFGWTOM2Q2D2C7DU",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/pkg-NJ6CH7QTZDKJ74FQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-QRYLRYB3UYN3ORNP",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:alpinelinux:musl:1.2.4_git20230717-r4:*:*:*:*:*:*:*\",\"cpe:2.3:a:musl:musl:1.2.4_git20230717-r4:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/pkg-NJ6CH7QTZDKJ74FQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-SSIB72NI3XSU4ULE",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"apk\"]}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-UD3IJ7E3R5WGLCDA",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-XAJGMJ67MOGHBLFC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-ZT46HRTDJISPXNAM",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG/anno-ZW3QXYM4DLYGTQ2E",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-KSIFDYILZTKEPHEFQ5IGUACG",
       "type": "Annotation"
     }
   ]

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/cargo.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/cargo.spdx3.json
@@ -5,15 +5,15 @@
       "@id": "_:creation-info",
       "created": "1970-01-01T00:00:00Z",
       "createdBy": [
-        "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/tool/mikebom"
+        "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/tool/mikebom"
       ],
       "specVersion": "3.0.1",
       "type": "CreationInfo"
     },
     {
       "creationInfo": "_:creation-info",
-      "name": "mikebom-0.1.0-alpha.9",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/tool/mikebom",
+      "name": "mikebom-0.1.0-alpha.10",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/tool/mikebom",
       "type": "Tool"
     },
     {
@@ -22,9 +22,9 @@
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "lockfile-v3",
       "rootElement": [
-        "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-root-H5VPHAIRCLACRQYQ"
+        "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-root-H5VPHAIRCLACRQYQ"
       ],
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN",
       "type": "SpdxDocument"
     },
     {
@@ -44,7 +44,7 @@
       "name": "lockfile-v3",
       "software_packageUrl": "pkg:generic/lockfile-v3@0.0.0",
       "software_packageVersion": "0.0.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-root-H5VPHAIRCLACRQYQ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-root-H5VPHAIRCLACRQYQ",
       "type": "software_Package"
     },
     {
@@ -64,7 +64,7 @@
       "name": "quote",
       "software_packageUrl": "pkg:cargo/quote@1.0.35",
       "software_packageVersion": "1.0.35",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-7QZEBQB7QRFNI5M5",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-7QZEBQB7QRFNI5M5",
       "type": "software_Package"
     },
     {
@@ -84,7 +84,7 @@
       "name": "my-fork",
       "software_packageUrl": "pkg:cargo/my-fork@0.1.0",
       "software_packageVersion": "0.1.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-AMQQ7AE3OQIQRIZH",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-AMQQ7AE3OQIQRIZH",
       "type": "software_Package"
     },
     {
@@ -104,7 +104,7 @@
       "name": "syn",
       "software_packageUrl": "pkg:cargo/syn@2.0.48",
       "software_packageVersion": "2.0.48",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-BKMD7Y4M3VJPWGQM",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-BKMD7Y4M3VJPWGQM",
       "type": "software_Package"
     },
     {
@@ -124,7 +124,7 @@
       "name": "serde_derive",
       "software_packageUrl": "pkg:cargo/serde_derive@1.0.197",
       "software_packageVersion": "1.0.197",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-CDE3XEXSDOGUXIZT",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-CDE3XEXSDOGUXIZT",
       "type": "software_Package"
     },
     {
@@ -144,7 +144,7 @@
       "name": "unicode-ident",
       "software_packageUrl": "pkg:cargo/unicode-ident@1.0.12",
       "software_packageVersion": "1.0.12",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-E3KDPHV32PPHGGT4",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-E3KDPHV32PPHGGT4",
       "type": "software_Package"
     },
     {
@@ -164,7 +164,7 @@
       "name": "anyhow",
       "software_packageUrl": "pkg:cargo/anyhow@1.0.80",
       "software_packageVersion": "1.0.80",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-IYTSKXZIE4RF3PSV",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-IYTSKXZIE4RF3PSV",
       "type": "software_Package"
     },
     {
@@ -184,7 +184,7 @@
       "name": "serde",
       "software_packageUrl": "pkg:cargo/serde@1.0.197",
       "software_packageVersion": "1.0.197",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-UFXHU3P5DZAY42HF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-UFXHU3P5DZAY42HF",
       "type": "software_Package"
     },
     {
@@ -204,353 +204,353 @@
       "name": "proc-macro2",
       "software_packageUrl": "pkg:cargo/proc-macro2@1.0.76",
       "software_packageVersion": "1.0.76",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-Z72PVEYDZTEVUFVQ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-Z72PVEYDZTEVUFVQ",
       "type": "software_Package"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-CDE3XEXSDOGUXIZT",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-BKMD7Y4M3VJPWGQM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/rel-5LZBDDQ536744IWC",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/rel-4E25RLYWO46EZP2P",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-Z72PVEYDZTEVUFVQ"
+        "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-Z72PVEYDZTEVUFVQ"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-Z72PVEYDZTEVUFVQ",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-BKMD7Y4M3VJPWGQM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/rel-6PZNS3YRPBAQ5ZD6",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/rel-5SAM22EMIZWPVF7P",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-E3KDPHV32PPHGGT4"
+        "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-7QZEBQB7QRFNI5M5"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-BKMD7Y4M3VJPWGQM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-UFXHU3P5DZAY42HF",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/rel-FWRRCRL2M5TO3QB4",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/rel-7Z45CKYUC7WGVQPO",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-E3KDPHV32PPHGGT4"
+        "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-CDE3XEXSDOGUXIZT"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-CDE3XEXSDOGUXIZT",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-Z72PVEYDZTEVUFVQ",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/rel-KN7P4YB2XQIC66JQ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/rel-D4JIV4VA2YO3FDO2",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-7QZEBQB7QRFNI5M5"
+        "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-E3KDPHV32PPHGGT4"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-CDE3XEXSDOGUXIZT",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-CDE3XEXSDOGUXIZT",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/rel-LSAIHG4SMXYYOWYM",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/rel-ESTYHFEJS26NPAIZ",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-BKMD7Y4M3VJPWGQM"
+        "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-Z72PVEYDZTEVUFVQ"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-UFXHU3P5DZAY42HF",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-7QZEBQB7QRFNI5M5",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/rel-OQY5K6BBKWZLTLDU",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/rel-JMOJX7NT4MNMIX22",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-CDE3XEXSDOGUXIZT"
+        "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-Z72PVEYDZTEVUFVQ"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-7QZEBQB7QRFNI5M5",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-CDE3XEXSDOGUXIZT",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/rel-OT3N5RWICIDU3LQM",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/rel-LN7667IGZNJXLU7H",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-Z72PVEYDZTEVUFVQ"
+        "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-7QZEBQB7QRFNI5M5"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-BKMD7Y4M3VJPWGQM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-BKMD7Y4M3VJPWGQM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/rel-U23C65NHITJ6V2PH",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/rel-RK6V7LQ2GDLMRVIT",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-7QZEBQB7QRFNI5M5"
+        "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-E3KDPHV32PPHGGT4"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-BKMD7Y4M3VJPWGQM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-CDE3XEXSDOGUXIZT",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/rel-YGRGDAZ7ROAQTQRF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/rel-TLO7VEZJ6CWYBCUX",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-Z72PVEYDZTEVUFVQ"
+        "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-BKMD7Y4M3VJPWGQM"
       ],
       "type": "Relationship"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-42HMDDU5FAAEMCVK",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-3DPPUZXSYUCVMALU",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-BKMD7Y4M3VJPWGQM",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-UFXHU3P5DZAY42HF",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-4L3BHIYK2VA2QCF7",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"cargo\"]}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-4ZXDYQ3H6V2ZDIUV",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-UFXHU3P5DZAY42HF",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-5TE2NSGA7QWXL5Z6",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-BKMD7Y4M3VJPWGQM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-5VU5FW7GPQ2V5FYD",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-3NCUJNXTF6YZWCCX",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-7QZEBQB7QRFNI5M5",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-CDE3XEXSDOGUXIZT",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-7Z3HFCWMBKJXJT5J",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-4KAWEGOT3MXYSPRM",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-BKMD7Y4M3VJPWGQM",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-E3KDPHV32PPHGGT4",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-CNLX6WDU4FNT4USK",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-UFXHU3P5DZAY42HF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-AHPJGKTJSB5YFWXA",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-AMQQ7AE3OQIQRIZH",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-DAQBWKRRJTWOTHEV",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-CDE3XEXSDOGUXIZT",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-DOVR27ITYNTTPZHS",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-AMZ6KHEISC35MEGH",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"git\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-AMQQ7AE3OQIQRIZH",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-AMQQ7AE3OQIQRIZH",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-DVO6C4YYI64Z4HEN",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-7QZEBQB7QRFNI5M5",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-EZAT7MEYWNZMDN3C",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-IYTSKXZIE4RF3PSV",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-IDGDGX4V26NLCX4U",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-Z72PVEYDZTEVUFVQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-KSCOYGED23LQXSGR",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-LMQXWULHJRAGSMJI",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-IYTSKXZIE4RF3PSV",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-LZZS4CIX7DLRDBVA",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-AMQQ7AE3OQIQRIZH",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-MBQWX23GELWC7EEB",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-E3KDPHV32PPHGGT4",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-Q4C42U2TZ6LK2D2N",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-CDE3XEXSDOGUXIZT",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-QK4277Z7CHPUHO3U",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-7QZEBQB7QRFNI5M5",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-R5ETVOI45D3O4GEB",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-E3KDPHV32PPHGGT4",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-RELESMZX6DVJRRWI",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-AMQQ7AE3OQIQRIZH",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-RG65IFH2E5OAR4DZ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-AMQQ7AE3OQIQRIZH",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-RK2ZAKIPOXO3CDUU",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-SBAMZDIRZOA3SGRS",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-TBIFLZRJYO2HFOP6",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-CDE3XEXSDOGUXIZT",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-URJRCQNEG7BU3X2Z",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-V7HQSNTY4JMYJLJG",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-Z72PVEYDZTEVUFVQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-VBSZFGGV5ZW5MVW7",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-WICQ2PHGQGMCBAJR",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-E3KDPHV32PPHGGT4",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-WKYX3ZBATYUGRU2N",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-Z72PVEYDZTEVUFVQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-XSWJQL3FJ3PCHQAY",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-UFXHU3P5DZAY42HF",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-ZPUVH5ST5UII5TSC",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/pkg-IYTSKXZIE4RF3PSV",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3/anno-ZZU5Y6SQMWMR4G6T",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-B5XILB5XT5WN47LK",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-J3F5E45VE7OHTMGU5NPXCAN3",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-BKN2AHUECYG45SFS",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-Z72PVEYDZTEVUFVQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-BO35DWOBDCL2Z2UL",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-E3KDPHV32PPHGGT4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-CCJNH7BEZC7GZ233",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-Z72PVEYDZTEVUFVQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-CTPJWXIKQVEWHZDI",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-D5M22A6J55GKJHZJ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-7QZEBQB7QRFNI5M5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-EXQZIKRGVT6R4RR4",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-E3KDPHV32PPHGGT4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-FPQO3HWT5UW6ZJJA",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-GUNXM6KWT7RLI3QB",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-BKMD7Y4M3VJPWGQM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-GWXXXD44LZMQ27RT",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-CDE3XEXSDOGUXIZT",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-HIBTT2VIZCX6U2HM",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-HRVXPKLCVIH25QUC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-IQZ476YZ7BJFJHLF",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-IYTSKXZIE4RF3PSV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-ITUAZZ5HPN57ZVUW",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-CDE3XEXSDOGUXIZT",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-KRD3UVK552QTEFHR",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-7QZEBQB7QRFNI5M5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-L4ORXCY7NQLLXT23",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-UFXHU3P5DZAY42HF",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-L4S7TATXMDXR2QOU",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-BKMD7Y4M3VJPWGQM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-LEF72HEU4RF3KJFN",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-7QZEBQB7QRFNI5M5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-M77FE42H7LXJT5FG",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-IYTSKXZIE4RF3PSV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-MN7P2S6MOONYDZ3V",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-MOWF3RSTG4CW3HKM",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-IYTSKXZIE4RF3PSV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-Q2GRN7NXS7H5OCRD",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-BKMD7Y4M3VJPWGQM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-QB6I6ZX3SXN6ROAO",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-AMQQ7AE3OQIQRIZH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-QWIMS27HEABX46EW",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-AMQQ7AE3OQIQRIZH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-SUGXDLAL5DVAXDZ2",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"cargo\"]}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-W4L22CDWM3U4JDHY",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-UFXHU3P5DZAY42HF",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/anno-ZZ55TL4CZHOMTZJV",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/cargo/lockfile-v3/Cargo.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-G5AMUJBNJ45WBPUOGK6AUIMN/pkg-Z72PVEYDZTEVUFVQ",
       "type": "Annotation"
     }
   ]

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/deb.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/deb.spdx3.json
@@ -5,15 +5,15 @@
       "@id": "_:creation-info",
       "created": "1970-01-01T00:00:00Z",
       "createdBy": [
-        "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/tool/mikebom"
+        "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/tool/mikebom"
       ],
       "specVersion": "3.0.1",
       "type": "CreationInfo"
     },
     {
       "creationInfo": "_:creation-info",
-      "name": "mikebom-0.1.0-alpha.9",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/tool/mikebom",
+      "name": "mikebom-0.1.0-alpha.10",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/tool/mikebom",
       "type": "Tool"
     },
     {
@@ -22,9 +22,9 @@
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "synthetic",
       "rootElement": [
-        "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/pkg-root-PEPQMV5CGEDHQJI2"
+        "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/pkg-root-PEPQMV5CGEDHQJI2"
       ],
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH",
       "type": "SpdxDocument"
     },
     {
@@ -44,7 +44,7 @@
       "name": "synthetic",
       "software_packageUrl": "pkg:generic/synthetic@0.0.0",
       "software_packageVersion": "0.0.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/pkg-root-PEPQMV5CGEDHQJI2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/pkg-root-PEPQMV5CGEDHQJI2",
       "type": "software_Package"
     },
     {
@@ -69,8 +69,8 @@
       "name": "zlib1g",
       "software_packageUrl": "pkg:deb/debian/zlib1g@1:1.2.13.dfsg-1?arch=amd64&distro=debian-12",
       "software_packageVersion": "1:1.2.13.dfsg-1",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/pkg-FBZUYFQKGJMH6COB",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/agent-org-DICFDSQT5TPIZIGM",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/pkg-FBZUYFQKGJMH6COB",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/agent-org-DICFDSQT5TPIZIGM",
       "type": "software_Package"
     },
     {
@@ -95,126 +95,126 @@
       "name": "libc6",
       "software_packageUrl": "pkg:deb/debian/libc6@2.36-9?arch=amd64&distro=debian-12",
       "software_packageVersion": "2.36-9",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/pkg-ZKB4GX3JBL66K2UG",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/agent-org-DICFDSQT5TPIZIGM",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/pkg-ZKB4GX3JBL66K2UG",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/agent-org-DICFDSQT5TPIZIGM",
       "type": "software_Package"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "Debian <debian@example.org>",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/agent-org-DICFDSQT5TPIZIGM",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/agent-org-DICFDSQT5TPIZIGM",
       "type": "Organization"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-2FAQ5RAK5B5ZLE2Y",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-6EIYOTBORKME2PLB",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-6ZM47CV2TPAR46V2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-25SN2GLPWSGOP2P2",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/pkg-ZKB4GX3JBL66K2UG",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/pkg-ZKB4GX3JBL66K2UG",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-AQFFEYV2MRQS34RE",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-EDOTLAMVISPGC5K4",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-AN4GMHU6HU4KEBUE",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:debian:libc6:2.36-9:*:*:*:*:*:*:*\",\"cpe:2.3:a:libc6:libc6:2.36-9:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/pkg-ZKB4GX3JBL66K2UG",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/pkg-ZKB4GX3JBL66K2UG",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-GK3M4SQKLI7BTUTW",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-AZ7SS4RKSHF3XHNA",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/pkg-FBZUYFQKGJMH6COB",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/pkg-FBZUYFQKGJMH6COB",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-LOYXHMOVF3YH35JW",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/deb/synthetic/var/lib/dpkg/status\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/pkg-FBZUYFQKGJMH6COB",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-PDDKWVTSNJC4OYE6",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-CCBRT2SV4XDH4RO5",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/pkg-FBZUYFQKGJMH6COB",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/pkg-FBZUYFQKGJMH6COB",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-QEJC6BWVDZ4XZSGX",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"deb\"]}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-SDQ6UTLO3Y5VSD6O",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-WHVG6XBE2EV434NN",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-CRKPF4DCRYZ2T35M",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:debian:zlib1g:1\\\\:1.2.13.dfsg-1:*:*:*:*:*:*:*\",\"cpe:2.3:a:zlib1g:zlib1g:1\\\\:1.2.13.dfsg-1:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/pkg-FBZUYFQKGJMH6COB",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/pkg-FBZUYFQKGJMH6COB",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-YVFIU2W5DTJRJZO2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-DGVAHV75XLISGXTS",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-DJIJFDGNCOBICQRX",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/pkg-ZKB4GX3JBL66K2UG",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/pkg-ZKB4GX3JBL66K2UG",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-Z5SZIJHXQTGPGBSM",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-DXCBPUTL5Q7JV743",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-ILFXT732FFIVLXFS",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/deb/synthetic/var/lib/dpkg/status\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/pkg-ZKB4GX3JBL66K2UG",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/pkg-ZKB4GX3JBL66K2UG",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A/anno-ZLJLMLKVUZP5NZPE",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-NTB47T47OAVT5SDC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"deb\"]}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-WE5RXTZYNJ3RZPLP",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-WIRSU7TJV2NOIYLS",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-VEN43JZGYMXOF3ODWHM2OK3A",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-WLMVYERGYT4L54TW",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/anno-XDJLOKS7DCNU4VWT",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/deb/synthetic/var/lib/dpkg/status\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XHR6A324OARNIDASONMLNBPH/pkg-FBZUYFQKGJMH6COB",
       "type": "Annotation"
     }
   ]

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/gem.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/gem.spdx3.json
@@ -5,15 +5,15 @@
       "@id": "_:creation-info",
       "created": "1970-01-01T00:00:00Z",
       "createdBy": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/tool/mikebom"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/tool/mikebom"
       ],
       "specVersion": "3.0.1",
       "type": "CreationInfo"
     },
     {
       "creationInfo": "_:creation-info",
-      "name": "mikebom-0.1.0-alpha.9",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/tool/mikebom",
+      "name": "mikebom-0.1.0-alpha.10",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/tool/mikebom",
       "type": "Tool"
     },
     {
@@ -22,9 +22,9 @@
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "simple-bundle",
       "rootElement": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-root-A7PUMI3DKMBL3GSJ"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-root-A7PUMI3DKMBL3GSJ"
       ],
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V",
       "type": "SpdxDocument"
     },
     {
@@ -44,7 +44,7 @@
       "name": "simple-bundle",
       "software_packageUrl": "pkg:generic/simple-bundle@0.0.0",
       "software_packageVersion": "0.0.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-root-A7PUMI3DKMBL3GSJ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-root-A7PUMI3DKMBL3GSJ",
       "type": "software_Package"
     },
     {
@@ -64,7 +64,7 @@
       "name": "concurrent-ruby",
       "software_packageUrl": "pkg:gem/concurrent-ruby@1.2.3",
       "software_packageVersion": "1.2.3",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-4JPHR2PPVHB67S4U",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-4JPHR2PPVHB67S4U",
       "type": "software_Package"
     },
     {
@@ -84,7 +84,7 @@
       "name": "mutex_m",
       "software_packageUrl": "pkg:gem/mutex_m@0.2.0",
       "software_packageVersion": "0.2.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-F5P3JITFDDGUOH6P",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-F5P3JITFDDGUOH6P",
       "type": "software_Package"
     },
     {
@@ -104,7 +104,7 @@
       "name": "drb",
       "software_packageUrl": "pkg:gem/drb@2.2.0",
       "software_packageVersion": "2.2.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-FRJBYOVWWI6W3FKC",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-FRJBYOVWWI6W3FKC",
       "type": "software_Package"
     },
     {
@@ -124,7 +124,7 @@
       "name": "base64",
       "software_packageUrl": "pkg:gem/base64@0.2.0",
       "software_packageVersion": "0.2.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-G4RUEL22CLJMBZFD",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-G4RUEL22CLJMBZFD",
       "type": "software_Package"
     },
     {
@@ -144,7 +144,7 @@
       "name": "minitest",
       "software_packageUrl": "pkg:gem/minitest@5.22.2",
       "software_packageVersion": "5.22.2",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-GMGKOLOFGMASIEY4",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-GMGKOLOFGMASIEY4",
       "type": "software_Package"
     },
     {
@@ -164,7 +164,7 @@
       "name": "rspec-core",
       "software_packageUrl": "pkg:gem/rspec-core@3.13.0",
       "software_packageVersion": "3.13.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-M2UW7GZUIUH5QD3L",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-M2UW7GZUIUH5QD3L",
       "type": "software_Package"
     },
     {
@@ -184,7 +184,7 @@
       "name": "connection_pool",
       "software_packageUrl": "pkg:gem/connection_pool@2.4.1",
       "software_packageVersion": "2.4.1",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-MFSMZPHRYON4RF6E",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-MFSMZPHRYON4RF6E",
       "type": "software_Package"
     },
     {
@@ -204,7 +204,7 @@
       "name": "rspec-support",
       "software_packageUrl": "pkg:gem/rspec-support@3.13.0",
       "software_packageVersion": "3.13.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-MZIZNOZFXPTTL3A7",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-MZIZNOZFXPTTL3A7",
       "type": "software_Package"
     },
     {
@@ -224,7 +224,7 @@
       "name": "rspec-expectations",
       "software_packageUrl": "pkg:gem/rspec-expectations@3.13.0",
       "software_packageVersion": "3.13.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-PMPBKMPDRNPMKQSQ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-PMPBKMPDRNPMKQSQ",
       "type": "software_Package"
     },
     {
@@ -244,7 +244,7 @@
       "name": "bigdecimal",
       "software_packageUrl": "pkg:gem/bigdecimal@3.1.5",
       "software_packageVersion": "3.1.5",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TF7KZG636E2WYOG4",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TF7KZG636E2WYOG4",
       "type": "software_Package"
     },
     {
@@ -264,7 +264,7 @@
       "name": "i18n",
       "software_packageUrl": "pkg:gem/i18n@1.14.1",
       "software_packageVersion": "1.14.1",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TJEJTY3TK6WNJVKY",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TJEJTY3TK6WNJVKY",
       "type": "software_Package"
     },
     {
@@ -284,7 +284,7 @@
       "name": "tzinfo",
       "software_packageUrl": "pkg:gem/tzinfo@2.0.6",
       "software_packageVersion": "2.0.6",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TR5HW53UTITK2X66",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TR5HW53UTITK2X66",
       "type": "software_Package"
     },
     {
@@ -304,7 +304,7 @@
       "name": "activesupport",
       "software_packageUrl": "pkg:gem/activesupport@7.1.3",
       "software_packageVersion": "7.1.3",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP",
       "type": "software_Package"
     },
     {
@@ -324,7 +324,7 @@
       "name": "my-gem",
       "software_packageUrl": "pkg:gem/my-gem@0.1.0",
       "software_packageVersion": "0.1.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-XTKK2VQX4KVZ2WZU",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-XTKK2VQX4KVZ2WZU",
       "type": "software_Package"
     },
     {
@@ -344,7 +344,7 @@
       "name": "rspec-mocks",
       "software_packageUrl": "pkg:gem/rspec-mocks@3.13.0",
       "software_packageVersion": "3.13.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-Y5OXYUAJ2AR7ARAQ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-Y5OXYUAJ2AR7ARAQ",
       "type": "software_Package"
     },
     {
@@ -364,7 +364,7 @@
       "name": "rspec",
       "software_packageUrl": "pkg:gem/rspec@3.13.0",
       "software_packageVersion": "3.13.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-YNQ5SQJBK7DHJ5GJ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-YNQ5SQJBK7DHJ5GJ",
       "type": "software_Package"
     },
     {
@@ -384,667 +384,667 @@
       "name": "rails",
       "software_packageUrl": "pkg:gem/rails@7.2.0.alpha1",
       "software_packageVersion": "7.2.0.alpha1",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-YWCQDJ2BTHI5GSS3",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-YWCQDJ2BTHI5GSS3",
       "type": "software_Package"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-YNQ5SQJBK7DHJ5GJ",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-3HLWTXRVC5ZEIWDT",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-27PIU2CMZTUHUW5R",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-M2UW7GZUIUH5QD3L"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-F5P3JITFDDGUOH6P"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-YNQ5SQJBK7DHJ5GJ",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-5L4D2YE4EDAPPG2H",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-AYANCRQ5ETSUMGYO",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-GMGKOLOFGMASIEY4"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-PMPBKMPDRNPMKQSQ"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TJEJTY3TK6WNJVKY",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-M2UW7GZUIUH5QD3L",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-7XLMSSQRYRIUQHAF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-AZC6HNVGLHJ5TRHL",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-4JPHR2PPVHB67S4U"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-MZIZNOZFXPTTL3A7"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-AQVJQZRDT5AWKW37",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-BJQ5MPY74QZ5X64W",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-G4RUEL22CLJMBZFD"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TJEJTY3TK6WNJVKY"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-AVYCIXDFC2QRWQVW",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-C4DA37PYEWILHHMM",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TF7KZG636E2WYOG4"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TF7KZG636E2WYOG4"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-AY6UYNRV7SD23V24",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-DUTWLP5MKQKSYRWY",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-FRJBYOVWWI6W3FKC"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-G4RUEL22CLJMBZFD"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-YNQ5SQJBK7DHJ5GJ",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-YNQ5SQJBK7DHJ5GJ",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-DV7ZKOMGSNTXRHT4",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-FP756X52SHLQAR4J",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-Y5OXYUAJ2AR7ARAQ"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-Y5OXYUAJ2AR7ARAQ"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-M2UW7GZUIUH5QD3L",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-ELATPLX6MP2KPFDJ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-GGBKHRXM4MY3IVVX",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-MZIZNOZFXPTTL3A7"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-4JPHR2PPVHB67S4U"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-YWCQDJ2BTHI5GSS3",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-PMPBKMPDRNPMKQSQ",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-FMDYIUESOKFGWVCO",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-IUEMKOBRX6NKJYK3",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-MZIZNOZFXPTTL3A7"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-YNQ5SQJBK7DHJ5GJ",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-IHGVJSQL5Q7MTZUD",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-MMZAMOA4GJ7QIIY5",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TR5HW53UTITK2X66"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-M2UW7GZUIUH5QD3L"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-NFVZKF7GE3ECNZQ6",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-OF4C56II4SRV5SNS",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-4JPHR2PPVHB67S4U"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-MFSMZPHRYON4RF6E"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-PMPBKMPDRNPMKQSQ",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TR5HW53UTITK2X66",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-QCVK2NZU4FXAQQUH",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-OWXCG4XMU5HLDTYS",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-MZIZNOZFXPTTL3A7"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-4JPHR2PPVHB67S4U"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-YNQ5SQJBK7DHJ5GJ",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-SPIUYECA4QMO5PVA",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-PXXCVB77FL44L7GE",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-PMPBKMPDRNPMKQSQ"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TR5HW53UTITK2X66"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TR5HW53UTITK2X66",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-X2ZYPYJ3NP4VJG7U",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-QIAK7X3NMB5PC4PN",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-4JPHR2PPVHB67S4U"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-FRJBYOVWWI6W3FKC"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-Y5OXYUAJ2AR7ARAQ",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TJEJTY3TK6WNJVKY",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-XZD34NJ6VWNKPUEL",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-RJZXRJRNDDHNBRDE",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-MZIZNOZFXPTTL3A7"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-4JPHR2PPVHB67S4U"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-ZFJMAJIDNLQHOGOV",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-RVUF4GDIPZOGUIHG",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-MFSMZPHRYON4RF6E"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-GMGKOLOFGMASIEY4"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-YWCQDJ2BTHI5GSS3",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-ZNY7VDKNKMNTBMN5",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-XEOXAGUGQ4GL7VDO",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TJEJTY3TK6WNJVKY"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-Y5OXYUAJ2AR7ARAQ",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/rel-ZZ7DNYUHCSJTYAMM",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/rel-Z5TC3ZUKTECN3N7U",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-F5P3JITFDDGUOH6P"
+        "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-MZIZNOZFXPTTL3A7"
       ],
       "type": "Relationship"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-2CNPNXVKH4QEFLYU",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-26ZAOVXSQJAEXTJK",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-G4RUEL22CLJMBZFD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-2IJQCUKZXYYQVQP2",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-2MXNYQ533CLUUJEQ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-FRJBYOVWWI6W3FKC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-334WPBEAL7VNJ52F",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-Y5OXYUAJ2AR7ARAQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-37J67KKSQCEHWGVG",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-G4RUEL22CLJMBZFD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-3GCY7BD3LF6UV3D2",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-4434CYEMNYH2HPRX",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-F5P3JITFDDGUOH6P",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-57LXRSHRZ2P75TUI",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-XTKK2VQX4KVZ2WZU",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-5K5ON3IMRO3IH7LF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-4BYXMXGRLLD3B5WO",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-5SYYIF2TOFVLSLUJ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-4WB5E5TAP24PBR5G",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TR5HW53UTITK2X66",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-5HN2EWUUWFWMT3GB",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-5ZTFGA7MOU7YD2KN",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-5W53UYH4GKF5Z6A2",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TJEJTY3TK6WNJVKY",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-Y5OXYUAJ2AR7ARAQ",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-6L552BFBYPKGBVEJ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-672EMRU427JHVV5G",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-YWCQDJ2BTHI5GSS3",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-6JSZ77VD63Y47A7O",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-YWCQDJ2BTHI5GSS3",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-F5P3JITFDDGUOH6P",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-72ZE743XR7A6CGBT",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-6V5M3JS2TC3ZWREP",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TR5HW53UTITK2X66",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-6Y7OUSFMHADWYIQ5",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-724GQRG36Y23LOC4",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-YNQ5SQJBK7DHJ5GJ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-7IEL4HMDEOM53ILD",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TF7KZG636E2WYOG4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-7LJA7TR6UIUMPMJL",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TR5HW53UTITK2X66",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-7JQAZCFB3TXAJMST",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-7UDG7NI6QLURKA65",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-F5P3JITFDDGUOH6P",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-7VYI4DZWWAK4CDFE",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"gem\"]}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-AB2WWPPXGQD67EOQ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TR5HW53UTITK2X66",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-AOGUYJH6UXPHHFWG",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-MZIZNOZFXPTTL3A7",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-APYH2IRZV34LUBIT",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-YNQ5SQJBK7DHJ5GJ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-BY6GXTN3YESO4PLT",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"git\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-YWCQDJ2BTHI5GSS3",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-CE2OPS7UAF6VPTVB",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-4JPHR2PPVHB67S4U",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-CMZMMCLZABRBYQ6P",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TR5HW53UTITK2X66",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-D27OLBDXBJWECFUF",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-DVLZF6T44CUM3TUP",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-PMPBKMPDRNPMKQSQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-DZOFLMH3EDPU2XD2",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TR5HW53UTITK2X66",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-EPDU36V5FFEQPQJ3",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-MZIZNOZFXPTTL3A7",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-EUX7ESB667XNKD2H",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-PMPBKMPDRNPMKQSQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-FBIYG7LIE7QTBJ5T",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-FFCLKTCCWMNIOT6S",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-MFSMZPHRYON4RF6E",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-FXJRGBKOFG7CONQG",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-GMGKOLOFGMASIEY4",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-FYWNOJPXY7RX4BVI",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TF7KZG636E2WYOG4",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-G3KJ6DO73WYKNXJA",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-MZIZNOZFXPTTL3A7",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-GCHUZOK4FDKCFBD3",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-Y5OXYUAJ2AR7ARAQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-HFTNPHNKZW2H4CYF",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-YWCQDJ2BTHI5GSS3",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-HUYSE4JJTEY6PHRE",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TJEJTY3TK6WNJVKY",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-I3H6B34IQEX4ZUEO",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-YNQ5SQJBK7DHJ5GJ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-IK6BC7N2REOYQQJR",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-YNQ5SQJBK7DHJ5GJ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-J6BOR5BENDYMRX4W",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-PMPBKMPDRNPMKQSQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-JLBBEAVJ2M6B2DZ7",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-FRJBYOVWWI6W3FKC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-JRWQFQNHX2BADPI6",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-F5P3JITFDDGUOH6P",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-JYJWF2UB6MRGYM4O",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TJEJTY3TK6WNJVKY",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-K67MRMHFT3ATVR3O",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-M2UW7GZUIUH5QD3L",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-KZBFG5GGBQ3PVBO3",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-MFSMZPHRYON4RF6E",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-L3PEA3ORHHKFWYO2",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-M2UW7GZUIUH5QD3L",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-LE43VH77A2VWRVRG",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TF7KZG636E2WYOG4",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-LOINYPNTJQCV2IQH",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-GMGKOLOFGMASIEY4",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-OLS4VQX6CYCYMSHR",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-Y5OXYUAJ2AR7ARAQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-P45KSKL7H4ZQD2QS",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-XTKK2VQX4KVZ2WZU",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-PGL5I724GOCMEK2X",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-G4RUEL22CLJMBZFD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-RB7SS3VBENYLWYSJ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-RFKJPJYNBMCU4X27",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-F5P3JITFDDGUOH6P",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-SAIRFH6PBPOP5DHZ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-4JPHR2PPVHB67S4U",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-SN2CNMNZQ7GI4PXM",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-AGY3NEBMBMXJSFXR",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"path\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-XTKK2VQX4KVZ2WZU",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-XTKK2VQX4KVZ2WZU",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-VWX2AZR7U63VNB7K",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-ALHOYZ5APFQYUSVS",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-YNQ5SQJBK7DHJ5GJ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-B5447DUDY4ARKDXX",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-M2UW7GZUIUH5QD3L",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-BB7HZHG2Z7E2AA2D",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-CV7MJRXHRJFBTGIP",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-XTKK2VQX4KVZ2WZU",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-WCLNAGELFXHKRNGM",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-4JPHR2PPVHB67S4U",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-WMFJ7YEVT46BKSVS",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-G4RUEL22CLJMBZFD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-WYXO7KT7UECOYENV",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-GMGKOLOFGMASIEY4",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-YGKJXFNKWR7KNL4V",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-TF7KZG636E2WYOG4",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-YIK33GNDIEK4I4CM",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-DUDKX7XC4E237SO5",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-FRJBYOVWWI6W3FKC",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-G4RUEL22CLJMBZFD",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-YUX2FWOK2CM2PEJY",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-E4IXKP6ZFDQQWDJB",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TF7KZG636E2WYOG4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-EL5CXEMK5Y7U3ICL",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-MFSMZPHRYON4RF6E",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-4JPHR2PPVHB67S4U",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-ZAM3FBS6GYBICCIX",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-EQQ2EY26AKFMIWP6",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-FRJBYOVWWI6W3FKC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-F2BNNGXTYXYZQAQ6",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-XTKK2VQX4KVZ2WZU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-FJVKJX4VJUJFFT6G",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-YNQ5SQJBK7DHJ5GJ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-GFQTAJ6AC6R33WXX",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-GFSAWM3FHCW45JZP",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-M2UW7GZUIUH5QD3L",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-MFSMZPHRYON4RF6E",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-ZDJVOIQOSRMU3TAL",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-X445XBQQTVVT2QRP",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-HRQYRUJ6SS4JE4GX",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/anno-ZPKJNFA3HRZX6TQ5",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-I2CPTZFMVEAA7KES",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TJEJTY3TK6WNJVKY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-IF262HXV7AZRNDVO",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TJEJTY3TK6WNJVKY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-KOKXONPAWURJYRFL",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ISX2DGIM2COGGXTPZME7QHRY/pkg-YWCQDJ2BTHI5GSS3",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-XTKK2VQX4KVZ2WZU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-KQU4ARFMFNREEMW4",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-M2UW7GZUIUH5QD3L",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-L5YFWQKC5AIIZQIB",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-F5P3JITFDDGUOH6P",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-LGXA6ZY7XXERJTGE",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-4JPHR2PPVHB67S4U",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-M4NOMCCILVFOWP5N",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-M2UW7GZUIUH5QD3L",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-NIGAU7N33AERZABN",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-YWCQDJ2BTHI5GSS3",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-O3F36LPGDWT3RGN6",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-G4RUEL22CLJMBZFD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-OE323HCJLVLR6V2D",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-MFSMZPHRYON4RF6E",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-OLP3MJDHF6GVU44L",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-MFSMZPHRYON4RF6E",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-P2X3KNTQD3TDCU6K",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-PMPBKMPDRNPMKQSQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-P6DV4VVYZQNJHJJI",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-XTKK2VQX4KVZ2WZU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-PIFUXILXVUVYZFVT",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-4JPHR2PPVHB67S4U",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-QGOW5VUPI4HPAHQK",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-X445XBQQTVVT2QRP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-R3BM66PHM56KR5VE",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-GMGKOLOFGMASIEY4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-SJLY62EOSBXUTXYY",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-PMPBKMPDRNPMKQSQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-SXRNSWCMQNE4DKIL",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-Y5OXYUAJ2AR7ARAQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-TJY52UTNQ2KDU3XJ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"git\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-YWCQDJ2BTHI5GSS3",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-TP2D4GKHIGCHKSSV",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-PMPBKMPDRNPMKQSQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-U7ZDHIB23HH7ZXND",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-MZIZNOZFXPTTL3A7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-ULOWBCBB2RG6QPZM",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TJEJTY3TK6WNJVKY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-V3KULOBU4OUHN4WC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-GMGKOLOFGMASIEY4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-WF7HOYMCX4LJ3GVB",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-GMGKOLOFGMASIEY4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-WV5BE2Q44B5TN4SN",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-FRJBYOVWWI6W3FKC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-WZPJYCFYGDJFPHCW",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-MZIZNOZFXPTTL3A7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-X3QO67Z27YJ6QMGO",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-YWCQDJ2BTHI5GSS3",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-X7ZHXGE4KTF5H45Z",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-Y5OXYUAJ2AR7ARAQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-XCNVD3RI6WJ6DN3M",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-FRJBYOVWWI6W3FKC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-XLPRZRES5XG7KROA",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-MZIZNOZFXPTTL3A7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/anno-ZY7A4UP54NBVPMWC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/gem/simple-bundle/Gemfile.lock\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-E5LW524LAXOCKAM3YIVUME7V/pkg-TF7KZG636E2WYOG4",
       "type": "Annotation"
     }
   ]

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/golang.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/golang.spdx3.json
@@ -5,15 +5,15 @@
       "@id": "_:creation-info",
       "created": "1970-01-01T00:00:00Z",
       "createdBy": [
-        "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/tool/mikebom"
+        "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/tool/mikebom"
       ],
       "specVersion": "3.0.1",
       "type": "CreationInfo"
     },
     {
       "creationInfo": "_:creation-info",
-      "name": "mikebom-0.1.0-alpha.9",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/tool/mikebom",
+      "name": "mikebom-0.1.0-alpha.10",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/tool/mikebom",
       "type": "Tool"
     },
     {
@@ -22,9 +22,9 @@
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "simple-module",
       "rootElement": [
-        "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-root-LIZGGP3G6P24VW23"
+        "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-root-LIZGGP3G6P24VW23"
       ],
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG",
       "type": "SpdxDocument"
     },
     {
@@ -44,7 +44,7 @@
       "name": "simple-module",
       "software_packageUrl": "pkg:generic/simple-module@0.0.0",
       "software_packageVersion": "0.0.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-root-LIZGGP3G6P24VW23",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-root-LIZGGP3G6P24VW23",
       "type": "software_Package"
     },
     {
@@ -70,8 +70,8 @@
       "software_packageUrl": "pkg:golang/example.com/simple@v0.0.0-unknown",
       "software_packageVersion": "v0.0.0-unknown",
       "software_primaryPurpose": "application",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-TJXDDWH2FBLDP7TA",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-TJXDDWH2FBLDP7TA",
       "type": "software_Package"
     },
     {
@@ -97,8 +97,8 @@
       "software_packageUrl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
       "software_packageVersion": "v1.0.0",
       "software_sourceInfo": "https://github.com/pmezard/go-difflib",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-6LPOVXNHYYPHFH7J",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-HOLDQLB4ZG2JENHT",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-6LPOVXNHYYPHFH7J",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-HOLDQLB4ZG2JENHT",
       "type": "software_Package"
     },
     {
@@ -123,8 +123,8 @@
       "name": "gopkg.in/yaml.v3",
       "software_packageUrl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
       "software_packageVersion": "v3.0.1",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-A3EJRWNXRJBCN4AR",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-P3H55RXVD3DOUGUX",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-A3EJRWNXRJBCN4AR",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-P3H55RXVD3DOUGUX",
       "type": "software_Package"
     },
     {
@@ -150,8 +150,8 @@
       "software_packageUrl": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
       "software_packageVersion": "v1.1.0",
       "software_sourceInfo": "https://github.com/inconshreveable/mousetrap",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-DJ3ZIKWTNBYO26BT",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-WDQXRU5U5VXMXD7I",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-DJ3ZIKWTNBYO26BT",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-WDQXRU5U5VXMXD7I",
       "type": "software_Package"
     },
     {
@@ -177,8 +177,8 @@
       "software_packageUrl": "pkg:golang/github.com/stretchr/testify@v1.11.1",
       "software_packageVersion": "v1.11.1",
       "software_sourceInfo": "https://github.com/stretchr/testify",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-FQD3O6TFIGWWRCL5",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-A2SLNI62QTZAA5ES",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-FQD3O6TFIGWWRCL5",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-A2SLNI62QTZAA5ES",
       "type": "software_Package"
     },
     {
@@ -204,8 +204,8 @@
       "software_packageUrl": "pkg:golang/github.com/sirupsen/logrus@v1.9.4",
       "software_packageVersion": "v1.9.4",
       "software_sourceInfo": "https://github.com/sirupsen/logrus",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-JBX4TYZ3HEXJNFYD",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-RJY2MTGHCO6RNAH7",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-JBX4TYZ3HEXJNFYD",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-RJY2MTGHCO6RNAH7",
       "type": "software_Package"
     },
     {
@@ -231,8 +231,8 @@
       "software_packageUrl": "pkg:golang/github.com/spf13/pflag@v1.0.9",
       "software_packageVersion": "v1.0.9",
       "software_sourceInfo": "https://github.com/spf13/pflag",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-JOU7AJL2C6XXTUFK",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-7G3YT5IGRPAH7OYU",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-JOU7AJL2C6XXTUFK",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-7G3YT5IGRPAH7OYU",
       "type": "software_Package"
     },
     {
@@ -257,8 +257,8 @@
       "name": "gopkg.in/check.v1",
       "software_packageUrl": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
       "software_packageVersion": "v0.0.0-20161208181325-20d25e280405",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-OPPLTPJ24FIGRUY2",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-P3H55RXVD3DOUGUX",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-OPPLTPJ24FIGRUY2",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-P3H55RXVD3DOUGUX",
       "type": "software_Package"
     },
     {
@@ -284,8 +284,8 @@
       "software_packageUrl": "pkg:golang/github.com/mattn/go-isatty@v0.0.21",
       "software_packageVersion": "v0.0.21",
       "software_sourceInfo": "https://github.com/mattn/go-isatty",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-UADJIBC3AU5U4VJC",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-JJFJHVXAR4WGQHI5",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-UADJIBC3AU5U4VJC",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-JJFJHVXAR4WGQHI5",
       "type": "software_Package"
     },
     {
@@ -310,8 +310,8 @@
       "name": "golang.org/x/sys",
       "software_packageUrl": "pkg:golang/golang.org/x/sys@v0.28.0",
       "software_packageVersion": "v0.28.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-XXDQJPHRGTN4ALYD",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-2ZDFNHBBEVR6S53W",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-XXDQJPHRGTN4ALYD",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-2ZDFNHBBEVR6S53W",
       "type": "software_Package"
     },
     {
@@ -337,8 +337,8 @@
       "software_packageUrl": "pkg:golang/github.com/spf13/cobra@v1.10.2",
       "software_packageVersion": "v1.10.2",
       "software_sourceInfo": "https://github.com/spf13/cobra",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-ZGOZVHQZC2RMR6GZ",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-7G3YT5IGRPAH7OYU",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-ZGOZVHQZC2RMR6GZ",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-7G3YT5IGRPAH7OYU",
       "type": "software_Package"
     },
     {
@@ -364,624 +364,624 @@
       "software_packageUrl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
       "software_packageVersion": "v1.1.1",
       "software_sourceInfo": "https://github.com/davecgh/go-spew",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-ZPQ6ND5QEI5V2QHC",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-HFZXHVDIK5L5YRH3",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-ZPQ6ND5QEI5V2QHC",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-HFZXHVDIK5L5YRH3",
       "type": "software_Package"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "golang.org/x",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-2ZDFNHBBEVR6S53W",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-2ZDFNHBBEVR6S53W",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/spf13",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-7G3YT5IGRPAH7OYU",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-7G3YT5IGRPAH7OYU",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/stretchr",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-A2SLNI62QTZAA5ES",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-A2SLNI62QTZAA5ES",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/davecgh",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-HFZXHVDIK5L5YRH3",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-HFZXHVDIK5L5YRH3",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/pmezard",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-HOLDQLB4ZG2JENHT",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-HOLDQLB4ZG2JENHT",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/mattn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-JJFJHVXAR4WGQHI5",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-JJFJHVXAR4WGQHI5",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "gopkg.in",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-P3H55RXVD3DOUGUX",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-P3H55RXVD3DOUGUX",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/sirupsen",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-RJY2MTGHCO6RNAH7",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-RJY2MTGHCO6RNAH7",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "example.com",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-TJXDDWH2FBLDP7TA",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-TJXDDWH2FBLDP7TA",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/inconshreveable",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/agent-org-WDQXRU5U5VXMXD7I",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/agent-org-WDQXRU5U5VXMXD7I",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/rel-BRGRNFMAKREDCZSN",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/rel-AAT5Q26WFMG6EMNX",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-ZPQ6ND5QEI5V2QHC"
+        "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-FQD3O6TFIGWWRCL5"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/rel-CVIY7F2FH3IRW4MV",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/rel-AWKT4CM2JRHPFL4D",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-A3EJRWNXRJBCN4AR"
+        "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-UADJIBC3AU5U4VJC"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/rel-HAWSWXAPBPRRZIDF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/rel-BCOI2HPQ6QAFML4G",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-UADJIBC3AU5U4VJC"
+        "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-6LPOVXNHYYPHFH7J"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/rel-QIABHQSIHJIRCAPX",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/rel-BKBC2PEVANXGT7DB",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-6LPOVXNHYYPHFH7J"
+        "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-JOU7AJL2C6XXTUFK"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/rel-SWP4LDR3OF6L4DVZ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/rel-DR6AJC34MX263EOZ",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-JOU7AJL2C6XXTUFK"
+        "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-DJ3ZIKWTNBYO26BT"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/rel-TCQGZOEAOM7II63V",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/rel-EC6XM7R53IYNQUOX",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-FQD3O6TFIGWWRCL5"
+        "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-ZPQ6ND5QEI5V2QHC"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/rel-UQ6GREXMUWBCCTR6",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/rel-JCMD3QLF4DT7R5ZA",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-ZGOZVHQZC2RMR6GZ"
+        "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-A3EJRWNXRJBCN4AR"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/rel-VU3HXZ3Z5KRG7FSI",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/rel-KHTINKMM2LVPZ6W6",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-XXDQJPHRGTN4ALYD"
+        "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-JBX4TYZ3HEXJNFYD"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/rel-VZFNDFI45KESTYMU",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/rel-QITVLPR4ICQNB6UL",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-DJ3ZIKWTNBYO26BT"
+        "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-ZGOZVHQZC2RMR6GZ"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/rel-YP3V5F6DLSUJLBMQ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/rel-VDWY7WRH25PJODHQ",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-JBX4TYZ3HEXJNFYD"
+        "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-XXDQJPHRGTN4ALYD"
       ],
       "type": "Relationship"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-23V37EGUWOP4HBTE",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-ZPQ6ND5QEI5V2QHC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-2DPQO46SRKQ6X77M",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:golang.org\\\\/x\\\\/sys:golang.org\\\\/x\\\\/sys:v0.28.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:golang.org\\\\/x:golang.org\\\\/x\\\\/sys:v0.28.0:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-XXDQJPHRGTN4ALYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-2HYJW4O4E2W4U6YZ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/inconshreveable\\\\/mousetrap:github.com\\\\/inconshreveable\\\\/mousetrap:v1.1.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/inconshreveable:github.com\\\\/inconshreveable\\\\/mousetrap:v1.1.0:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-DJ3ZIKWTNBYO26BT",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-3HARBB3F3AULVX6T",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-XXDQJPHRGTN4ALYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-4ALNP2PQ4G6D5CJQ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-4OS7PV6GTDNNS2H4",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-JBX4TYZ3HEXJNFYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-4TI2KZJIAXHUHXDY",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-56VICSNIDAHPPXFR",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-37J4IHVQ2JAUDKHH",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/davecgh\\\\/go-spew:github.com\\\\/davecgh\\\\/go-spew:v1.1.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/davecgh:github.com\\\\/davecgh\\\\/go-spew:v1.1.1:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-ZPQ6ND5QEI5V2QHC",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-ZPQ6ND5QEI5V2QHC",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-576CF3SQV3SYQDW5",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-JOU7AJL2C6XXTUFK",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-5MCDBBS3ZAQQIXII",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/spf13\\\\/cobra:github.com\\\\/spf13\\\\/cobra:v1.10.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/spf13:github.com\\\\/spf13\\\\/cobra:v1.10.2:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-ZGOZVHQZC2RMR6GZ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-5MRPQXS5OHUGCQR2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-3MDRGQ3NZXFQTD5I",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-DJ3ZIKWTNBYO26BT",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-A3EJRWNXRJBCN4AR",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-5ZIMUWELMNW5DA3Y",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-6CIGRYITMGVAMB2U",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-6QUWUZVAZM2OCLCY",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/mattn\\\\/go-isatty:github.com\\\\/mattn\\\\/go-isatty:v0.0.21:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/mattn:github.com\\\\/mattn\\\\/go-isatty:v0.0.21:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-UADJIBC3AU5U4VJC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-73A3L5ZNY45PSA7K",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-FQD3O6TFIGWWRCL5",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-7NUCXZU5246RS6MF",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-XXDQJPHRGTN4ALYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-7RY2EV6JOXO4NUAO",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:gopkg.in\\\\/yaml.v3:gopkg.in\\\\/yaml.v3:v3.0.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:gopkg.in:gopkg.in\\\\/yaml.v3:v3.0.1:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-A3EJRWNXRJBCN4AR",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-7XRYGEXHZ2NPYGLP",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-OPPLTPJ24FIGRUY2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-A3YSTRY3IMVLKJE6",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-ZGOZVHQZC2RMR6GZ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-AAETQKT2EO2VI2FS",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-XXDQJPHRGTN4ALYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-ARCJ3F7IXBSGD5AA",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-A3EJRWNXRJBCN4AR",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-BHDXDFZPEPND5ERR",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/pmezard\\\\/go-difflib:github.com\\\\/pmezard\\\\/go-difflib:v1.0.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/pmezard:github.com\\\\/pmezard\\\\/go-difflib:v1.0.0:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-6LPOVXNHYYPHFH7J",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-BYZOX3EYTD32WOER",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"golang\"]}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-DNW4WDP4VW3S6BFA",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-A3EJRWNXRJBCN4AR",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-DPCFMVCB2RZPCRVT",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:example.com\\\\/simple:example.com\\\\/simple:v0.0.0-unknown:*:*:*:*:*:*:*\",\"cpe:2.3:a:example.com:example.com\\\\/simple:v0.0.0-unknown:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-DWER72AZAJYGZRT5",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-OPPLTPJ24FIGRUY2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-EANYDZDDXM5M4LMQ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.mod\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-EGH6DUP4VUVG4FE4",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-JOU7AJL2C6XXTUFK",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-EWJLKNN7N7ZRVFAI",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-ZGOZVHQZC2RMR6GZ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-FVPWFB7CS4HMOEGF",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-ZGOZVHQZC2RMR6GZ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-I7EELRD3OVKYKZKS",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-DJ3ZIKWTNBYO26BT",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-J5XMPUYRXLRWG5AM",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-JBX4TYZ3HEXJNFYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-KAPWLKZBHTNXHGA2",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-6LPOVXNHYYPHFH7J",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-KDC66I6LWNHJRMX5",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/sirupsen\\\\/logrus:github.com\\\\/sirupsen\\\\/logrus:v1.9.4:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/sirupsen:github.com\\\\/sirupsen\\\\/logrus:v1.9.4:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-JBX4TYZ3HEXJNFYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-KEK4TLY6VUQLKDU4",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-DJ3ZIKWTNBYO26BT",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-LRJILP7N3DM53TIZ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:detected-go\",\"value\":\"true\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-MAW6DS5LZY3UQUOL",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-FQD3O6TFIGWWRCL5",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-MZSG6PPMIFGYRDJ7",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-3X7AH6K3PWM7LYN4",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-NOLX27NUJF26HBMF",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-JOU7AJL2C6XXTUFK",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-NWB2U6R3C74KZOTE",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-A3EJRWNXRJBCN4AR",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-O4CNRSTT2JGFGA45",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:gopkg.in\\\\/check.v1:gopkg.in\\\\/check.v1:v0.0.0-20161208181325-20d25e280405:*:*:*:*:*:*:*\",\"cpe:2.3:a:gopkg.in:gopkg.in\\\\/check.v1:v0.0.0-20161208181325-20d25e280405:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-OPPLTPJ24FIGRUY2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-PKGTH7BBXHL6MXFP",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/stretchr\\\\/testify:github.com\\\\/stretchr\\\\/testify:v1.11.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/stretchr:github.com\\\\/stretchr\\\\/testify:v1.11.1:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-FQD3O6TFIGWWRCL5",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-QRDKGSKE7O74YOEE",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-42ZJ6URPZCGGA4E2",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-UADJIBC3AU5U4VJC",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-JBX4TYZ3HEXJNFYD",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-RBVP2FBHUM4OMCBD",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-S62JJFW5ZB3CQAZG",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-ZPQ6ND5QEI5V2QHC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-SGESXJL35Y2HK3I3",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-6LPOVXNHYYPHFH7J",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-TXSKK5Q44GYMRFHS",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-4CMD2DKOC5AJZCV2",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/spf13\\\\/pflag:github.com\\\\/spf13\\\\/pflag:v1.0.9:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/spf13:github.com\\\\/spf13\\\\/pflag:v1.0.9:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-JOU7AJL2C6XXTUFK",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-JOU7AJL2C6XXTUFK",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-UEBWO5HRA2EZLNHQ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:component-role\",\"value\":\"main-module\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-4BC3TYO5L6QI7GXM",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-4DHCQLETZ2XBCHUN",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-UH4BBBNACYFPZQWK",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-4IWFZRRLRUOXMCKM",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-ZPQ6ND5QEI5V2QHC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-5EEXAQGUX7NSDQJ2",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-6LPOVXNHYYPHFH7J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-5NA3UPZZMN5QN5QV",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-XXDQJPHRGTN4ALYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-5OR6ZO77IKRUX34U",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.mod\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-7HCYFIRVYFRBZDI3",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:gopkg.in\\\\/yaml.v3:gopkg.in\\\\/yaml.v3:v3.0.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:gopkg.in:gopkg.in\\\\/yaml.v3:v3.0.1:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-A3EJRWNXRJBCN4AR",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-7SMYWDNEYMS47Z3O",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-FQD3O6TFIGWWRCL5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-A3WTCIM6T7R6Y4UW",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-ZGOZVHQZC2RMR6GZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-A5JIWVO3YRWHQ6VC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-6LPOVXNHYYPHFH7J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-AJ4GTDUEUFSTPJ5T",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/stretchr\\\\/testify:github.com\\\\/stretchr\\\\/testify:v1.11.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/stretchr:github.com\\\\/stretchr\\\\/testify:v1.11.1:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-FQD3O6TFIGWWRCL5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-BGZXBLBKTGTIHSTN",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-JOU7AJL2C6XXTUFK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-DLHAL4JQORM24T3F",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:gopkg.in\\\\/check.v1:gopkg.in\\\\/check.v1:v0.0.0-20161208181325-20d25e280405:*:*:*:*:*:*:*\",\"cpe:2.3:a:gopkg.in:gopkg.in\\\\/check.v1:v0.0.0-20161208181325-20d25e280405:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-OPPLTPJ24FIGRUY2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-DS4C5MHBE5YZR72J",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-UNJ5YQRHYSYAFF5N",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-DUHWM5T4ZEXVZVAY",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-FQD3O6TFIGWWRCL5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-DVFV3CD4V7QDN5GL",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-ZPQ6ND5QEI5V2QHC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-DX3MDDA7MGXZYSNJ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/pmezard\\\\/go-difflib:github.com\\\\/pmezard\\\\/go-difflib:v1.0.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/pmezard:github.com\\\\/pmezard\\\\/go-difflib:v1.0.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-6LPOVXNHYYPHFH7J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-EFINYE3V32VSF33T",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:golang.org\\\\/x\\\\/sys:golang.org\\\\/x\\\\/sys:v0.28.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:golang.org\\\\/x:golang.org\\\\/x\\\\/sys:v0.28.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-XXDQJPHRGTN4ALYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-EQJCXM23BOR2FHEH",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:component-role\",\"value\":\"main-module\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-FSCDRPRMYG4IJOPB",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-XXDQJPHRGTN4ALYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-GCAQWWE3IJDBVHKN",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-6LPOVXNHYYPHFH7J",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-A3EJRWNXRJBCN4AR",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-UQ46SM7CVKC2ZYW2",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-UADJIBC3AU5U4VJC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-UVCT6LO5O63DINM3",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-HHINRQWXY4CBVGW3",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-UADJIBC3AU5U4VJC",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-XXDQJPHRGTN4ALYD",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-VYZ6B4WXMTBZPFMZ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-FQD3O6TFIGWWRCL5",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-WZSXWR7QLI3ELIOF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-I46ASHXJTJYELMT3",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-OPPLTPJ24FIGRUY2",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-6LPOVXNHYYPHFH7J",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-XU3OSC2X3LSHMVC7",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-JYSN2D34RXKEKAJV",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-FQD3O6TFIGWWRCL5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-KMRS3NLEV3WCCTZW",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-DJ3ZIKWTNBYO26BT",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-M2XCU5K6LQ2J5ITH",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-JOU7AJL2C6XXTUFK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-MVC55ZE5FUSGV6TT",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-JBX4TYZ3HEXJNFYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-NEOUW2ZEX7RBIR5K",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-OPPLTPJ24FIGRUY2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-NVLRHXAJBRC6SFY6",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/sirupsen\\\\/logrus:github.com\\\\/sirupsen\\\\/logrus:v1.9.4:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/sirupsen:github.com\\\\/sirupsen\\\\/logrus:v1.9.4:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-JBX4TYZ3HEXJNFYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-ORZDWRSYNCHC3ENU",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-PZFHA4Y4LGCFKCKT",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-ZPQ6ND5QEI5V2QHC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-QDCG4FLMPADB32N4",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-YOG4IQ2TGTYTGLCF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-R65GDD772BOUI6DW",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-RAIJKVXUVKD7F4B4",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-JBX4TYZ3HEXJNFYD",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-ZGOZVHQZC2RMR6GZ",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/anno-ZWW33HY6BRVNREWE",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-REL4BAGIDCNM3IHG",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:example.com\\\\/simple:example.com\\\\/simple:v0.0.0-unknown:*:*:*:*:*:*:*\",\"cpe:2.3:a:example.com:example.com\\\\/simple:v0.0.0-unknown:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-T4B677EGJY43SIMZ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:detected-go\",\"value\":\"true\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-TSATRK3UOLWJ6KYD",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/mattn\\\\/go-isatty:github.com\\\\/mattn\\\\/go-isatty:v0.0.21:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/mattn:github.com\\\\/mattn\\\\/go-isatty:v0.0.21:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-UADJIBC3AU5U4VJC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-TV4ZIPRIM6WP5N5X",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-ZDJ6UECDPJ5HGQUOO7VJR3M7/pkg-ZPQ6ND5QEI5V2QHC",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-4BC3TYO5L6QI7GXM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-TZYWZ5PZFAYK3XNP",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-DJ3ZIKWTNBYO26BT",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-UOIPHC7DKGUX5SSD",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/inconshreveable\\\\/mousetrap:github.com\\\\/inconshreveable\\\\/mousetrap:v1.1.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/inconshreveable:github.com\\\\/inconshreveable\\\\/mousetrap:v1.1.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-DJ3ZIKWTNBYO26BT",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-UQGCJB4A7AISEJ3A",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-UADJIBC3AU5U4VJC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-UT2P3YDYA2XXZLMH",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-UADJIBC3AU5U4VJC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-VKTVACMGDV7YZDTL",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-JOU7AJL2C6XXTUFK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-WC3HWJMEWMI3FDGE",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"golang\"]}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-WQSQQEWUWMYNVBJB",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-ZGOZVHQZC2RMR6GZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-XPSWZN67JRBT3VL6",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-DJ3ZIKWTNBYO26BT",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-Y5JJYV3ZAH2OXL3M",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-A3EJRWNXRJBCN4AR",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-YLB4FCM5ITN2Y2OL",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-JBX4TYZ3HEXJNFYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-YSAFPAPODJ3DXE33",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-UADJIBC3AU5U4VJC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-YT6GSHCEPOGGWL4V",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/spf13\\\\/cobra:github.com\\\\/spf13\\\\/cobra:v1.10.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/spf13:github.com\\\\/spf13\\\\/cobra:v1.10.2:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-ZGOZVHQZC2RMR6GZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-YTU7JKUM4OLJGEWZ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-OPPLTPJ24FIGRUY2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-YVDQ6KEW4PBFD44I",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/go/simple-module/go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/pkg-OPPLTPJ24FIGRUY2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG/anno-YZQFCBFS5QBVPYEW",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-LRV3IQYWGYCFJDRHIQ7P2XMG",
       "type": "Annotation"
     }
   ]

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/maven.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/maven.spdx3.json
@@ -5,15 +5,15 @@
       "@id": "_:creation-info",
       "created": "1970-01-01T00:00:00Z",
       "createdBy": [
-        "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/tool/mikebom"
+        "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/tool/mikebom"
       ],
       "specVersion": "3.0.1",
       "type": "CreationInfo"
     },
     {
       "creationInfo": "_:creation-info",
-      "name": "mikebom-0.1.0-alpha.9",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/tool/mikebom",
+      "name": "mikebom-0.1.0-alpha.10",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/tool/mikebom",
       "type": "Tool"
     },
     {
@@ -22,9 +22,9 @@
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "pom-three-deps",
       "rootElement": [
-        "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-root-3DTLP7KN7ZVD7SR2"
+        "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-root-3DTLP7KN7ZVD7SR2"
       ],
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB",
       "type": "SpdxDocument"
     },
     {
@@ -44,7 +44,7 @@
       "name": "pom-three-deps",
       "software_packageUrl": "pkg:generic/pom-three-deps@0.0.0",
       "software_packageVersion": "0.0.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-root-3DTLP7KN7ZVD7SR2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-root-3DTLP7KN7ZVD7SR2",
       "type": "software_Package"
     },
     {
@@ -64,8 +64,8 @@
       "name": "junit",
       "software_packageUrl": "pkg:maven/junit/junit@4.13.2",
       "software_packageVersion": "4.13.2",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-B7B65U5T2YH5ZD5T",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/agent-org-WUWCD6TLHXMD4KGD",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-B7B65U5T2YH5ZD5T",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/agent-org-WUWCD6TLHXMD4KGD",
       "type": "software_Package"
     },
     {
@@ -95,8 +95,8 @@
       "name": "commons-lang3",
       "software_packageUrl": "pkg:maven/org.apache.commons/commons-lang3@3.14.0",
       "software_packageVersion": "3.14.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-BE4OZRGHG4BEYMYQ",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/agent-org-NAKORBDKTDT5HS6S",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-BE4OZRGHG4BEYMYQ",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/agent-org-NAKORBDKTDT5HS6S",
       "type": "software_Package"
     },
     {
@@ -121,194 +121,194 @@
       "name": "guava",
       "software_packageUrl": "pkg:maven/com.google.guava/guava@32.1.3-jre",
       "software_packageVersion": "32.1.3-jre",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-MVONQLC7NTCYCDSJ",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/agent-org-QLBI4RSKO3LKIWSE",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-MVONQLC7NTCYCDSJ",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/agent-org-QLBI4RSKO3LKIWSE",
       "type": "software_Package"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "org.apache.commons",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/agent-org-NAKORBDKTDT5HS6S",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/agent-org-NAKORBDKTDT5HS6S",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "com.google.guava",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/agent-org-QLBI4RSKO3LKIWSE",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/agent-org-QLBI4RSKO3LKIWSE",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "junit",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/agent-org-WUWCD6TLHXMD4KGD",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/agent-org-WUWCD6TLHXMD4KGD",
       "type": "Organization"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-2DETP7LTD6QGAEWV",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-4UAWGV2O7BC4N5TN",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-MVONQLC7NTCYCDSJ",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-35FYONLCG5XB5FWM",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-MVONQLC7NTCYCDSJ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-4MIEXKULAHO5FMCE",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"maven\"]}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-5PQGH645OHTCL3TN",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-B7B65U5T2YH5ZD5T",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-APJEUJQAXISJREFN",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"workspace\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-BE4OZRGHG4BEYMYQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-DRPRUYXYH6UUQ725",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-564ZUZRGWMCBHUCC",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/maven/pom-three-deps/pom.xml\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-B7B65U5T2YH5ZD5T",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-B7B65U5T2YH5ZD5T",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-ERUKNTUGXYAIF557",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-MVONQLC7NTCYCDSJ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-F52Y3VKA3ZSHXD3Y",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-JKT4ZOTZV25FYZLQ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-LZTJRIONZQZZ4U6I",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-MHL2Z3PN3KNJF2GK",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"workspace\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-B7B65U5T2YH5ZD5T",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-OGOX5OOQGCULMOML",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-OMESGATMPVUPTZL6",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-B7B65U5T2YH5ZD5T",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-OWOUO45DGUN6GXYZ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-BE4OZRGHG4BEYMYQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-PRVHSD3O3FLZCSMH",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-BE4OZRGHG4BEYMYQ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-PXRT6L4JWIUILBHV",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"workspace\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-MVONQLC7NTCYCDSJ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-QWO22CKXLG5DOKV6",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-R7WYP657PX3XQ5SF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-6N54KXBVHAIYMSE7",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:com.google.guava:guava:32.1.3-jre:*:*:*:*:*:*:*\",\"cpe:2.3:a:guava:guava:32.1.3-jre:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-MVONQLC7NTCYCDSJ",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-MVONQLC7NTCYCDSJ",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-RAGXTV7YYUJOAEWC",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-CITQCU3KKWHRSLSU",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"maven\"]}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-GKFVUQDZVTGGV7PA",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-B7B65U5T2YH5ZD5T",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-GUOC7JEKOCLUH7AU",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-BE4OZRGHG4BEYMYQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-GUUXG73QWRXXX4ZM",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-H4D6XOHLXDEHKUG6",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-BE4OZRGHG4BEYMYQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-JSWFHFO7AOCYTP54",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"workspace\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-MVONQLC7NTCYCDSJ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-JTV67D7L53TSPP4U",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-KJYUEW2ZKRCKMB7Y",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/maven/pom-three-deps/pom.xml\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-BE4OZRGHG4BEYMYQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-LRUHLGAXQP5NGMAM",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-M24MEJ7QVCMMNTW3",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"workspace\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-B7B65U5T2YH5ZD5T",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-MRB5MVRNXFBWHSW2",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:org.apache.commons:commons-lang3:3.14.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:commons:commons-lang3:3.14.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:commons-lang3:commons-lang3:3.14.0:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-BE4OZRGHG4BEYMYQ",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-BE4OZRGHG4BEYMYQ",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-ULSCKPMGWP3D5AFU",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/maven/pom-three-deps/pom.xml\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-MVONQLC7NTCYCDSJ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-QDMMIGGQAMAF4S5B",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"workspace\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-BE4OZRGHG4BEYMYQ",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/anno-Z5YG4C4SWFMJEOFK",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-R5DZ6WTFMWSR7VBT",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/maven/pom-three-deps/pom.xml\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OPU6ZNQ44Q5IJHW4E6I2BSDC/pkg-BE4OZRGHG4BEYMYQ",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-MVONQLC7NTCYCDSJ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-SKMMOMLAK5FIGAQZ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-B7B65U5T2YH5ZD5T",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-U4HNTJAJFXRSMR4W",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-VTKGEWPTNABADYKV",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-WCYFRNIIUDBMNI3Y",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/pkg-MVONQLC7NTCYCDSJ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB/anno-ZPZREWOHH3SBSRBN",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-BKMKEFG564WWQSWLFNV3QTMB",
       "type": "Annotation"
     }
   ]

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/npm.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/npm.spdx3.json
@@ -5,15 +5,15 @@
       "@id": "_:creation-info",
       "created": "1970-01-01T00:00:00Z",
       "createdBy": [
-        "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/tool/mikebom"
+        "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/tool/mikebom"
       ],
       "specVersion": "3.0.1",
       "type": "CreationInfo"
     },
     {
       "creationInfo": "_:creation-info",
-      "name": "mikebom-0.1.0-alpha.9",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/tool/mikebom",
+      "name": "mikebom-0.1.0-alpha.10",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/tool/mikebom",
       "type": "Tool"
     },
     {
@@ -22,9 +22,9 @@
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "node-modules-walk",
       "rootElement": [
-        "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-root-GYXCCVGN7I4UMIPA"
+        "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-root-GYXCCVGN7I4UMIPA"
       ],
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB",
       "type": "SpdxDocument"
     },
     {
@@ -44,7 +44,7 @@
       "name": "node-modules-walk",
       "software_packageUrl": "pkg:generic/node-modules-walk@0.0.0",
       "software_packageVersion": "0.0.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-root-GYXCCVGN7I4UMIPA",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-root-GYXCCVGN7I4UMIPA",
       "type": "software_Package"
     },
     {
@@ -64,7 +64,7 @@
       "name": "safe-buffer",
       "software_packageUrl": "pkg:npm/safe-buffer@5.2.1",
       "software_packageVersion": "5.2.1",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-M4HOORJPEJNNEAJV",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-M4HOORJPEJNNEAJV",
       "type": "software_Package"
     },
     {
@@ -84,147 +84,147 @@
       "name": "express",
       "software_packageUrl": "pkg:npm/express@4.18.2",
       "software_packageVersion": "4.18.2",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-TXLIZUEJRNELTNPP",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-TXLIZUEJRNELTNPP",
       "type": "software_Package"
     },
     {
       "creationInfo": "_:creation-info",
       "simplelicensing_licenseExpression": "MIT",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/license-decl-4XOP72BWW3WIUWHE",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/license-decl-4XOP72BWW3WIUWHE",
       "type": "simplelicensing_LicenseExpression"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-TXLIZUEJRNELTNPP",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-TXLIZUEJRNELTNPP",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/rel-KIJWTPKSJOBOFJFO",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/rel-CLW3URFO65YM6WXC",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-M4HOORJPEJNNEAJV"
+        "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-M4HOORJPEJNNEAJV"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-TXLIZUEJRNELTNPP",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-M4HOORJPEJNNEAJV",
       "relationshipType": "hasDeclaredLicense",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/rel-TDDBCWY45BAAANUH",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/rel-JDQNHB34SEFAPGPY",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/license-decl-4XOP72BWW3WIUWHE"
+        "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/license-decl-4XOP72BWW3WIUWHE"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-M4HOORJPEJNNEAJV",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-TXLIZUEJRNELTNPP",
       "relationshipType": "hasDeclaredLicense",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/rel-Z76JCB4BOWZB6O6R",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/rel-KHVYIFU4H2HP6WTF",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/license-decl-4XOP72BWW3WIUWHE"
+        "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/license-decl-4XOP72BWW3WIUWHE"
       ],
       "type": "Relationship"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/anno-24AGOZDONTRBXHZN",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/anno-42FFJCKA75ZKXTDL",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-TXLIZUEJRNELTNPP",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/anno-42Y7ZO5SN7AXKNME",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-M4HOORJPEJNNEAJV",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/anno-6C2T45ESMYZWTVWA",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"npm\"]}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/anno-E7GM7BVENHD3W4BP",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/anno-FXIZUYFDSKNRMCFX",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-TXLIZUEJRNELTNPP",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/anno-G3EKASJT3EVUYSTO",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/anno-J2XOKYZX2R3SNWSL",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/anno-JE2NNSUVFQOZL3F6",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/anno-MOH6LCLVIE6WZN6N",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/anno-26FUPKRKP7VO3OLU",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/npm/node-modules-walk/node_modules/safe-buffer/package.json\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-M4HOORJPEJNNEAJV",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-M4HOORJPEJNNEAJV",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/anno-O2GRTSOOEHPITKE6",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-M4HOORJPEJNNEAJV",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/anno-T56XX2VC2VGKZT4L",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/anno-2XGKU4MNVFJPA6D6",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/npm/node-modules-walk/node_modules/express/package.json\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/pkg-TXLIZUEJRNELTNPP",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-TXLIZUEJRNELTNPP",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB/anno-YTPY4WVUX2AUPA2I",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/anno-EF5W2UDWG3LM3U5V",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/anno-KKR6HX6XSKT4OAQX",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-M4HOORJPEJNNEAJV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/anno-MQIV4TX76N6GAQXA",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"npm\"]}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/anno-NEIRJ5UGK33LP3ZZ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-M4HOORJPEJNNEAJV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/anno-RZOSU7YPNGCDCFWX",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/anno-TLSLEUHTE5EDBHZX",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/anno-TRT24KA4VK7Q55U6",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/anno-TUWQJWCCOTBPKDZR",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-TXLIZUEJRNELTNPP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/anno-UCHMYBIRGCSJJSOQ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/pkg-TXLIZUEJRNELTNPP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/anno-ZMXIKH3S7BP6HASD",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB/anno-ZN7AF7GDHFNJUQ2Y",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-4ALEUSCL5KBX4O4AJ2JXMSTB",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-UP6PK6FKHK22YTSG3XXDAEXB",
       "type": "Annotation"
     }
   ]

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/pip.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/pip.spdx3.json
@@ -5,15 +5,15 @@
       "@id": "_:creation-info",
       "created": "1970-01-01T00:00:00Z",
       "createdBy": [
-        "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/tool/mikebom"
+        "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/tool/mikebom"
       ],
       "specVersion": "3.0.1",
       "type": "CreationInfo"
     },
     {
       "creationInfo": "_:creation-info",
-      "name": "mikebom-0.1.0-alpha.9",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/tool/mikebom",
+      "name": "mikebom-0.1.0-alpha.10",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/tool/mikebom",
       "type": "Tool"
     },
     {
@@ -22,9 +22,9 @@
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "simple-venv",
       "rootElement": [
-        "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-root-O4XGGFIAI4WU3KZ2"
+        "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-root-O4XGGFIAI4WU3KZ2"
       ],
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ",
       "type": "SpdxDocument"
     },
     {
@@ -44,7 +44,7 @@
       "name": "simple-venv",
       "software_packageUrl": "pkg:generic/simple-venv@0.0.0",
       "software_packageVersion": "0.0.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-root-O4XGGFIAI4WU3KZ2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-root-O4XGGFIAI4WU3KZ2",
       "type": "software_Package"
     },
     {
@@ -69,7 +69,7 @@
       "name": "requests",
       "software_packageUrl": "pkg:pypi/requests@2.31.0",
       "software_packageVersion": "2.31.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-6PK6TYQPA2QWXM26",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-6PK6TYQPA2QWXM26",
       "type": "software_Package"
     },
     {
@@ -94,7 +94,7 @@
       "name": "jinja2",
       "software_packageUrl": "pkg:pypi/jinja2@3.1.2",
       "software_packageVersion": "3.1.2",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-E7GW44NAPCTLSLSL",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-E7GW44NAPCTLSLSL",
       "type": "software_Package"
     },
     {
@@ -119,7 +119,7 @@
       "name": "certifi",
       "software_packageUrl": "pkg:pypi/certifi@2023.7.22",
       "software_packageVersion": "2023.7.22",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-IGBIL3UCACAQFOM3",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-IGBIL3UCACAQFOM3",
       "type": "software_Package"
     },
     {
@@ -144,7 +144,7 @@
       "name": "idna",
       "software_packageUrl": "pkg:pypi/idna@3.6",
       "software_packageVersion": "3.6",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-KVTB5ZDMEOOSAO3A",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-KVTB5ZDMEOOSAO3A",
       "type": "software_Package"
     },
     {
@@ -169,7 +169,7 @@
       "name": "flask",
       "software_packageUrl": "pkg:pypi/flask@3.0.0",
       "software_packageVersion": "3.0.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-ND26YIDZX2IHEVKH",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-ND26YIDZX2IHEVKH",
       "type": "software_Package"
     },
     {
@@ -194,7 +194,7 @@
       "name": "urllib3",
       "software_packageUrl": "pkg:pypi/urllib3@2.0.7",
       "software_packageVersion": "2.0.7",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-R4X6ZI7PYUOFDI6S",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-R4X6ZI7PYUOFDI6S",
       "type": "software_Package"
     },
     {
@@ -219,421 +219,421 @@
       "name": "charset-normalizer",
       "software_packageUrl": "pkg:pypi/charset-normalizer@3.3.2",
       "software_packageVersion": "3.3.2",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-Z2NM5GYCT4SAIAVF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-Z2NM5GYCT4SAIAVF",
       "type": "software_Package"
     },
     {
       "creationInfo": "_:creation-info",
       "simplelicensing_licenseExpression": "MIT",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/license-decl-4XOP72BWW3WIUWHE",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/license-decl-4XOP72BWW3WIUWHE",
       "type": "simplelicensing_LicenseExpression"
     },
     {
       "creationInfo": "_:creation-info",
       "simplelicensing_licenseExpression": "MPL-2.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/license-decl-BGLCYHOCH6WIBIHF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/license-decl-BGLCYHOCH6WIBIHF",
       "type": "simplelicensing_LicenseExpression"
     },
     {
       "creationInfo": "_:creation-info",
       "simplelicensing_licenseExpression": "BSD-3-Clause",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/license-decl-CGG3ZUWVZH43FFVJ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/license-decl-CGG3ZUWVZH43FFVJ",
       "type": "simplelicensing_LicenseExpression"
     },
     {
       "creationInfo": "_:creation-info",
       "simplelicensing_licenseExpression": "Apache-2.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/license-decl-FL3RKWHEHDNQW45C",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/license-decl-FL3RKWHEHDNQW45C",
       "type": "simplelicensing_LicenseExpression"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-E7GW44NAPCTLSLSL",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-IGBIL3UCACAQFOM3",
       "relationshipType": "hasDeclaredLicense",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/rel-5O42LBQQLW2Q3WRC",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/rel-2A7RYJIR3SFTZT5N",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/license-decl-CGG3ZUWVZH43FFVJ"
+        "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/license-decl-BGLCYHOCH6WIBIHF"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-IGBIL3UCACAQFOM3",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-ND26YIDZX2IHEVKH",
       "relationshipType": "hasDeclaredLicense",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/rel-7DPFBP3XDRPAC5AF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/rel-3AGN2BMFELVUG4ND",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/license-decl-BGLCYHOCH6WIBIHF"
+        "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/license-decl-CGG3ZUWVZH43FFVJ"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-6PK6TYQPA2QWXM26",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-R4X6ZI7PYUOFDI6S",
       "relationshipType": "hasDeclaredLicense",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/rel-FC27ZQYT6MXLADXJ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/rel-7JAF23Z4DWIUXAT5",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/license-decl-FL3RKWHEHDNQW45C"
+        "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/license-decl-4XOP72BWW3WIUWHE"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-KVTB5ZDMEOOSAO3A",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-KVTB5ZDMEOOSAO3A",
       "relationshipType": "hasDeclaredLicense",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/rel-HFDTWUN5QQEWIXXP",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/rel-BQB3OJ6HD6QMX3SL",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/license-decl-CGG3ZUWVZH43FFVJ"
+        "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/license-decl-CGG3ZUWVZH43FFVJ"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-R4X6ZI7PYUOFDI6S",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-6PK6TYQPA2QWXM26",
       "relationshipType": "hasDeclaredLicense",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/rel-JOW652RPMMMZHT42",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/rel-E3FDN77LJQUF2VTW",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/license-decl-4XOP72BWW3WIUWHE"
+        "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/license-decl-FL3RKWHEHDNQW45C"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-6PK6TYQPA2QWXM26",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-6PK6TYQPA2QWXM26",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/rel-K4ANLWVYVYOXFKF3",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/rel-F5ZHGKGQ4NQ7N5IV",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-KVTB5ZDMEOOSAO3A"
+        "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-R4X6ZI7PYUOFDI6S"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-6PK6TYQPA2QWXM26",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-6PK6TYQPA2QWXM26",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/rel-OPW5K5ZZZMAOBVR2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/rel-HANPWVWZYFQFH7NM",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-Z2NM5GYCT4SAIAVF"
+        "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-KVTB5ZDMEOOSAO3A"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-Z2NM5GYCT4SAIAVF",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-Z2NM5GYCT4SAIAVF",
       "relationshipType": "hasDeclaredLicense",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/rel-OUAQF64ROJLKD6B6",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/rel-LFC7IVNWHA2E4RRZ",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/license-decl-4XOP72BWW3WIUWHE"
+        "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/license-decl-4XOP72BWW3WIUWHE"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-6PK6TYQPA2QWXM26",
-      "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/rel-RMYO7HDTFGV4A7PU",
-      "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-IGBIL3UCACAQFOM3"
-      ],
-      "type": "Relationship"
-    },
-    {
-      "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-ND26YIDZX2IHEVKH",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-E7GW44NAPCTLSLSL",
       "relationshipType": "hasDeclaredLicense",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/rel-RROGUJMSDIMWSPSP",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/rel-QALMF74T6P4POHX7",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/license-decl-CGG3ZUWVZH43FFVJ"
+        "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/license-decl-CGG3ZUWVZH43FFVJ"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-6PK6TYQPA2QWXM26",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-6PK6TYQPA2QWXM26",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/rel-YS3DQHESU4XLKP5P",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/rel-XRKBBWHJZCONNLEL",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-R4X6ZI7PYUOFDI6S"
+        "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-IGBIL3UCACAQFOM3"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-6PK6TYQPA2QWXM26",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/rel-YLNQA2CLDRAEYFJA",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-Z2NM5GYCT4SAIAVF"
       ],
       "type": "Relationship"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-2AL7QO5C6WOMI7IO",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-2FXZQ7OHV6YHNVFC",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-IGBIL3UCACAQFOM3",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-Z2NM5GYCT4SAIAVF",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-2BDPPXN6F5WKSJ5U",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:certifi:certifi:2023.7.22:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-certifi:certifi:2023.7.22:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-IGBIL3UCACAQFOM3",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-2RDVQJSZY7STYRPL",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-R4X6ZI7PYUOFDI6S",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-5HMA5FHPPTNO5JS2",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-KVTB5ZDMEOOSAO3A",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-5MMUDIX5RS3OKVWZ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-IGBIL3UCACAQFOM3",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-5T5M3LM7PFD4QZTM",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:jinja2:jinja2:3.1.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-jinja2:jinja2:3.1.2:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-E7GW44NAPCTLSLSL",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-6VG7XOHGOHRUBATM",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-7FG5XJO52KLXODR2",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-Z2NM5GYCT4SAIAVF",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-7WTLTLZSS5Z4TFLX",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/requests-2.31.0.dist-info/METADATA\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-6PK6TYQPA2QWXM26",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-AJ3EEYL4GNNEWRVI",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-E7GW44NAPCTLSLSL",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-BFYKDMEXERQK2D4W",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-E7GW44NAPCTLSLSL",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-BILM7QXZ4GHO4QBR",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/urllib3-2.0.7.dist-info/METADATA\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-R4X6ZI7PYUOFDI6S",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-BN6NGXYET5QPALZN",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-R4X6ZI7PYUOFDI6S",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-GC27FT26F4MHMP2M",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:flask:flask:3.0.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-flask:flask:3.0.0:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-ND26YIDZX2IHEVKH",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-JHQDFBKQHFIXO4H6",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-JK5KMV2EY5T5PPIP",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-JSAMG4HB7F5O5JMX",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/flask-3.0.0.dist-info/METADATA\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-ND26YIDZX2IHEVKH",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-KVAUOI2CSIGZN5TU",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"pypi\"]}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-L2KDZU2CIBTSJ2MV",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:idna:idna:3.6:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-idna:idna:3.6:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-KVTB5ZDMEOOSAO3A",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-LFLNDIONIDQLR4PG",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-Z2NM5GYCT4SAIAVF",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-MEVIXDFZFSBDD27M",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-ND26YIDZX2IHEVKH",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-MRMEWQGMHYCKK46X",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/jinja2-3.1.2.dist-info/METADATA\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-E7GW44NAPCTLSLSL",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-N5K24YT2GLUXAPDT",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/certifi-2023.7.22.dist-info/METADATA\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-IGBIL3UCACAQFOM3",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-P2LG2NCMQ4P5QB7U",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-PRAVKJIAL5BLF6AD",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-6PK6TYQPA2QWXM26",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-QIXFZZBF75BAOAWI",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-2HVXUAXYOIY5VSQN",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:charset-normalizer:charset-normalizer:3.3.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-charset-normalizer:charset-normalizer:3.3.2:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-Z2NM5GYCT4SAIAVF",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-Z2NM5GYCT4SAIAVF",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-RDFHNWSWNWFU5PBL",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-2IDJNB4EPCPKESMO",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-ND26YIDZX2IHEVKH",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-R4X6ZI7PYUOFDI6S",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-RHXM7KLTQA4GEOWN",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-RWOXB3UY5ZBLF5JL",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-2UB7UHPKJEM3INIS",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:urllib3:urllib3:2.0.7:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-urllib3:urllib3:2.0.7:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-R4X6ZI7PYUOFDI6S",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-R4X6ZI7PYUOFDI6S",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-SUINQELP2FBIND3D",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-6PK6TYQPA2QWXM26",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-2YGRMUER7PCN235D",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"pypi\"]}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-TUH6JRALUN6CYNHQ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-455BVRVTHDY766B5",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-U4TAEZD2J2YBS2D4",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/charset_normalizer-3.3.2.dist-info/METADATA\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-Z2NM5GYCT4SAIAVF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-4O3LDZQCOAKAG2IU",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-Z2NM5GYCT4SAIAVF",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-VMIVWMT67342JUUK",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-KVTB5ZDMEOOSAO3A",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-4QY2A3L2QUHCESZT",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-IGBIL3UCACAQFOM3",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-W7NC5F4QBBKVNCT2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-6D5T6R6546GYF2HZ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/flask-3.0.0.dist-info/METADATA\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-ND26YIDZX2IHEVKH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-7OA47I2MUEAZ3UDG",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/certifi-2023.7.22.dist-info/METADATA\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-IGBIL3UCACAQFOM3",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-BLZBQR5ZFYGJWJ5J",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:jinja2:jinja2:3.1.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-jinja2:jinja2:3.1.2:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-E7GW44NAPCTLSLSL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-EIYKHP2AQCBG4WAB",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/idna-3.6.dist-info/METADATA\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-KVTB5ZDMEOOSAO3A",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-KVTB5ZDMEOOSAO3A",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/anno-WFIYHYBEWW7CATJ3",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-EPN2HUABBJPDV7KC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:idna:idna:3.6:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-idna:idna:3.6:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-KVTB5ZDMEOOSAO3A",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-FLPC23JZX63NTRTK",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/requests-2.31.0.dist-info/METADATA\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-6PK6TYQPA2QWXM26",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-FQKTE7NJUBMWPVZA",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-6PK6TYQPA2QWXM26",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-FTXUEBHCZLNTPZTC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-KVTB5ZDMEOOSAO3A",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-HGVVA2P3K4TRNHOI",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-ND26YIDZX2IHEVKH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-IDGCG6K4337LBMV2",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/charset_normalizer-3.3.2.dist-info/METADATA\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-Z2NM5GYCT4SAIAVF",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-J3HLYTA3QM5RDSE3",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-JDLLLHOXNKB5LKXS",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-MVJ75Z2YKOO2RQ46",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/jinja2-3.1.2.dist-info/METADATA\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-E7GW44NAPCTLSLSL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-NC2T2L3XZMRTUJJI",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-6PK6TYQPA2QWXM26",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-NQAPMBUIT6WUHFQQ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-ND26YIDZX2IHEVKH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-NR2ANCEH6MJTSKZQ",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:requests:requests:2.31.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-requests:requests:2.31.0:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-OVXFBQTJ5BJOMDTSTQHLKRZI/pkg-6PK6TYQPA2QWXM26",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-6PK6TYQPA2QWXM26",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-OL6ILNHOW37FY3N5",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:flask:flask:3.0.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-flask:flask:3.0.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-ND26YIDZX2IHEVKH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-ONR3WA7HQNM4MZBC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-KVTB5ZDMEOOSAO3A",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-PUV2J54RUJLHPIRR",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-PYDYSOPTWYY3ZEE2",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-R4X6ZI7PYUOFDI6S",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-QGZKANUAORL2ZMEX",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"<WORKSPACE>/tests/fixtures/python/simple-venv/.venv/lib/python3.12/site-packages/urllib3-2.0.7.dist-info/METADATA\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-R4X6ZI7PYUOFDI6S",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-QYHEUBP3NTWASAYS",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"deployed\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-E7GW44NAPCTLSLSL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-TAV4KD24CFWSHWPE",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-W7HVEBT5Q3ZGHZGX",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:certifi:certifi:2023.7.22:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-certifi:certifi:2023.7.22:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-IGBIL3UCACAQFOM3",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-WYZGWITIO5A5IKAU",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-E7GW44NAPCTLSLSL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-ZDDAZ4TVHATPSZ5W",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/pkg-IGBIL3UCACAQFOM3",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ/anno-ZXZERUXGROPYMKRM",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-RKMJNBMWL7TJAIA73IBH5OFZ",
       "type": "Annotation"
     }
   ]

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/rpm.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/rpm.spdx3.json
@@ -5,15 +5,15 @@
       "@id": "_:creation-info",
       "created": "1970-01-01T00:00:00Z",
       "createdBy": [
-        "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM/tool/mikebom"
+        "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH/tool/mikebom"
       ],
       "specVersion": "3.0.1",
       "type": "CreationInfo"
     },
     {
       "creationInfo": "_:creation-info",
-      "name": "mikebom-0.1.0-alpha.9",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM/tool/mikebom",
+      "name": "mikebom-0.1.0-alpha.10",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH/tool/mikebom",
       "type": "Tool"
     },
     {
@@ -22,9 +22,9 @@
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "bdb-only",
       "rootElement": [
-        "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM/pkg-root-GAECKAZT2GMN6PKP"
+        "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH/pkg-root-GAECKAZT2GMN6PKP"
       ],
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH",
       "type": "SpdxDocument"
     },
     {
@@ -44,55 +44,55 @@
       "name": "bdb-only",
       "software_packageUrl": "pkg:generic/bdb-only@0.0.0",
       "software_packageVersion": "0.0.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM/pkg-root-GAECKAZT2GMN6PKP",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH/pkg-root-GAECKAZT2GMN6PKP",
       "type": "software_Package"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM/anno-3ZD6HWSMWY346ZIP",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM/anno-6VMEPTFV4C2ESORX",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM/anno-IAVDNRW65XILVHFV",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH/anno-ABH4LZCYLWKS37D5",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM/anno-R6OUXZ7QE3Z5BBQQ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM/anno-XJFL2635TWEIE3DJ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH/anno-CQLVN5X6N4BJHJOX",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM/anno-XZYM4ZSZZK44F3CQ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH/anno-EPNLLNHMTNV7DDY2",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-GN6KVUA5NXTEYGJI6MHKRYSM",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH/anno-HI6G2Y3ATGPCOE5E",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH/anno-ODSAQACIFF5PBU5K",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH/anno-UYMXN7YHIJUOAZCR",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GCVCCTZND3FOGUYWSTXYGRGH",
       "type": "Annotation"
     }
   ]


### PR DESCRIPTION
## Summary

Cuts a release covering six milestones shipped since alpha.9
(~1 day later):

- **053**: Go main-module component + direct dep edges (closes
  #102; PR #105)
- **052/part-3**: `--exclude-scope` flag + default scope flip +
  `--include-dev` deprecation (PR #100)
- **052/part-2**: native CDX/SPDX 2.3/SPDX 3 lifecycle-scope
  emission + edge rewrite (PR #99)
- **052/part-1**: `LifecycleScope` data model + Constitution
  Principle V (v1.4.0) codification (PR #98)
- **051**: polyglot dev/test tagging via
  `mikebom:dev-dependency` (PR #96)
- **050**: `mikebom:not-linked` annotation + Go source-tree
  scope hint (PR #93)

## Breaking changes — SBOM consumer migration

Three user-visible breaks documented in CHANGELOG
`[0.1.0-alpha.10]`:

1. **CDX `metadata.component.purl` for Go-only scans** shifts
   from synthetic `pkg:generic/<target>@0.0.0` to the real
   `pkg:golang/<module-path>@<version>`.
2. **SPDX `documentDescribes` for Go-only scans** targets the
   Go main-module's SPDXID instead of a `SPDXRef-DocumentRoot-*`
   placeholder.
3. **`mikebom:dev-dependency` annotation removed everywhere**;
   migrate to CDX `components[].scope = "excluded"` / SPDX 2.3
   `*_DEPENDENCY_OF` / SPDX 3 `lifecycleScope` on `dependsOn`.

`--include-dev` is a deprecated parse-and-warn no-op shim;
`--exclude-scope dev,build,test` restores the strict pre-052
prod-only view.

## Test plan

- [x] `./scripts/pre-pr.sh` clean (clippy `--all-targets -D warnings`
  + `cargo +stable test --workspace` zero failures).
- [x] 27 byte-identity goldens regenerated (CDX 9 + SPDX 2.3 9 +
  SPDX 3 9). CDX diff is just the version-string bump in
  `metadata.tools[].version`. SPDX 2.3 + 3 have larger diffs
  because the version is in `creators[]` strings + Tool-Agent IRIs.
- [x] Cross-host byte-identity preserved via the existing playbook
  (fake `HOME` / no-`.git` fixtures / hash-stripping / serial +
  timestamp masks).
- [x] No code changes outside `Cargo.toml` / `Cargo.lock` /
  `CHANGELOG.md` / golden files.

## Follow-ups (open issues)

- #101: remove deprecated `--include-dev` shim post-soak.
- #103: LICENSE-file detection on Go main-module.
- #104: per-ecosystem main-modules for npm / cargo / maven /
  pip / gem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)