### PR TITLE
fix(075): strip userinfo credentials from auto-detected git URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-05
 - N/A — identifier metadata lives in emitted SBOMs only. (073-source-identifiers)
 - Rust stable (workspace toolchain inherited from milestones 001–073; no nightly required for this user-space-only work). + Existing only — `std::process::Command` for the new `git rev-parse HEAD` shell-out (same pattern as the existing `git remote get-url` calls at `auto_detect.rs:32`+ and as milestone 053's `git describe` ladder), `tracing` for info/warn logs, `anyhow` for error propagation. **No new `Cargo.toml` deps.** (074-build-tier-id-autodetect)
 - N/A — identifiers live in emitted SBOMs only; no caches, no persistence. (074-build-tier-id-autodetect)
+- Rust stable (workspace toolchain inherited from milestones 001–074; no nightly). + Existing only — the `url = "2.5.8"` crate is already in the dependency closure (transitive via `reqwest`); this milestone promotes it to a direct workspace dependency. No new transitive deps. Plus `tracing` (info-level logs), `anyhow` (error propagation), `clap` (the new boolean flag — `Args`-derive picks it up). **No additions to the dependency tree at the lockfile level.** (075-strip-id-credentials)
+- N/A — sanitization is a pure-function transformation; no caches, no persistence. (075-strip-id-credentials)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -113,9 +115,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 075-strip-id-credentials: Added Rust stable (workspace toolchain inherited from milestones 001–074; no nightly). + Existing only — the `url = "2.5.8"` crate is already in the dependency closure (transitive via `reqwest`); this milestone promotes it to a direct workspace dependency. No new transitive deps. Plus `tracing` (info-level logs), `anyhow` (error propagation), `clap` (the new boolean flag — `Args`-derive picks it up). **No additions to the dependency tree at the lockfile level.**
 - 074-build-tier-id-autodetect: Added Rust stable (workspace toolchain inherited from milestones 001–073; no nightly required for this user-space-only work). + Existing only — `std::process::Command` for the new `git rev-parse HEAD` shell-out (same pattern as the existing `git remote get-url` calls at `auto_detect.rs:32`+ and as milestone 053's `git describe` ladder), `tracing` for info/warn logs, `anyhow` for error propagation. **No new `Cargo.toml` deps.**
 - 073-source-identifiers: Added Rust stable (workspace toolchain inherited from milestones 001–072; no nightly). + Existing only — `serde`/`serde_json` (envelope decode), `tracing` (info/warn logs), `anyhow` (CLI error propagation), `clap` (`ValueEnum` not needed — `Vec<String>` with manual validation is fine since the scheme syntax is regex-bounded; alternatively a custom `Identifier` newtype that implements `FromStr` and clap's `Args`-derive picks it up). `Command::new("git")` for the auto-detection shell-out (same pattern as milestone 053's `git describe`). No new `Cargo.toml` deps.
-- 072-cross-tier-sbom-binding: Added Rust stable (workspace toolchain inherited from milestones 001–071; no nightly). + Existing only — `sha2` (workspace; SHA-256 over the canonical JSON envelope), `serde`/`serde_json` (canonicalization via the milestone-071 `canonicalize_for_compare` helper at `parity/extractors/common.rs`), `data-encoding` (already used for hex-encoding hashes), `tracing`, `anyhow`, `clap` (for the new flag + new subcommands). No new crates.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,6 +2206,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "wiremock",
  "x509-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,12 @@ thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Milestone 075 — RFC 3986 URL parsing for stripping userinfo
+# credentials from auto-detected git remote URLs before they get
+# embedded in published SBOMs. Already pinned at 2.5.8 transitively
+# (via reqwest); promotion to a direct workspace dep changes nothing
+# in Cargo.lock.
+url = "2"
 
 # mikebom-ebpf is built separately via xtask (different target triple)
 # and is NOT a workspace member — it uses #![no_std] + nightly + bpf target

--- a/docs/reference/identifiers.md
+++ b/docs/reference/identifiers.md
@@ -438,6 +438,89 @@ Future milestones may automate the correlation; this milestone lays
 the foundation by making every tier emit its identifiers
 automatically.
 
+### 4.6 Credential sanitization (milestone 075)
+
+When the discovered remote URL carries RFC 3986 userinfo
+(`<user>[:<password>]@host` — common in CI runners using GitHub App
+tokens or HTTPS deploy tokens, e.g., `https://x-access-token:ghs_AAA
+@github.com/foo.git`), mikebom strips the userinfo before the URL
+becomes an identifier value. SBOMs are typically published artifacts
+(release attachments, OCI registry referrers, signed attestations);
+the strip prevents accidental token disclosure.
+
+Sanitization fires on auto-detected URLs in BOTH tiers:
+
+- Source-tier `repo:` identifier (§4.1).
+- Build-tier `repo:` and `git:` identifiers (§4.4). For `git:`, the
+  URL portion is sanitized BEFORE the `#<sha>` is appended, so a
+  credentialed `https://USER:TOKEN@github.com/foo.git` at HEAD
+  `abc1234...` emits as `git:https://github.com/foo.git#abc1234...`.
+
+When sanitization fires, the `source_label` is augmented with the
+suffix ` (credentials stripped)`:
+
+```text
+"auto-detected from git remote `origin` (credentials stripped)"
+"auto-detected from build-tier git remote `origin` (credentials stripped)"
+"auto-detected from build-tier `git rev-parse HEAD` (credentials stripped)"
+```
+
+An info-level log line is emitted per sanitized identifier with the
+userinfo replaced by the literal `<userinfo redacted>` placeholder
+so operators can audit the action without the actual credential
+appearing in the log.
+
+#### What gets stripped vs not
+
+| Input URL | Auto-detect default | With `--keep-credentials-in-identifiers` |
+|---|---|---|
+| `https://USER:TOKEN@github.com/foo.git` | `https://github.com/foo.git` | unchanged (verbatim) |
+| `https://TOKEN@github.com/foo.git` | `https://github.com/foo.git` | unchanged (verbatim) |
+| `https://github.com/foo.git` (no userinfo) | unchanged | unchanged |
+| `git@github.com:foo/bar.git` (SSH form) | unchanged (no userinfo per RFC 3986) | unchanged |
+| `git://github.com/foo.git` | unchanged (no userinfo present) | unchanged |
+| `git://USER:TOKEN@github.com/foo.git` | `git://github.com/foo.git` | unchanged (verbatim) |
+
+SSH-form URLs (`git@host:path` — the SCP-like syntax) carry no
+userinfo by construction; the `git@` is a fixed SSH username, not a
+credential. mikebom passes them through unchanged in both modes.
+
+#### Manual flags emit verbatim
+
+Manual `--repo`, `--git-ref`, `--image-id`, `--attestation`, and
+`--id <scheme>=<value>` flag values are NOT sanitized — operators
+who explicitly type credentialed URLs are responsible for their
+choice (FR-004). The boundary is "auto-detected = sanitized;
+manual = verbatim", and it applies regardless of the
+`--keep-credentials-in-identifiers` flag value.
+
+#### Opt-out flag
+
+Operators on private/internal-network setups where the credentials
+are deliberately non-sensitive (e.g., a public read-only deploy
+token, an internal-network-only HTTPS token with no value outside
+the corporate VPN) can preserve userinfo via:
+
+```bash
+mikebom sbom scan --path . --keep-credentials-in-identifiers
+mikebom trace run --keep-credentials-in-identifiers -- ./build.sh
+```
+
+When set, the flag suppresses sanitization for all auto-detected
+identifiers in the scan. mikebom emits one info-level log line
+acknowledging the suppression so the audit trail records the
+operator's choice. The `(credentials stripped)` suffix does NOT
+appear on `source_label`s in this mode.
+
+#### Cross-tier picture
+
+The cross-tier correlation recipe in §4.5 stays valid post-075: the
+sanitized URL is the canonical correlation key. A downstream tool
+matching SBOMs by `repo:` value gets identical canonical forms
+across tiers regardless of which side originally observed
+credentials. See `specs/075-strip-id-credentials/quickstart.md`
+Recipe 5 for a worked end-to-end example.
+
 ---
 
 ## Section 5 — Determinism contract

--- a/mikebom-cli/Cargo.toml
+++ b/mikebom-cli/Cargo.toml
@@ -159,6 +159,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+url.workspace = true
 
 # Milestone 031 — direct OCI-registry image scan. Activated by the
 # `oci-registry` feature only. Built on oci-spec (types-only,

--- a/mikebom-cli/src/binding/identifiers/auto_detect.rs
+++ b/mikebom-cli/src/binding/identifiers/auto_detect.rs
@@ -24,6 +24,163 @@ use std::process::Command;
 
 use super::{Identifier, IdentifierKind, IdentifierValue, SchemeName};
 
+/// Result of running `sanitize_userinfo` on a candidate URL string.
+///
+/// Private to this module; not part of the public surface. Lifetime
+/// is ephemeral — the helper returns one of these, the caller
+/// inspects the fields once and emits its identifier, and the
+/// struct is dropped.
+///
+/// Field semantics per data-model.md (milestone 075):
+/// - `original`: the URL string exactly as it came back from
+///   `git remote get-url`. Preserved so callers can still reference
+///   the host/path for operator-debuggability log output via
+///   `redact_userinfo_for_log`.
+/// - `sanitized`: the URL with RFC 3986 userinfo removed when the
+///   parser saw any. Equal to `original` when the URL had no
+///   userinfo, when the URL fails to parse (SSH-form, malformed),
+///   or when one of the setter calls rejects the URL (cannot-be-base
+///   path).
+/// - `was_sanitized`: `true` iff this run actually stripped userinfo.
+///   Drives FR-006 log-line emission and FR-008 `(credentials
+///   stripped)` source_label suffix.
+struct SanitizedUrl {
+    original: String,
+    sanitized: String,
+    was_sanitized: bool,
+}
+
+/// Strip RFC 3986 userinfo from a candidate git remote URL before
+/// it gets embedded as an identifier value in a published SBOM.
+///
+/// Behavior (data-model.md §`sanitize_userinfo`, research §1, §6):
+///
+/// 1. `url::Url::parse(url)` — on `Err`, return passthrough
+///    (`sanitized == original`, `was_sanitized == false`). Covers
+///    SSH-form URLs (`git@host:foo/bar.git`) and any other
+///    non-RFC-3986 input.
+/// 2. On parse success, check whether the parsed URL carries
+///    userinfo (`username().is_empty() == false ||
+///    password().is_some()`). If neither is present, return
+///    passthrough.
+/// 3. On userinfo present, call `set_username("")` followed by
+///    `set_password(None)`. Either setter returning `Err` (the
+///    "cannot-be-base" path) collapses to passthrough — preserves
+///    the FR-009 soft-fail rule.
+/// 4. On both setters succeeding, return `SanitizedUrl { original,
+///    sanitized: parsed.to_string(), was_sanitized: true }`.
+///
+/// Never panics, never returns `Result`. All failure modes (parse
+/// error, setter rejection, missing authority) collapse to a
+/// passthrough — the original string emits verbatim, milestone
+/// 073's existing soft-fail-to-`UserDefined` rule (FR-009) handles
+/// downstream classification.
+fn sanitize_userinfo(url: &str) -> SanitizedUrl {
+    let original = url.to_string();
+    let mut parsed = match url::Url::parse(url) {
+        Ok(p) => p,
+        Err(_) => {
+            // Parse failure: SSH-form URLs and other non-RFC-3986
+            // inputs. Pass through unchanged; downstream validators
+            // soft-fail to `UserDefined` per FR-009.
+            return SanitizedUrl {
+                original: original.clone(),
+                sanitized: original,
+                was_sanitized: false,
+            };
+        }
+    };
+    // `set_username("")` and `set_password(None)` reject cannot-be-
+    // base URLs (e.g., `mailto:`). Vanishingly rare for the
+    // git-remote input domain, but the safe fallback is still
+    // passthrough. Always call them — that way even the
+    // `https://@host/...` empty-userinfo edge case (where
+    // `username().is_empty()` already and `password()` is `None` but
+    // the literal `@` survives the parse) gets cleaned up: the
+    // setters re-canonicalize the URL through the `url` crate's
+    // serializer, which writes neither `user`, nor `:password`, nor
+    // a stray `@` when both are empty/None.
+    if parsed.set_username("").is_err() {
+        return SanitizedUrl {
+            original: original.clone(),
+            sanitized: original,
+            was_sanitized: false,
+        };
+    }
+    if parsed.set_password(None).is_err() {
+        return SanitizedUrl {
+            original: original.clone(),
+            sanitized: original,
+            was_sanitized: false,
+        };
+    }
+    let sanitized = parsed.to_string();
+    // Compare against the parser's round-trip of the original URL
+    // (NOT the raw input) so URL canonicalization (default-port
+    // stripping, percent-encoding normalization, trailing-slash
+    // additions) doesn't falsely register as "userinfo stripped".
+    // Only userinfo presence/absence drives `was_sanitized`.
+    let original_round_trip = match url::Url::parse(&original) {
+        Ok(p) => p.to_string(),
+        Err(_) => original.clone(),
+    };
+    let was_sanitized = sanitized != original_round_trip;
+    SanitizedUrl {
+        original,
+        sanitized,
+        was_sanitized,
+    }
+}
+
+/// Build a redacted form of a URL for log output. Replaces userinfo
+/// with the literal string `<userinfo redacted>` while preserving
+/// scheme/host/port/path/query/fragment so operators can identify
+/// which remote was sanitized without leaking the credential value.
+///
+/// Behavior:
+/// - Parse-success with userinfo present: emit
+///   `<scheme>://<userinfo redacted>@<host>[:<port>]<path>...`.
+/// - Parse-success without userinfo: pass the input through
+///   unchanged (no redaction marker).
+/// - Parse-failure (SSH-form, malformed): pass the input through
+///   unchanged. Used in code paths gated on `was_sanitized == true`,
+///   so SSH-form never reaches this helper in production.
+///
+/// The literal credential value MUST NOT appear in the output
+/// (FR-006). Callers route the result through `tracing::info!` as a
+/// `Display` field.
+fn redact_userinfo_for_log(url_str: &str) -> String {
+    let parsed = match url::Url::parse(url_str) {
+        Ok(p) => p,
+        Err(_) => return url_str.to_string(),
+    };
+    let has_userinfo = !parsed.username().is_empty() || parsed.password().is_some();
+    if !has_userinfo {
+        return url_str.to_string();
+    }
+    // Reconstruct: <scheme>://<userinfo redacted>@<host>[:<port>]<path>?<query>#<fragment>
+    let mut out = String::new();
+    out.push_str(parsed.scheme());
+    out.push_str("://<userinfo redacted>@");
+    if let Some(host) = parsed.host_str() {
+        out.push_str(host);
+    }
+    if let Some(port) = parsed.port() {
+        out.push(':');
+        out.push_str(&port.to_string());
+    }
+    out.push_str(parsed.path());
+    if let Some(q) = parsed.query() {
+        out.push('?');
+        out.push_str(q);
+    }
+    if let Some(f) = parsed.fragment() {
+        out.push('#');
+        out.push_str(f);
+    }
+    out
+}
+
 /// Auto-detect a `repo:` identifier from a git checkout. Returns `None`
 /// when the scan root isn't a git checkout, has no remotes, or any git
 /// subprocess errors out — all such conditions log at `tracing::info!`
@@ -38,26 +195,67 @@ use super::{Identifier, IdentifierKind, IdentifierValue, SchemeName};
 /// Internally a thin wrapper over the shared `discover_repo_url` core
 /// (milestone 074 refactor extract): URL discovery is tier-agnostic;
 /// each tier formats its own `source_label` string.
-pub fn auto_detect_repo_identifier(scan_root: &Path) -> Option<Identifier> {
+///
+/// Milestone 075 — `keep_credentials` controls userinfo sanitization:
+/// `false` (default) strips RFC 3986 userinfo from the discovered URL
+/// before identifier construction (FR-001); `true` (operator opted in
+/// via `--keep-credentials-in-identifiers`) emits the URL verbatim
+/// and emits a one-time acknowledgment log line (FR-007) at the top
+/// of the call so the audit trail records the operator's choice.
+pub fn auto_detect_repo_identifier(
+    scan_root: &Path,
+    keep_credentials: bool,
+) -> Option<Identifier> {
+    if keep_credentials {
+        tracing::info!(
+            "--keep-credentials-in-identifiers set; userinfo in auto-detected identifiers will be preserved verbatim"
+        );
+    }
     let (url, remote_name, fallback_used) = discover_repo_url(scan_root)?;
-    build_repo_identifier_with_label(
-        url,
-        &remote_name,
-        source_tier_repo_label(&remote_name, fallback_used),
-    )
+    let sanitized = if keep_credentials {
+        SanitizedUrl {
+            original: url.clone(),
+            sanitized: url,
+            was_sanitized: false,
+        }
+    } else {
+        sanitize_userinfo(&url)
+    };
+    if sanitized.was_sanitized {
+        tracing::info!(
+            scheme = "repo",
+            url_safe = %redact_userinfo_for_log(&sanitized.original),
+            "sanitized userinfo from auto-detected identifier"
+        );
+    }
+    let label = source_tier_repo_label(&remote_name, fallback_used, sanitized.was_sanitized);
+    build_repo_identifier_with_label(sanitized.sanitized, &remote_name, label)
 }
 
 /// Source-tier `source_label` formatter. Kept stable across milestones
 /// 073 and 074 — pre-refactor strings are reproduced verbatim so the
 /// existing source-tier goldens remain byte-identical (per VR-074-007 /
 /// research §5).
-fn source_tier_repo_label(remote_name: &str, fallback_used: bool) -> String {
-    if fallback_used {
+///
+/// Milestone 075 — when `was_sanitized == true`, the FR-008 suffix
+/// ` (credentials stripped)` is appended (research §3). When `false`,
+/// label is byte-identical to milestones 073/074.
+fn source_tier_repo_label(
+    remote_name: &str,
+    fallback_used: bool,
+    was_sanitized: bool,
+) -> String {
+    let base = if fallback_used {
         format!(
             "auto-detected from git remote `{remote_name}` (origin/upstream absent; first-listed)"
         )
     } else {
         format!("auto-detected from git remote `{remote_name}`")
+    };
+    if was_sanitized {
+        format!("{base} (credentials stripped)")
+    } else {
+        base
     }
 }
 
@@ -65,13 +263,25 @@ fn source_tier_repo_label(remote_name: &str, fallback_used: bool) -> String {
 /// research §4. Inserts `build-tier ` between `from` and `git remote`
 /// so consumers reading SBOMs without surrounding tier-context can
 /// disambiguate per-identifier (FR-006).
-fn build_tier_repo_label(remote_name: &str, fallback_used: bool) -> String {
-    if fallback_used {
+///
+/// Milestone 075 — when `was_sanitized == true`, the FR-008 suffix
+/// ` (credentials stripped)` is appended (research §3).
+fn build_tier_repo_label(
+    remote_name: &str,
+    fallback_used: bool,
+    was_sanitized: bool,
+) -> String {
+    let base = if fallback_used {
         format!(
             "auto-detected from build-tier git remote `{remote_name}` (origin/upstream absent; first-listed)"
         )
     } else {
         format!("auto-detected from build-tier git remote `{remote_name}`")
+    };
+    if was_sanitized {
+        format!("{base} (credentials stripped)")
+    } else {
+        base
     }
 }
 
@@ -79,6 +289,11 @@ fn build_tier_repo_label(remote_name: &str, fallback_used: bool) -> String {
 /// per research §4.
 const BUILD_TIER_GIT_LABEL: &str =
     "auto-detected from build-tier `git rev-parse HEAD`";
+
+/// Build-tier `source_label` for the auto-detected `git:` identifier
+/// when sanitization fired (milestone 075 FR-008, research §3).
+const BUILD_TIER_GIT_LABEL_SANITIZED: &str =
+    "auto-detected from build-tier `git rev-parse HEAD` (credentials stripped)";
 
 /// Tier-agnostic URL-discovery core: 3-step git-remote fallback
 /// (`origin` → `upstream` → first-listed alphabetical). Returns
@@ -212,7 +427,23 @@ fn build_repo_identifier_with_label(
 ///
 /// Determinism (FR-009): given fixed git remote configuration and
 /// fixed `HEAD` commit, repeated calls produce byte-identical output.
-pub fn auto_detect_build_tier_identifiers(invocation_cwd: &Path) -> Vec<Identifier> {
+///
+/// Milestone 075 — `keep_credentials` controls userinfo sanitization
+/// for both the auto-detected `repo:` and `git:` identifier slots
+/// (FR-001 + FR-002). Default `false`: strip userinfo from the
+/// discovered URL before identifier construction; per VR-075-005
+/// the URL portion of the `git:` value is sanitized BEFORE the
+/// `#<sha>` is appended. `true`: emit verbatim and emit a one-time
+/// FR-007 acknowledgment log line at the top of the call.
+pub fn auto_detect_build_tier_identifiers(
+    invocation_cwd: &Path,
+    keep_credentials: bool,
+) -> Vec<Identifier> {
+    if keep_credentials {
+        tracing::info!(
+            "--keep-credentials-in-identifiers set; userinfo in auto-detected identifiers will be preserved verbatim"
+        );
+    }
     let mut out: Vec<Identifier> = Vec::new();
     // Step 1: discover the remote URL via the shared core.
     let (url, remote_name, fallback_used) = match discover_repo_url(invocation_cwd) {
@@ -222,16 +453,36 @@ pub fn auto_detect_build_tier_identifiers(invocation_cwd: &Path) -> Vec<Identifi
             return out;
         }
     };
-    let label = build_tier_repo_label(&remote_name, fallback_used);
-    let repo_id = match build_repo_identifier_with_label(url.clone(), &remote_name, label) {
-        Some(id) => id,
-        None => {
-            // Construction failure (empty URL, etc.); without a
-            // resolvable repo URL we can't synthesize the `git:`
-            // identifier either, so bail.
-            return out;
+    // Milestone 075 — sanitize the URL ONCE up front; both the
+    // `repo:` value and the `git:` value reuse the sanitized form
+    // (VR-075-005: URL portion sanitized BEFORE `#<sha>` append).
+    let sanitized = if keep_credentials {
+        SanitizedUrl {
+            original: url.clone(),
+            sanitized: url.clone(),
+            was_sanitized: false,
         }
+    } else {
+        sanitize_userinfo(&url)
     };
+    if sanitized.was_sanitized {
+        tracing::info!(
+            scheme = "repo",
+            url_safe = %redact_userinfo_for_log(&sanitized.original),
+            "sanitized userinfo from auto-detected identifier"
+        );
+    }
+    let label = build_tier_repo_label(&remote_name, fallback_used, sanitized.was_sanitized);
+    let repo_id =
+        match build_repo_identifier_with_label(sanitized.sanitized.clone(), &remote_name, label) {
+            Some(id) => id,
+            None => {
+                // Construction failure (empty URL, etc.); without a
+                // resolvable repo URL we can't synthesize the `git:`
+                // identifier either, so bail.
+                return out;
+            }
+        };
     tracing::info!(
         scheme = repo_id.scheme.as_str(),
         value = repo_id.value.as_str(),
@@ -244,7 +495,7 @@ pub fn auto_detect_build_tier_identifiers(invocation_cwd: &Path) -> Vec<Identifi
 
     // Step 2: attempt `git rev-parse HEAD`. Only fires if step 1
     // produced a `repo:` identifier — the `git:` value reuses the
-    // same URL string per VR-074-002.
+    // sanitized URL string per VR-074-002 + VR-075-005.
     let sha = match git_rev_parse_head(invocation_cwd) {
         Some(s) => s,
         None => {
@@ -255,7 +506,18 @@ pub fn auto_detect_build_tier_identifiers(invocation_cwd: &Path) -> Vec<Identifi
             return out;
         }
     };
-    let git_value_str = format!("{url}#{sha}");
+    // VR-075-005: sanitize the URL portion BEFORE appending `#<sha>`.
+    let git_value_str = format!("{}#{sha}", sanitized.sanitized);
+    if sanitized.was_sanitized {
+        // Per-identifier log line for the `git:` slot — separate
+        // from the `repo:` log so operators can see both
+        // sanitizations in the audit trail (FR-006 per-identifier).
+        tracing::info!(
+            scheme = "git",
+            url_safe = %format!("{}#{sha}", redact_userinfo_for_log(&sanitized.original)),
+            "sanitized userinfo from auto-detected identifier"
+        );
+    }
     let git_scheme = match SchemeName::new("git".to_string()) {
         Ok(s) => s,
         Err(_) => return out,
@@ -280,11 +542,16 @@ pub fn auto_detect_build_tier_identifiers(invocation_cwd: &Path) -> Vec<Identifi
         },
         None => IdentifierKind::UserDefined,
     };
+    let git_label = if sanitized.was_sanitized {
+        BUILD_TIER_GIT_LABEL_SANITIZED
+    } else {
+        BUILD_TIER_GIT_LABEL
+    };
     let git_id = Identifier::from_parts_with_label(
         git_scheme,
         git_value,
         git_kind,
-        Some(BUILD_TIER_GIT_LABEL.to_string()),
+        Some(git_label.to_string()),
     );
     tracing::info!(
         value = %git_value_str,
@@ -484,14 +751,14 @@ mod tests {
     #[test]
     fn no_git_dir_returns_none() {
         let td = tempfile::tempdir().unwrap();
-        assert!(auto_detect_repo_identifier(td.path()).is_none());
+        assert!(auto_detect_repo_identifier(td.path(), false).is_none());
     }
 
     #[test]
     fn git_dir_no_remotes_returns_none() {
         let td = tempfile::tempdir().unwrap();
         git_init(td.path());
-        assert!(auto_detect_repo_identifier(td.path()).is_none());
+        assert!(auto_detect_repo_identifier(td.path(), false).is_none());
     }
 
     #[test]
@@ -499,7 +766,7 @@ mod tests {
         let td = tempfile::tempdir().unwrap();
         git_init(td.path());
         git_remote_add(td.path(), "origin", "git@github.com:test/foo.git");
-        let id = auto_detect_repo_identifier(td.path()).expect("origin detected");
+        let id = auto_detect_repo_identifier(td.path(), false).expect("origin detected");
         assert_eq!(id.scheme.as_str(), "repo");
         assert_eq!(id.value.as_str(), "git@github.com:test/foo.git");
         assert_eq!(
@@ -514,7 +781,7 @@ mod tests {
         let td = tempfile::tempdir().unwrap();
         git_init(td.path());
         git_remote_add(td.path(), "upstream", "git@github.com:acme/foo.git");
-        let id = auto_detect_repo_identifier(td.path()).expect("upstream detected");
+        let id = auto_detect_repo_identifier(td.path(), false).expect("upstream detected");
         assert_eq!(id.scheme.as_str(), "repo");
         assert_eq!(id.value.as_str(), "git@github.com:acme/foo.git");
         assert_eq!(
@@ -530,7 +797,7 @@ mod tests {
         // Add only third-named remotes (no origin/upstream).
         git_remote_add(td.path(), "zebra", "git@example.com:z/foo.git");
         git_remote_add(td.path(), "alpha", "git@example.com:a/foo.git");
-        let id = auto_detect_repo_identifier(td.path()).expect("first-listed detected");
+        let id = auto_detect_repo_identifier(td.path(), false).expect("first-listed detected");
         // Alphabetical first → alpha.
         assert_eq!(id.value.as_str(), "git@example.com:a/foo.git");
         assert_eq!(
@@ -547,7 +814,7 @@ mod tests {
         git_init(td.path());
         git_remote_add(td.path(), "origin", "git@github.com:o/foo.git");
         git_remote_add(td.path(), "upstream", "git@github.com:u/foo.git");
-        let id = auto_detect_repo_identifier(td.path()).unwrap();
+        let id = auto_detect_repo_identifier(td.path(), false).unwrap();
         assert_eq!(id.value.as_str(), "git@github.com:o/foo.git");
     }
 
@@ -678,7 +945,7 @@ mod tests {
     #[test]
     fn build_tier_empty_on_non_git_dir() {
         let td = tempfile::tempdir().unwrap();
-        let ids = auto_detect_build_tier_identifiers(td.path());
+        let ids = auto_detect_build_tier_identifiers(td.path(), false);
         assert!(
             ids.is_empty(),
             "non-git dir must yield zero auto-detected identifiers"
@@ -691,7 +958,7 @@ mod tests {
         git_init(td.path());
         git_remote_add(td.path(), "origin", "git@github.com:test/foo.git");
         // No commit — `git rev-parse HEAD` will fail.
-        let ids = auto_detect_build_tier_identifiers(td.path());
+        let ids = auto_detect_build_tier_identifiers(td.path(), false);
         assert_eq!(
             ids.len(),
             1,
@@ -721,7 +988,7 @@ mod tests {
         git_commit_empty(td.path(), "first");
         let head_sha = git_rev_parse_head_via_subprocess(td.path());
 
-        let ids = auto_detect_build_tier_identifiers(td.path());
+        let ids = auto_detect_build_tier_identifiers(td.path(), false);
         assert_eq!(
             ids.len(),
             2,
@@ -753,8 +1020,8 @@ mod tests {
         git_remote_add(td.path(), "origin", "git@github.com:test/foo.git");
         git_commit_empty(td.path(), "first");
 
-        let a = auto_detect_build_tier_identifiers(td.path());
-        let b = auto_detect_build_tier_identifiers(td.path());
+        let a = auto_detect_build_tier_identifiers(td.path(), false);
+        let b = auto_detect_build_tier_identifiers(td.path(), false);
         assert_eq!(a.len(), b.len());
         for (x, y) in a.iter().zip(b.iter()) {
             assert_eq!(x.scheme.as_str(), y.scheme.as_str());
@@ -768,7 +1035,7 @@ mod tests {
         let td = tempfile::tempdir().unwrap();
         git_init(td.path());
         git_remote_add(td.path(), "upstream", "git@github.com:acme/foo.git");
-        let ids = auto_detect_build_tier_identifiers(td.path());
+        let ids = auto_detect_build_tier_identifiers(td.path(), false);
         assert_eq!(ids.len(), 1);
         assert_eq!(ids[0].scheme.as_str(), "repo");
         assert_eq!(ids[0].value.as_str(), "git@github.com:acme/foo.git");
@@ -784,7 +1051,7 @@ mod tests {
         git_init(td.path());
         git_remote_add(td.path(), "zebra", "git@example.com:z/foo.git");
         git_remote_add(td.path(), "alpha", "git@example.com:a/foo.git");
-        let ids = auto_detect_build_tier_identifiers(td.path());
+        let ids = auto_detect_build_tier_identifiers(td.path(), false);
         assert_eq!(ids.len(), 1);
         assert_eq!(ids[0].value.as_str(), "git@example.com:a/foo.git");
         assert_eq!(
@@ -816,7 +1083,7 @@ mod tests {
         // `kind` here. Per research §7's test guidance: assert the
         // identifier slot is present, do NOT assert the kind.
         git_remote_add(td.path(), "origin", "not-a-real-url");
-        let ids = auto_detect_build_tier_identifiers(td.path());
+        let ids = auto_detect_build_tier_identifiers(td.path(), false);
         assert!(!ids.is_empty(), "soft-fail must still emit the identifier");
         assert_eq!(ids[0].scheme.as_str(), "repo");
         assert_eq!(ids[0].value.as_str(), "not-a-real-url");
@@ -828,8 +1095,140 @@ mod tests {
         git_init(td.path());
         git_remote_add(td.path(), "origin", "git@github.com:o/foo.git");
         git_remote_add(td.path(), "upstream", "git@github.com:u/foo.git");
-        let ids = auto_detect_build_tier_identifiers(td.path());
+        let ids = auto_detect_build_tier_identifiers(td.path(), false);
         assert!(!ids.is_empty());
         assert_eq!(ids[0].value.as_str(), "git@github.com:o/foo.git");
+    }
+
+    // ----------------------------------------------------------------
+    // Milestone 075 — sanitize_userinfo unit tests
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn sanitize_strips_user_password_https() {
+        let s = sanitize_userinfo("https://USER:TOKEN@github.com/foo/bar.git");
+        assert!(s.was_sanitized);
+        assert_eq!(s.original, "https://USER:TOKEN@github.com/foo/bar.git");
+        assert_eq!(s.sanitized, "https://github.com/foo/bar.git");
+        assert!(!s.sanitized.contains("USER"));
+        assert!(!s.sanitized.contains("TOKEN"));
+    }
+
+    #[test]
+    fn sanitize_strips_user_only_no_password() {
+        // GitHub App pattern: bare `<token>@host` without a colon.
+        let s = sanitize_userinfo("https://ghp_AAA123@github.com/foo/bar.git");
+        assert!(s.was_sanitized);
+        assert_eq!(s.sanitized, "https://github.com/foo/bar.git");
+        assert!(!s.sanitized.contains("ghp_AAA123"));
+    }
+
+    #[test]
+    fn sanitize_handles_empty_userinfo() {
+        // Edge case: `https://@host/...` — empty userinfo is still
+        // userinfo per RFC 3986.
+        //
+        // Note: `url::Url::parse` may normalize `https://@github.com/foo.git`
+        // to `https://github.com/foo.git` even before the setters run.
+        // Either way, the result is "no userinfo present in the
+        // sanitized output". Don't assert on `was_sanitized` since
+        // the parser may already have stripped it.
+        let s = sanitize_userinfo("https://@github.com/foo.git");
+        assert!(!s.sanitized.contains('@'));
+        assert!(s.sanitized.starts_with("https://github.com/foo.git"));
+    }
+
+    #[test]
+    fn sanitize_preserves_port_when_stripping() {
+        let s = sanitize_userinfo("https://USER:TOKEN@github.com:8443/foo.git");
+        assert!(s.was_sanitized);
+        assert_eq!(s.sanitized, "https://github.com:8443/foo.git");
+    }
+
+    #[test]
+    fn sanitize_passthrough_on_parse_failure() {
+        // Bare token with no scheme — url::Url::parse rejects.
+        let s = sanitize_userinfo("not a url at all");
+        assert!(!s.was_sanitized);
+        assert_eq!(s.original, "not a url at all");
+        assert_eq!(s.sanitized, "not a url at all");
+    }
+
+    #[test]
+    fn sanitize_passthrough_on_no_userinfo() {
+        let s = sanitize_userinfo("https://github.com/foo/bar.git");
+        assert!(!s.was_sanitized);
+        assert_eq!(s.original, "https://github.com/foo/bar.git");
+        assert_eq!(s.sanitized, "https://github.com/foo/bar.git");
+    }
+
+    #[test]
+    fn sanitize_passthrough_on_ssh_form() {
+        // SCP-like syntax — url::Url::parse rejects it (research §6).
+        // Treated identically to no-userinfo for downstream emission.
+        let s = sanitize_userinfo("git@github.com:foo/bar.git");
+        assert!(!s.was_sanitized);
+        assert_eq!(s.original, "git@github.com:foo/bar.git");
+        assert_eq!(s.sanitized, "git@github.com:foo/bar.git");
+    }
+
+    #[test]
+    fn sanitize_is_deterministic() {
+        // VR-075-002: same input → byte-identical sanitized output
+        // across runs.
+        let inputs = [
+            "https://USER:TOKEN@github.com/foo.git",
+            "https://github.com/foo.git",
+            "git@github.com:foo/bar.git",
+            "https://USER@github.com:443/foo.git",
+        ];
+        for input in &inputs {
+            let a = sanitize_userinfo(input);
+            for _ in 0..10 {
+                let b = sanitize_userinfo(input);
+                assert_eq!(a.original, b.original);
+                assert_eq!(a.sanitized, b.sanitized);
+                assert_eq!(a.was_sanitized, b.was_sanitized);
+            }
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Milestone 075 — redact_userinfo_for_log unit tests
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn redact_substitutes_userinfo_marker() {
+        let r = redact_userinfo_for_log("https://USER:TOKEN@github.com/foo.git");
+        assert_eq!(r, "https://<userinfo redacted>@github.com/foo.git");
+        assert!(!r.contains("USER"));
+        assert!(!r.contains("TOKEN"));
+    }
+
+    #[test]
+    fn redact_passes_through_no_userinfo() {
+        let r = redact_userinfo_for_log("https://github.com/foo.git");
+        assert_eq!(r, "https://github.com/foo.git");
+    }
+
+    #[test]
+    fn redact_passes_through_parse_failure() {
+        let r = redact_userinfo_for_log("git@github.com:foo/bar.git");
+        assert_eq!(r, "git@github.com:foo/bar.git");
+    }
+
+    #[test]
+    fn redact_preserves_port_path_query_fragment() {
+        // Use port 8443 — `url::Url` normalizes away default scheme
+        // ports (`:443` for `https://`) at parse time, which is
+        // expected URL-canonicalization behavior, not a redaction
+        // bug. A non-default port survives intact.
+        let r = redact_userinfo_for_log(
+            "https://USER:TOKEN@github.com:8443/foo/bar.git?a=1#frag",
+        );
+        assert_eq!(
+            r,
+            "https://<userinfo redacted>@github.com:8443/foo/bar.git?a=1#frag"
+        );
     }
 }

--- a/mikebom-cli/src/cli/run.rs
+++ b/mikebom-cli/src/cli/run.rs
@@ -134,6 +134,17 @@ pub struct RunArgs {
     )]
     pub id: Vec<mikebom::binding::identifiers::Identifier>,
 
+    /// Preserve userinfo (e.g., `USER:TOKEN@host`) in auto-detected git
+    /// remote URLs when constructing `repo:` and `git:` identifiers.
+    /// By default, mikebom strips userinfo to prevent accidental
+    /// credential disclosure in published SBOMs. Use this flag only
+    /// when the credentials are deliberately non-sensitive (e.g., a
+    /// public read-only deploy token, internal-network-only
+    /// credentials). Manual `--repo` / `--git-ref` / `--id` flag
+    /// values are emitted verbatim regardless of this flag.
+    #[arg(long)]
+    pub keep_credentials_in_identifiers: bool,
+
     /// Directories to scan for artifact files after the traced command
     /// exits. Forwarded verbatim to `mikebom trace capture`. See the
     /// `--artifact-dir` flag there for details.
@@ -208,6 +219,7 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
     let auto_detected_ids =
         mikebom::binding::identifiers::auto_detect::auto_detect_build_tier_identifiers(
             &invocation_cwd,
+            args.keep_credentials_in_identifiers,
         );
 
     // Phase 1: capture the trace → attestation.

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -335,6 +335,17 @@ pub struct ScanArgs {
         value_parser = parse_user_defined_id_flag,
     )]
     pub id: Vec<mikebom::binding::identifiers::Identifier>,
+
+    /// Preserve userinfo (e.g., `USER:TOKEN@host`) in auto-detected git
+    /// remote URLs when constructing `repo:` and `git:` identifiers.
+    /// By default, mikebom strips userinfo to prevent accidental
+    /// credential disclosure in published SBOMs. Use this flag only
+    /// when the credentials are deliberately non-sensitive (e.g., a
+    /// public read-only deploy token, internal-network-only
+    /// credentials). Manual `--repo` / `--git-ref` / `--id` flag
+    /// values are emitted verbatim regardless of this flag.
+    #[arg(long)]
+    pub keep_credentials_in_identifiers: bool,
 }
 
 /// Parse a `--id <scheme>=<value>` flag for a user-defined identifier.
@@ -1378,7 +1389,12 @@ pub async fn execute(
             image_auto_identifier(_extracted.as_ref(), args.image.as_deref())
         } else {
             // Source-tier auto-detection — git-remote 3-step fallback.
-            mikebom::binding::identifiers::auto_detect::auto_detect_repo_identifier(&root_path)
+            // Milestone 075 — `keep_credentials` boolean controls
+            // userinfo sanitization (default: strip for security).
+            mikebom::binding::identifiers::auto_detect::auto_detect_repo_identifier(
+                &root_path,
+                args.keep_credentials_in_identifiers,
+            )
         };
     let manual_identifiers = assemble_manual_identifiers(&args);
     let identifiers = mikebom::binding::identifiers::resolve_identifiers(
@@ -2024,6 +2040,7 @@ mod tests {
             image_id: None,
             attestation: None,
             id: vec![],
+            keep_credentials_in_identifiers: false,
         }
     }
 

--- a/mikebom-cli/tests/identifiers_build_tier_autodetect.rs
+++ b/mikebom-cli/tests/identifiers_build_tier_autodetect.rs
@@ -109,7 +109,7 @@ fn make_git_fixture(remotes: &[(&str, &str)], commit: bool) -> tempfile::TempDir
 #[test]
 fn build_tier_autodetect_repo_in_git_checkout() {
     let td = make_git_fixture(&[("origin", "git@github.com:acme/foo.git")], false);
-    let ids = auto_detect_build_tier_identifiers(td.path());
+    let ids = auto_detect_build_tier_identifiers(td.path(), false);
     assert!(!ids.is_empty(), "expected `repo:` auto-detected");
     assert_eq!(ids[0].scheme.as_str(), "repo");
     assert_eq!(ids[0].value.as_str(), "git@github.com:acme/foo.git");
@@ -125,7 +125,7 @@ fn build_tier_autodetect_repo_in_git_checkout() {
 #[test]
 fn build_tier_autodetect_upstream_fallback() {
     let td = make_git_fixture(&[("upstream", "git@github.com:acme/up.git")], false);
-    let ids = auto_detect_build_tier_identifiers(td.path());
+    let ids = auto_detect_build_tier_identifiers(td.path(), false);
     assert_eq!(ids.len(), 1);
     assert_eq!(ids[0].value.as_str(), "git@github.com:acme/up.git");
     assert_eq!(
@@ -146,7 +146,7 @@ fn build_tier_autodetect_first_listed_fallback() {
         ],
         false,
     );
-    let ids = auto_detect_build_tier_identifiers(td.path());
+    let ids = auto_detect_build_tier_identifiers(td.path(), false);
     assert_eq!(ids.len(), 1);
     assert_eq!(ids[0].value.as_str(), "git@example.com:a/foo.git");
     let label = ids[0].source_label.as_deref().unwrap();
@@ -160,7 +160,7 @@ fn build_tier_autodetect_first_listed_fallback() {
 #[test]
 fn build_tier_skips_outside_git() {
     let td = tempfile::tempdir().unwrap();
-    let ids = auto_detect_build_tier_identifiers(td.path());
+    let ids = auto_detect_build_tier_identifiers(td.path(), false);
     assert!(
         ids.is_empty(),
         "non-git dir must yield zero auto-detected identifiers; got {ids:?}"
@@ -176,7 +176,7 @@ fn build_tier_skips_outside_git() {
 #[test]
 fn build_tier_manual_repo_overrides_autodetect() {
     let td = make_git_fixture(&[("origin", "git@github.com:acme/foo.git")], false);
-    let auto = auto_detect_build_tier_identifiers(td.path());
+    let auto = auto_detect_build_tier_identifiers(td.path(), false);
     assert_eq!(auto.len(), 1);
     let manual = mikebom::binding::identifiers::Identifier::parse(
         "repo:git@github.com:acme/override.git",
@@ -203,7 +203,7 @@ fn build_tier_autodetect_git_with_full_sha() {
     let head = git_rev_parse_head_subprocess(td.path());
     assert_eq!(head.len(), 40);
 
-    let ids = auto_detect_build_tier_identifiers(td.path());
+    let ids = auto_detect_build_tier_identifiers(td.path(), false);
     assert_eq!(ids.len(), 2, "expected [repo:, git:] when both resolvable");
     assert_eq!(ids[1].scheme.as_str(), "git");
     let git_value = ids[1].value.as_str();
@@ -231,7 +231,7 @@ fn build_tier_autodetect_git_in_detached_head() {
     // Detach HEAD by checking out the commit by SHA.
     run_git(td.path(), &["checkout", "--detach", "-q", &head]);
 
-    let ids = auto_detect_build_tier_identifiers(td.path());
+    let ids = auto_detect_build_tier_identifiers(td.path(), false);
     assert_eq!(ids.len(), 2, "detached HEAD is not an error condition");
     assert_eq!(ids[1].scheme.as_str(), "git");
     assert_eq!(
@@ -246,7 +246,7 @@ fn build_tier_autodetect_git_in_detached_head() {
 #[test]
 fn build_tier_skips_git_in_empty_repo() {
     let td = make_git_fixture(&[("origin", "git@github.com:acme/foo.git")], false);
-    let ids = auto_detect_build_tier_identifiers(td.path());
+    let ids = auto_detect_build_tier_identifiers(td.path(), false);
     assert_eq!(
         ids.len(),
         1,
@@ -260,7 +260,7 @@ fn build_tier_skips_git_in_empty_repo() {
 #[test]
 fn build_tier_emits_zero_identifiers_in_non_git_dir() {
     let td = tempfile::tempdir().unwrap();
-    let ids = auto_detect_build_tier_identifiers(td.path());
+    let ids = auto_detect_build_tier_identifiers(td.path(), false);
     assert!(ids.is_empty());
 }
 
@@ -271,7 +271,7 @@ fn build_tier_emits_zero_identifiers_in_non_git_dir() {
 fn build_tier_autodetect_git_with_ssh_form_remote() {
     let td = make_git_fixture(&[("origin", "git@github.com:fake/repo.git")], true);
     let head = git_rev_parse_head_subprocess(td.path());
-    let ids = auto_detect_build_tier_identifiers(td.path());
+    let ids = auto_detect_build_tier_identifiers(td.path(), false);
     assert_eq!(ids.len(), 2);
     assert_eq!(ids[1].scheme.as_str(), "git");
     // Verbatim URL is preserved (no normalization to https).
@@ -319,7 +319,7 @@ fn build_tier_cross_tier_correlation_byte_identical_repo() {
     let head = git_rev_parse_head_subprocess(td.path());
 
     // Build-tier auto-detect via library API.
-    let build_ids = auto_detect_build_tier_identifiers(td.path());
+    let build_ids = auto_detect_build_tier_identifiers(td.path(), false);
     assert_eq!(build_ids.len(), 2, "expected [repo:, git:] for build-tier");
     assert_eq!(build_ids[0].scheme.as_str(), "repo");
     let build_repo_value = build_ids[0].value.as_str().to_string();
@@ -382,9 +382,9 @@ fn build_tier_cross_tier_correlation_byte_identical_repo() {
 #[test]
 fn build_tier_autodetect_deterministic_across_reruns() {
     let td = make_git_fixture(&[("origin", "git@github.com:acme/foo.git")], true);
-    let a = auto_detect_build_tier_identifiers(td.path());
-    let b = auto_detect_build_tier_identifiers(td.path());
-    let c = auto_detect_build_tier_identifiers(td.path());
+    let a = auto_detect_build_tier_identifiers(td.path(), false);
+    let b = auto_detect_build_tier_identifiers(td.path(), false);
+    let c = auto_detect_build_tier_identifiers(td.path(), false);
     assert_eq!(a.len(), b.len());
     assert_eq!(a.len(), c.len());
     for (idx, ((x, y), z)) in a.iter().zip(b.iter()).zip(c.iter()).enumerate() {

--- a/mikebom-cli/tests/identifiers_credential_strip.rs
+++ b/mikebom-cli/tests/identifiers_credential_strip.rs
@@ -1,0 +1,574 @@
+//! Milestone 075 — auto-detected userinfo credential stripping
+//! integration tests.
+//!
+//! ## Why a separate test file
+//!
+//! Milestones 073 and 074 currently embed the literal output of
+//! `git remote get-url` into emitted SBOMs verbatim. When operators
+//! configure a credentialed origin (e.g., `https://x-access-token:ghs_...
+//! @github.com/foo.git`, the standard GitHub App token form), the
+//! token leaks into every published SBOM. Milestone 075 closes that
+//! leak by stripping RFC 3986 userinfo from auto-detected URLs
+//! before identifier construction. Manual flag values stay verbatim;
+//! `--keep-credentials-in-identifiers` opts back in.
+//!
+//! ## Coverage
+//!
+//! Tests are organized by user story (3× P1, 1× P2):
+//!
+//! - **US1** — source-tier auto-detect strips credentials by default.
+//!   Drives `mikebom sbom scan --path` against a tempdir git fixture
+//!   with a credentialed origin URL; asserts the emitted JSON SBOM
+//!   contains zero literal-token occurrences and the
+//!   `(credentials stripped)` source_label suffix.
+//! - **US2** — build-tier auto-detect strips credentials by default.
+//!   `mikebom trace run` requires eBPF (Linux-only, not exercisable
+//!   on macOS dev / unprivileged CI per milestone 074's policy
+//!   documented at `identifiers_build_tier_autodetect.rs:6-13`), so
+//!   we exercise `auto_detect_build_tier_identifiers` directly via
+//!   the public library API on the same fixture. The `git:` slot's
+//!   value is also asserted to have its URL portion sanitized
+//!   BEFORE the `#<sha>` is appended (VR-075-005).
+//! - **US3** — manual identifier flags emit verbatim. Operator-typed
+//!   `--repo` with a credentialed URL flows through unchanged; the
+//!   manual-vs-auto-detected boundary is preserved.
+//! - **US4** — `--keep-credentials-in-identifiers` opt-out preserves
+//!   userinfo in both source-tier (CLI invocation) and build-tier
+//!   (library API) flows.
+//! - **Edge case** — parse-failure soft-fails through milestone
+//!   073's existing `UserDefined` rule (FR-009).
+//!
+//! ## Log-content assertions
+//!
+//! `mikebom-cli` does not currently install a project-wide tracing
+//! capture pattern in its test suite. FR-006 / FR-007 log-line
+//! content is therefore asserted indirectly: the runtime side-effects
+//! (identifier value, source_label, identifier kind) are observable
+//! and are tested here. A future test-only `tracing` subscriber
+//! could provide direct log-line assertion; out of scope for this
+//! milestone.
+
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+use std::path::Path;
+use std::process::Command;
+
+use mikebom::binding::identifiers::auto_detect::auto_detect_build_tier_identifiers;
+use mikebom::binding::identifiers::IdentifierKind;
+
+mod common;
+use common::bin;
+use common::normalize::apply_fake_home_env;
+
+// ---------------------------------------------------------------------
+// Tempdir-based git fixture builder (mirrors the milestone-074 pattern
+// in identifiers_build_tier_autodetect.rs).
+// ---------------------------------------------------------------------
+
+/// A known-fake credential string used in test fixtures. Unique
+/// enough to grep for unambiguously across emitted SBOMs.
+const FAKE_TOKEN: &str = "ghs_NEVERREALSURELYFAKE0123456789ABCDEFXYZ";
+
+/// A known-fake credential URL using `FAKE_TOKEN`. Resembles the
+/// GitHub App token form that's the most common leak vector.
+fn credentialed_origin_url() -> String {
+    format!("https://x-access-token:{FAKE_TOKEN}@github.com/acme/test-repo.git")
+}
+
+/// Sanitized form of `credentialed_origin_url` — what milestone 075
+/// must produce when sanitization fires.
+const SANITIZED_ORIGIN_URL: &str = "https://github.com/acme/test-repo.git";
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let mut cmd = Command::new("git");
+    cmd.arg("-C").arg(dir.to_str().unwrap()).args(args);
+    let status = cmd.status().expect("git subprocess");
+    assert!(status.success(), "git command failed: {cmd:?}");
+}
+
+fn git_init(dir: &Path) {
+    run_git(dir, &["init", "-q"]);
+}
+
+fn git_remote_add(dir: &Path, name: &str, url: &str) {
+    run_git(dir, &["remote", "add", name, url]);
+}
+
+fn git_config_user(dir: &Path) {
+    run_git(dir, &["config", "user.email", "test@example.com"]);
+    run_git(dir, &["config", "user.name", "Test User"]);
+}
+
+fn git_commit_empty(dir: &Path, msg: &str) {
+    git_config_user(dir);
+    run_git(dir, &["commit", "--allow-empty", "-q", "-m", msg]);
+}
+
+fn git_rev_parse_head_subprocess(dir: &Path) -> String {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir.to_str().unwrap())
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .expect("git subprocess");
+    assert!(out.status.success());
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+/// Produce a tempdir that's a git checkout with the supplied
+/// remotes, optionally with one empty HEAD commit, plus a tiny
+/// Cargo manifest so source-tier scans produce a valid SBOM rather
+/// than erroring on no-content.
+fn make_git_fixture(remotes: &[(&str, &str)], commit: bool) -> tempfile::TempDir {
+    let td = tempfile::tempdir().unwrap();
+    git_init(td.path());
+    for (name, url) in remotes {
+        git_remote_add(td.path(), name, url);
+    }
+    if commit {
+        git_commit_empty(td.path(), "initial");
+    }
+    std::fs::write(
+        td.path().join("Cargo.toml"),
+        b"[package]\nname = \"x\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\n",
+    )
+    .unwrap();
+    std::fs::write(
+        td.path().join("Cargo.lock"),
+        b"version = 3\n\n[[package]]\nname = \"x\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    td
+}
+
+/// Produce a tempdir that is NOT a git checkout (so source-tier
+/// auto-detection skips). Includes the same minimal Cargo manifest
+/// as `make_git_fixture` so the scan produces a valid SBOM.
+fn make_non_git_fixture() -> tempfile::TempDir {
+    let td = tempfile::tempdir().unwrap();
+    std::fs::write(
+        td.path().join("Cargo.toml"),
+        b"[package]\nname = \"x\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\n",
+    )
+    .unwrap();
+    std::fs::write(
+        td.path().join("Cargo.lock"),
+        b"version = 3\n\n[[package]]\nname = \"x\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    td
+}
+
+/// Run `mikebom sbom scan --path <path>` and return the parsed
+/// CDX 1.6 JSON document. Each invocation gets a fresh fake HOME
+/// to neutralize per-host config drift.
+fn run_scan_to_cdx(td: &Path, extra_args: &[&str]) -> serde_json::Value {
+    let fake_home = tempfile::tempdir().unwrap();
+    let out_path = td.join("out.cdx.json");
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(td)
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(format!("cyclonedx-json={}", out_path.to_string_lossy()))
+        .arg("--no-deep-hash");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("scan runs");
+    assert!(
+        out.status.success(),
+        "sbom scan failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let bytes = std::fs::read(&out_path).unwrap();
+    serde_json::from_slice(&bytes).expect("CDX output parses as JSON")
+}
+
+/// Extract the `repo:` (CDX `externalReferences[type:vcs]`) URL +
+/// comment fields from a CDX document. Returns None when no
+/// type:vcs entry exists.
+fn extract_vcs_ref(cdx: &serde_json::Value) -> Option<(String, Option<String>)> {
+    let refs = cdx
+        .get("metadata")?
+        .get("component")?
+        .get("externalReferences")?
+        .as_array()?;
+    refs.iter()
+        .find(|r| r.get("type").and_then(|v| v.as_str()) == Some("vcs"))
+        .map(|r| {
+            (
+                r["url"].as_str().unwrap_or("").to_string(),
+                r.get("comment")
+                    .and_then(|c| c.as_str())
+                    .map(|s| s.to_string()),
+            )
+        })
+}
+
+// ---------------------------------------------------------------------
+// User Story 1 — source-tier strip-by-default
+// ---------------------------------------------------------------------
+
+/// US1 (a) — source-tier scan over a credentialed origin emits a
+/// sanitized `repo:` URL; the literal token string occurs zero times
+/// in the document. Validates FR-001 + SC-001.
+#[test]
+fn source_tier_strips_credentials_from_https_origin() {
+    let url = credentialed_origin_url();
+    let td = make_git_fixture(&[("origin", &url)], false);
+    let cdx = run_scan_to_cdx(td.path(), &[]);
+    let (vcs_url, _comment) = extract_vcs_ref(&cdx).expect("vcs externalReference present");
+    assert_eq!(
+        vcs_url, SANITIZED_ORIGIN_URL,
+        "FR-001: auto-detected URL must have userinfo stripped"
+    );
+    // SC-001: zero literal-token occurrences anywhere in the document.
+    let bytes = serde_json::to_vec(&cdx).unwrap();
+    let body = String::from_utf8(bytes).unwrap();
+    assert_eq!(
+        body.matches(FAKE_TOKEN).count(),
+        0,
+        "SC-001: literal token MUST NOT appear in emitted SBOM",
+    );
+    // Defense-in-depth: also assert the `x-access-token` username
+    // didn't survive — the userinfo as a whole is what gets stripped.
+    assert_eq!(
+        body.matches("x-access-token").count(),
+        0,
+        "userinfo username portion MUST NOT appear in emitted SBOM",
+    );
+}
+
+/// US1 (b) — source_label / `comment` field reflects the
+/// sanitization with the `(credentials stripped)` suffix per FR-008
+/// + SC-006.
+#[test]
+fn source_tier_source_label_carries_stripped_suffix() {
+    let url = credentialed_origin_url();
+    let td = make_git_fixture(&[("origin", &url)], false);
+    let cdx = run_scan_to_cdx(td.path(), &[]);
+    let (_vcs_url, comment) = extract_vcs_ref(&cdx).expect("vcs externalReference present");
+    let comment = comment.expect("comment field present (carries source_label)");
+    assert!(
+        comment.contains("(credentials stripped)"),
+        "FR-008: source_label must contain `(credentials stripped)` when \
+         sanitization fires; got {comment:?}"
+    );
+    // The original auto-detect prefix must remain — we APPEND, not
+    // REPLACE, per research §3.
+    assert!(
+        comment.contains("auto-detected from git remote `origin`"),
+        "FR-008: existing milestone-073 prefix must be preserved when \
+         appending the suffix; got {comment:?}"
+    );
+}
+
+/// US1 (c) — info-level log line for the sanitization event.
+///
+/// Log capture pattern is not in place in this test crate (see
+/// module-level rationale). We assert the runtime side-effects that
+/// indicate the log path was taken — matching auto-detected URL,
+/// matching source_label suffix, zero token occurrences. Direct
+/// log-content assertion is reserved for a future tracing-subscriber
+/// addition.
+#[test]
+fn source_tier_emits_redacted_info_log() {
+    let url = credentialed_origin_url();
+    let td = make_git_fixture(&[("origin", &url)], false);
+    let cdx = run_scan_to_cdx(td.path(), &[]);
+    let (vcs_url, comment) = extract_vcs_ref(&cdx).expect("vcs externalReference present");
+    // Triple-check: identifier sanitized, label augmented, no token.
+    assert_eq!(vcs_url, SANITIZED_ORIGIN_URL);
+    assert!(comment
+        .as_deref()
+        .unwrap_or("")
+        .contains("(credentials stripped)"));
+    let body = serde_json::to_string(&cdx).unwrap();
+    assert!(!body.contains(FAKE_TOKEN));
+}
+
+/// US1 (d) — SSH-form remotes carry no userinfo; `comment` field is
+/// byte-identical to alpha.16 (no `(credentials stripped)` suffix).
+/// Validates FR-003 SSH passthrough + SC-007.
+#[test]
+fn source_tier_ssh_form_unchanged() {
+    let td = make_git_fixture(&[("origin", "git@github.com:acme/test-repo.git")], false);
+    let cdx = run_scan_to_cdx(td.path(), &[]);
+    let (vcs_url, comment) = extract_vcs_ref(&cdx).expect("vcs externalReference present");
+    assert_eq!(
+        vcs_url, "git@github.com:acme/test-repo.git",
+        "SSH-form URL MUST emit byte-identical to alpha.16"
+    );
+    let comment = comment.expect("comment field present");
+    assert!(
+        !comment.contains("(credentials stripped)"),
+        "SC-007: SSH-form must NOT trigger the sanitization suffix; got {comment:?}"
+    );
+    assert_eq!(
+        comment, "auto-detected from git remote `origin`",
+        "comment field byte-identical to alpha.16 source-tier label"
+    );
+}
+
+// ---------------------------------------------------------------------
+// User Story 2 — build-tier strip-by-default
+// ---------------------------------------------------------------------
+
+/// US2 (a) — build-tier auto-detect sanitizes both `repo:` and `git:`
+/// identifier slots; the literal token string occurs zero times in
+/// any emitted identifier value. Validates FR-001 + FR-002 + SC-002.
+#[test]
+fn build_tier_strips_credentials_from_repo_and_git() {
+    let url = credentialed_origin_url();
+    let td = make_git_fixture(&[("origin", &url)], true);
+    let head = git_rev_parse_head_subprocess(td.path());
+
+    let ids = auto_detect_build_tier_identifiers(td.path(), false);
+    assert_eq!(
+        ids.len(),
+        2,
+        "expected [repo:, git:] both auto-detected; got {ids:?}"
+    );
+    assert_eq!(ids[0].scheme.as_str(), "repo");
+    assert_eq!(
+        ids[0].value.as_str(),
+        SANITIZED_ORIGIN_URL,
+        "FR-001: build-tier `repo:` must sanitize userinfo"
+    );
+    assert_eq!(ids[1].scheme.as_str(), "git");
+    assert_eq!(
+        ids[1].value.as_str(),
+        format!("{SANITIZED_ORIGIN_URL}#{head}"),
+        "FR-002: build-tier `git:` URL portion must be sanitized BEFORE #<sha> append"
+    );
+    // SC-002 zero-token check — covers BOTH identifier values.
+    for id in &ids {
+        assert!(
+            !id.value.as_str().contains(FAKE_TOKEN),
+            "literal token must not appear in any identifier value; got {}",
+            id.value.as_str()
+        );
+        assert!(
+            !id.value.as_str().contains("x-access-token"),
+            "userinfo username must not appear in any identifier value; got {}",
+            id.value.as_str()
+        );
+    }
+    // Both source_labels carry the `(credentials stripped)` suffix.
+    for id in &ids {
+        let label = id.source_label.as_deref().unwrap();
+        assert!(
+            label.contains("(credentials stripped)"),
+            "FR-008: build-tier source_label must contain suffix; got {label:?}"
+        );
+        assert!(label.contains("build-tier"));
+    }
+}
+
+/// US2 (b) — VR-075-005: the `git:` value's URL portion has the
+/// userinfo stripped, then `#<sha>` appended. The URL portion
+/// (everything before `#`) MUST contain zero `@` characters.
+#[test]
+fn build_tier_git_value_has_sha_appended_after_sanitization() {
+    let url = credentialed_origin_url();
+    let td = make_git_fixture(&[("origin", &url)], true);
+    let head = git_rev_parse_head_subprocess(td.path());
+    let ids = auto_detect_build_tier_identifiers(td.path(), false);
+    assert_eq!(ids.len(), 2);
+    let git_value = ids[1].value.as_str();
+    let (url_part, sha_part) = git_value
+        .split_once('#')
+        .expect("git: value must have `#<sha>`");
+    assert_eq!(
+        sha_part, head,
+        "SHA portion MUST match `git rev-parse HEAD`"
+    );
+    assert!(
+        !url_part.contains('@'),
+        "VR-075-005: URL portion MUST contain zero `@` after sanitization; got {url_part}"
+    );
+    assert_eq!(url_part, SANITIZED_ORIGIN_URL);
+}
+
+// ---------------------------------------------------------------------
+// User Story 3 — manual identifier flags emit verbatim
+// ---------------------------------------------------------------------
+
+/// US3 (a) — operator-typed `--repo` with credentials goes through
+/// verbatim. No sanitization, no warning. Validates FR-004 + SC-003.
+#[test]
+fn manual_repo_emits_verbatim_with_credentials() {
+    // Use a non-git tempdir so source-tier auto-detect skips, leaving
+    // the manual flag as the only identifier source.
+    let td = make_non_git_fixture();
+    let url = credentialed_origin_url();
+    let cdx = run_scan_to_cdx(td.path(), &["--repo", &url]);
+    let (vcs_url, _comment) = extract_vcs_ref(&cdx).expect("manual repo: should appear");
+    assert_eq!(
+        vcs_url, url,
+        "FR-004: manual --repo flag MUST emit verbatim, including userinfo"
+    );
+    // SC-003: literal token DOES appear (in the manual value).
+    let body = serde_json::to_string(&cdx).unwrap();
+    assert!(
+        body.contains(FAKE_TOKEN),
+        "manual flag is verbatim; token presence is intentional"
+    );
+}
+
+/// US3 (b) — manual `--repo` overrides auto-detected `repo:` per
+/// milestone 074's manual-wins rule. The auto-detected sanitized
+/// value does NOT appear; the manual credentialed value DOES.
+#[test]
+fn manual_repo_overrides_strip_with_credentials_in_value() {
+    let auto_url = credentialed_origin_url();
+    let manual_url =
+        format!("https://other-user:OTHER-{FAKE_TOKEN}@gitlab.example.com/manual/path.git");
+    let td = make_git_fixture(&[("origin", &auto_url)], false);
+    let cdx = run_scan_to_cdx(td.path(), &["--repo", &manual_url]);
+    let (vcs_url, _comment) = extract_vcs_ref(&cdx).expect("vcs ref present");
+    assert_eq!(
+        vcs_url, manual_url,
+        "manual --repo flag MUST win over auto-detected per FR-004 + 074's manual-wins rule"
+    );
+    // The auto-detected sanitized form must NOT appear (it was
+    // overridden by manual).
+    let body = serde_json::to_string(&cdx).unwrap();
+    assert!(
+        !body.contains("acme/test-repo.git"),
+        "auto-detected repo path must be overridden by manual flag; got body containing it"
+    );
+    // The manual value's literal token DOES appear (manual = verbatim).
+    assert!(body.contains(FAKE_TOKEN), "manual flag value emits verbatim");
+}
+
+// ---------------------------------------------------------------------
+// User Story 4 — opt-out flag preserves credentials
+// ---------------------------------------------------------------------
+
+/// US4 (a) — `--keep-credentials-in-identifiers` preserves userinfo
+/// in source-tier auto-detected `repo:` and skips the
+/// `(credentials stripped)` suffix. Validates FR-005 + FR-007.
+#[test]
+fn keep_credentials_flag_preserves_userinfo_source_tier() {
+    let url = credentialed_origin_url();
+    let td = make_git_fixture(&[("origin", &url)], false);
+    let cdx = run_scan_to_cdx(td.path(), &["--keep-credentials-in-identifiers"]);
+    let (vcs_url, comment) = extract_vcs_ref(&cdx).expect("vcs ref present");
+    assert_eq!(
+        vcs_url, url,
+        "opt-out: auto-detected URL MUST be preserved verbatim including userinfo"
+    );
+    let comment = comment.expect("comment field present");
+    assert!(
+        !comment.contains("(credentials stripped)"),
+        "opt-out: NO `(credentials stripped)` suffix; got {comment:?}"
+    );
+    assert_eq!(
+        comment, "auto-detected from git remote `origin`",
+        "comment field byte-identical to milestone-073/074 source-tier label"
+    );
+    // Token IS present (intentional).
+    let body = serde_json::to_string(&cdx).unwrap();
+    assert!(body.contains(FAKE_TOKEN));
+}
+
+/// US4 (b) — `keep_credentials=true` preserves userinfo in the
+/// build-tier flow for both `repo:` and `git:` slots. Validates
+/// FR-005 + FR-002 in opt-out mode.
+#[test]
+fn keep_credentials_flag_preserves_userinfo_build_tier() {
+    let url = credentialed_origin_url();
+    let td = make_git_fixture(&[("origin", &url)], true);
+    let head = git_rev_parse_head_subprocess(td.path());
+    let ids = auto_detect_build_tier_identifiers(td.path(), true);
+    assert_eq!(ids.len(), 2);
+    assert_eq!(
+        ids[0].value.as_str(),
+        url,
+        "opt-out: build-tier `repo:` MUST preserve userinfo verbatim"
+    );
+    assert_eq!(
+        ids[1].value.as_str(),
+        format!("{url}#{head}"),
+        "opt-out: build-tier `git:` URL portion MUST preserve userinfo (then #sha appended)"
+    );
+    // Neither label carries the suffix.
+    for id in &ids {
+        let label = id.source_label.as_deref().unwrap();
+        assert!(
+            !label.contains("(credentials stripped)"),
+            "opt-out: source_label MUST NOT carry the suffix; got {label:?}"
+        );
+        assert!(label.contains("build-tier"));
+    }
+}
+
+/// US4 (c) — FR-007 acknowledgment log.
+///
+/// Log capture is not in place in this test crate (see module-level
+/// rationale). We exercise the opt-out invocation end-to-end and
+/// confirm the operator-observable side-effects: zero sanitization
+/// fired, both identifier slots preserve userinfo, source_label
+/// unchanged. Direct log-line assertion is reserved for a future
+/// tracing-subscriber addition.
+#[test]
+fn keep_credentials_flag_emits_acknowledgment_log() {
+    let url = credentialed_origin_url();
+    let td = make_git_fixture(&[("origin", &url)], false);
+    // Source-tier path — invokes the FR-007 log emission at the top
+    // of `auto_detect_repo_identifier`.
+    let cdx = run_scan_to_cdx(td.path(), &["--keep-credentials-in-identifiers"]);
+    let (vcs_url, comment) = extract_vcs_ref(&cdx).expect("vcs ref present");
+    assert_eq!(vcs_url, url);
+    assert!(!comment
+        .as_deref()
+        .unwrap_or("")
+        .contains("(credentials stripped)"));
+    // Build-tier path also emits the FR-007 log (different code site).
+    let _ids = auto_detect_build_tier_identifiers(td.path(), true);
+    // Test passes if both invocations completed without panicking
+    // and the runtime side-effects match opt-out semantics.
+}
+
+// ---------------------------------------------------------------------
+// Edge case — parse-failure soft-fails through milestone 073's
+// existing UserDefined rule (FR-009).
+// ---------------------------------------------------------------------
+
+/// Edge case — a non-RFC-3986 URL value passes through
+/// `sanitize_userinfo` unchanged (passthrough); milestone 073's
+/// existing `validate_for_scheme` validator then soft-fails to
+/// `UserDefined`. Validates FR-009.
+///
+/// Uses a value that survives `IdentifierValue::new` (i.e., non-empty
+/// and within the existing length cap) but fails the milestone-073
+/// `validate_repo` regex / heuristic. A bare token without `://`
+/// or `@host:` structure exercises the soft-fail path. If
+/// `validate_repo` happens to accept the value as `Builtin`, the
+/// test still passes — we assert the identifier slot is present and
+/// the value flows through unchanged, NOT a specific kind.
+#[test]
+fn parse_failure_falls_through_to_user_defined() {
+    let td = make_git_fixture(&[("origin", "not-a-real-url-abc-123")], false);
+    let ids = auto_detect_build_tier_identifiers(td.path(), false);
+    assert!(!ids.is_empty(), "FR-009: soft-fail must still emit");
+    assert_eq!(ids[0].scheme.as_str(), "repo");
+    assert_eq!(
+        ids[0].value.as_str(),
+        "not-a-real-url-abc-123",
+        "FR-009: passthrough on parse failure — value flows through unchanged"
+    );
+    // Per milestone 074's pattern (research §7), don't pin the kind.
+    // Both `Builtin` (if the validator accepts the value) and
+    // `UserDefined` (if it doesn't) are acceptable per FR-009.
+    match ids[0].kind {
+        IdentifierKind::Builtin(_) | IdentifierKind::UserDefined => {}
+    }
+}

--- a/specs/075-strip-id-credentials/checklists/requirements.md
+++ b/specs/075-strip-id-credentials/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Strip userinfo credentials from auto-detected git URLs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Scope is deliberately narrow: userinfo-only sanitization in the auto-detect path of milestones 073/074. Query-string credentials, manual-flag input warnings, and broader URL hardening are explicitly out of scope (called out in Assumptions).
+- All decisions inherit defaults from milestones 073/074 where applicable (manual-flag precedence, soft-fail on parse failure, determinism contract, source_label format augmentation). No clarifications required because every behavior with a precedent reuses the precedent.
+- One opt-out flag (`--keep-credentials-in-identifiers`) is the only new CLI surface. No new identifier types, no new schemes, no new annotations.
+- Per milestone 074's T001 audit, no existing fixture has a credentialed remote — so golden regen is empirically a no-op for this milestone. Confirmed in FR-012 + SC-008.
+- All items pass on first iteration; spec is ready for `/speckit.plan` (skip `/speckit.clarify` since there are no open questions).

--- a/specs/075-strip-id-credentials/contracts/credential-strip.md
+++ b/specs/075-strip-id-credentials/contracts/credential-strip.md
@@ -1,0 +1,218 @@
+# Contract — milestone 075 credential stripping
+
+The milestone's only contract. The change at the CLI level is "one new boolean opt-out flag on `mikebom sbom scan` and `mikebom trace run`, default false." The change at the library level is "one new `sanitize_userinfo` function plus a new boolean param on the two existing auto-detect entry points."
+
+## CLI surface
+
+### New flag
+
+```
+--keep-credentials-in-identifiers
+```
+
+- Available on: `mikebom sbom scan`, `mikebom trace run`
+- Type: boolean (presence enables; absence default false)
+- Effect: when set, the FR-001/FR-002 sanitization step is suppressed and auto-detected URLs emit verbatim
+
+### Help-text shape (clap-derived)
+
+```
+--keep-credentials-in-identifiers
+        Preserve userinfo (e.g., `USER:TOKEN@host`) in auto-detected git
+        remote URLs when constructing `repo:` and `git:` identifiers.
+        By default, mikebom strips userinfo to prevent accidental
+        credential disclosure in published SBOMs. Use this flag only
+        when the credentials are deliberately non-sensitive (e.g., a
+        public read-only deploy token, internal-network-only
+        credentials). Manual `--repo` / `--git-ref` / `--id` flag
+        values are emitted verbatim regardless of this flag.
+```
+
+## Library surface (`mikebom-cli` crate)
+
+### New public function
+
+```rust
+// In mikebom-cli/src/binding/identifiers/auto_detect.rs
+
+/// Strip RFC 3986 userinfo from a URL before it gets embedded as an
+/// identifier value in a published SBOM.
+///
+/// Returns a `SanitizedUrl` carrying the original, the sanitized
+/// form, and a flag indicating whether userinfo was actually
+/// removed. Callers use the flag to drive log-line emission and
+/// `source_label` augmentation.
+///
+/// Never panics. Never returns `Result`. All failure modes
+/// (parse error, cannot-be-base URLs, missing authority) collapse
+/// to a passthrough `SanitizedUrl` where `sanitized == original`
+/// and `was_sanitized == false`.
+pub fn sanitize_userinfo(url: &str) -> SanitizedUrl;
+```
+
+### Updated public signatures
+
+```rust
+// (was: pub fn auto_detect_repo_identifier(scan_root: &Path) -> Option<Identifier>)
+pub fn auto_detect_repo_identifier(
+    scan_root: &Path,
+    keep_credentials: bool,
+) -> Option<Identifier>;
+
+// (was: pub fn auto_detect_build_tier_identifiers(invocation_cwd: &Path) -> Vec<Identifier>)
+pub fn auto_detect_build_tier_identifiers(
+    invocation_cwd: &Path,
+    keep_credentials: bool,
+) -> Vec<Identifier>;
+```
+
+Both signatures gain a single trailing `keep_credentials: bool` parameter. The two production call sites (in `scan_cmd.rs` and `run.rs`) pass `args.keep_credentials_in_identifiers` directly. No other callers exist (verified by grep at planning time).
+
+### Internal data shape
+
+```rust
+// Private to auto_detect.rs; not exported.
+struct SanitizedUrl {
+    original: String,
+    sanitized: String,
+    was_sanitized: bool,
+}
+```
+
+## Integration boundary
+
+### Where `sanitize_userinfo` is called
+
+```rust
+// Inside discover_repo_url's caller (the source-tier wrapper):
+let raw_url = git_remote_get_url(scan_root, name)?;
+let sanitized = if keep_credentials {
+    SanitizedUrl { original: raw_url.clone(), sanitized: raw_url.clone(), was_sanitized: false }
+} else {
+    sanitize_userinfo(&raw_url)
+};
+
+if sanitized.was_sanitized {
+    tracing::info!(
+        scheme = "repo",
+        // host + path only; userinfo redacted in the log
+        url_safe = %redact_userinfo_for_log(&sanitized.original),
+        "sanitized userinfo from auto-detected identifier"
+    );
+}
+
+let label = build_source_label(remote_name, fallback_used, sanitized.was_sanitized);
+Identifier::from_parts_with_label(scheme, value_of(&sanitized.sanitized), kind, Some(label))
+```
+
+The `redact_userinfo_for_log` helper is private and produces a string like `https://<userinfo redacted>@github.com/foo.git` — host and path preserved, secret portion replaced.
+
+The build-tier flow at `auto_detect_build_tier_identifiers` mirrors this exactly for both the `repo:` and `git:` identifier construction.
+
+### Opt-out logging
+
+```rust
+if keep_credentials {
+    tracing::info!(
+        "--keep-credentials-in-identifiers set; userinfo in auto-detected identifiers will be preserved verbatim"
+    );
+}
+```
+
+Emitted once per scan invocation, not per identifier. Placed at the top of the auto-detect entry point so it appears before any identifier construction.
+
+## Observable contract from outside the binary
+
+### Default behavior (sanitization on)
+
+```
+$ git remote get-url origin
+https://x-access-token:ghs_AAA123@github.com/acme/private-repo.git
+
+$ mikebom sbom scan --path . --output out.cdx.json
+INFO sanitized userinfo from auto-detected identifier; scheme=`repo`; url_safe=`https://<userinfo redacted>@github.com/acme/private-repo.git`
+... (rest of scan flow unchanged)
+
+$ jq '.metadata.component.externalReferences[] | select(.type == "vcs") | .url' out.cdx.json
+"https://github.com/acme/private-repo.git"
+
+$ jq '.metadata.component.externalReferences[] | select(.type == "vcs") | .comment' out.cdx.json
+"auto-detected from git remote `origin` (credentials stripped)"
+
+$ grep -c "ghs_AAA123" out.cdx.json
+0
+```
+
+### Opt-out behavior (sanitization off)
+
+```
+$ mikebom sbom scan --path . --keep-credentials-in-identifiers --output out.cdx.json
+INFO --keep-credentials-in-identifiers set; userinfo in auto-detected identifiers will be preserved verbatim
+... (no per-identifier sanitization log lines)
+
+$ jq '.metadata.component.externalReferences[] | select(.type == "vcs") | .url' out.cdx.json
+"https://x-access-token:ghs_AAA123@github.com/acme/private-repo.git"
+
+$ jq '.metadata.component.externalReferences[] | select(.type == "vcs") | .comment' out.cdx.json
+"auto-detected from git remote `origin`"
+```
+
+### SSH-form passthrough
+
+```
+$ git remote get-url origin
+git@github.com:acme/foo.git
+
+$ mikebom sbom scan --path . --output out.cdx.json
+... (no sanitization log line — Url::parse rejects SSH form, sanitize_userinfo returns passthrough)
+
+$ jq '.metadata.component.externalReferences[] | select(.type == "vcs") | .url' out.cdx.json
+"git@github.com:acme/foo.git"
+
+$ jq '.metadata.component.externalReferences[] | select(.type == "vcs") | .comment' out.cdx.json
+"auto-detected from git remote `origin`"
+```
+
+## Test contract (extends `mikebom-cli/tests/identifiers_*` patterns)
+
+A new integration-test file `mikebom-cli/tests/identifiers_credential_strip.rs` MUST cover:
+
+| Test | Acceptance scenario | Validates |
+|------|--------------------|-----------|
+| `source_tier_strips_credentials_from_https_origin` | US1 §1, SC-001 | FR-001 |
+| `source_tier_source_label_carries_stripped_suffix` | US1 §2, SC-006 | FR-008 |
+| `source_tier_emits_redacted_info_log` | US1 §3 | FR-006 |
+| `source_tier_ssh_form_unchanged` | US1 §4, SC-007 | FR-003 (SSH passthrough) |
+| `build_tier_strips_credentials_from_repo_and_git` | US2 §1, SC-002 | FR-001 + FR-002 |
+| `manual_repo_emits_verbatim_with_credentials` | US3 §1, SC-003 | FR-004 |
+| `manual_repo_overrides_strip_with_credentials_in_value` | US3 §2 | FR-004 + 074's manual-wins |
+| `keep_credentials_flag_preserves_userinfo_source_tier` | US4 §1, SC-004 | FR-005 + FR-007 |
+| `keep_credentials_flag_preserves_userinfo_build_tier` | US4 §2 | FR-005 + FR-002 |
+| `parse_failure_falls_through_to_user_defined` | edge case | FR-009 |
+
+Plus unit tests for `sanitize_userinfo` directly:
+
+| Test | Validates |
+|------|-----------|
+| `sanitize_strips_user_password_https` | FR-001 base case |
+| `sanitize_strips_user_only_no_password` | edge case (token-only userinfo) |
+| `sanitize_handles_empty_userinfo` | edge case (`https://@host/...`) |
+| `sanitize_preserves_port_when_stripping` | FR-001 + port |
+| `sanitize_passthrough_on_parse_failure` | FR-009 + research §6 |
+| `sanitize_passthrough_on_no_userinfo` | no-op identity |
+| `sanitize_passthrough_on_ssh_form` | research §6 |
+
+Tests use the project's standard `#[cfg_attr(test, allow(clippy::unwrap_used))]` convention.
+
+## Performance contract (per SC-005)
+
+- One `Url::parse` per auto-detected URL. Bounded by `url` crate's parser (microseconds).
+- Two setter calls when userinfo is present. Bounded by string allocation cost.
+- Total: well under 1ms per identifier on a typical input.
+- No new subprocess invocations. No new I/O.
+
+## Determinism contract (per FR-010)
+
+- Same input URL → byte-identical `SanitizedUrl` content. Verified by unit test running the same input 100× and asserting identical results.
+- Sanitization happens once per `(scheme, value)` at construction time and is cached in the `Identifier` value. Per-format emission consumes the cached value without re-running sanitization.
+- The opt-out flag does not change the sanitization function — it changes whether the function is called. Determinism holds in both paths.

--- a/specs/075-strip-id-credentials/data-model.md
+++ b/specs/075-strip-id-credentials/data-model.md
@@ -1,0 +1,105 @@
+# Data Model — milestone 075 credential stripping
+
+The milestone introduces zero new public types. One small private return-shape struct (`SanitizedUrl`) lives in `auto_detect.rs`; one boolean parameter threads through the call chain. Both compose existing milestone-073/074 types.
+
+## Entities
+
+### `SanitizedUrl` (new, private to `auto_detect.rs`)
+
+Return shape of the new `sanitize_userinfo` helper.
+
+```rust
+struct SanitizedUrl {
+    /// The URL as returned by `git remote get-url`, unchanged.
+    /// Preserved so callers can still log the host/path for
+    /// operator debuggability.
+    original: String,
+    /// The URL with RFC 3986 userinfo removed. Equal to `original`
+    /// when no userinfo was present, when the URL fails to parse,
+    /// or when the operator passed `--keep-credentials-in-identifiers`.
+    sanitized: String,
+    /// True iff `sanitize_userinfo` actually removed userinfo.
+    /// Drives log-line emission and `source_label` augmentation.
+    was_sanitized: bool,
+}
+```
+
+Lifetime: ephemeral — created by `sanitize_userinfo`, consumed immediately by the caller, never stored.
+
+### `CredentialOptOut` (conceptual; materialized as a `bool`)
+
+The boolean state flowing from the new `--keep-credentials-in-identifiers` flag through `ScanArgs` / `RunArgs` into the auto-detect call sites. When `true`, the sanitize function is bypassed and the original URL is used verbatim. Default `false`.
+
+## Functions (public surface added by this milestone)
+
+### `sanitize_userinfo` (new, public to the `auto_detect` module)
+
+```rust
+pub fn sanitize_userinfo(url: &str) -> SanitizedUrl;
+```
+
+**Behavior**:
+1. Call `url::Url::parse(url)`. On `Err`, return `SanitizedUrl { original: url.to_string(), sanitized: url.to_string(), was_sanitized: false }` (passthrough; covers SSH-form URLs and other non-RFC-3986 inputs per research §6).
+2. On parse success, check whether the parsed URL has userinfo (`url.username().is_empty() == false || url.password().is_some()`). If neither is present, return passthrough.
+3. If userinfo is present, call `url.set_username("")` and `url.set_password(None)`. On `Err` from either setter (cannot-be-base path), return passthrough (preserves the FR-009 soft-fail rule).
+4. On both setters succeeding, return `SanitizedUrl { original: url.to_string(), sanitized: url_modified.to_string(), was_sanitized: true }`.
+
+**Error model**: never panics, never returns `Result`. All failure modes (parse error, setter error, cannot-be-base URLs) collapse to passthrough — the original string emits verbatim.
+
+### Updated signatures (existing functions, opt-out param added)
+
+```rust
+// Source-tier (was: scan_root → Option<Identifier>)
+pub fn auto_detect_repo_identifier(
+    scan_root: &Path,
+    keep_credentials: bool,  // NEW
+) -> Option<Identifier>;
+
+// Build-tier (was: invocation_cwd → Vec<Identifier>)
+pub fn auto_detect_build_tier_identifiers(
+    invocation_cwd: &Path,
+    keep_credentials: bool,  // NEW
+) -> Vec<Identifier>;
+```
+
+The new `keep_credentials` parameter is forwarded to internal logic that decides whether to call `sanitize_userinfo` on the discovered URL. When `true`, `sanitize_userinfo` is bypassed.
+
+Existing callers in `scan_cmd.rs` and `run.rs` get a one-line update each: pass `args.keep_credentials_in_identifiers` instead of nothing.
+
+## Validation rules
+
+- **VR-075-001**: `sanitize_userinfo` MUST never panic. All error paths collapse to passthrough.
+- **VR-075-002**: `sanitize_userinfo` MUST be deterministic — same input → byte-identical `SanitizedUrl` content (FR-010).
+- **VR-075-003**: When `was_sanitized == true`, the caller MUST emit exactly one info-level log line and append `(credentials stripped)` to the constructed identifier's `source_label`. When `was_sanitized == false`, the caller MUST NOT log and MUST NOT augment.
+- **VR-075-004**: When `keep_credentials == true`, `sanitize_userinfo` MUST NOT be called. The original URL flows through unchanged. The caller MUST emit one info-level log line acknowledging the suppression (FR-007).
+- **VR-075-005**: The `git:` identifier value `git:<url>#<sha>` MUST have `<url>` produced from `sanitize_userinfo(url).sanitized` (when not opted out), then the `#<sha>` appended. Sanitization happens on the URL part only — not on the SHA.
+
+## Relationships
+
+```text
+mikebom sbom scan / mikebom trace run
+    │
+    ├── ScanArgs.keep_credentials_in_identifiers : bool
+    │   RunArgs.keep_credentials_in_identifiers  : bool
+    │
+    └── auto_detect_repo_identifier(scan_root, keep_credentials)
+        auto_detect_build_tier_identifiers(invocation_cwd, keep_credentials)
+            │
+            ├── discover_repo_url(scan_root) → Option<(url, remote_name, fallback_used)>
+            │
+            ├── if !keep_credentials: sanitize_userinfo(&url) → SanitizedUrl
+            │   else:                 SanitizedUrl { original=url, sanitized=url, was_sanitized=false }
+            │
+            ├── If was_sanitized: tracing::info!("sanitized userinfo from `<scheme>`; URL: <userinfo redacted>@<host><path>")
+            │   If keep_credentials: tracing::info!("--keep-credentials-in-identifiers set; userinfo preserved verbatim")
+            │
+            └── Identifier::from_parts_with_label(scheme, value=sanitized_value, kind, source_label_with_suffix)
+```
+
+## Backward compatibility
+
+- No `Cargo.toml` deps removed; `url = "2"` promoted from transitive to direct (lockfile churn: zero).
+- Existing CLI surface is unchanged for operators who don't pass the new flag. Default behavior changes from "emit verbatim" to "strip credentials" — this is the intended security fix and the only operator-visible change.
+- Operators who relied on credentials being preserved (rare, internal-network case) get a one-flag opt-out path: `--keep-credentials-in-identifiers`. Their workflow continues unchanged once they pass the flag.
+- Existing milestone-073/074 byte-identity goldens stay byte-identical because, per milestone 074's T001 audit, no fixture has a credentialed remote (FR-012 + SC-008).
+- Cross-tier correlation contract (milestones 072–074) is preserved because the sanitized URL is the canonical correlation key — downstream tools matching SBOMs by `repo:` value get identical canonical forms regardless of which side sanitized.

--- a/specs/075-strip-id-credentials/plan.md
+++ b/specs/075-strip-id-credentials/plan.md
@@ -1,0 +1,165 @@
+# Implementation Plan: Strip userinfo credentials from auto-detected git URLs
+
+**Branch**: `075-strip-id-credentials` | **Date**: 2026-05-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/075-strip-id-credentials/spec.md`
+
+## Summary
+
+Closes a known information-disclosure path that pre-dated milestone 074: when an operator has a credentialed `git remote get-url` output (e.g., `https://USER:TOKEN@github.com/foo.git`), milestones 073/074 currently embed the full URL — including the secret — into emitted SBOMs. SBOMs are typically published artifacts; the secret leaks publicly as a side-effect.
+
+This milestone adds a single sanitization step in the auto-detect pipeline that strips RFC 3986 userinfo from auto-detected URLs before the identifier is constructed. Manual operator-supplied values stay verbatim (operators who type credentials own that choice). One new opt-out flag `--keep-credentials-in-identifiers` exists for operators with non-sensitive credentials they want preserved.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–074; no nightly).
+**Primary Dependencies**: Existing only — the `url = "2.5.8"` crate is already in the dependency closure (transitive via `reqwest`); this milestone promotes it to a direct workspace dependency. No new transitive deps. Plus `tracing` (info-level logs), `anyhow` (error propagation), `clap` (the new boolean flag — `Args`-derive picks it up). **No additions to the dependency tree at the lockfile level.**
+**Storage**: N/A — sanitization is a pure-function transformation; no caches, no persistence.
+**Testing**: `cargo +stable test --workspace`. New integration tests in `mikebom-cli/tests/identifiers_credential_strip.rs` reuse the tempdir-based git fixture pattern from milestones 073/074 and assert on emitted SBOM JSON content.
+**Target Platform**: Linux (CI primary), macOS (developer workstations). Sanitization logic is OS-agnostic; depends only on RFC 3986 URL parsing and string manipulation.
+**Project Type**: CLI tool — single workspace, three crates (`mikebom-cli` is the only one touched).
+**Performance Goals**: Sanitization adds <1ms per identifier — bounded by `url::Url::parse` + two `set_*` calls. Negligible against the existing `git` subprocess invocation cost.
+**Constraints**: Determinism per FR-010 (same input → byte-identical output). Soft-fail per FR-009 (parse failure routes to milestone 073's existing `UserDefined` path; never fails the scan). No regression on existing milestone 073/074 byte-identity goldens per SC-008 (none of the existing fixtures has a credentialed remote per milestone 074's T001 audit).
+**Scale/Scope**: One new function (`sanitize_userinfo`) of estimated ~25 LOC; two call sites updated (`discover_repo_url`, `auto_detect_build_tier_identifiers`); two CLI flag additions (one each on `ScanArgs` and `RunArgs`); one new integration-test file (~250 LOC); zero golden regen.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution v1.4.0 (last amended 2026-05-01). All twelve principles + four strict boundaries reviewed:
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| I. Pure Rust, Zero C | ✅ Pass | Rust-only sanitization. The `url` crate is pure Rust. |
+| II. eBPF-Only Observation | ✅ Pass / N/A | This milestone touches identifier metadata, not dependency discovery. The eBPF trace is unchanged. |
+| III. Fail Closed | ✅ Pass | Sanitization parse-failure path soft-fails through milestone 073's existing `UserDefined` rule (FR-009). Scan integrity is unaffected. |
+| IV. Type-Driven Correctness | ✅ Pass | The `SanitizedUrl` shape from data-model.md uses an explicit struct holding `(original, sanitized, was_sanitized)`. No raw `String` boundary crossings. Production code uses `anyhow::Result`; tests retain the established `#[cfg_attr(test, allow(clippy::unwrap_used))]` convention. |
+| V. Specification Compliance | ✅ Pass | **Native-first audit (constitution v1.4.0 5th bullet):** Sanitization changes the *value* of identifiers that already ride existing standards-native carriers from milestones 073/074. No new fields, no new annotations, no new `mikebom:*` properties. The `source_label` augmentation flows through the existing `Identifier::source_label: Option<String>` field. |
+| VI. Three-Crate Architecture | ✅ Pass | All changes in `mikebom-cli`. |
+| VII. Test Isolation | ✅ Pass | Sanitization is a pure function; tests need no privilege. Integration tests use tempdirs. |
+| VIII. Completeness | ✅ Pass / N/A | Doesn't affect dependency discovery. |
+| IX. Accuracy | ✅ Pass | Sanitization preserves the FR-010 soft-fail-to-`UserDefined` rule from milestone 073 — malformed URLs still classify correctly without falsely-`Builtin` emission. |
+| X. Transparency | ✅ Pass | Sanitization fires audibly: info-level log line per affected identifier (FR-006), augmented `source_label` reflects the action (FR-008), opt-out is logged when used (FR-007). |
+| XI. Enrichment | ✅ Pass / N/A | Not enrichment. |
+| XII. External Data Source Enrichment | ✅ Pass / N/A | `git remote get-url` is local subprocess output, not an external data source. |
+
+| Strict Boundary | Status |
+|-----------------|--------|
+| 1. No lockfile-based dependency discovery | ✅ Pass |
+| 2. No MITM proxy | ✅ Pass |
+| 3. No C code | ✅ Pass |
+| 4. No `.unwrap()` in production | ✅ Pass — sanitization uses `Url::parse` which returns `Result`; production code propagates via `?` or maps to `None` per the existing soft-fail pattern. Tests use the standard `#[cfg_attr(test, allow(clippy::unwrap_used))]` guard. |
+
+**Gate result: PASS.** No violations; no Complexity Tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/075-strip-id-credentials/
+├── plan.md                         # This file
+├── spec.md                         # /speckit.specify output
+├── research.md                     # Phase 0 output
+├── data-model.md                   # Phase 1 output
+├── quickstart.md                   # Phase 1 output
+├── contracts/
+│   └── credential-strip.md         # Phase 1 output — single CLI/lib contract
+├── checklists/
+│   └── requirements.md             # Already passing
+└── tasks.md                        # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+The milestone touches four production files plus one new integration-test file. No new modules, no new crates.
+
+```text
+Cargo.toml                                          # MODIFY (small) — promote
+                                                    # url = "2" to workspace dep
+mikebom-cli/
+├── Cargo.toml                                      # MODIFY — consume workspace.url
+├── src/
+│   ├── binding/
+│   │   └── identifiers/
+│   │       └── auto_detect.rs                      # MODIFY — add sanitize_userinfo
+│   │                                               # helper; wire into both
+│   │                                               # discover_repo_url and
+│   │                                               # auto_detect_build_tier_
+│   │                                               # identifiers; thread an
+│   │                                               # opt-out boolean parameter.
+│   └── cli/
+│       ├── scan_cmd.rs                             # MODIFY — add the
+│       │                                           # --keep-credentials-in-
+│       │                                           # identifiers flag to
+│       │                                           # ScanArgs; pass to auto-
+│       │                                           # detect call site.
+│       └── run.rs                                  # MODIFY — same flag on
+│                                                   # RunArgs; pass to build-
+│                                                   # tier auto-detect call.
+└── tests/
+    └── identifiers_credential_strip.rs             # NEW — integration tests
+                                                    # for SC-001..SC-008. ~10
+                                                    # tests covering: source-
+                                                    # tier strip, build-tier
+                                                    # strip, manual verbatim,
+                                                    # opt-out preserves, SSH-
+                                                    # form unchanged, log-
+                                                    # line redaction, source_
+                                                    # label augmentation,
+                                                    # parse-failure soft-fail.
+
+docs/reference/identifiers.md                       # MODIFY (small) — add
+                                                    # subsection on credential
+                                                    # sanitization + opt-out
+                                                    # flag documentation.
+```
+
+**Structure Decision**: Single project. Extends `mikebom-cli` with no new modules. Smallest-possible-surface-change, matching the milestone-074 posture.
+
+## Phase 0 — Research questions
+
+Implementation-level decisions to pin in `research.md` before Phase 1 design.
+
+1. **`url` crate API surface for userinfo manipulation** — `Url::set_username("")` plus `Url::set_password(None)` is the documented way to strip both halves. Confirm both calls return `Result`, document the failure mode (cannot-be-base URLs reject these calls), and pin the sanitize function's error-handling shape.
+2. **Promotion strategy for the `url` crate** — `url = "2.5.8"` is in the lockfile transitively. Adding it to `[workspace.dependencies]` and `mikebom-cli` `[dependencies]` should be a one-line addition each; verify cargo's dedup works as expected and the lockfile doesn't churn.
+3. **Sanitization sentinel for the source_label** — exact string to append: `(credentials stripped)`. Pin so goldens don't drift later.
+4. **Log-line shape and redaction marker** — exact `tracing::info!` template. Decide between `<userinfo redacted>` vs `[redacted]` vs other forms; pick one that matches existing project conventions.
+5. **Opt-out flag plumbing** — `clap`'s `bool` derive default-false pattern. The flag lives on `ScanArgs` and `RunArgs`; needs identical handling in both. Decide whether a workspace-level shared `IdentifierOpts` struct is worth creating now or deferred.
+6. **Edge case: SSH form vs `Url::parse`** — `git@github.com:foo/bar.git` is not RFC 3986 compliant and `Url::parse` rejects it. Confirm the sanitize function returns the original string verbatim on parse failure (passthrough), not None — preserving the milestone-073 soft-fail semantics for downstream classification.
+
+## Phase 1 — Design & contracts
+
+### data-model.md
+
+One new conceptual entity (`SanitizedUrl`, materialized as a small `(original, sanitized, was_sanitized)` return shape). One new param threading concept (`CredentialOptOut` boolean propagated through the auto-detect call chain). Both compose existing milestone-073/074 types.
+
+### contracts/credential-strip.md
+
+The milestone's only contract. Documents:
+- The new public function signature `pub fn sanitize_userinfo(url: &str) -> SanitizedUrl`.
+- The CLI flag contract for `--keep-credentials-in-identifiers` on both `mikebom sbom scan` and `mikebom trace run`.
+- The integration boundary: where `sanitize_userinfo` is called within `discover_repo_url` and `auto_detect_build_tier_identifiers`, and how the opt-out boolean threads through.
+- Observable contracts: log-line phrasing, `source_label` augmentation rules, identifier-emission shape (unchanged from 073/074 modulo the URL value).
+
+### quickstart.md
+
+Operator-facing recipes:
+1. **Default behavior — credentials stripped** (the headline).
+2. **Manual flag emits verbatim** (the symmetric rule).
+3. **Opt-out flag preserves credentials** (for operators on internal networks).
+4. **SSH-form URLs unchanged** (sanity-check the no-op path).
+5. **What to look for in the emitted SBOM** (jq snippet showing `externalReferences[type:vcs].url` is sanitized, `comment` field has `(credentials stripped)` suffix).
+
+### Agent context update
+
+Run `.specify/scripts/bash/update-agent-context.sh claude` after Phase 1 docs land. Expected: appends a `075-strip-id-credentials` row to the "Active Technologies" table in `CLAUDE.md`.
+
+## Phase 2 — Out of scope for this command
+
+`/speckit.plan` ends here. The next command (`/speckit.tasks`) consumes plan.md + spec.md + the Phase 1 docs and emits `tasks.md`. Estimated task count: ~10-12 (smaller than milestone 074's 14 because no refactor, no `resolve_identifiers` generalization, no new `Vec<Identifier>`-shape change).
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified.**
+
+Not applicable — Constitution Check passes on all twelve principles + four strict boundaries with zero violations.

--- a/specs/075-strip-id-credentials/quickstart.md
+++ b/specs/075-strip-id-credentials/quickstart.md
@@ -1,0 +1,146 @@
+# Quickstart — milestone 075 credential stripping
+
+Five operator-facing recipes. Each runs end-to-end against a post-075 mikebom build.
+
+## Recipe 1 — Default behavior: credentials stripped
+
+The headline new behavior. No flags needed beyond the normal scan command.
+
+```bash
+# Set up a git remote with embedded credentials (common GitHub App pattern)
+cd ~/projects/my-app
+git remote set-url origin https://x-access-token:ghs_AAA123XYZ@github.com/acme/my-app.git
+
+# Run mikebom — credentials get stripped automatically
+mikebom sbom scan --path . --output out.cdx.json
+# INFO sanitized userinfo from auto-detected identifier; scheme=`repo`; url_safe=`https://<userinfo redacted>@github.com/acme/my-app.git`
+```
+
+Inspect the emitted SBOM:
+
+```bash
+jq '.metadata.component.externalReferences[] | select(.type == "vcs")' out.cdx.json
+# {
+#   "type": "vcs",
+#   "url": "https://github.com/acme/my-app.git",
+#   "comment": "auto-detected from git remote `origin` (credentials stripped)"
+# }
+
+# Verify the token is gone:
+grep -c "ghs_AAA123XYZ" out.cdx.json
+# 0
+```
+
+The `url` has the userinfo stripped. The `comment` field (which carries the `source_label`) reflects the sanitization with `(credentials stripped)`. The original token string appears nowhere in the document.
+
+## Recipe 2 — Manual flag emits verbatim
+
+Operators who explicitly type credentials get them through verbatim. No sanitization, no warning.
+
+```bash
+mikebom sbom scan \
+  --repo https://USER:TOKEN@github.com/acme/foo.git \
+  --path /tmp/non-git-dir \
+  --output out.cdx.json
+```
+
+Inspect:
+
+```bash
+jq '.metadata.component.externalReferences[] | select(.type == "vcs") | .url' out.cdx.json
+# "https://USER:TOKEN@github.com/acme/foo.git"
+```
+
+Manual = verbatim. The operator typed it; the tool respects that. Use this path if you have credentials you specifically want emitted (typically: airgapped or internal-network setups).
+
+## Recipe 3 — Opt out for non-sensitive credentials
+
+For organizations with internal SBOM pipelines where the credentials are infrastructure-level (e.g., a public read-only deploy token), pass the opt-out flag.
+
+```bash
+mikebom sbom scan --path . --keep-credentials-in-identifiers --output out.cdx.json
+# INFO --keep-credentials-in-identifiers set; userinfo in auto-detected identifiers will be preserved verbatim
+```
+
+Inspect:
+
+```bash
+jq '.metadata.component.externalReferences[] | select(.type == "vcs")' out.cdx.json
+# {
+#   "type": "vcs",
+#   "url": "https://x-access-token:ghs_AAA123XYZ@github.com/acme/my-app.git",
+#   "comment": "auto-detected from git remote `origin`"
+# }
+```
+
+The auto-detected URL preserves userinfo. The `(credentials stripped)` suffix is absent because no sanitization happened. An info-level log line at scan start records that the operator opted out.
+
+## Recipe 4 — SSH-form URLs unchanged
+
+SSH-form URLs (`git@github.com:foo/bar.git`) carry no userinfo by construction. Sanitization is a no-op; the SBOM is byte-identical to alpha.16.
+
+```bash
+git remote set-url origin git@github.com:acme/my-app.git
+mikebom sbom scan --path . --output out.cdx.json
+# (no sanitization log line — nothing to strip)
+```
+
+```bash
+jq '.metadata.component.externalReferences[] | select(.type == "vcs")' out.cdx.json
+# {
+#   "type": "vcs",
+#   "url": "git@github.com:acme/my-app.git",
+#   "comment": "auto-detected from git remote `origin`"
+# }
+```
+
+The `(credentials stripped)` suffix is absent. SSH-form is the safest operator pattern for environments where SBOMs ship publicly.
+
+## Recipe 5 — Build-tier sanitization (mikebom trace run)
+
+The same default-strip behavior applies to `mikebom trace run`. Both auto-detected `repo:` and `git:` identifiers get sanitized.
+
+```bash
+git remote set-url origin https://x-access-token:ghs_BBB456@github.com/acme/my-app.git
+mikebom trace run -- ./build.sh
+# INFO sanitized userinfo from auto-detected identifier; scheme=`repo`; url_safe=`https://<userinfo redacted>@github.com/acme/my-app.git`
+# INFO sanitized userinfo from auto-detected identifier; scheme=`git`; url_safe=`https://<userinfo redacted>@github.com/acme/my-app.git#abc1234567890...`
+```
+
+Inspect the build-tier SBOM:
+
+```bash
+jq '.metadata.component.externalReferences[] | select(.type == "vcs")' build.cdx.json
+# [
+#   {
+#     "type": "vcs",
+#     "url": "https://github.com/acme/my-app.git",
+#     "comment": "auto-detected from build-tier git remote `origin` (credentials stripped)"
+#   },
+#   {
+#     "type": "vcs",
+#     "url": "https://github.com/acme/my-app.git#abc1234567890abcdef1234567890abcdef1234",
+#     "comment": "auto-detected from build-tier `git rev-parse HEAD` (credentials stripped)"
+#   }
+# ]
+```
+
+Both identifier slots sanitized; both `comment` fields carry the suffix. The token appears nowhere in the build SBOM, the eBPF trace output, or the signed attestation envelope.
+
+## How to verify on existing alpha.16 outputs (regression check)
+
+Before upgrading: re-scan a repo with a credentialed remote on alpha.16 and confirm the leak.
+
+```bash
+mikebom-alpha.16 sbom scan --path . --output before.cdx.json
+grep -c "ghs_" before.cdx.json
+# (count > 0 means token is in the output — that is the bug 075 fixes)
+```
+
+After upgrading to alpha.17 (which ships milestone 075):
+
+```bash
+mikebom-alpha.17 sbom scan --path . --output after.cdx.json
+grep -c "ghs_" after.cdx.json
+# 0 (token successfully stripped)
+```

--- a/specs/075-strip-id-credentials/research.md
+++ b/specs/075-strip-id-credentials/research.md
@@ -1,0 +1,87 @@
+# Research — milestone 075 credential stripping
+
+Six implementation-level decisions to pin before Phase 1 design.
+
+## §1 — `url` crate API for userinfo manipulation
+
+**Decision**: Use `url::Url::parse` plus `set_username("")` and `set_password(None)`. Both setter calls return `Result<(), ()>` (cannot-be-base error variant); on Err, the function falls through to the FR-009 soft-fail path and returns the original string unchanged.
+
+**Rationale**: Documented public API. Both setters succeed for any URL with a well-formed authority component (which is exactly the set of URLs that have userinfo to begin with). Cannot-be-base URLs (e.g., `mailto:`) lack an authority and reject these setters; for our auto-detect input domain (git remote URLs), this is a vanishingly rare path but still needs a safe fallback.
+
+**Alternatives considered**:
+- Manual string manipulation (split on `://`, find the next `@`) — Rejected: error-prone with corner cases (port-only userinfo, URL-encoded userinfo, bracketed IPv6 hosts). The `url` crate's parser is the well-tested standard.
+- Use `Url::set_authority` with a manually-constructed host:port string — Rejected: unnecessarily reinvents what the dedicated setters already do.
+
+## §2 — `url` crate dependency promotion
+
+**Decision**: Add `url = "2"` to `[workspace.dependencies]` in the root `Cargo.toml`, and `url = { workspace = true }` to `[dependencies]` in `mikebom-cli/Cargo.toml`. The workspace `Cargo.lock` already pins `url 2.5.8` transitively (via `reqwest`); promotion does not change the lockfile resolution.
+
+**Rationale**: The crate is already in the dep graph. Direct dep declaration just makes the import valid in `mikebom-cli/src/binding/identifiers/auto_detect.rs`. Cargo's MVS resolver dedups to the existing version. Lockfile churn is zero.
+
+**Alternatives considered**:
+- Re-export `url::Url` through a thin wrapper crate — Rejected: pure overhead.
+- Vendor a minimal URL parser into `mikebom-cli` — Rejected: violates the project's "no NIH" posture and creates maintenance burden.
+
+## §3 — Sanitization sentinel for `source_label`
+
+**Decision**: Append the string ` (credentials stripped)` to the existing `source_label` value. Specifically:
+
+- Source-tier sanitized: `"auto-detected from git remote `origin` (credentials stripped)"`
+- Source-tier fallback-listed sanitized: `"auto-detected from git remote `<name>` (origin/upstream absent; first-listed) (credentials stripped)"`
+- Build-tier sanitized: `"auto-detected from build-tier git remote `origin` (credentials stripped)"`
+- Build-tier `git:` sanitized: `"auto-detected from build-tier `git rev-parse HEAD` (credentials stripped)"`
+
+Pin these strings now; goldens depend on them.
+
+**Rationale**: Suffix-append preserves the existing milestone-073/074 prefix structure that consumers may already parse (especially the build-tier / source-tier distinction). Parenthesized clause is easy to read and matches the existing `(origin/upstream absent; first-listed)` parenthetical convention from milestone 073.
+
+**Alternatives considered**:
+- Replace the entire label with a sanitization-specific phrasing — Rejected: loses the original auto-detect provenance information.
+- Use a structured suffix like `[sanitized]` — Rejected: inconsistent with the existing free-prose label style.
+
+## §4 — Log-line redaction marker
+
+**Decision**: Use the literal placeholder string `<userinfo redacted>` in info-level log lines. The full log line shape:
+
+```
+INFO sanitized userinfo from auto-detected `<scheme>` identifier; original URL prefix: `<scheme>://<userinfo redacted>@<host><path>`
+```
+
+Both `<userinfo redacted>` and any subsequent fields exclude the actual credential value. The host and path are not sensitive and ARE included for operator debuggability.
+
+**Rationale**: Angle-bracket placeholder is conventional for "machine-meaningful redaction marker" across log standards. Including host + path lets operators identify which remote was sanitized without revealing the secret. Matches the project's existing `tracing::warn!(reason = %err, ...)` style at `auto_detect.rs:96-104`.
+
+**Alternatives considered**:
+- `[redacted]` (square brackets) — Rejected: less distinctive in a stream of log output where square brackets often denote metadata.
+- Omit the URL entirely from the log — Rejected: operators lose the ability to identify which remote was affected without re-running the scan.
+- Log a hash of the userinfo — Rejected: overkill; the host already disambiguates.
+
+## §5 — Opt-out flag plumbing
+
+**Decision**: Add a single new boolean `--keep-credentials-in-identifiers` flag to both `ScanArgs` (in `scan_cmd.rs`) and `RunArgs` (in `run.rs`). Default false. Clap's derive macros pick it up automatically. Each call site passes the boolean to its respective auto-detect call:
+
+```rust
+auto_detect_repo_identifier(scan_root, args.keep_credentials_in_identifiers);  // source-tier
+auto_detect_build_tier_identifiers(invocation_cwd, args.keep_credentials_in_identifiers);  // build-tier
+```
+
+No shared struct. Two-line CLI surface, two-line call-site update.
+
+**Rationale**: Smallest viable plumbing. A shared `IdentifierOpts` struct is premature abstraction at this milestone's scale (one shared boolean across two `Args` structs). If a future milestone adds more identifier-related flags, the abstraction can emerge organically.
+
+**Alternatives considered**:
+- Shared `#[derive(Args)]` `IdentifierOpts` struct — Deferred. Add when there are 3+ shared flags.
+- Per-tier flags (`--scan-keep-credentials`, `--trace-keep-credentials`) — Rejected: same flag, same meaning, different command. Single flag name preserves predictability.
+- Environment variable opt-out (`MIKEBOM_KEEP_CREDENTIALS=1`) — Rejected: explicit CLI flag is more discoverable. Environment fallback can be added later if operators ask.
+
+## §6 — SSH form passthrough behavior
+
+**Decision**: When `Url::parse` rejects the input string (which happens for SSH-form URLs like `git@github.com:foo/bar.git`), `sanitize_userinfo` returns `SanitizedUrl { original, sanitized: original.clone(), was_sanitized: false }`. The downstream code path is identical to the no-userinfo case: emit verbatim, no `source_label` augmentation, no log line.
+
+**Rationale**: SSH-form URLs have no userinfo by construction (the `git@` is a fixed SSH username, not a credential). Treating parse-failure as "nothing to sanitize" is the correct semantic: we couldn't analyze it, but we know there's nothing to strip in the SSH-form case. The downstream identifier still gets classified by milestone-073's existing soft-fail logic — if `validate_repo` accepts the SSH form (it does, per current behavior), the identifier emits as `Builtin`; if not, it soft-fails to `UserDefined`.
+
+**Side effect for SC-007**: SSH-form URLs emit byte-identical to alpha.16 — `was_sanitized` is false, no log line, no label change, no value change. The existing milestone 073/074 contracts are preserved unchanged for the SSH case.
+
+**Alternatives considered**:
+- Return `None` on parse failure and have callers fall through — Rejected: changes the existing call-site signature; breaks the "transparent passthrough" semantic that the milestone needs for SSH-form correctness.
+- Implement a manual SSH-form detection (regex match `^[^/@]+@[^/]+:`) — Rejected: not needed. The `Url::parse` failure path covers SSH-form transparently. Additional detection is duplicative.

--- a/specs/075-strip-id-credentials/spec.md
+++ b/specs/075-strip-id-credentials/spec.md
@@ -1,0 +1,143 @@
+# Feature Specification: Strip userinfo credentials from auto-detected git URLs
+
+**Feature Branch**: `075-strip-id-credentials`
+**Created**: 2026-05-06
+**Status**: Draft
+**Input**: User description: "When mikebom auto-detects a `repo:` or `git:` identifier from a git remote URL, the URL MUST have userinfo (the `USER:TOKEN@` portion of `https://USER:TOKEN@github.com/...`) stripped before being embedded in the emitted SBOM. Manual flags emit verbatim. Provide an opt-out flag for operators who legitimately want credentials preserved."
+
+## Overview
+
+Milestones 073 and 074 ship identifier auto-detection that calls `git remote get-url` and embeds the result verbatim in published SBOMs. If an operator has configured a git remote with userinfo credentials — e.g., `https://USER:TOKEN@github.com/acme/foo.git`, common in CI runners using GitHub App tokens or deploy tokens for private-repo access — those credentials currently end up visible in:
+
+- CDX `metadata.component.externalReferences[type:vcs].url`
+- SPDX 2.3 `Package.externalRefs[PERSISTENT-ID].referenceLocator` and `creationInfo.creators[]` redundant text line
+- SPDX 3 `Element.externalIdentifier[].identifier`
+
+SBOMs are typically published artifacts (release attachments, OCI registry referrers, attached to images, archived in compliance pipelines, ingested by third-party scanners). A token visible in any one of those carriers is a supply-chain leak path: the operator never intended to publish the token; the publication happened as a side-effect of running mikebom.
+
+This milestone closes the leak path. Auto-detected URL values get sanitized (userinfo stripped) before being embedded in any emitted identifier. Manual operator-supplied values stay verbatim — the operator typed them explicitly and the tool respects that. An opt-out flag exists for operators on private/internal networks where the credentials are non-sensitive and they specifically want the original URL preserved.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Source-tier auto-detect strips credentials by default (Priority: P1)
+
+A developer or CI runner has configured a git remote URL with embedded credentials (e.g., `https://x-access-token:ghs_AAA...@github.com/acme/private-repo.git`, the standard GitHub App token form). They run `mikebom sbom scan --path .` with no manual identifier flags. The emitted source SBOM contains a `repo:` identifier with the URL sanitized to `https://github.com/acme/private-repo.git` — the token is gone.
+
+**Why this priority**: This is the most common leak vector. Source-tier scans run on every CI build of every repo that uses mikebom. Without this protection, every published source SBOM is a potential token-disclosure incident. P1 because it's the largest blast-radius surface in mikebom's public footprint.
+
+**Independent Test**: Initialize a git repo with `git remote add origin https://USER:TOKEN@github.com/foo/bar.git`, run `mikebom sbom scan --path . --output out.cdx.json`, and verify the emitted SBOM contains `repo:https://github.com/foo/bar.git` (no userinfo). Equivalently, `jq` over the emitted SBOM finds zero occurrences of the literal token string.
+
+**Acceptance Scenarios**:
+
+1. **Given** a source repository with `origin` set to `https://USER:TOKEN@github.com/foo/bar.git`, **When** the operator runs `mikebom sbom scan --path .` with no identifier flags, **Then** the emitted SBOM's `repo:` identifier has value `https://github.com/foo/bar.git` (userinfo stripped). The literal token string MUST NOT appear anywhere in the emitted document.
+2. **Given** the same repository, **When** the operator inspects the emitted SBOM, **Then** the `source_label` for the auto-detected identifier reflects the sanitization (e.g., `"auto-detected from git remote `origin` (credentials stripped)"`).
+3. **Given** the same repository, **When** the operator runs the scan, **Then** an info-level log line records the sanitization: which identifier was affected and that userinfo was stripped (without revealing the redacted credential value — log `<userinfo redacted>` or similar).
+4. **Given** a source repository with an SSH-form remote `git@github.com:foo/bar.git` (no userinfo by construction), **When** the operator runs the scan, **Then** the emitted `repo:` identifier matches the original URL byte-for-byte. SSH-form URLs are unaffected.
+
+---
+
+### User Story 2 - Build-tier auto-detect strips credentials by default (Priority: P1)
+
+The same protection applies to `mikebom trace run` (milestone 074's auto-detection path). A developer running `mikebom trace run -- ./build.sh` in a git checkout configured with credentialed origin URL gets a build-tier SBOM with both `repo:` and `git:` identifiers sanitized.
+
+**Why this priority**: Build-tier scans run as part of CI build-and-publish flows. The same leak vector applies — the build SBOM gets attached to artifacts, included in attestations, and signed by Sigstore. A token in a signed attestation is *worse* than one in a plain SBOM because it's now cryptographically bound to the supply-chain proof itself; revoking the token doesn't undo the publication. P1 for the same reasoning as US1 plus the attestation amplification.
+
+**Independent Test**: In a git checkout with `origin` set to a credentialed URL, run `mikebom trace run -- /usr/bin/true`. Verify the emitted build-tier SBOM contains `repo:` and `git:` identifier slots whose URLs have userinfo stripped, and the literal token string appears nowhere in the document.
+
+**Acceptance Scenarios**:
+
+1. **Given** a build cwd with `origin` set to `https://x-access-token:TOKEN@github.com/foo/bar.git`, **When** the operator runs `mikebom trace run`, **Then** the emitted build-tier SBOM's `repo:` identifier has value `https://github.com/foo/bar.git` and the `git:` identifier has value `https://github.com/foo/bar.git#<commit-sha>` — both sanitized; the original token string appears nowhere in the emitted document.
+2. **Given** the same setup, **When** the operator inspects log output, **Then** info-level log lines record both sanitizations (one per affected identifier).
+
+---
+
+### User Story 3 - Manual identifier flags emit verbatim (Priority: P1)
+
+Operators who explicitly supply identifier values via `--repo`, `--git-ref`, or `--id repo=...` flags get those values emitted verbatim in the SBOM. No sanitization. If the operator typed credentials, mikebom respects that.
+
+**Why this priority**: Operators have legitimate reasons to type a credentialed URL — internal/airgapped deployments where the credential is shared infrastructure, or test scenarios where the URL is known-fake. Sanitizing manual input would surprise operators and break workflows that explicitly want the original URL. P1 because the rule is symmetric with the auto-detect strip rule: auto = strip, manual = verbatim, and getting that boundary right is what makes the feature trustworthy.
+
+**Independent Test**: Run `mikebom sbom scan --repo https://USER:TOKEN@github.com/foo/bar.git --path /tmp/non-git-dir --output out.cdx.json`. Verify the emitted SBOM contains `repo:https://USER:TOKEN@github.com/foo/bar.git` exactly as typed.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator runs `mikebom sbom scan --repo https://USER:TOKEN@github.com/foo.git --path .`, **When** the SBOM is emitted, **Then** the `repo:` identifier value is `https://USER:TOKEN@github.com/foo.git` byte-for-byte. No sanitization, no warning.
+2. **Given** an operator runs `mikebom trace run --repo https://USER:TOKEN@github.com/foo.git -- ./build.sh`, **Then** the manual flag wins over auto-detection (per milestone 074's FR-004) and the emitted `repo:` value is the operator's verbatim input.
+3. **Given** auto-detection emits a sanitized `repo:https://github.com/foo.git` and the operator additionally passes `--id custom_repo=https://USER:TOKEN@internal.acme.corp/foo.git`, **Then** the user-defined `custom_repo:` identifier rides through verbatim (manual = verbatim rule applies to user-defined schemes too).
+
+---
+
+### User Story 4 - Opt-out flag preserves original URL (Priority: P2)
+
+Operators on private/internal-network setups where the credentials are deliberately non-sensitive (e.g., a public read-only deploy token, an internal-network-only HTTPS token that has no value outside the corporate VPN) can opt out of sanitization globally for their scan via a CLI flag.
+
+**Why this priority**: Real but narrow use case. The default behavior (strip) handles 95% of operators correctly. The opt-out is for edge cases — large organizations with internal SBOM pipelines where the credentials are infrastructure-level, not secrets. P2 because the absence of the flag is acceptable for the milestone's MVP (operators with that need can pass manual `--repo` to override per US3); the flag is a convenience.
+
+**Independent Test**: With a credentialed `origin` URL, run `mikebom sbom scan --path . --keep-credentials-in-identifiers`. Verify the emitted SBOM's `repo:` identifier preserves the userinfo verbatim.
+
+**Acceptance Scenarios**:
+
+1. **Given** a credentialed `origin` URL, **When** the operator runs `mikebom sbom scan --path . --keep-credentials-in-identifiers`, **Then** the emitted SBOM's `repo:` identifier preserves the original URL with userinfo intact.
+2. **Given** the same flag is passed to `mikebom trace run`, **Then** both auto-detected `repo:` and `git:` identifiers preserve userinfo in the emitted build-tier SBOM.
+3. **Given** the flag is set, **When** the operator inspects log output, **Then** an info-level log line records that sanitization was suppressed by the flag (so the audit trail still reflects the operator's choice).
+
+---
+
+### Edge Cases
+
+- **URL with empty userinfo**: `https://@github.com/foo.git` (a malformed-but-syntactically-valid URL with empty userinfo). The empty userinfo is still userinfo per RFC 3986 — strip it, leaving `https://github.com/foo.git`.
+- **URL with userinfo but no password**: `https://username@github.com/foo.git` (legitimate auth pattern for some setups). Strip it — the username may be a personal access token in some configurations (`oauth2:TOKEN` pattern is the explicit token form, but bare `TOKEN@` is also possible). Treating any userinfo as sensitive is the safe-by-default rule.
+- **`git://` and other non-HTTPS schemes**: Apply the same userinfo-strip rule. RFC 3986 defines userinfo for any URI scheme that uses the `authority` component, including `git://` (rare but legitimate).
+- **Malformed URLs that don't parse cleanly**: A `git remote get-url` output that doesn't parse as RFC 3986 falls back to milestone 073's existing soft-fail-to-`UserDefined` rule (FR-010 in 073). Sanitization is best-effort: parse failure → emit verbatim and fall through to the existing soft-fail. Don't fail the scan over a parse error.
+- **SSH-form URLs**: `git@github.com:foo/bar.git` is the SCP-like syntax. RFC 3986 doesn't define this form; it has no userinfo by construction (the `git@` is just a fixed username for the SSH protocol, not a credential). Pass through unchanged.
+- **URL with both userinfo AND port**: `https://USER:TOKEN@github.com:443/foo.git`. Strip only the userinfo; preserve the port and everything else. Result: `https://github.com:443/foo.git`.
+- **URL with userinfo AND fragment** (relevant for `git:<url>#<sha>`): `https://USER:TOKEN@github.com/foo.git`. After stripping userinfo and combining with the SHA: `git:https://github.com/foo.git#<sha>`. The sanitization happens before the SHA is appended.
+- **Stripping makes the URL identical to a manually-supplied verbatim value**: An operator runs `mikebom sbom scan --repo https://github.com/foo.git --path .` AND auto-detection finds `https://USER:TOKEN@github.com/foo.git` — after sanitization both reduce to `https://github.com/foo.git`. Per milestone 073's FR-006 dedup-by-(scheme, value) rule, these collapse to a single entry attributed to the manual flag.
+- **Multiple credentialed remotes**: A repo has `origin` and `upstream` both with different credentials. Only one wins per the milestone-073 fallback algorithm; the chosen one gets sanitized. The losing remote's URL never reaches the SBOM regardless. No new behavior.
+- **Operator passes both `--keep-credentials-in-identifiers` AND `--id ...` with a credentialed user-defined value**: Both signals point the same direction — keep credentials. No conflict.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When auto-detecting a `repo:` identifier (source-tier per milestone 073, build-tier per milestone 074), mikebom MUST strip userinfo from the discovered URL before constructing the identifier value. URL parsing follows RFC 3986; userinfo is the `<user>[:<password>]@` segment that precedes the host.
+- **FR-002**: When auto-detecting a `git:<repo-url>#<sha>` identifier (build-tier per milestone 074), the sanitization rule from FR-001 MUST be applied to the `<repo-url>` portion before the `#<sha>` is appended. The result is a `git:` value with the SHA intact and userinfo absent from the URL.
+- **FR-003**: Sanitization MUST apply uniformly to HTTPS, HTTP, `git://`, and any other URI scheme that uses the RFC 3986 `authority` component. SSH-form URLs (`git@host:path`) carry no userinfo by construction and pass through unchanged.
+- **FR-004**: Manual identifier flags (`--repo`, `--git-ref`, `--image-id`, `--attestation`, `--id <scheme>=<value>`) MUST emit values verbatim. No sanitization is applied to operator-supplied input.
+- **FR-005**: A new opt-out flag `--keep-credentials-in-identifiers` MUST be available on `mikebom sbom scan` and `mikebom trace run`. When set, the FR-001/FR-002 sanitization is suppressed and auto-detected URLs emit verbatim. The flag is a boolean, default false.
+- **FR-006**: When sanitization fires (i.e., FR-001 or FR-002 actually removed userinfo from a URL), mikebom MUST emit an info-level log line per affected identifier recording: which scheme (`repo` or `git`), that userinfo was stripped, and a `<userinfo redacted>` placeholder where the secret would otherwise appear in the log. The literal credential value MUST NOT appear in the log.
+- **FR-007**: When sanitization is suppressed by `--keep-credentials-in-identifiers`, mikebom MUST emit an info-level log line acknowledging the suppression so the audit trail reflects the operator's choice.
+- **FR-008**: The `source_label` field on auto-detected identifiers whose URL was sanitized MUST be augmented to indicate the sanitization (e.g., the source-tier label becomes `"auto-detected from git remote `origin` (credentials stripped)"`; build-tier labels follow the same `(credentials stripped)` suffix). When sanitization does NOT fire (the URL had no userinfo to strip), the label is unchanged from milestones 073/074.
+- **FR-009**: When the discovered URL fails to parse as RFC 3986, sanitization MUST fall through to milestone 073's existing soft-fail-to-`UserDefined` rule (FR-010 in 073). The scan MUST NOT fail over a URL parse error. The unparseable value emits as user-defined under the `mikebom:identifiers` namespace, unchanged from existing behavior.
+- **FR-010**: Sanitization MUST be deterministic. Given a fixed input URL, the sanitized output is byte-identical across runs. No randomness, no timestamping, no environment-dependent transformation.
+- **FR-011**: The sanitization step MUST execute exactly once per `(scheme, value)` pair at identifier-construction time. It MUST NOT re-run during emission per format. The post-sanitization value is what flows into all per-format carriers (CDX `externalReferences`, SPDX 2.3 `externalRefs`, SPDX 3 `externalIdentifier`) without further transformation.
+- **FR-012**: Cross-format byte-identity goldens for fixtures whose `git remote` configuration had no userinfo MUST stay byte-identical to alpha.16 (no sanitization fires; no behavior change). Per milestone 074's T001 audit, no existing fixture has a credentialed remote, so the golden regen is empirically a no-op for this milestone. Test fixtures that exercise the credentialed-URL path live in the new integration test file and produce no goldens.
+
+### Key Entities
+
+- **SanitizedUrl**: A URL value that has had its RFC 3986 userinfo component removed (if present) prior to embedding in an identifier. Composed of: the original URL string, the sanitized URL string, and a boolean `sanitized` flag indicating whether userinfo was actually present and removed. Used internally by `discover_repo_url` and the build-tier wrapper to drive log-line emission and `source_label` augmentation.
+- **CredentialOptOut**: The boolean state flowing from the `--keep-credentials-in-identifiers` flag through both `mikebom sbom scan` and `mikebom trace run`. Threaded into the identifier construction path so the sanitization step can be conditionally suppressed. Default false.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For an operator with `https://USER:TOKEN@github.com/foo.git` configured as origin, the emitted source-tier SBOM (with no manual flags, no opt-out flag) contains zero occurrences of the literal token string anywhere in the document. Verified by integration test: build a tempdir git fixture with a known-fake token, run `mikebom sbom scan`, search the emitted JSON for the token string, assert zero matches.
+- **SC-002**: The same zero-occurrence guarantee holds for build-tier SBOMs emitted by `mikebom trace run` against the same fixture — both the `repo:` and `git:` identifier slots sanitized, and zero occurrences in the document.
+- **SC-003**: When the operator passes `--repo https://USER:TOKEN@github.com/foo.git` explicitly, the emitted SBOM contains the literal token string in exactly one place: the `repo:` identifier value. Manual = verbatim, no sanitization. Verified by integration test on both `mikebom sbom scan` and `mikebom trace run`.
+- **SC-004**: When the operator passes `--keep-credentials-in-identifiers`, auto-detected URLs emit verbatim. The emitted SBOM contains the literal token string in the auto-detected identifier slots. Verified by integration test against the same fixtures.
+- **SC-005**: Sanitization adds less than 1ms to identifier construction for a typical git checkout (one URL parse + one userinfo-clear per identifier). Verified by manual smoke timing during quickstart validation; no dedicated benchmark fixture.
+- **SC-006**: The `source_label` field on sanitized identifiers contains the substring `credentials stripped`. Verified by unit and integration tests asserting on the `source_label` value.
+- **SC-007**: SSH-form URLs (`git@host:path`) emit byte-identical to alpha.16 in both auto-detected and manual paths. Verified by integration test using an SSH-form remote.
+- **SC-008**: 100% of existing milestone-073 and milestone-074 byte-identity goldens stay byte-identical after milestone 075 ships, since the existing fixture set has no credentialed remotes (audit per milestone 074 task T001 confirmed). Verified by the existing parity-check golden suite continuing to pass unchanged.
+
+## Assumptions
+
+- The implementation reuses Rust's `url` crate (already in the workspace dep graph if available, or addable as a small dependency) for RFC 3986 parsing. Rolling our own URL parser is out of scope. If `url` isn't already a workspace dep, this milestone adds it — a one-line `Cargo.toml` change with broad ecosystem use.
+- Sanitization scope is **userinfo only**. Other URL components (scheme, host, port, path, query, fragment) pass through unchanged. Specifically: query-string credentials (e.g., `https://github.com/foo.git?token=ABC`) are NOT sanitized by this milestone — they are an extremely rare pattern and addressing them would expand scope significantly. Operators with query-string credentials should pass `--repo` manually with sanitized URL, or accept the verbatim emission.
+- The opt-out flag `--keep-credentials-in-identifiers` lives on `mikebom sbom scan` and `mikebom trace run`. It does NOT affect manual flag values (which are already verbatim per FR-004). Setting the flag has no observable effect when the operator provides only manual identifier flags.
+- This milestone fixes a known information-disclosure path that pre-dated 074 (introduced in 073 when source-tier auto-detect first shipped). 074 inherited it without making it worse. The fix applies symmetrically across both auto-detect call sites and inherits 074's per-tier `source_label` distinction (FR-008 augmentation preserves the build-tier vs source-tier prefix).
+- Manual flag verbatim emission preserves the existing milestone 073/074 contract that operators who explicitly type credentials are responsible for their choice. This milestone does not introduce any "smart" detection on manual input (e.g., warning the operator that their manual `--repo` value contains userinfo). That is reserved for a future hardening milestone if an operator-survey-like signal indicates demand.
+- Goldens for the existing fixture set are unaffected per milestone 074's T001 audit (no fixture has a credentialed remote). The new integration test file for this milestone uses tempdir-based fixtures and produces no goldens.
+- The released alpha.16 binaries are NOT re-published as a hotfix. Operators concerned about the leak path can mitigate today by passing `--repo <sanitized-url>` manually. This milestone ships in alpha.17.
+- The SBOM consumer ecosystem treats userinfo-bearing URLs as semantically equivalent to userinfo-stripped URLs for correlation purposes — i.e., a downstream tool resolving `repo:https://github.com/foo.git` should match an SBOM that originally had `repo:https://USER:TOKEN@github.com/foo.git`. Sanitization preserves the cross-tier correlation contract from milestones 072-074 because the sanitized form is the canonical one.

--- a/specs/075-strip-id-credentials/tasks.md
+++ b/specs/075-strip-id-credentials/tasks.md
@@ -1,0 +1,183 @@
+---
+description: "Task list for milestone 075 — strip userinfo credentials from auto-detected git URLs"
+---
+
+# Tasks: Strip userinfo credentials from auto-detected git URLs
+
+**Input**: Design documents from `/specs/075-strip-id-credentials/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/credential-strip.md, quickstart.md
+
+**Tests**: Spec references SC-001 through SC-008 plus 7 unit tests for `sanitize_userinfo`. Test tasks are included.
+
+**Organization**: Four user stories (3× P1, 1× P2). The implementation is small enough that all stories share a single test file and most production-code tasks. Phases group tasks by what blocks what.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different files, no incomplete-task dependencies)
+- **[Story]**: US1 / US2 / US3 / US4 (story-phase tasks only)
+- File paths are absolute or repository-relative
+
+## Path Conventions
+
+Single workspace; all 075 changes inside `mikebom-cli` plus a small workspace-Cargo.toml change.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Promote the `url` crate to a direct workspace dep.
+
+- [X] T001 Add `url = "2"` to `[workspace.dependencies]` in `/Users/mlieberman/Projects/mikebom/Cargo.toml`. Add `url = { workspace = true }` to `[dependencies]` in `/Users/mlieberman/Projects/mikebom/mikebom-cli/Cargo.toml`. Run `cargo build --workspace` and verify `Cargo.lock` is unchanged (the crate is already at `url 2.5.8` transitively per research §2). If lockfile churn appears, investigate before proceeding.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Ship the core sanitization helper and updated auto-detect signatures. After this phase, the production code is sanitization-aware but no integration tests have been written yet.
+
+**⚠️ CRITICAL**: User-story phases depend on these.
+
+- [X] T002 Implement `pub fn sanitize_userinfo(url: &str) -> SanitizedUrl` in `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/binding/identifiers/auto_detect.rs`. Behavior per data-model.md §`sanitize_userinfo`: parse via `url::Url::parse`; on Err return passthrough; on success check `username().is_empty() == false || password().is_some()`; if userinfo present call `set_username("")` then `set_password(None)`; on either setter Err return passthrough; on success return `SanitizedUrl { original, sanitized: parsed.to_string(), was_sanitized: true }`. Add the private `SanitizedUrl` struct in the same file. Add 7 unit tests per contracts/credential-strip.md "Test contract" unit-test list (covering: user+password, user-only, empty userinfo, port preservation, parse failure passthrough, no-userinfo passthrough, SSH-form passthrough). Tests guarded with `#[cfg_attr(test, allow(clippy::unwrap_used))]`.
+
+- [X] T003 Implement private helper `fn redact_userinfo_for_log(url_str: &str) -> String` in the same file. Replaces userinfo with the literal string `<userinfo redacted>` while preserving scheme/host/path/query/fragment. Used by the info-log call sites in T004 + T005. Add unit tests for: with-userinfo URL gets `<userinfo redacted>` substituted; no-userinfo URL passes through; parse-failure case returns the input unchanged.
+
+- [X] T004 Update `auto_detect_repo_identifier` signature in the same file to add the trailing `keep_credentials: bool` parameter per data-model.md "Updated public signatures". Wire into the body: after `discover_repo_url` succeeds, call `sanitize_userinfo(&url)` (or skip and use passthrough when `keep_credentials == true`); use `sanitized.sanitized` as the identifier value; emit `tracing::info!` per FR-006 when `was_sanitized == true`; augment `source_label` with ` (credentials stripped)` per research §3 when `was_sanitized == true`. Update existing unit tests in `auto_detect.rs` to pass `false` (default behavior) for the new param so they keep covering source-tier behavior. Verify all existing source-tier tests still pass.
+
+- [X] T005 Update `auto_detect_build_tier_identifiers` signature to take the same `keep_credentials: bool` param. Wire into the body for both the `repo:` construction (mirrors T004) and the `git:` construction (sanitize the URL portion BEFORE appending `#<sha>`, per VR-075-005). At the top of the function, log `tracing::info!("--keep-credentials-in-identifiers set; userinfo in auto-detected identifiers will be preserved verbatim")` when `keep_credentials == true` per FR-007. Update existing tests to pass `false`. Verify all existing build-tier tests still pass.
+
+- [X] T006 [P] Add the `--keep-credentials-in-identifiers` flag to `ScanArgs` in `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/cli/scan_cmd.rs` (clap `Args`-derive: `#[arg(long)]` `pub keep_credentials_in_identifiers: bool`). Pass `args.keep_credentials_in_identifiers` to the existing `auto_detect_repo_identifier` call (around `scan_cmd.rs:1467`). Help text per contracts/credential-strip.md "Help-text shape".
+
+- [X] T007 [P] Add the same `--keep-credentials-in-identifiers` flag to `RunArgs` in `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/cli/run.rs`. Pass `args.keep_credentials_in_identifiers` to the existing `auto_detect_build_tier_identifiers` call. Help text per contracts/credential-strip.md.
+
+**Checkpoint**: production code is sanitization-aware. CLI flags wired. All existing tests pass with the default-false flag value. Both user-story phases can begin.
+
+---
+
+## Phase 3: User Story 1 — Source-tier auto-detect strips credentials by default (Priority: P1)
+
+**Goal**: `mikebom sbom scan --path .` in a git checkout with a credentialed origin URL produces a source SBOM with the userinfo stripped from the `repo:` identifier value, the `source_label` augmented, and an info log emitted.
+
+**Independent Test**: Build a tempdir git fixture with `origin` set to `https://USER:TOKEN@github.com/foo/bar.git`. Run `mikebom sbom scan --path <fixture> --output out.cdx.json`. Assert: emitted `repo:` URL is `https://github.com/foo/bar.git`; literal token string occurs zero times in `out.cdx.json`; `comment` field contains `(credentials stripped)`.
+
+### Tests for User Story 1
+
+- [X] T008 [US1] Create `/Users/mlieberman/Projects/mikebom/mikebom-cli/tests/identifiers_credential_strip.rs` with the tempdir-based git fixture builder helper (same pattern as `mikebom-cli/tests/identifiers_build_tier_autodetect.rs`'s helper from milestone 074). Add tests:
+  - (a) `source_tier_strips_credentials_from_https_origin` — fixture has credentialed origin; assert `repo:` value sanitized + zero literal-token occurrences in emitted JSON.
+  - (b) `source_tier_source_label_carries_stripped_suffix` — same fixture; assert `comment` field contains `(credentials stripped)`.
+  - (c) `source_tier_emits_redacted_info_log` — capture log output (test-tracing or similar pattern); assert info-level log line contains `<userinfo redacted>` and host but NOT the literal token.
+  - (d) `source_tier_ssh_form_unchanged` — fixture has SSH-form origin; assert emitted `repo:` URL is byte-identical to the original; `comment` field has NO `(credentials stripped)` suffix.
+
+  Tests guarded with `#[cfg_attr(test, allow(clippy::unwrap_used))]`.
+
+**Checkpoint**: US1 passes. Source-tier flow correctly sanitizes by default.
+
+---
+
+## Phase 4: User Story 2 — Build-tier auto-detect strips credentials by default (Priority: P1)
+
+**Goal**: `mikebom trace run` in a credentialed git checkout produces a build-tier SBOM with both `repo:` and `git:` identifiers sanitized, source_label augmented, info logs emitted for each.
+
+**Independent Test**: Same fixture as US1 plus a HEAD commit. Invoke `auto_detect_build_tier_identifiers` directly (as in milestone 074's tests) and assert both identifier slots sanitized; literal token string absent.
+
+### Tests for User Story 2
+
+- [X] T009 [US2] Add to `mikebom-cli/tests/identifiers_credential_strip.rs`:
+  - (a) `build_tier_strips_credentials_from_repo_and_git` — fixture has credentialed origin + a commit; assert both auto-detected `repo:` and `git:` identifiers have URLs without userinfo; literal token string occurs zero times in the resulting `Vec<Identifier>` (serialize each `value` and grep). The test invokes `auto_detect_build_tier_identifiers` directly per the milestone-074 pattern (eBPF unavailable in standard test env).
+  - (b) `build_tier_git_value_has_sha_appended_after_sanitization` — VR-075-005: assert the `git:` value matches `git:https://github.com/<...>.git#<40-hex-sha>` and contains zero `@` characters in the URL portion (because credentials stripped).
+
+**Checkpoint**: US2 passes. Build-tier flow correctly sanitizes both identifier slots.
+
+---
+
+## Phase 5: User Story 3 — Manual identifier flags emit verbatim (Priority: P1)
+
+**Goal**: Operator-supplied `--repo`, `--git-ref`, or `--id repo=...` values flow through the SBOM unchanged. No sanitization applied to manual input.
+
+**Independent Test**: `mikebom sbom scan --path /tmp/non-git --repo https://USER:TOKEN@github.com/foo.git --output out.cdx.json` produces an SBOM where the `repo:` value is byte-identical to the operator's input.
+
+### Tests for User Story 3
+
+- [X] T010 [US3] Add to `mikebom-cli/tests/identifiers_credential_strip.rs`:
+  - (a) `manual_repo_emits_verbatim_with_credentials` — `--repo https://USER:TOKEN@github.com/foo.git` against a non-git tempdir; assert emitted `repo:` value is byte-identical to the input including the userinfo.
+  - (b) `manual_repo_overrides_strip_with_credentials_in_value` — fixture has credentialed origin AND operator passes `--repo` with a different credentialed value; assert the manual value wins (per milestone 074's manual-precedence rule) and emits verbatim. The auto-detected sanitized value does NOT appear; the manual credentialed value DOES appear.
+
+**Checkpoint**: US3 passes. The auto/manual boundary is correctly enforced.
+
+---
+
+## Phase 6: User Story 4 — Opt-out flag preserves credentials (Priority: P2)
+
+**Goal**: When `--keep-credentials-in-identifiers` is passed, auto-detected URLs emit verbatim. Source-tier and build-tier both honor the flag.
+
+**Independent Test**: Same credentialed fixture as US1; with the opt-out flag, assert the `repo:` URL preserves userinfo and the `comment` field has no `(credentials stripped)` suffix.
+
+### Tests for User Story 4
+
+- [X] T011 [US4] Add to `mikebom-cli/tests/identifiers_credential_strip.rs`:
+  - (a) `keep_credentials_flag_preserves_userinfo_source_tier` — credentialed fixture + `--keep-credentials-in-identifiers`; assert `repo:` URL contains userinfo verbatim; `comment` field is the unchanged source-tier label (no `(credentials stripped)` suffix).
+  - (b) `keep_credentials_flag_preserves_userinfo_build_tier` — same fixture invoked through `auto_detect_build_tier_identifiers(..., keep_credentials=true)`; assert both `repo:` and `git:` values preserve userinfo.
+  - (c) `keep_credentials_flag_emits_acknowledgment_log` — assert the FR-007 info log line `--keep-credentials-in-identifiers set; ...` is emitted exactly once per scan invocation.
+
+- [X] T012 [US4] Add edge-case test `parse_failure_falls_through_to_user_defined` (FR-009): an exotic non-RFC-3986 URL value reaches `sanitize_userinfo` (passthrough), then milestone 073's existing `validate_for_scheme` validator soft-fails to `UserDefined`. Assert the resulting `Identifier` has `kind == IdentifierKind::UserDefined`.
+
+**Checkpoint**: US4 passes. All four user stories covered.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [X] T013 [P] Update `/Users/mlieberman/Projects/mikebom/docs/reference/identifiers.md`: add a new subsection (around §4 or wherever auto-detection is currently documented) titled "Credential sanitization" covering: default-strip behavior, the `(credentials stripped)` suffix, the `--keep-credentials-in-identifiers` opt-out flag, and SSH-form passthrough. Add an explicit "What gets stripped vs not" table covering HTTPS-with-userinfo, HTTPS-no-userinfo, SSH-form, and `git://` cases. Reference quickstart.md Recipe 5 for the cross-tier picture.
+
+- [X] T014 Run pre-PR gate per CLAUDE.md: (a) `cargo +stable clippy --workspace --all-targets -- -D warnings` zero warnings; (b) `cargo +stable test --workspace` every suite `0 failed`. Convenience: `./scripts/pre-pr.sh`. A failing per-crate `cargo test -p mikebom` does NOT discharge this requirement.
+
+- [X] T015 Manually validate quickstart.md recipes 1–5 end-to-end against a real local build of milestone 075. Confirm log-line phrasing matches contracts/credential-strip.md exactly. Time Recipe 1 with `time` to verify SC-005 (<1ms sanitization overhead).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: T001 depends on nothing.
+- **Phase 2 (Foundational)**: T002 → T003 → T004 → T005 are sequential (same file, building up). T006 [P] and T007 [P] are parallel with each other and parallel-safe with T004/T005 since they touch different files (`scan_cmd.rs` and `run.rs`); however they CALL the new function signatures from T004/T005, so they must land AFTER those land in `auto_detect.rs`. In practice: T002 → T003 → T004 → T005 → (T006 [P] || T007 [P]).
+- **Phase 3 (US1)** through **Phase 6 (US4)**: depend on Phase 2 complete. T008 (US1 test file creation) must precede T009 / T010 / T011 / T012 (those add tests to the file T008 created). T009 / T010 / T011 / T012 can run in any order against the existing test file.
+- **Phase 7 (Polish)**: depends on Phases 1-6 complete. T013 [P] (docs) parallel with T014 (gate). T015 last.
+
+### User Story Dependencies
+
+All four stories share the production code from Phase 2. The tests are independent test functions in a shared file; merge conflicts limited to the file's `mod tests` import block.
+
+### Parallel Opportunities
+
+- T006 [P] and T007 [P] in Phase 2 — different files (`scan_cmd.rs` vs `run.rs`), no inter-dep.
+- T013 [P] in Phase 7 — different file (docs), parallel with T014/T015.
+
+---
+
+## Implementation Strategy
+
+### MVP First (Phases 1-3 = US1)
+
+1. Phase 1 setup (T001).
+2. Phase 2 foundational (T002–T007).
+3. Phase 3 US1 (T008).
+4. **STOP and VALIDATE**: at this checkpoint the source-tier strip path is fully working with tests. The build-tier path is also working (T005 wired it) but untested. This is *not* shippable as MVP because US2 (build-tier) is also P1 — both half-shipped is worse than both finished.
+5. Continue through Phases 4-7.
+
+### Incremental Delivery
+
+Single PR. Milestone is small (~14 tasks, all in one file or its tests, no refactors, no new modules). Splitting into multiple PRs would create transient states where the source-tier ships sanitization but build-tier doesn't, and vice versa — same-day asymmetry.
+
+### Parallel Team Strategy
+
+Single developer + reviewer. Total estimated effort: <1 person-day.
+
+---
+
+## Notes
+
+- [P] = different files, no incomplete-task dependencies.
+- All four user stories share production code; test surface splits by US.
+- Per CLAUDE.md: pre-PR gate REQUIRES both `cargo +stable clippy --workspace --all-targets -- -D warnings` clean AND `cargo +stable test --workspace` clean. Cite both in the PR description.
+- Tests in `identifiers_credential_strip.rs` MUST guard their `mod tests` items with `#[cfg_attr(test, allow(clippy::unwrap_used))]` per CLAUDE.md.
+- Total estimated tasks: 15. Total estimated effort: <1 person-day.


### PR DESCRIPTION
## Summary

Closes a known information-disclosure path: milestones 073/074 embed `git remote get-url` output verbatim into emitted SBOMs. If an operator has `https://USER:TOKEN@github.com/foo.git` configured (common GitHub App / deploy-token CI pattern), the token leaks into every published SBOM, OCI referrer, and signed attestation as a side-effect of running mikebom.

This milestone adds a sanitization step that strips RFC 3986 userinfo from **auto-detected** URLs before they become identifier values. Manual operator-supplied values (`--repo`, `--git-ref`, `--id`) stay verbatim — the operator typed them, the tool respects that. New opt-out flag `--keep-credentials-in-identifiers` preserves userinfo for operators on private/internal-network setups where the credentials are deliberately non-sensitive.

The `url 2.5.8` crate (promoted from transitive to direct workspace dep) does the parsing. Net new transitive deps: zero — already in the lockfile via `reqwest`.

## Spec

- [`specs/075-strip-id-credentials/spec.md`](specs/075-strip-id-credentials/spec.md) — 4 user stories (3× P1, 1× P2), 12 FRs, 8 SCs
- [`specs/075-strip-id-credentials/research.md`](specs/075-strip-id-credentials/research.md) — 6 implementation decisions (URL crate API, log-line shape, label sentinel, etc.)
- [`specs/075-strip-id-credentials/data-model.md`](specs/075-strip-id-credentials/data-model.md) — `SanitizedUrl` shape + VR-075-001..005

## Test plan

- [x] Pre-PR gate clean: `cargo +stable clippy --workspace --all-targets -- -D warnings` (zero warnings); `cargo +stable test --workspace` — all 56 test targets `0 failed`
- [x] 12 new integration tests in `mikebom-cli/tests/identifiers_credential_strip.rs` cover all 4 user stories: US1 source-tier strip, US2 build-tier strip (both `repo:` and `git:` slots), US3 manual verbatim, US4 opt-out preserves
- [x] 12 new unit tests in `auto_detect.rs` cover `sanitize_userinfo` (8 tests: user+password, user-only, empty userinfo, port preservation, parse failure, no-userinfo passthrough, SSH-form passthrough, determinism) and `redact_userinfo_for_log` (4 tests)
- [x] Existing `identifiers_build_tier_autodetect.rs` updated for the new signature; all 14 tests still pass
- [x] Zero golden churn: per milestone 074's T001 audit, no existing fixture has a credentialed remote, so SC-008 (no regression) holds empirically — verified by clean test run
- [x] SSH-form URLs emit byte-identical to alpha.16 (FR-003, SC-007) — `Url::parse` rejects SSH form, `sanitize_userinfo` returns passthrough
- [ ] Reviewer sanity-check: clone a repo locally, set `origin` to `https://USER:TOKEN@github.com/foo.git`, run `mikebom sbom scan --path .`, `grep -c TOKEN out.cdx.json` should report `0`
- [ ] Reviewer sanity-check: same setup with `--keep-credentials-in-identifiers`, `grep -c TOKEN` should report `>0` (opt-out works)

## Notable design decisions

- **`sanitize_userinfo` is a passthrough on parse failure.** SSH-form URLs (`git@host:path`) are not RFC 3986 compliant and `Url::parse` rejects them; passthrough preserves the milestone-073 soft-fail-to-`UserDefined` semantics for downstream classification. SSH-form output is byte-identical to alpha.16.
- **Manual flags emit verbatim, no sanitization.** The auto/manual boundary is the trust boundary: auto-detected = mikebom doesn't know what it found, must default-strip; manual = operator-typed, operator's responsibility.
- **Source-tier and build-tier signatures both gained `keep_credentials: bool`.** Forward-compatible if a future milestone wants to add more identifier-related options (an `IdentifierOpts` struct can emerge organically when ≥3 flags exist).
- **Log redaction uses `<userinfo redacted>` placeholder + preserves host/path.** Operators can identify which remote was sanitized without revealing the secret.

## Constitution check

All 12 principles + 4 strict boundaries pass per [`plan.md`](specs/075-strip-id-credentials/plan.md#constitution-check). Specifically:
- Principle V native-first audit: zero new `mikebom:*` annotations introduced; sanitization changes the *value* of identifiers that already ride milestone 073/074's standards-native carriers
- Principle X (Transparency): sanitization fires audibly via info-level log + augmented `source_label`; opt-out is logged

## Release notes (for the changelog when one is cut)

Security hardening: auto-detected git remote URLs in `repo:` and `git:` identifiers now have userinfo stripped by default to prevent accidental credential disclosure in published SBOMs. Manual flag values are unchanged (verbatim emission). New `--keep-credentials-in-identifiers` flag opts out for non-sensitive credentials. Operators with credentialed `origin` URLs should re-scan and re-publish previously-released SBOMs (alpha.13–alpha.16) if they may have leaked tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)