### PR TITLE
feat(076): subject identifier scheme + per-component user-defined identifiers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-05
+Auto-generated from all feature plans. Last updated: 2026-05-06
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -53,6 +53,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-05
 - N/A — identifiers live in emitted SBOMs only; no caches, no persistence. (074-build-tier-id-autodetect)
 - Rust stable (workspace toolchain inherited from milestones 001–074; no nightly). + Existing only — the `url = "2.5.8"` crate is already in the dependency closure (transitive via `reqwest`); this milestone promotes it to a direct workspace dependency. No new transitive deps. Plus `tracing` (info-level logs), `anyhow` (error propagation), `clap` (the new boolean flag — `Args`-derive picks it up). **No additions to the dependency tree at the lockfile level.** (075-strip-id-credentials)
 - N/A — sanitization is a pure-function transformation; no caches, no persistence. (075-strip-id-credentials)
+- Rust stable (workspace toolchain inherited from milestones 001–075; no nightly). + Existing only — `serde`/`serde_json`, `tracing`, `anyhow`, `clap` (the two new flags via derive), `thiserror`. The build-tier subject extraction reuses the in-toto witness-v0.1 subject set the existing trace pipeline already collects in-process; no new subprocess calls, no new I/O, no new crates. **No additions to the dependency tree at the lockfile level.** (076-subject-component-ids)
+- N/A — identifier emission is a pure metadata transform; no caches, no persistence. (076-subject-component-ids)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -115,9 +117,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 076-subject-component-ids: Added Rust stable (workspace toolchain inherited from milestones 001–075; no nightly). + Existing only — `serde`/`serde_json`, `tracing`, `anyhow`, `clap` (the two new flags via derive), `thiserror`. The build-tier subject extraction reuses the in-toto witness-v0.1 subject set the existing trace pipeline already collects in-process; no new subprocess calls, no new I/O, no new crates. **No additions to the dependency tree at the lockfile level.**
 - 075-strip-id-credentials: Added Rust stable (workspace toolchain inherited from milestones 001–074; no nightly). + Existing only — the `url = "2.5.8"` crate is already in the dependency closure (transitive via `reqwest`); this milestone promotes it to a direct workspace dependency. No new transitive deps. Plus `tracing` (info-level logs), `anyhow` (error propagation), `clap` (the new boolean flag — `Args`-derive picks it up). **No additions to the dependency tree at the lockfile level.**
 - 074-build-tier-id-autodetect: Added Rust stable (workspace toolchain inherited from milestones 001–073; no nightly required for this user-space-only work). + Existing only — `std::process::Command` for the new `git rev-parse HEAD` shell-out (same pattern as the existing `git remote get-url` calls at `auto_detect.rs:32`+ and as milestone 053's `git describe` ladder), `tracing` for info/warn logs, `anyhow` for error propagation. **No new `Cargo.toml` deps.**
-- 073-source-identifiers: Added Rust stable (workspace toolchain inherited from milestones 001–072; no nightly). + Existing only — `serde`/`serde_json` (envelope decode), `tracing` (info/warn logs), `anyhow` (CLI error propagation), `clap` (`ValueEnum` not needed — `Vec<String>` with manual validation is fine since the scheme syntax is regex-bounded; alternatively a custom `Identifier` newtype that implements `FromStr` and clap's `Args`-derive picks it up). `Command::new("git")` for the auto-detection shell-out (same pattern as milestone 053's `git describe`). No new `Cargo.toml` deps.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/docs/reference/identifiers.md
+++ b/docs/reference/identifiers.md
@@ -705,17 +705,150 @@ preserved.
 
 ## Section 8 — Milestone 074 status
 
-Milestone 074 (this milestone) closes the symmetry gap between
-source-tier, image-tier, and build-tier auto-detection. Build-tier
-scans now auto-detect `repo:` and `git:` identifiers from the
-invocation cwd's git state — see §4.4 above and §4.5's cross-tier
-correlation recipe.
+Milestone 074 closes the symmetry gap between source-tier, image-tier,
+and build-tier auto-detection. Build-tier scans now auto-detect
+`repo:` and `git:` identifiers from the invocation cwd's git state —
+see §4.4 above and §4.5's cross-tier correlation recipe.
 
 A future milestone will automate the cross-tier correlation itself
 (via a local SBOM index, OCI referrers, or external-registry
 resolvers — exact mechanism is yet to be scoped). The cross-tier
 identifier byte-equality this milestone guarantees is the deciding
 substrate that future milestone consumes.
+
+---
+
+## Section 9 — Milestone 076: subject identifier scheme + per-component identifiers
+
+Milestone 076 closes the cross-tier content-addressable correlation
+chain by adding two operator-visible features:
+
+1. **`subject:` document-level identifier scheme** (fifth built-in).
+2. **Per-component user-defined identifiers** via a new
+   `--component-id <PURL>=<scheme>:<value>` flag.
+
+### 9.1 `subject:` identifier scheme
+
+`subject:<algo>:<hex>` declares "this SBOM describes the artifact
+with the given content hash." Allowed algos: `sha256` (64 lowercase
+hex chars), `sha512` (128 lowercase hex chars). Other algos and
+mixed/uppercase hex soft-fail to `IdentifierKind::UserDefined` per
+FR-005.
+
+**Auto-detection** (build-tier only): on `mikebom trace run`, the
+trace's in-toto attestation envelope captures `subject[]` entries
+with digest maps. mikebom emits one `subject:sha256:<hex>` identifier
+per subject that has a sha256 digest in its map, in input order.
+Subjects without sha256 are skipped with `tracing::info!`. Multi-digest
+subjects (sha256 AND sha512) auto-emit sha256 only — the 2026-05-06
+clarification. Operators who need other algos pass
+`--subject-hash sha512:<hex>` manually.
+
+**Manual** (any tier): `--subject-hash <ALGO>:<HEX>` is repeatable on
+both `mikebom sbom scan` and `mikebom trace run`. Manual values
+augment auto-detected entries (deduplicated by `(scheme, value)` per
+milestone 073's resolution pipeline).
+
+**Per-format wire mapping**:
+
+| Format | Carrier | Shape |
+|---|---|---|
+| CDX 1.6 | `metadata.component.externalReferences[]` | `{type:"attestation", url:"sha256:<hex>", comment:"..."}` |
+| SPDX 2.3 | `Package.externalRefs[]` on main-module + `creationInfo.creators[]` redundant text | `{referenceCategory:"PERSISTENT-ID", referenceType:"subject", referenceLocator:"sha256:<hex>"}` |
+| SPDX 3 | `SpdxDocument.externalIdentifier[]` | `{type:"ExternalIdentifier", externalIdentifierType:"subject", identifier:"sha256:<hex>"}` |
+
+CDX reuses the `attestation` enum value — coexists with milestone-073
+attestation IRIs in the same array, distinguishable by `url` shape
+(digest vs IRI). The SPDX 2.3 main-module gate is the same one
+milestone 073 introduced; subject identifiers without a main-module
+package still appear in `creationInfo.creators[]` for fixture-agnostic
+discovery.
+
+### 9.2 Cross-tier digest handshake
+
+External SBOM-store consumers can correlate components across SBOMs
+purely by string match:
+
+```text
+image-SBOM.components[].hashes[].sha256 == X
+    →   build-SBOM with subject:sha256:X identifier
+        →   that build SBOM's git: identifier
+            →   matching source SBOM
+```
+
+No mikebom-side resolver. The `subject:` value's hex portion equals
+the digest portion of an `image:` value when they refer to the same
+artifact (FR-014).
+
+### 9.3 Per-component user-defined identifiers (`--component-id`)
+
+Attach an operator-defined identifier to a specific component:
+
+```bash
+mikebom sbom scan --path . \
+    --component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-shared-lib-v2" \
+    --output out.cdx.json
+```
+
+The flag is repeatable. Built-in scheme names (`repo`, `git`,
+`image`, `attestation`, `subject`) are rejected at clap parse time
+per FR-009 — those slots are reserved for document-level use. PURL
+matching is byte-equality only (no glob, no version-range). Selectors
+matching multiple components attach the identifier to ALL matches
+(FR-011); selectors matching zero components emit a `tracing::warn!`
+and the scan continues (FR-010).
+
+**Per-format wire mapping**:
+
+| Format | Carrier | Shape |
+|---|---|---|
+| CDX 1.6 | `components[].properties[]` | `{name:"<scheme>", value:"<value>"}` |
+| SPDX 2.3 | `Package.externalRefs[]` | `{referenceCategory:"PERSISTENT-ID", referenceType:"<scheme>", referenceLocator:"<value>"}` |
+| SPDX 3 | `Element.externalIdentifier[]` | `{type:"ExternalIdentifier", externalIdentifierType:"<scheme>", identifier:"<value>"}` |
+
+Pre-existing per-component entries (`mikebom:not-linked`,
+`mikebom:shade-relocation`, the SPDX 2.3 `purl` externalRef, etc.)
+preserve their original positions; new `--component-id` entries
+append after, lex-sorted by `(scheme, value)` per research §6.
+
+### 9.4 jq decode recipes
+
+Extract `subject:` from a CDX build SBOM:
+
+```bash
+jq '.metadata.component.externalReferences[]
+    | select(.type == "attestation")
+    | select(.url | startswith("sha256:") or startswith("sha512:"))
+    | .url' out.cdx.json
+```
+
+Extract per-component user-defined identifiers from a CDX SBOM:
+
+```bash
+jq '.components[]
+    | {purl: .purl, ids: [.properties[]?
+        | select(.name | test("^[a-z][a-z0-9_-]*$"))
+        | select(.name | startswith("mikebom:") | not)
+        | {(.name): .value}]}' out.cdx.json
+```
+
+Same against SPDX 2.3:
+
+```bash
+jq '.packages[]
+    | {purl: (.externalRefs[] | select(.referenceType == "purl") | .referenceLocator),
+       ids: [.externalRefs[]
+        | select(.referenceCategory == "PERSISTENT-ID")
+        | {(.referenceType): .referenceLocator}]}' out.spdx.json
+```
+
+### 9.5 Backward compatibility
+
+All milestone-073/074/075 byte-identity goldens stay byte-identical:
+no fixture passes `--subject-hash` or `--component-id` today. New
+fixtures that exercise the new paths gain additive entries — the
+expected golden regen for this milestone. See quickstart.md for
+operator recipes covering all four user stories.
 
 ---
 

--- a/mikebom-cli/src/binding/identifiers/auto_detect.rs
+++ b/mikebom-cli/src/binding/identifiers/auto_detect.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 use std::process::Command;
 
 use super::{Identifier, IdentifierKind, IdentifierValue, SchemeName};
+use mikebom_common::attestation::statement::ResourceDescriptor;
 
 /// Result of running `sanitize_userinfo` on a candidate URL string.
 ///
@@ -721,6 +722,110 @@ pub fn image_reference_to_identifier(
 }
 
 // ---------------------------------------------------------------------
+// Milestone 076 — build-tier `subject:` auto-detection
+// ---------------------------------------------------------------------
+
+/// Convert an in-toto attestation subject set into `subject:` identifiers
+/// per milestone 076 FR-002 + the 2026-05-06 sha256-only clarification.
+///
+/// Behavior:
+///
+/// 1. Iterate `subjects` in input order (witness-v0.1 already lex-sorts
+///    subjects by `(name, digest)` before serialization, so this loop
+///    inherits that ordering).
+/// 2. For each subject, look up the `"sha256"` key in its digest map.
+///    If absent, log `tracing::info!` listing the subject name and the
+///    available algos, then skip this subject (FR-002 + 2026-05-06
+///    clarification: sha256-only auto-emit; operators who need other
+///    algos pass `--subject-hash sha512:<hex>` manually).
+/// 3. If sha256 is present, construct an `Identifier` with scheme
+///    `subject`, value `sha256:<hex>`, kind `Builtin(Subject)` (after
+///    a defensive `validate_for_scheme` round-trip — well-formed
+///    digest-map values produced by the trace pipeline always pass,
+///    but the validator runs for defense in depth and the soft-fail
+///    path covers any future producer that emits a malformed value),
+///    and source_label `"auto-detected from build-tier in-toto subject
+///    \`<name>\`"`.
+///
+/// Multi-digest subjects (e.g., both sha256 AND sha512 in a single
+/// digest map) emit only the sha256 form per the 2026-05-06
+/// clarification. Synthetic subjects (digest map keyed by
+/// `"synthetic"` not `"sha256"`) skip emission per the same rule.
+///
+/// Never panics, never returns `Result`. All failure modes collapse
+/// to "skip this subject" with an `tracing::info!` info-log.
+pub fn subject_identifiers_from_attestation_subjects(
+    subjects: &[ResourceDescriptor],
+) -> Vec<Identifier> {
+    let mut out: Vec<Identifier> = Vec::with_capacity(subjects.len());
+    for subject in subjects {
+        let Some(sha256) = subject.digest.get("sha256") else {
+            // FR-002 + 2026-05-06 clarification: skip subjects without
+            // sha256 and surface the reason so operators can decide
+            // whether to backfill with `--subject-hash`.
+            let available: Vec<&str> =
+                subject.digest.keys().map(String::as_str).collect();
+            tracing::info!(
+                subject = %subject.name,
+                available_algos = ?available,
+                "subject `{}` has no sha256 digest (available algos: {:?}); \
+                 skipping subject: identifier auto-emit. Pass --subject-hash \
+                 sha512:<hex> manually if needed.",
+                subject.name,
+                available,
+            );
+            continue;
+        };
+        let value_str = format!("sha256:{sha256}");
+        let scheme = match SchemeName::new("subject".to_string()) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let value = match IdentifierValue::new(value_str.clone()) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        // Defense-in-depth validator round-trip — well-formed inputs
+        // always pass; soft-fail paths exist for future producer drift.
+        let kind = match super::BuiltinScheme::from_scheme_name(&scheme) {
+            Some(b) => match super::validators::validate_for_scheme(b, value.as_str()) {
+                Ok(()) => IdentifierKind::Builtin(b),
+                Err(err) => {
+                    tracing::warn!(
+                        subject = %subject.name,
+                        value = %value_str,
+                        reason = %err,
+                        "auto-detected `subject:` value failed validation; \
+                         emitting as user-defined under \
+                         mikebom:identifiers"
+                    );
+                    IdentifierKind::UserDefined
+                }
+            },
+            None => IdentifierKind::UserDefined,
+        };
+        let label = format!(
+            "auto-detected from build-tier in-toto subject `{}`",
+            subject.name
+        );
+        tracing::info!(
+            value = %value_str,
+            subject = %subject.name,
+            "build-tier auto-detected `subject:{}` from in-toto subject `{}`",
+            value_str,
+            subject.name,
+        );
+        out.push(Identifier::from_parts_with_label(
+            scheme,
+            value,
+            kind,
+            Some(label),
+        ));
+    }
+    out
+}
+
+// ---------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------
 
@@ -1230,5 +1335,108 @@ mod tests {
             r,
             "https://<userinfo redacted>@github.com:8443/foo/bar.git?a=1#frag"
         );
+    }
+
+    // ----------------------------------------------------------------
+    // Milestone 076 — subject_identifiers_from_attestation_subjects
+    // ----------------------------------------------------------------
+
+    fn rd(name: &str, digests: &[(&str, &str)]) -> ResourceDescriptor {
+        let mut digest = std::collections::BTreeMap::new();
+        for (k, v) in digests {
+            digest.insert((*k).to_string(), (*v).to_string());
+        }
+        ResourceDescriptor {
+            name: name.to_string(),
+            digest,
+        }
+    }
+
+    const SHA256_A: &str =
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const SHA256_B: &str =
+        "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+    const SHA512_A: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    #[test]
+    fn subject_autodetect_single_subject_sha256_happy_path() {
+        let subjects = vec![rd("myapp", &[("sha256", SHA256_A)])];
+        let ids = subject_identifiers_from_attestation_subjects(&subjects);
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0].scheme.as_str(), "subject");
+        assert_eq!(ids[0].value.as_str(), format!("sha256:{SHA256_A}"));
+        assert!(ids[0].is_builtin());
+        let label = ids[0].source_label.as_deref().unwrap();
+        assert!(
+            label.contains("build-tier") && label.contains("myapp"),
+            "expected source_label to mention build-tier + subject name; got {label:?}"
+        );
+    }
+
+    #[test]
+    fn subject_autodetect_multi_subject_input_order() {
+        // The function preserves input order — witness-v0.1 already
+        // produces lex-sorted subjects upstream.
+        let subjects = vec![
+            rd("myapp-a", &[("sha256", SHA256_A)]),
+            rd("myapp-b", &[("sha256", SHA256_B)]),
+            rd("myapp-c", &[("sha256", SHA256_A)]),
+        ];
+        let ids = subject_identifiers_from_attestation_subjects(&subjects);
+        assert_eq!(ids.len(), 3);
+        assert_eq!(ids[0].value.as_str(), format!("sha256:{SHA256_A}"));
+        assert_eq!(ids[1].value.as_str(), format!("sha256:{SHA256_B}"));
+        assert_eq!(ids[2].value.as_str(), format!("sha256:{SHA256_A}"));
+        // Each carries a unique source_label naming its subject.
+        assert!(ids[0].source_label.as_deref().unwrap().contains("myapp-a"));
+        assert!(ids[1].source_label.as_deref().unwrap().contains("myapp-b"));
+        assert!(ids[2].source_label.as_deref().unwrap().contains("myapp-c"));
+    }
+
+    #[test]
+    fn subject_autodetect_skips_subject_without_sha256() {
+        // Only sha512 in the digest map — sha256 absent. Per the
+        // 2026-05-06 clarification + FR-002, this subject is skipped
+        // with an info-log; nothing emits.
+        let subjects = vec![rd("legacy", &[("sha512", SHA512_A)])];
+        let ids = subject_identifiers_from_attestation_subjects(&subjects);
+        assert!(
+            ids.is_empty(),
+            "subject without sha256 must not auto-emit; got {ids:?}"
+        );
+    }
+
+    #[test]
+    fn subject_autodetect_emits_sha256_only_when_multi_digest() {
+        // Both sha256 AND sha512 — auto-emit picks sha256 only per the
+        // 2026-05-06 clarification.
+        let subjects = vec![rd(
+            "myapp",
+            &[("sha256", SHA256_A), ("sha512", SHA512_A)],
+        )];
+        let ids = subject_identifiers_from_attestation_subjects(&subjects);
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0].value.as_str(), format!("sha256:{SHA256_A}"));
+        // No sha512 entry emitted from auto-detection.
+        assert!(!ids
+            .iter()
+            .any(|id| id.value.as_str().starts_with("sha512:")));
+    }
+
+    #[test]
+    fn subject_autodetect_empty_subject_set_returns_empty_vec() {
+        let ids = subject_identifiers_from_attestation_subjects(&[]);
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn subject_autodetect_skips_synthetic_subjects() {
+        // Synthetic-fallback subjects use a `synthetic` digest key, not
+        // `sha256`. Per FR-002 they don't auto-emit a `subject:`
+        // identifier — only the underlying real-content sha256 ever
+        // makes it into the SBOM body.
+        let subjects = vec![rd("synthetic:echo-hello", &[("synthetic", "abc123")])];
+        let ids = subject_identifiers_from_attestation_subjects(&subjects);
+        assert!(ids.is_empty());
     }
 }

--- a/mikebom-cli/src/binding/identifiers/component_id.rs
+++ b/mikebom-cli/src/binding/identifiers/component_id.rs
@@ -1,0 +1,276 @@
+//! Per-component user-defined identifiers (milestone 076).
+//!
+//! A `--component-id <PURL>=<scheme>:<value>` flag is parsed once at
+//! CLI parse time into a `ComponentIdentifierFlag`. Per-format emitters
+//! (`mikebom-cli/src/generate/{cyclonedx,spdx}/...`) consume the
+//! flag list and append the identifier to every component whose
+//! emitted `purl` byte-equals `selector_purl`.
+//!
+//! Built-in scheme names (`repo`, `git`, `image`, `attestation`,
+//! `subject`) are rejected at parse time per FR-009 — those slots are
+//! reserved for document-level use.
+
+use super::{IdentifierError, IdentifierValue, SchemeName};
+
+/// One parsed `--component-id <PURL>=<scheme>:<value>` flag.
+///
+/// Lifetime: parsed once at CLI parse time, stored in
+/// `ScanArgs.component_id` / `RunArgs.component_id`, threaded through
+/// `ScanArtifacts.component_identifiers` to per-format emitters.
+#[derive(Debug, Clone)]
+pub struct ComponentIdentifierFlag {
+    /// Exact PURL string the operator typed. Matched byte-identically
+    /// against `components[].purl` per research §5 — no glob, no
+    /// version-range, no fuzzy matching.
+    pub selector_purl: String,
+    /// User-defined scheme name. Validated against milestone 073's
+    /// FR-004 regex (`^[a-z][a-z0-9_-]*$`). Built-in scheme names are
+    /// rejected at parse time per FR-009.
+    pub scheme: SchemeName,
+    /// The identifier value. Non-empty (enforced by `IdentifierValue`).
+    pub value: IdentifierValue,
+}
+
+/// Errors emitted while parsing a `--component-id` flag value.
+#[derive(Debug, thiserror::Error)]
+pub enum ComponentIdentifierFlagError {
+    #[error("--component-id missing `=` separator: {0:?} (expected form: --component-id <PURL>=<SCHEME>:<VALUE>)")]
+    MissingEquals(String),
+
+    #[error("--component-id PURL (LHS of `=`) is empty: {0:?}")]
+    EmptyPurl(String),
+
+    #[error("--component-id RHS missing `:` separator: {0:?} (expected form: <SCHEME>:<VALUE>)")]
+    MissingColon(String),
+
+    #[error("--component-id scheme is empty")]
+    EmptyScheme,
+
+    #[error("--component-id value is empty")]
+    EmptyValue,
+
+    #[error("--component-id scheme `{0}` is reserved for document-level built-in usage; user-defined schemes only at this layer (allowed regex: ^[a-z][a-z0-9_-]*$, excluding `repo`, `git`, `image`, `attestation`, `subject`)")]
+    BuiltinSchemeRejected(String),
+
+    #[error("--component-id scheme `{0}` fails the FR-004 regex from milestone 073: {1}")]
+    InvalidSchemeName(String, IdentifierError),
+}
+
+impl ComponentIdentifierFlag {
+    /// Parse a flag value of form `<PURL>=<scheme>:<value>`.
+    ///
+    /// Splits on the FIRST `=` (the LHS is the selector PURL; the RHS
+    /// is `<scheme>:<value>`). Splits the RHS on the FIRST `:`
+    /// (PURLs and values may contain `:` and `=` after these initial
+    /// splits — they're preserved verbatim).
+    ///
+    /// Rejects:
+    /// - Missing `=` separator
+    /// - Empty LHS (selector_purl)
+    /// - Missing `:` separator on RHS
+    /// - Empty scheme
+    /// - Empty value
+    /// - Built-in scheme names (`repo`, `git`, `image`, `attestation`,
+    ///   `subject`) per FR-009 — operators directed to document-level
+    ///   flags or warned that the scheme is reserved
+    /// - Scheme failing milestone 073's FR-004 regex
+    ///
+    /// Apply VR-076-003 in detail.
+    pub fn parse(raw: &str) -> Result<Self, ComponentIdentifierFlagError> {
+        let Some(eq_idx) = raw.find('=') else {
+            return Err(ComponentIdentifierFlagError::MissingEquals(raw.to_string()));
+        };
+        let lhs = &raw[..eq_idx];
+        let rhs = &raw[eq_idx + 1..];
+        if lhs.is_empty() {
+            return Err(ComponentIdentifierFlagError::EmptyPurl(raw.to_string()));
+        }
+        let Some(colon_idx) = rhs.find(':') else {
+            return Err(ComponentIdentifierFlagError::MissingColon(rhs.to_string()));
+        };
+        let scheme_str = &rhs[..colon_idx];
+        let value_str = &rhs[colon_idx + 1..];
+        if scheme_str.is_empty() {
+            return Err(ComponentIdentifierFlagError::EmptyScheme);
+        }
+        if value_str.is_empty() {
+            return Err(ComponentIdentifierFlagError::EmptyValue);
+        }
+        // Validate the scheme name first — `SchemeName::new` enforces
+        // the FR-004 regex.
+        let scheme = SchemeName::new(scheme_str.to_string()).map_err(|e| {
+            ComponentIdentifierFlagError::InvalidSchemeName(scheme_str.to_string(), e)
+        })?;
+        // FR-009: reject built-in scheme names. The `--component-id`
+        // flag is for user-defined schemes only — built-in slots are
+        // reserved for document-level usage.
+        if super::BuiltinScheme::from_scheme_name(&scheme).is_some() {
+            return Err(ComponentIdentifierFlagError::BuiltinSchemeRejected(
+                scheme_str.to_string(),
+            ));
+        }
+        let value = IdentifierValue::new(value_str.to_string()).map_err(|_| {
+            // The empty-value case is already short-circuited above;
+            // any other `IdentifierValue::new` failure is unreachable
+            // today, but route to the EmptyValue variant defensively.
+            ComponentIdentifierFlagError::EmptyValue
+        })?;
+        Ok(Self {
+            selector_purl: lhs.to_string(),
+            scheme,
+            value,
+        })
+    }
+}
+
+/// `clap::value_parser` adapter for `--component-id`.
+///
+/// Returns `Result<ComponentIdentifierFlag, String>` because clap
+/// requires a `String` error type for value parsers; the
+/// `ComponentIdentifierFlagError` `Display` impl provides
+/// human-readable error text.
+pub fn parse_component_id_flag(raw: &str) -> Result<ComponentIdentifierFlag, String> {
+    ComponentIdentifierFlag::parse(raw).map_err(|e| e.to_string())
+}
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_happy_path_simple() {
+        let f = ComponentIdentifierFlag::parse(
+            "pkg:cargo/serde@1.0.0=kusari-id:asset-shared-lib-v2",
+        )
+        .unwrap();
+        assert_eq!(f.selector_purl, "pkg:cargo/serde@1.0.0");
+        assert_eq!(f.scheme.as_str(), "kusari-id");
+        assert_eq!(f.value.as_str(), "asset-shared-lib-v2");
+    }
+
+    #[test]
+    fn parse_value_may_contain_colons() {
+        // Splits RHS on FIRST `:` only — value may contain `:`.
+        let f = ComponentIdentifierFlag::parse(
+            "pkg:cargo/foo@1.0.0=internal_ticket:PROJ-456:sub:1",
+        )
+        .unwrap();
+        assert_eq!(f.selector_purl, "pkg:cargo/foo@1.0.0");
+        assert_eq!(f.scheme.as_str(), "internal_ticket");
+        assert_eq!(f.value.as_str(), "PROJ-456:sub:1");
+    }
+
+    #[test]
+    fn parse_purl_may_contain_equals_after_first() {
+        // Splits LHS on FIRST `=` only — PURLs containing `=` (rare;
+        // qualifier syntax) survive on the value side. We split LHS on
+        // the FIRST `=`, so `pkg:type/name?key=val=scheme:value`
+        // takes everything up to FIRST `=` as LHS. This case is
+        // technically degenerate (PURL containing `=` AND a separate
+        // scheme:value section). Here we test the documented behavior:
+        // LHS = up to first `=`, RHS = rest.
+        let f =
+            ComponentIdentifierFlag::parse("pkg:cargo/serde=acme:foo").unwrap();
+        assert_eq!(f.selector_purl, "pkg:cargo/serde");
+        assert_eq!(f.scheme.as_str(), "acme");
+        assert_eq!(f.value.as_str(), "foo");
+    }
+
+    #[test]
+    fn parse_rejects_missing_equals() {
+        let err = ComponentIdentifierFlag::parse("pkg:cargo/foo@1.0.0").unwrap_err();
+        assert!(matches!(
+            err,
+            ComponentIdentifierFlagError::MissingEquals(_)
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_empty_purl() {
+        let err = ComponentIdentifierFlag::parse("=acme:foo").unwrap_err();
+        assert!(matches!(err, ComponentIdentifierFlagError::EmptyPurl(_)));
+    }
+
+    #[test]
+    fn parse_rejects_missing_colon() {
+        let err = ComponentIdentifierFlag::parse("pkg:cargo/foo@1.0.0=acme").unwrap_err();
+        assert!(matches!(
+            err,
+            ComponentIdentifierFlagError::MissingColon(_)
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_empty_scheme() {
+        let err = ComponentIdentifierFlag::parse("pkg:cargo/foo@1.0.0=:foo").unwrap_err();
+        assert!(matches!(err, ComponentIdentifierFlagError::EmptyScheme));
+    }
+
+    #[test]
+    fn parse_rejects_empty_value() {
+        let err = ComponentIdentifierFlag::parse("pkg:cargo/foo@1.0.0=acme:").unwrap_err();
+        assert!(matches!(err, ComponentIdentifierFlagError::EmptyValue));
+    }
+
+    #[test]
+    fn parse_rejects_builtin_scheme_repo() {
+        let err = ComponentIdentifierFlag::parse(
+            "pkg:cargo/foo@1.0.0=repo:git@github.com:foo/bar.git",
+        )
+        .unwrap_err();
+        match err {
+            ComponentIdentifierFlagError::BuiltinSchemeRejected(s) => {
+                assert_eq!(s, "repo");
+            }
+            other => panic!("expected BuiltinSchemeRejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_rejects_builtin_scheme_subject() {
+        // Milestone 076 — the new built-in must also be rejected for
+        // per-component flags per FR-009.
+        let err = ComponentIdentifierFlag::parse(
+            "pkg:cargo/foo@1.0.0=subject:sha256:abc",
+        )
+        .unwrap_err();
+        match err {
+            ComponentIdentifierFlagError::BuiltinSchemeRejected(s) => {
+                assert_eq!(s, "subject");
+            }
+            other => panic!("expected BuiltinSchemeRejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_rejects_all_builtin_schemes() {
+        for scheme in &["repo", "git", "image", "attestation", "subject"] {
+            let raw = format!("pkg:cargo/foo@1.0.0={scheme}:value");
+            let err = ComponentIdentifierFlag::parse(&raw).unwrap_err();
+            assert!(
+                matches!(err, ComponentIdentifierFlagError::BuiltinSchemeRejected(_)),
+                "scheme {scheme} should be rejected as built-in; got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_rejects_invalid_scheme_name_uppercase() {
+        let err = ComponentIdentifierFlag::parse("pkg:cargo/foo@1.0.0=Acme:foo").unwrap_err();
+        assert!(matches!(
+            err,
+            ComponentIdentifierFlagError::InvalidSchemeName(_, _)
+        ));
+    }
+
+    #[test]
+    fn parse_clap_adapter_returns_string_error() {
+        let err = parse_component_id_flag("malformed").unwrap_err();
+        assert!(err.contains("missing `=` separator"));
+    }
+}

--- a/mikebom-cli/src/binding/identifiers/mod.rs
+++ b/mikebom-cli/src/binding/identifiers/mod.rs
@@ -34,6 +34,7 @@
 //!   identifier's `kind` to `IdentifierKind::UserDefined`.
 
 pub mod auto_detect;
+pub mod component_id;
 pub mod validators;
 
 // ---------------------------------------------------------------------
@@ -142,12 +143,21 @@ impl IdentifierValue {
 // ---------------------------------------------------------------------
 
 /// Closed registry of recognized built-in schemes (research.md §2).
+///
+/// Milestone 076 extends the registry with `Subject` — a fifth variant
+/// declaring "this SBOM describes the artifact with the given content
+/// hash" (`subject:<algo>:<hex>`). Build-tier scans auto-detect
+/// `subject:` from the in-toto attestation envelope's subject set;
+/// source-tier and image-tier scans accept manual `--subject-hash`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BuiltinScheme {
     Repo,
     Git,
     Image,
     Attestation,
+    /// Milestone 076: content-hash subject identifier
+    /// (`subject:sha256:<hex>` or `subject:sha512:<hex>`).
+    Subject,
 }
 
 impl BuiltinScheme {
@@ -159,6 +169,8 @@ impl BuiltinScheme {
             "git" => Some(Self::Git),
             "image" => Some(Self::Image),
             "attestation" => Some(Self::Attestation),
+            // Milestone 076.
+            "subject" => Some(Self::Subject),
             _ => None,
         }
     }
@@ -170,21 +182,30 @@ impl BuiltinScheme {
             Self::Git => "git",
             Self::Image => "image",
             Self::Attestation => "attestation",
+            Self::Subject => "subject",
         }
     }
 
     /// CDX 1.6 `externalReferences[].type` value for this scheme
     /// (research.md §2 mapping).
+    ///
+    /// Milestone 076 — `Subject` reuses the CDX 1.6 `attestation` enum
+    /// value per research §1: a `subject:` identifier IS attestation
+    /// metadata declaring the artifact-of-record's content hash, and
+    /// CDX 1.6 has no narrower native type for content-hash subjects.
+    /// The two co-exist in `metadata.component.externalReferences[]`
+    /// — distinguishable by the `url` shape (digest vs IRI).
     pub fn cdx_external_reference_type(self) -> &'static str {
         match self {
             Self::Repo | Self::Git => "vcs",
             Self::Image => "distribution",
-            Self::Attestation => "attestation",
+            Self::Attestation | Self::Subject => "attestation",
         }
     }
 
     /// SPDX 2.3 `Package.externalRefs[].referenceCategory`. Uniformly
-    /// `"PERSISTENT-ID"` for all built-in schemes per FR-005.
+    /// `"PERSISTENT-ID"` for all built-in schemes per FR-005 + FR-004
+    /// (milestone 076).
     pub fn spdx23_reference_category(self) -> &'static str {
         "PERSISTENT-ID"
     }
@@ -573,11 +594,18 @@ mod tests {
             BuiltinScheme::Attestation.cdx_external_reference_type(),
             "attestation"
         );
+        // Milestone 076 — `subject:` reuses the CDX `attestation` enum
+        // value per research §1.
+        assert_eq!(
+            BuiltinScheme::Subject.cdx_external_reference_type(),
+            "attestation"
+        );
     }
 
     #[test]
     fn builtin_scheme_spdx23_reference_category_uniform() {
-        // FR-005 — uniformly PERSISTENT-ID for all 4 built-ins.
+        // FR-005 — uniformly PERSISTENT-ID for all built-ins
+        // (extended in milestone 076 to include `subject:`).
         assert_eq!(BuiltinScheme::Repo.spdx23_reference_category(), "PERSISTENT-ID");
         assert_eq!(BuiltinScheme::Git.spdx23_reference_category(), "PERSISTENT-ID");
         assert_eq!(BuiltinScheme::Image.spdx23_reference_category(), "PERSISTENT-ID");
@@ -585,6 +613,21 @@ mod tests {
             BuiltinScheme::Attestation.spdx23_reference_category(),
             "PERSISTENT-ID"
         );
+        assert_eq!(
+            BuiltinScheme::Subject.spdx23_reference_category(),
+            "PERSISTENT-ID"
+        );
+    }
+
+    #[test]
+    fn builtin_scheme_from_scheme_name_recognizes_subject() {
+        // Milestone 076 — fifth built-in scheme.
+        let s = SchemeName::new("subject").unwrap();
+        assert_eq!(
+            BuiltinScheme::from_scheme_name(&s),
+            Some(BuiltinScheme::Subject)
+        );
+        assert_eq!(BuiltinScheme::Subject.as_str(), "subject");
     }
 
     #[test]

--- a/mikebom-cli/src/binding/identifiers/validators.rs
+++ b/mikebom-cli/src/binding/identifiers/validators.rs
@@ -22,6 +22,8 @@ pub fn validate_for_scheme(scheme: BuiltinScheme, value: &str) -> Result<(), Ide
         BuiltinScheme::Git => validate_git(value),
         BuiltinScheme::Image => validate_image(value),
         BuiltinScheme::Attestation => validate_attestation(value),
+        // Milestone 076.
+        BuiltinScheme::Subject => validate_subject(value),
     }
 }
 
@@ -228,6 +230,68 @@ pub fn validate_attestation(value: &str) -> Result<(), IdentifierError> {
     ensure_no_whitespace("attestation", value)
 }
 
+/// Validate a `subject:` value (milestone 076).
+///
+/// Accepts exactly two shapes per research §4 + FR-001:
+///
+/// - `sha256:<64 lowercase hex chars>`
+/// - `sha512:<128 lowercase hex chars>`
+///
+/// Anything else (uppercase or mixed-case hex, missing algo prefix,
+/// prefix-only / no hex, wrong-length hex, other algos like `sha1:`,
+/// embedded whitespace) returns `Err(BuiltinValidation)` triggering
+/// soft-fail to `IdentifierKind::UserDefined` per FR-005.
+pub fn validate_subject(value: &str) -> Result<(), IdentifierError> {
+    if value.is_empty() {
+        return Err(err_subject(value, "value is empty"));
+    }
+    let Some(idx) = value.find(':') else {
+        return Err(err_subject(value, "missing `<algo>:` prefix"));
+    };
+    let (algo, hex) = (&value[..idx], &value[idx + 1..]);
+    let expected_len = match algo {
+        "sha256" => 64,
+        "sha512" => 128,
+        other => {
+            return Err(err_subject(
+                value,
+                &format!(
+                    "unsupported algo `{other}` (allowed: `sha256`, `sha512`)"
+                ),
+            ));
+        }
+    };
+    if hex.len() != expected_len {
+        return Err(err_subject(
+            value,
+            &format!(
+                "hex portion must be exactly {expected_len} chars for {algo} (got {})",
+                hex.len()
+            ),
+        ));
+    }
+    // Strict lowercase hex per FR-001 — uppercase and mixed-case are
+    // rejected so byte-identity correlation across SBOMs (the
+    // milestone's whole point) is unambiguous.
+    for c in hex.chars() {
+        let ok = c.is_ascii_digit() || ('a'..='f').contains(&c);
+        if !ok {
+            return Err(err_subject(
+                value,
+                "hex portion must be lowercase [0-9a-f] only",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn err_subject(value: &str, reason: &str) -> IdentifierError {
+    IdentifierError::BuiltinValidation {
+        scheme: "subject".to_string(),
+        reason: format!("value {value:?}: {reason}"),
+    }
+}
+
 fn ensure_no_whitespace(scheme: &str, value: &str) -> Result<(), IdentifierError> {
     if value.chars().any(|c| c.is_whitespace()) {
         return Err(IdentifierError::BuiltinValidation {
@@ -377,10 +441,123 @@ mod tests {
         validate_for_scheme(BuiltinScheme::Git, "https://x/y#c").unwrap();
         validate_for_scheme(BuiltinScheme::Image, "foo/bar").unwrap();
         validate_for_scheme(BuiltinScheme::Attestation, "https://x").unwrap();
+        // Milestone 076.
+        validate_for_scheme(
+            BuiltinScheme::Subject,
+            "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .unwrap();
 
         assert!(validate_for_scheme(BuiltinScheme::Repo, "garbage").is_err());
         assert!(validate_for_scheme(BuiltinScheme::Git, "garbage").is_err());
         assert!(validate_for_scheme(BuiltinScheme::Image, "").is_err());
         assert!(validate_for_scheme(BuiltinScheme::Attestation, "").is_err());
+        assert!(validate_for_scheme(BuiltinScheme::Subject, "garbage").is_err());
+    }
+
+    // ----------------------------------------------------------------
+    // Milestone 076 — validate_subject unit tests
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn validate_subject_accepts_sha256_64_lowercase_hex() {
+        validate_subject(
+            "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn validate_subject_accepts_sha512_128_lowercase_hex() {
+        validate_subject(
+            "sha512:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn validate_subject_rejects_uppercase_hex() {
+        // FR-001: hex MUST be lowercase. Uppercase and mixed-case are
+        // rejected so byte-identity correlation is unambiguous.
+        assert!(validate_subject(
+            "sha256:0123456789ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef"
+        )
+        .is_err());
+        assert!(validate_subject(
+            "sha256:ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn validate_subject_rejects_missing_algo_prefix() {
+        // No `:` separator at all.
+        assert!(validate_subject(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn validate_subject_rejects_wrong_length_sha256() {
+        // 63 chars after `sha256:` (one short).
+        assert!(validate_subject(
+            "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde"
+        )
+        .is_err());
+        // 65 chars after `sha256:` (one long).
+        assert!(validate_subject(
+            "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn validate_subject_rejects_wrong_length_sha512() {
+        // 127 chars after `sha512:` (one short).
+        assert!(validate_subject(
+            "sha512:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde"
+        )
+        .is_err());
+        // 129 chars after `sha512:` (one long).
+        assert!(validate_subject(
+            "sha512:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn validate_subject_rejects_unknown_algo() {
+        // sha1 is not allowed in milestone 076 (FR-001).
+        assert!(validate_subject("sha1:0123456789abcdef0123456789abcdef01234567").is_err());
+        // blake2b — explicitly out of scope.
+        assert!(validate_subject(
+            "blake2b:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn validate_subject_rejects_whitespace() {
+        // Embedded whitespace anywhere triggers rejection.
+        assert!(validate_subject(
+            "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde "
+        )
+        .is_err());
+        assert!(validate_subject(
+            "sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        )
+        .is_err());
+        // Algo with whitespace.
+        assert!(validate_subject(
+            "sha256 :0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn validate_subject_rejects_prefix_only_no_hex() {
+        assert!(validate_subject("sha256:").is_err());
+        assert!(validate_subject("sha512:").is_err());
     }
 }

--- a/mikebom-cli/src/cli/generate.rs
+++ b/mikebom-cli/src/cli/generate.rs
@@ -72,6 +72,15 @@ pub struct GenerateArgs {
     /// `generate::execute`. Default empty.
     #[arg(skip)]
     pub identifiers: Vec<mikebom::binding::identifiers::Identifier>,
+
+    /// Milestone 076: per-component user-defined identifiers from
+    /// `--component-id <PURL>=<scheme>:<value>` flags on
+    /// `mikebom trace run`. Threaded through to the CycloneDX builder
+    /// so per-component matching can fire on the emitted build-tier
+    /// SBOM.
+    #[arg(skip)]
+    pub component_identifiers:
+        Vec<mikebom::binding::identifiers::component_id::ComponentIdentifierFlag>,
 }
 
 pub async fn execute(args: GenerateArgs, offline: bool) -> anyhow::Result<()> {
@@ -145,7 +154,12 @@ pub async fn execute(args: GenerateArgs, offline: bool) -> anyhow::Result<()> {
     let builder = CycloneDxBuilder::new(cdx_config)
         // Milestone 073 — propagate manual identifier flags to the
         // builder. Build-tier scans don't auto-detect; manual only.
-        .with_identifiers(args.identifiers.clone());
+        .with_identifiers(args.identifiers.clone())
+        // Milestone 076 — propagate per-component user-defined
+        // identifiers so build-tier `mikebom trace run` honors
+        // `--component-id` matches against the emitted CDX
+        // `components[]`.
+        .with_component_identifiers(args.component_identifiers.clone());
     let bom = builder.build(
         &components,
         &relationships,

--- a/mikebom-cli/src/cli/run.rs
+++ b/mikebom-cli/src/cli/run.rs
@@ -145,6 +145,36 @@ pub struct RunArgs {
     #[arg(long)]
     pub keep_credentials_in_identifiers: bool,
 
+    /// Attach a `subject:` identifier declaring "this SBOM describes
+    /// the artifact with the given content hash." Format:
+    /// `sha256:<64-lowercase-hex>` or `sha512:<128-lowercase-hex>`.
+    /// Repeatable. On `mikebom trace run`, subject identifiers are
+    /// auto-detected from the in-toto attestation envelope's subject
+    /// set; manual flags augment auto-detected entries (deduplicated
+    /// by exact match per milestone 073).
+    #[arg(
+        long = "subject-hash",
+        action = clap::ArgAction::Append,
+        value_name = "ALGO:HEX",
+    )]
+    pub subject_hash: Vec<String>,
+
+    /// Attach a user-defined identifier to a specific component in the
+    /// emitted SBOM. The PURL must byte-equal a component's `purl`
+    /// field in the emitted output; the SCHEME must be a non-built-in
+    /// scheme name (built-in schemes `repo`, `git`, `image`,
+    /// `attestation`, `subject` are reserved for document-level use).
+    /// See `mikebom sbom scan --help` for full examples. Repeatable.
+    /// Zero-match selectors warn and the scan continues.
+    #[arg(
+        long = "component-id",
+        action = clap::ArgAction::Append,
+        value_name = "PURL=SCHEME:VALUE",
+        value_parser = mikebom::binding::identifiers::component_id::parse_component_id_flag,
+    )]
+    pub component_id:
+        Vec<mikebom::binding::identifiers::component_id::ComponentIdentifierFlag>,
+
     /// Directories to scan for artifact files after the traced command
     /// exits. Forwarded verbatim to `mikebom trace capture`. See the
     /// `--artifact-dir` flag there for details.
@@ -248,12 +278,40 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
     };
     super::scan::execute(scan_args).await?;
 
+    // Milestone 076 — read the attestation file the trace pipeline
+    // just produced, extract its `subject[]` array (the in-toto
+    // ResourceDescriptor list), and synthesize `subject:` identifiers
+    // per FR-002. Subjects without sha256 digests skip with an
+    // info-log; subjects with sha256 emit `subject:sha256:<hex>`
+    // identifiers in input order. Append AFTER milestone-074's
+    // auto-detected `repo:` / `git:` entries per data-model.md
+    // "Updated `auto_detect_build_tier_identifiers` flow".
+    let mut auto_detected_ids = auto_detected_ids;
+    match crate::attestation::serializer::read_attestation(&args.attestation_output) {
+        Ok(statement) => {
+            let subject_ids =
+                mikebom::binding::identifiers::auto_detect::subject_identifiers_from_attestation_subjects(
+                    &statement.subject,
+                );
+            auto_detected_ids.extend(subject_ids);
+        }
+        Err(e) => {
+            tracing::info!(
+                error = %e,
+                attestation = %args.attestation_output.display(),
+                "could not re-read attestation for build-tier subject \
+                 auto-detect; skipping subject: identifier auto-emit"
+            );
+        }
+    }
+
     // Milestone 073/074 — assemble manual identifiers from dedicated
-    // flags. Order: repo-or-git → image → attestation → user-defined
-    // --id flags. Then route through the shared `resolve_identifiers`
-    // helper (milestone 074 T005 refactor) which applies the FR-006
-    // manual-wins precedence + dedup-by-(scheme, value) per scheme
-    // — supporting the build-tier two-auto-detected case.
+    // flags. Order: repo-or-git → image → attestation → --subject-hash
+    // → user-defined --id flags. Then route through the shared
+    // `resolve_identifiers` helper (milestone 074 T005 refactor) which
+    // applies the FR-006 manual-wins precedence + dedup-by-(scheme,
+    // value) per scheme — supporting the build-tier multi-auto-detected
+    // case (now including auto-detected `subject:` from milestone 076).
     let mut manual_ids: Vec<mikebom::binding::identifiers::Identifier> = Vec::new();
     if let Some(repo_url) = args.repo.as_deref() {
         let raw = if let Some(rev) = args.git_ref.as_deref() {
@@ -292,6 +350,21 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
             ),
         }
     }
+    // Milestone 076 — manual --subject-hash flags. Wrap each
+    // `<algo>:<hex>` value into a full `subject:<algo>:<hex>` shape
+    // before parsing so the soft-fail-to-UserDefined path triggers
+    // identically to other built-ins on validation failure (FR-005).
+    for sh in &args.subject_hash {
+        let raw = format!("subject:{sh}");
+        match mikebom::binding::identifiers::Identifier::parse(&raw) {
+            Ok(id) => manual_ids.push(id),
+            Err(e) => tracing::warn!(
+                error = %e,
+                raw = %raw,
+                "failed to parse manual --subject-hash identifier on trace; skipping"
+            ),
+        }
+    }
     for id in &args.id {
         manual_ids.push(id.clone());
     }
@@ -316,6 +389,9 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
         vex_overrides: None,
         json: false,
         identifiers: assembled_ids,
+        // Milestone 076 — forward per-component user-defined
+        // identifiers for the CDX build-tier emission path.
+        component_identifiers: args.component_id.clone(),
     };
     // Trace's one-shot `run` wrapper doesn't thread the global --offline
     // flag through (yet). Default to online — the enrichment doesn't

--- a/mikebom-cli/src/cli/sbom_cmd.rs
+++ b/mikebom-cli/src/cli/sbom_cmd.rs
@@ -16,6 +16,13 @@ pub struct SbomCommand {
     pub command: SbomSubcommand,
 }
 
+// Milestone 076 — `ScanArgs` grows two new repeatable `Vec<...>`
+// fields (`subject_hash`, `component_id`) and the variant size
+// diverges further from the smallest sibling. The enum stays the
+// natural way to model clap subcommands; boxing every variant is
+// invasive and would require pattern-match updates throughout the
+// dispatch layer.
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 pub enum SbomSubcommand {
     /// Generate an SBOM from an attestation file

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -346,6 +346,47 @@ pub struct ScanArgs {
     /// values are emitted verbatim regardless of this flag.
     #[arg(long)]
     pub keep_credentials_in_identifiers: bool,
+
+    /// Attach a `subject:` identifier declaring "this SBOM describes
+    /// the artifact with the given content hash." Format:
+    /// `sha256:<64-lowercase-hex>` or `sha512:<128-lowercase-hex>`.
+    /// Repeatable for multi-subject SBOMs. On build-tier scans
+    /// (`mikebom trace run`), subject identifiers are auto-detected
+    /// from the in-toto attestation envelope's subject set; manual
+    /// flags augment auto-detected entries (deduplicated by exact
+    /// match per milestone 073). On source-tier and image-tier
+    /// scans, no auto-detect runs; manual flags are the only source
+    /// of `subject:` identifiers.
+    #[arg(
+        long = "subject-hash",
+        action = clap::ArgAction::Append,
+        value_name = "ALGO:HEX",
+    )]
+    pub subject_hash: Vec<String>,
+
+    /// Attach a user-defined identifier to a specific component in the
+    /// emitted SBOM. The PURL must byte-equal a component's `purl`
+    /// field in the emitted output; the SCHEME must be a non-built-in
+    /// scheme name (built-in schemes `repo`, `git`, `image`,
+    /// `attestation`, `subject` are reserved for document-level use).
+    /// Examples:
+    ///
+    /// `--component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-shared-lib-v2"`
+    ///
+    /// `--component-id "pkg:cargo/myapp@0.5.1=acme-asset:myapp-prod-001"`
+    ///
+    /// Repeatable. If a selector PURL matches multiple components
+    /// (same PURL across different bom-ref values), the identifier is
+    /// attached to ALL matching components. If a selector matches
+    /// zero components, the scan logs a warning and continues.
+    #[arg(
+        long = "component-id",
+        action = clap::ArgAction::Append,
+        value_name = "PURL=SCHEME:VALUE",
+        value_parser = mikebom::binding::identifiers::component_id::parse_component_id_flag,
+    )]
+    pub component_id:
+        Vec<mikebom::binding::identifiers::component_id::ComponentIdentifierFlag>,
 }
 
 /// Parse a `--id <scheme>=<value>` flag for a user-defined identifier.
@@ -446,6 +487,22 @@ fn assemble_manual_identifiers(args: &ScanArgs) -> Vec<mikebom::binding::identif
                 error = %e,
                 raw = %raw,
                 "failed to parse manual --attestation identifier; skipping"
+            ),
+        }
+    }
+    // Milestone 076 — manual --subject-hash flags. Format: `algo:hex`.
+    // Wrap each value into a full `subject:<algo>:<hex>` shape and
+    // route through `Identifier::parse` so the soft-fail path
+    // (downgrade to UserDefined per FR-005) handles malformed input
+    // identically to other built-ins.
+    for sh in &args.subject_hash {
+        let raw = format!("subject:{sh}");
+        match mikebom::binding::identifiers::Identifier::parse(&raw) {
+            Ok(id) => out.push(id),
+            Err(e) => tracing::warn!(
+                error = %e,
+                raw = %raw,
+                "failed to parse manual --subject-hash identifier; skipping"
             ),
         }
     }
@@ -1439,6 +1496,10 @@ pub async fn execute(
         // Milestone 073: identifiers — populated by T013's
         // resolution pipeline before this struct is constructed.
         identifiers: &identifiers,
+        // Milestone 076: per-component user-defined identifiers from
+        // `--component-id <PURL>=<scheme>:<value>` flags. Threaded to
+        // per-format emitters which match against `components[].purl`.
+        component_identifiers: &args.component_id,
     };
     let output_cfg = OutputConfig {
         mikebom_version: env!("CARGO_PKG_VERSION"),
@@ -2041,6 +2102,8 @@ mod tests {
             attestation: None,
             id: vec![],
             keep_credentials_in_identifiers: false,
+            subject_hash: vec![],
+            component_id: vec![],
         }
     }
 

--- a/mikebom-cli/src/cli/trace_cmd.rs
+++ b/mikebom-cli/src/cli/trace_cmd.rs
@@ -26,6 +26,10 @@ pub struct TraceCommand {
     pub command: TraceSubcommand,
 }
 
+// Milestone 076 — `RunArgs` grows two new repeatable `Vec<...>` fields
+// (`subject_hash`, `component_id`); see `sbom_cmd.rs` for the same
+// rationale.
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 pub enum TraceSubcommand {
     /// [EXPERIMENTAL, Linux-only] Capture a build trace via eBPF and produce an in-toto attestation

--- a/mikebom-cli/src/generate/cyclonedx/builder.rs
+++ b/mikebom-cli/src/generate/cyclonedx/builder.rs
@@ -72,6 +72,12 @@ pub struct CycloneDxBuilder {
     /// deduplicated and ordered by the resolution pipeline in
     /// `cli/scan_cmd.rs::resolve_identifiers`.
     identifiers: Vec<mikebom::binding::identifiers::Identifier>,
+    /// Milestone 076 — per-component user-defined identifiers from
+    /// `--component-id <PURL>=<scheme>:<value>` flags. Threaded into
+    /// `build_components` so each per-component `properties[]` array
+    /// gains entries for matching PURLs.
+    component_identifiers:
+        Vec<mikebom::binding::identifiers::component_id::ComponentIdentifierFlag>,
 }
 
 impl CycloneDxBuilder {
@@ -84,6 +90,7 @@ impl CycloneDxBuilder {
             go_graph_completeness_reason: None,
             source_document_binding: None,
             identifiers: Vec::new(),
+            component_identifiers: Vec::new(),
         }
     }
 
@@ -109,6 +116,21 @@ impl CycloneDxBuilder {
         ids: Vec<mikebom::binding::identifiers::Identifier>,
     ) -> Self {
         self.identifiers = ids;
+        self
+    }
+
+    /// Milestone 076 — record per-component user-defined identifiers
+    /// from `--component-id <PURL>=<scheme>:<value>` flags. Each
+    /// matching component gets the identifier appended to its
+    /// `properties[]` array per research §2 + FR-008. Zero-match
+    /// selectors warn and the scan continues per FR-010.
+    pub fn with_component_identifiers(
+        mut self,
+        ids: Vec<
+            mikebom::binding::identifiers::component_id::ComponentIdentifierFlag,
+        >,
+    ) -> Self {
+        self.component_identifiers = ids;
         self
     }
 
@@ -164,7 +186,30 @@ impl CycloneDxBuilder {
             self.source_document_binding.as_ref(),
             &self.identifiers,
         );
-        let cdx_components = self.build_components(components)?;
+        // Milestone 076 — track per-component identifier matches so
+        // we can emit a warn for any selector that matched zero
+        // components (FR-010 / VR-076-004).
+        let mut match_counts: std::collections::BTreeMap<usize, usize> =
+            std::collections::BTreeMap::new();
+        for i in 0..self.component_identifiers.len() {
+            match_counts.insert(i, 0);
+        }
+        let cdx_components = self.build_components(components, &mut match_counts)?;
+        for (idx, count) in &match_counts {
+            if *count == 0 {
+                let flag = &self.component_identifiers[*idx];
+                tracing::warn!(
+                    selector = %flag.selector_purl,
+                    scheme = flag.scheme.as_str(),
+                    value = flag.value.as_str(),
+                    "--component-id selector `{}` matched zero components; \
+                     identifier `{}:{}` not attached",
+                    flag.selector_purl,
+                    flag.scheme.as_str(),
+                    flag.value.as_str(),
+                );
+            }
+        }
         let compositions =
             build_compositions(integrity, &target_ref, components, complete_ecosystems);
         let deps = build_dependencies(components, relationships, &target_ref);
@@ -206,6 +251,7 @@ impl CycloneDxBuilder {
     fn build_components(
         &self,
         components: &[ResolvedComponent],
+        match_counts: &mut std::collections::BTreeMap<usize, usize>,
     ) -> anyhow::Result<serde_json::Value> {
         // Milestones 053 (Go) + 064 (cargo) FR-001a: a main-module is
         // emitted via CDX `metadata.component` per Constitution
@@ -642,6 +688,31 @@ impl CycloneDxBuilder {
                 properties.push(json!({
                     "name": key,
                     "value": value_str,
+                }));
+            }
+
+            // Milestone 076: per-component user-defined identifiers
+            // from `--component-id <PURL>=<scheme>:<value>` flags.
+            // Match by byte-equality of `purl` per research §5; append
+            // matching entries AFTER pre-existing properties (research
+            // §6 — preserve original positions, lex-sort the new
+            // entries by `(scheme, value)`).
+            let mut new_per_component_props: Vec<(String, String)> = Vec::new();
+            for (idx, flag) in self.component_identifiers.iter().enumerate() {
+                if flag.selector_purl == component.purl.as_str() {
+                    *match_counts.entry(idx).or_insert(0) += 1;
+                    new_per_component_props.push((
+                        flag.scheme.as_str().to_string(),
+                        flag.value.as_str().to_string(),
+                    ));
+                }
+            }
+            new_per_component_props.sort();
+            new_per_component_props.dedup();
+            for (name, value) in new_per_component_props {
+                properties.push(json!({
+                    "name": name,
+                    "value": value,
                 }));
             }
 

--- a/mikebom-cli/src/generate/cyclonedx/mod.rs
+++ b/mikebom-cli/src/generate/cyclonedx/mod.rs
@@ -70,7 +70,13 @@ impl SbomSerializer for CycloneDxJsonSerializer {
             // `metadata.properties[]` entry under
             // `mikebom:identifiers`. The Vec is already
             // deduplicated and ordered by the resolution pipeline.
-            .with_identifiers(scan.identifiers.to_vec());
+            .with_identifiers(scan.identifiers.to_vec())
+            // Milestone 076 — propagate per-component user-defined
+            // identifiers from `--component-id <PURL>=<scheme>:<value>`
+            // flags. Matched against `components[].purl` byte-equally
+            // and appended as additional `properties[]` entries per
+            // research §2.
+            .with_component_identifiers(scan.component_identifiers.to_vec());
         let bom = builder.build(
             scan.components,
             scan.relationships,

--- a/mikebom-cli/src/generate/mod.rs
+++ b/mikebom-cli/src/generate/mod.rs
@@ -105,6 +105,22 @@ pub struct ScanArtifacts<'a> {
     /// `contracts/identifiers-annotation.md` C-1.
     pub identifiers:
         &'a [mikebom::binding::identifiers::Identifier],
+    /// Milestone 076: per-component user-defined identifiers from
+    /// `--component-id <PURL>=<scheme>:<value>` flags. Threaded to
+    /// per-format emitters which match `selector_purl` byte-equally
+    /// against emitted `components[].purl` and append the identifier
+    /// to every match in the per-format native carrier (CDX
+    /// `components[].properties[]`, SPDX 2.3
+    /// `Package.externalRefs[PERSISTENT-ID]`, SPDX 3
+    /// `Element.externalIdentifier[]`). Emission is deterministic per
+    /// FR-012 — pre-existing entries preserve their original
+    /// positions; new per-component identifier entries append after
+    /// in lexical order by `(scheme, value)`. Built-in scheme names
+    /// (`repo`, `git`, `image`, `attestation`, `subject`) are rejected
+    /// at CLI parse time per FR-009. Default empty for callers not
+    /// using the flag — backwards-compatible.
+    pub component_identifiers:
+        &'a [mikebom::binding::identifiers::component_id::ComponentIdentifierFlag],
 }
 
 /// Document-level scope mode for a single mikebom scan. Surfaced

--- a/mikebom-cli/src/generate/openvex/mod.rs
+++ b/mikebom-cli/src/generate/openvex/mod.rs
@@ -251,6 +251,7 @@ mod tests {
             scope_mode: crate::generate::ScopeMode::Artifact,
             source_document_binding: None,
             identifiers: &[],
+            component_identifiers: &[],
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/document.rs
+++ b/mikebom-cli/src/generate/spdx/document.rs
@@ -598,6 +598,7 @@ mod tests {
             scope_mode: crate::generate::ScopeMode::Artifact,
             source_document_binding: None,
             identifiers: &[],
+            component_identifiers: &[],
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/mod.rs
+++ b/mikebom-cli/src/generate/spdx/mod.rs
@@ -392,6 +392,7 @@ mod tests {
             scope_mode: crate::generate::ScopeMode::Artifact,
             source_document_binding: None,
             identifiers: &[],
+            component_identifiers: &[],
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/packages.rs
+++ b/mikebom-cli/src/generate/spdx/packages.rs
@@ -313,6 +313,12 @@ pub fn build_packages(
     // produce one document-level entry referenced many times.
     let mut extracted_by_id: BTreeMap<String, super::document::SpdxExtractedLicensingInfo> =
         BTreeMap::new();
+    // Milestone 076 — track per-component identifier matches so
+    // unmatched selectors warn after the loop completes (FR-010).
+    let mut match_counts: BTreeMap<usize, usize> = BTreeMap::new();
+    for i in 0..artifacts.component_identifiers.len() {
+        match_counts.insert(i, 0);
+    }
     for c in artifacts.components {
         let (pkg, decl_extracted, conc_extracted) = component_to_package(
             c,
@@ -322,6 +328,8 @@ pub fn build_packages(
             annotator,
             date,
             artifacts.identifiers,
+            artifacts.component_identifiers,
+            &mut match_counts,
         );
         packages.push(pkg);
         if let Some(info) = decl_extracted {
@@ -331,6 +339,22 @@ pub fn build_packages(
             extracted_by_id.entry(info.license_id.clone()).or_insert(info);
         }
     }
+    // Milestone 076 — warn for unmatched per-component selectors.
+    for (idx, count) in &match_counts {
+        if *count == 0 {
+            let flag = &artifacts.component_identifiers[*idx];
+            tracing::warn!(
+                selector = %flag.selector_purl,
+                scheme = flag.scheme.as_str(),
+                value = flag.value.as_str(),
+                "--component-id selector `{}` matched zero components; \
+                 identifier `{}:{}` not attached",
+                flag.selector_purl,
+                flag.scheme.as_str(),
+                flag.value.as_str(),
+            );
+        }
+    }
     // BTreeMap iterates in license_id-sorted order, which gives
     // deterministic document output (FR-009 / SC-007).
     let extracted: Vec<super::document::SpdxExtractedLicensingInfo> =
@@ -338,6 +362,7 @@ pub fn build_packages(
     (packages, extracted)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn component_to_package(
     c: &ResolvedComponent,
     include_hashes: bool,
@@ -346,6 +371,8 @@ fn component_to_package(
     annotator: &str,
     date: &str,
     identifiers: &[mikebom::binding::identifiers::Identifier],
+    component_identifiers: &[mikebom::binding::identifiers::component_id::ComponentIdentifierFlag],
+    match_counts: &mut std::collections::BTreeMap<usize, usize>,
 ) -> (
     SpdxPackage,
     Option<super::document::SpdxExtractedLicensingInfo>,
@@ -423,6 +450,35 @@ fn component_to_package(
                 });
             }
         }
+    }
+
+    // Milestone 076 — per-component user-defined identifiers from
+    // `--component-id <PURL>=<scheme>:<value>` flags. Append matching
+    // entries to this package's `externalRefs[]` as PERSISTENT-ID rows
+    // per FR-008 + research §2 + research §6 (lex-sort the new
+    // entries by `(scheme, value)`; pre-existing rows preserve their
+    // positions). Unlike the milestone-073 main-module-only block
+    // above, per-component identifiers attach to ANY package whose
+    // PURL matches a `--component-id` selector — no main-module gate.
+    let mut new_per_component_refs: Vec<(String, String)> = Vec::new();
+    for (idx, flag) in component_identifiers.iter().enumerate() {
+        if flag.selector_purl == c.purl.as_str() {
+            *match_counts.entry(idx).or_insert(0) += 1;
+            new_per_component_refs.push((
+                flag.scheme.as_str().to_string(),
+                flag.value.as_str().to_string(),
+            ));
+        }
+    }
+    new_per_component_refs.sort();
+    new_per_component_refs.dedup();
+    for (ref_type, locator) in new_per_component_refs {
+        external_refs.push(SpdxExternalRef {
+            category: SpdxExternalRefCategory::PersistentId,
+            ref_type,
+            locator,
+            comment: None,
+        });
     }
 
     let supplier = c.supplier.as_deref().map(supplier_string);
@@ -564,6 +620,7 @@ mod tests {
             scope_mode: crate::generate::ScopeMode::Artifact,
             source_document_binding: None,
             identifiers: &[],
+            component_identifiers: &[],
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/relationships.rs
+++ b/mikebom-cli/src/generate/spdx/relationships.rs
@@ -293,6 +293,7 @@ mod tests {
             scope_mode: crate::generate::ScopeMode::Artifact,
             source_document_binding: None,
             identifiers: &[],
+            component_identifiers: &[],
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/v3_document.rs
+++ b/mikebom-cli/src/generate/spdx/v3_document.rs
@@ -80,12 +80,37 @@ pub fn build_document(
         CREATION_INFO_ID,
     );
 
+    // Milestone 076 — track per-component identifier matches so
+    // unmatched selectors warn after build_packages completes
+    // (FR-010 / VR-076-004).
+    let mut match_counts: std::collections::BTreeMap<usize, usize> =
+        std::collections::BTreeMap::new();
+    for i in 0..scan.component_identifiers.len() {
+        match_counts.insert(i, 0);
+    }
     let (mut packages, _) = super::v3_packages::build_packages(
         scan.components,
         &doc_iri,
         CREATION_INFO_ID,
         &agent_build.attachments,
+        scan.component_identifiers,
+        &mut match_counts,
     );
+    for (idx, count) in &match_counts {
+        if *count == 0 {
+            let flag = &scan.component_identifiers[*idx];
+            tracing::warn!(
+                selector = %flag.selector_purl,
+                scheme = flag.scheme.as_str(),
+                value = flag.value.as_str(),
+                "--component-id selector `{}` matched zero components; \
+                 identifier `{}:{}` not attached",
+                flag.selector_purl,
+                flag.scheme.as_str(),
+                flag.value.as_str(),
+            );
+        }
+    }
 
     // Choose root element. If no Package matches the scan target
     // and the scan is non-empty, fall back to the first Package.

--- a/mikebom-cli/src/generate/spdx/v3_packages.rs
+++ b/mikebom-cli/src/generate/spdx/v3_packages.rs
@@ -54,6 +54,8 @@ pub fn build_packages(
     doc_iri: &str,
     creation_info_id: &str,
     agent_attachments: &BTreeMap<String, PackageAgentAttachments>,
+    component_identifiers: &[mikebom::binding::identifiers::component_id::ComponentIdentifierFlag],
+    match_counts: &mut BTreeMap<usize, usize>,
 ) -> (Vec<Value>, BTreeMap<String, String>) {
     let mut package_iri_by_purl: BTreeMap<String, String> = BTreeMap::new();
     let mut packages: Vec<Value> = Vec::with_capacity(components.len());
@@ -146,7 +148,29 @@ pub fn build_packages(
         // fully-resolved CPE vectors. Delegated to
         // v3_external_ids::build_external_identifiers_for so the
         // shape is owned by one module.
-        let ext_ids = build_external_identifiers_for(c);
+        let mut ext_ids = build_external_identifiers_for(c);
+        // Milestone 076 — append per-component user-defined
+        // identifiers in lexical order by `(scheme, value)` after the
+        // pre-existing PURL/CPE entries (research §6).
+        let mut new_per_component_ids: Vec<(String, String)> = Vec::new();
+        for (idx, flag) in component_identifiers.iter().enumerate() {
+            if flag.selector_purl == c.purl.as_str() {
+                *match_counts.entry(idx).or_insert(0) += 1;
+                new_per_component_ids.push((
+                    flag.scheme.as_str().to_string(),
+                    flag.value.as_str().to_string(),
+                ));
+            }
+        }
+        new_per_component_ids.sort();
+        new_per_component_ids.dedup();
+        for (ext_type, identifier) in new_per_component_ids {
+            ext_ids.push(json!({
+                "type": "ExternalIdentifier",
+                "externalIdentifierType": ext_type,
+                "identifier": identifier,
+            }));
+        }
         if !ext_ids.is_empty() {
             pkg.insert("externalIdentifier".to_string(), json!(ext_ids));
         }

--- a/mikebom-cli/src/parity/extractors/mod.rs
+++ b/mikebom-cli/src/parity/extractors/mod.rs
@@ -13,6 +13,37 @@
 //! otherwise. Per spec FR-005a / clarification Q2: the catalog
 //! is the source of truth; the extractor table is the executable
 //! interpretation; mismatches surface at the pre-PR gate.
+//!
+//! ## Milestone 076 — `subject:` + per-component `--component-id`
+//!
+//! Both new identifier surfaces ride **standards-native carriers** per
+//! Constitution Principle V (native-precedence) and therefore do NOT
+//! introduce new catalog rows:
+//!
+//! - **`subject:` document-level identifier** (built-in scheme, fifth
+//!   in the registry): emits via the same CDX
+//!   `metadata.component.externalReferences[type:attestation]` carrier
+//!   as milestone 073's `attestation:` identifiers, plus SPDX 2.3
+//!   main-module `Package.externalRefs[PERSISTENT-ID]` (via existing
+//!   milestone-073 logic) + redundant `creationInfo.creators[]` text
+//!   line, plus SPDX 3 `SpdxDocument.externalIdentifier[]`. No
+//!   `mikebom:*` annotation introduced. The CDX externalReferences
+//!   union with milestone 073's `attestation:` IRI emissions is
+//!   distinguishable by `url` shape (digest vs IRI).
+//!
+//! - **Per-component user-defined identifiers** (via
+//!   `--component-id <PURL>=<scheme>:<value>`): emit via CDX
+//!   `components[].properties[]` (matching mikebom's existing
+//!   per-component property emission pattern), SPDX 2.3
+//!   `Package.externalRefs[PERSISTENT-ID]`, and SPDX 3
+//!   `Element.externalIdentifier[]`. These are NOT envelope-wrapped
+//!   under `mikebom:identifiers` (C47); they ride the native
+//!   per-component identifier carriers directly. No catalog row
+//!   needed — the surfaces are already type-checked at the format-
+//!   shape level by each format's existing schema-validation tests.
+//!
+//! See `specs/076-subject-component-ids/contracts/{subject-identifier,
+//! per-component-id}.md` for the per-format wire contracts.
 
 mod cdx;
 mod common;

--- a/mikebom-cli/tests/identifiers_subject_and_component.rs
+++ b/mikebom-cli/tests/identifiers_subject_and_component.rs
@@ -1,0 +1,853 @@
+//! Milestone 076 — `subject:` identifier scheme + per-component
+//! user-defined identifier integration tests.
+//!
+//! ## Test harness rationale
+//!
+//! `mikebom trace run` (the build-tier subject auto-detect path)
+//! requires Linux + eBPF + privileges, so end-to-end driving a real
+//! trace through the CLI binary isn't feasible cross-platform. This
+//! file follows the milestone-074 / milestone-073 pattern:
+//!
+//! 1. **Direct library-level tests** of
+//!    `subject_identifiers_from_attestation_subjects` against synthetic
+//!    `Vec<ResourceDescriptor>` fixtures — covers US1's auto-detect
+//!    behavior (FR-002 + 2026-05-06 sha256-only clarification).
+//!
+//! 2. **`mikebom sbom scan`-driven tests** for the source-tier and
+//!    image-tier `--subject-hash` / `--component-id` flags — covers
+//!    US2 / US3 / US4 cross-format wire mapping. Source-tier scans
+//!    can be driven cross-platform.
+//!
+//! Tests guard `.unwrap()` use per CLAUDE.md.
+
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use mikebom::binding::identifiers::auto_detect::subject_identifiers_from_attestation_subjects;
+use mikebom::binding::identifiers::component_id::{
+    parse_component_id_flag, ComponentIdentifierFlag, ComponentIdentifierFlagError,
+};
+use mikebom_common::attestation::statement::ResourceDescriptor;
+
+mod common;
+use common::bin;
+use common::normalize::apply_fake_home_env;
+
+// ---------------------------------------------------------------------
+// Synthetic-subject-set fixture builder
+// ---------------------------------------------------------------------
+
+const SHA256_A: &str =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const SHA256_B: &str =
+    "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+const SHA256_C: &str =
+    "1111111122222222333333334444444455555555666666667777777788888888";
+const SHA512_A: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+fn make_subject(name: &str, digests: &[(&str, &str)]) -> ResourceDescriptor {
+    let mut digest = BTreeMap::new();
+    for (algo, hex) in digests {
+        digest.insert((*algo).to_string(), (*hex).to_string());
+    }
+    ResourceDescriptor {
+        name: name.to_string(),
+        digest,
+    }
+}
+
+// ---------------------------------------------------------------------
+// US1 — build-tier auto-detect from in-toto subject set
+// ---------------------------------------------------------------------
+
+#[test]
+fn build_tier_autodetects_subject_from_in_toto_subjects() {
+    // US1 §1: one subject with sha256 → one subject: identifier.
+    let subjects = vec![make_subject("myapp", &[("sha256", SHA256_A)])];
+    let ids = subject_identifiers_from_attestation_subjects(&subjects);
+    assert_eq!(ids.len(), 1);
+    assert_eq!(ids[0].scheme.as_str(), "subject");
+    assert_eq!(ids[0].value.as_str(), format!("sha256:{SHA256_A}"));
+    assert!(ids[0].is_builtin());
+    let label = ids[0].source_label.as_deref().unwrap();
+    assert!(
+        label.contains("build-tier") && label.contains("myapp"),
+        "expected build-tier label naming subject; got {label:?}"
+    );
+}
+
+#[test]
+fn build_tier_autodetect_emits_one_subject_per_in_toto_subject() {
+    // US1 §2: 3 subjects → 3 identifiers in input order.
+    let subjects = vec![
+        make_subject("myapp-a", &[("sha256", SHA256_A)]),
+        make_subject("myapp-b", &[("sha256", SHA256_B)]),
+        make_subject("myapp-c", &[("sha256", SHA256_C)]),
+    ];
+    let ids = subject_identifiers_from_attestation_subjects(&subjects);
+    assert_eq!(ids.len(), 3);
+    assert_eq!(ids[0].value.as_str(), format!("sha256:{SHA256_A}"));
+    assert_eq!(ids[1].value.as_str(), format!("sha256:{SHA256_B}"));
+    assert_eq!(ids[2].value.as_str(), format!("sha256:{SHA256_C}"));
+}
+
+#[test]
+fn build_tier_autodetect_skips_subject_without_sha256() {
+    // US1 §3 + 2026-05-06 clarification: subject with only sha512 →
+    // no identifier.
+    let subjects = vec![make_subject("legacy-app", &[("sha512", SHA512_A)])];
+    let ids = subject_identifiers_from_attestation_subjects(&subjects);
+    assert!(ids.is_empty());
+}
+
+#[test]
+fn build_tier_autodetect_emits_sha256_only_when_multi_digest() {
+    // 2026-05-06 clarification: multi-digest subjects auto-emit
+    // sha256 only; sha512 is dropped from auto-detection.
+    let subjects = vec![make_subject(
+        "myapp",
+        &[("sha256", SHA256_A), ("sha512", SHA512_A)],
+    )];
+    let ids = subject_identifiers_from_attestation_subjects(&subjects);
+    assert_eq!(ids.len(), 1);
+    assert_eq!(ids[0].value.as_str(), format!("sha256:{SHA256_A}"));
+}
+
+#[test]
+fn build_tier_autodetect_empty_subject_set() {
+    let ids = subject_identifiers_from_attestation_subjects(&[]);
+    assert!(ids.is_empty());
+}
+
+// ---------------------------------------------------------------------
+// US2 — source-tier and image-tier accept manual --subject-hash
+// ---------------------------------------------------------------------
+
+fn fixture_root() -> PathBuf {
+    common::workspace_root().join("tests/fixtures/cargo/lockfile-v3")
+}
+
+fn run_scan(
+    fake_home: &Path,
+    fixture: &Path,
+    extra_args: &[&str],
+    out_format: &str,
+    out_filename: &str,
+) -> (serde_json::Value, String) {
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join(out_filename);
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home);
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(fixture)
+        .arg("--format")
+        .arg(out_format)
+        .arg("--output")
+        .arg(format!("{out_format}={}", out_path.to_string_lossy()))
+        .arg("--no-deep-hash");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("scan runs");
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert!(
+        out.status.success(),
+        "scan failed: stderr={stderr}\nstdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let bytes = std::fs::read(&out_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    drop(out_dir);
+    (parsed, stderr)
+}
+
+#[test]
+fn manual_subject_hash_flag_works_on_source_tier() {
+    // US2 §1: --subject-hash on source-tier scan emits subject:
+    // identifier in the CDX externalReferences[type:attestation].
+    let fake_home = tempfile::tempdir().unwrap();
+    let (cdx, _stderr) = run_scan(
+        fake_home.path(),
+        &fixture_root(),
+        &["--subject-hash", &format!("sha256:{SHA256_A}")],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    // metadata.component.externalReferences[] should contain an
+    // attestation-typed entry whose URL is `sha256:<hex>`.
+    let ext_refs = cdx["metadata"]["component"]["externalReferences"]
+        .as_array()
+        .expect("metadata.component.externalReferences[] present");
+    let found = ext_refs.iter().any(|r| {
+        r["type"].as_str() == Some("attestation")
+            && r["url"].as_str() == Some(&format!("sha256:{SHA256_A}"))
+    });
+    assert!(
+        found,
+        "expected externalReferences[type:attestation] with url=sha256:{SHA256_A}; got {ext_refs:#?}"
+    );
+}
+
+#[test]
+fn manual_subject_hash_flag_repeatable() {
+    // US2 §2: pass --subject-hash twice; both appear in supply order.
+    let fake_home = tempfile::tempdir().unwrap();
+    let (cdx, _) = run_scan(
+        fake_home.path(),
+        &fixture_root(),
+        &[
+            "--subject-hash",
+            &format!("sha256:{SHA256_A}"),
+            "--subject-hash",
+            &format!("sha256:{SHA256_B}"),
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let ext_refs = cdx["metadata"]["component"]["externalReferences"]
+        .as_array()
+        .expect("metadata.component.externalReferences[] present");
+    let urls: Vec<&str> = ext_refs
+        .iter()
+        .filter(|r| r["type"].as_str() == Some("attestation"))
+        .filter_map(|r| r["url"].as_str())
+        .collect();
+    let pos_a = urls.iter().position(|u| *u == format!("sha256:{SHA256_A}"));
+    let pos_b = urls.iter().position(|u| *u == format!("sha256:{SHA256_B}"));
+    assert!(pos_a.is_some(), "first --subject-hash present: {urls:?}");
+    assert!(pos_b.is_some(), "second --subject-hash present: {urls:?}");
+    assert!(
+        pos_a.unwrap() < pos_b.unwrap(),
+        "supply order preserved: {urls:?}"
+    );
+}
+
+#[test]
+fn subject_value_validation_soft_fails_to_user_defined() {
+    // US2 §3 / FR-005: malformed --subject-hash value soft-fails to
+    // user-defined under mikebom:identifiers; the scan still exits 0.
+    let fake_home = tempfile::tempdir().unwrap();
+    let (cdx, _) = run_scan(
+        fake_home.path(),
+        &fixture_root(),
+        &["--subject-hash", "banana"],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    // The scan succeeded (the run_scan helper asserts non-zero exit
+    // panics). The malformed value rides under mikebom:identifiers.
+    let props = cdx["metadata"]["properties"].as_array();
+    let mut found_userdef = false;
+    if let Some(arr) = props {
+        for p in arr {
+            if p["name"].as_str() == Some("mikebom:identifiers") {
+                let v = p["value"].as_str().unwrap_or("");
+                // The mikebom:identifiers annotation envelope is a
+                // JSON-encoded list of {scheme, value} entries — the
+                // soft-failed entry rides as scheme="subject",
+                // value="banana".
+                if v.contains("\"subject\"") && v.contains("\"banana\"") {
+                    found_userdef = true;
+                    break;
+                }
+            }
+        }
+    }
+    assert!(
+        found_userdef,
+        "malformed `subject:banana` should ride under mikebom:identifiers; got props={props:?}"
+    );
+}
+
+#[test]
+fn subject_identifier_emits_in_all_three_formats() {
+    // FR-004: `subject:` value rides per-format native carriers
+    // across CDX 1.6, SPDX 2.3, SPDX 3.0.1.
+    let fake_home = tempfile::tempdir().unwrap();
+    let value = format!("sha256:{SHA256_A}");
+
+    // CDX
+    let (cdx, _) = run_scan(
+        fake_home.path(),
+        &fixture_root(),
+        &["--subject-hash", &value],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let cdx_refs = cdx["metadata"]["component"]["externalReferences"]
+        .as_array()
+        .unwrap();
+    assert!(
+        cdx_refs.iter().any(|r| r["type"].as_str() == Some("attestation")
+            && r["url"].as_str() == Some(&value)),
+        "CDX missing subject identifier"
+    );
+
+    // SPDX 2.3
+    let (spdx, _) = run_scan(
+        fake_home.path(),
+        &fixture_root(),
+        &["--subject-hash", &value],
+        "spdx-2.3-json",
+        "out.spdx.json",
+    );
+    // The identifier rides on (a) a main-module Package's externalRefs
+    // when one exists, and ALWAYS (b) `creationInfo.creators[]` as a
+    // redundant text line per milestone 073's dual-carrier pattern. We
+    // check the always-emitted carrier here; the main-module gate is
+    // fixture-dependent (a Cargo.lock-only fixture has no main-module).
+    let creators = spdx["creationInfo"]["creators"]
+        .as_array()
+        .expect("creationInfo.creators[]");
+    let needle = format!("subject:{value}");
+    let found_creator = creators.iter().any(|c| {
+        c.as_str().map(|s| s.contains(&needle)).unwrap_or(false)
+    });
+    assert!(
+        found_creator,
+        "SPDX 2.3 creators[] missing subject:{value} entry; got {creators:?}"
+    );
+
+    // SPDX 3
+    let (spdx3, _) = run_scan(
+        fake_home.path(),
+        &fixture_root(),
+        &["--subject-hash", &value],
+        "spdx-3-json",
+        "out.spdx3.json",
+    );
+    // SpdxDocument.externalIdentifier[] carries the subject entry.
+    let graph = spdx3["@graph"].as_array().expect("@graph");
+    let mut found_3 = false;
+    for n in graph {
+        if n["type"].as_str() == Some("SpdxDocument") {
+            if let Some(eids) = n["externalIdentifier"].as_array() {
+                for e in eids {
+                    if e["externalIdentifierType"].as_str() == Some("subject")
+                        && e["identifier"].as_str() == Some(&value)
+                    {
+                        found_3 = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    assert!(found_3, "SPDX 3 missing subject identifier");
+}
+
+#[test]
+fn manual_subject_hash_flag_works_on_image_tier() {
+    // FR-003 coverage: image-tier scans accept --subject-hash. We
+    // build a synthetic docker-save tarball, scan it with both
+    // --image and --subject-hash, then assert both `image:` (auto)
+    // and `subject:` (manual) identifiers ride the CDX
+    // externalReferences[].
+    let fake_home = tempfile::tempdir().unwrap();
+    let (tarball_path, _td) = build_synthetic_image_tarball();
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("out.cdx.json");
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--image")
+        .arg(&tarball_path)
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(format!("cyclonedx-json={}", out_path.to_string_lossy()))
+        .arg("--no-deep-hash")
+        .arg("--subject-hash")
+        .arg(format!("sha256:{SHA256_B}"));
+    let out = cmd.output().expect("scan runs");
+    assert!(
+        out.status.success(),
+        "image-tier scan failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let bytes = std::fs::read(&out_path).unwrap();
+    let cdx: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let refs = cdx["metadata"]["component"]["externalReferences"]
+        .as_array()
+        .expect("externalReferences[] present");
+    let has_subject = refs.iter().any(|r| {
+        r["type"].as_str() == Some("attestation")
+            && r["url"].as_str() == Some(&format!("sha256:{SHA256_B}"))
+    });
+    assert!(has_subject, "expected subject: identifier on image-tier scan; got {refs:#?}");
+}
+
+fn build_synthetic_image_tarball() -> (PathBuf, tempfile::TempDir) {
+    use std::io::Write as _;
+    let mut layer_bytes = Vec::new();
+    {
+        let mut layer_tar = tar::Builder::new(&mut layer_bytes);
+        let os_release =
+            b"NAME=\"Debian\"\nID=debian\nVERSION_ID=\"12\"\nVERSION_CODENAME=bookworm\n";
+        let mut h = tar::Header::new_ustar();
+        h.set_path("etc/os-release").unwrap();
+        h.set_size(os_release.len() as u64);
+        h.set_mode(0o644);
+        h.set_cksum();
+        layer_tar.append(&h, os_release.as_slice()).unwrap();
+        let dpkg_status =
+            b"Package: foo\nStatus: install ok installed\nVersion: 1.0\nArchitecture: amd64\nMaintainer: Debian <debian@example.org>\n\n";
+        let mut h = tar::Header::new_ustar();
+        h.set_path("var/lib/dpkg/status").unwrap();
+        h.set_size(dpkg_status.len() as u64);
+        h.set_mode(0o644);
+        h.set_cksum();
+        layer_tar.append(&h, dpkg_status.as_slice()).unwrap();
+        layer_tar.finish().unwrap();
+    }
+    let manifest = r#"[{"Config":"config.json","RepoTags":["docker.io/test/foo:v1"],"Layers":["layer0/layer.tar"]}]"#;
+    let td = tempfile::tempdir().unwrap();
+    let tarball_path = td.path().join("img.tar");
+    let file = std::fs::File::create(&tarball_path).unwrap();
+    {
+        let mut outer = tar::Builder::new(file);
+        let mut mh = tar::Header::new_ustar();
+        mh.set_path("manifest.json").unwrap();
+        mh.set_size(manifest.len() as u64);
+        mh.set_mode(0o644);
+        mh.set_cksum();
+        outer.append(&mh, manifest.as_bytes()).unwrap();
+        let mut lh = tar::Header::new_ustar();
+        lh.set_path("layer0/layer.tar").unwrap();
+        lh.set_size(layer_bytes.len() as u64);
+        lh.set_mode(0o644);
+        lh.set_cksum();
+        outer.append(&lh, layer_bytes.as_slice()).unwrap();
+        outer.into_inner().unwrap().flush().unwrap();
+    }
+    (tarball_path, td)
+}
+
+// ---------------------------------------------------------------------
+// US3 — cross-tier digest handshake by string match
+// ---------------------------------------------------------------------
+
+#[test]
+fn cross_tier_handshake_image_digest_matches_build_subject() {
+    // US3 §1, SC-002: an external SBOM-store consumer holding a build
+    // SBOM with `subject:sha256:X` and an image SBOM whose components
+    // have `hashes[].sha256 == X` can correlate the two by string
+    // match alone, with no mikebom-side resolver. This test
+    // synthesizes two SBOMs and runs the correlation in serde_json.
+
+    let target = SHA256_A;
+
+    // Build SBOM (synthetic): one document with subject:sha256:<target>.
+    let build_sbom = serde_json::json!({
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "metadata": {
+            "component": {
+                "name": "build-myapp",
+                "externalReferences": [
+                    {
+                        "type": "attestation",
+                        "url": format!("sha256:{target}"),
+                        "comment": "auto-detected from build-tier in-toto subject `myapp`"
+                    }
+                ]
+            }
+        }
+    });
+
+    // Image SBOM (synthetic): one component whose hash[sha256] matches.
+    let image_sbom = serde_json::json!({
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "components": [
+            {
+                "name": "myapp",
+                "purl": "pkg:generic/myapp@0.0.0",
+                "hashes": [
+                    {"alg": "SHA-256", "content": target}
+                ]
+            }
+        ]
+    });
+
+    // Pure string-match correlation: extract image components' hashes,
+    // then look up the build SBOM by `subject:sha256:<hash>`.
+    let mut correlated = false;
+    if let Some(comps) = image_sbom["components"].as_array() {
+        for c in comps {
+            if let Some(hashes) = c["hashes"].as_array() {
+                for h in hashes {
+                    if h["alg"].as_str() == Some("SHA-256") {
+                        if let Some(hex) = h["content"].as_str() {
+                            // Look for a build SBOM with
+                            // subject:sha256:<hex> in its
+                            // metadata.component.externalReferences[].
+                            let needle = format!("sha256:{hex}");
+                            if let Some(refs) =
+                                build_sbom["metadata"]["component"]["externalReferences"]
+                                    .as_array()
+                            {
+                                for r in refs {
+                                    if r["type"].as_str() == Some("attestation")
+                                        && r["url"].as_str() == Some(needle.as_str())
+                                    {
+                                        correlated = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    assert!(
+        correlated,
+        "expected to correlate image component hash with build SBOM subject identifier"
+    );
+}
+
+// ---------------------------------------------------------------------
+// US4 — per-component user-defined identifier attachment
+// ---------------------------------------------------------------------
+
+#[test]
+fn component_id_attaches_to_matching_component_cdx() {
+    // US4 §1, SC-003 (CDX): --component-id attaches to the matching
+    // component's properties[]; non-matching components unchanged.
+    let fake_home = tempfile::tempdir().unwrap();
+    let (cdx, _) = run_scan(
+        fake_home.path(),
+        &fixture_root(),
+        &[
+            "--component-id",
+            "pkg:cargo/serde@1.0.197=kusari-id:asset-foo",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comps = cdx["components"].as_array().expect("components[]");
+    let mut serde_found = false;
+    let mut other_unchanged = true;
+    for c in comps {
+        if c["purl"].as_str() == Some("pkg:cargo/serde@1.0.197") {
+            let props = c["properties"].as_array();
+            if let Some(arr) = props {
+                if arr.iter().any(|p| {
+                    p["name"].as_str() == Some("kusari-id")
+                        && p["value"].as_str() == Some("asset-foo")
+                }) {
+                    serde_found = true;
+                }
+            }
+        } else {
+            // Other components must not have a `kusari-id` property.
+            if let Some(props) = c["properties"].as_array() {
+                if props.iter().any(|p| p["name"].as_str() == Some("kusari-id")) {
+                    other_unchanged = false;
+                }
+            }
+        }
+    }
+    assert!(serde_found, "expected matching component to carry kusari-id");
+    assert!(
+        other_unchanged,
+        "non-matching components must remain unchanged"
+    );
+}
+
+#[test]
+fn component_id_attaches_to_matching_component_spdx23() {
+    // US4 §1, SC-003 (SPDX 2.3): --component-id attaches to the
+    // matching package's externalRefs[PERSISTENT-ID].
+    let fake_home = tempfile::tempdir().unwrap();
+    let (spdx, _) = run_scan(
+        fake_home.path(),
+        &fixture_root(),
+        &[
+            "--component-id",
+            "pkg:cargo/serde@1.0.197=kusari-id:asset-foo",
+        ],
+        "spdx-2.3-json",
+        "out.spdx.json",
+    );
+    let pkgs = spdx["packages"].as_array().expect("packages[]");
+    let mut serde_found = false;
+    for p in pkgs {
+        // Find the package via its `purl` externalRef.
+        let is_serde = p["externalRefs"]
+            .as_array()
+            .map(|refs| {
+                refs.iter().any(|r| {
+                    r["referenceType"].as_str() == Some("purl")
+                        && r["referenceLocator"].as_str()
+                            == Some("pkg:cargo/serde@1.0.197")
+                })
+            })
+            .unwrap_or(false);
+        if is_serde {
+            if let Some(refs) = p["externalRefs"].as_array() {
+                serde_found = refs.iter().any(|r| {
+                    r["referenceCategory"].as_str() == Some("PERSISTENT-ID")
+                        && r["referenceType"].as_str() == Some("kusari-id")
+                        && r["referenceLocator"].as_str() == Some("asset-foo")
+                });
+            }
+        }
+    }
+    assert!(serde_found, "expected SPDX 2.3 PERSISTENT-ID externalRef on matching package");
+}
+
+#[test]
+fn component_id_attaches_to_matching_component_spdx3() {
+    // US4 §1, SC-003 (SPDX 3): --component-id attaches to the matching
+    // Element's externalIdentifier[].
+    let fake_home = tempfile::tempdir().unwrap();
+    let (spdx3, _) = run_scan(
+        fake_home.path(),
+        &fixture_root(),
+        &[
+            "--component-id",
+            "pkg:cargo/serde@1.0.197=kusari-id:asset-foo",
+        ],
+        "spdx-3-json",
+        "out.spdx3.json",
+    );
+    let graph = spdx3["@graph"].as_array().expect("@graph");
+    let mut serde_found = false;
+    for n in graph {
+        if n["type"].as_str() == Some("software_Package")
+            && n["software_packageUrl"].as_str() == Some("pkg:cargo/serde@1.0.197")
+        {
+            if let Some(eids) = n["externalIdentifier"].as_array() {
+                serde_found = eids.iter().any(|e| {
+                    e["externalIdentifierType"].as_str() == Some("kusari-id")
+                        && e["identifier"].as_str() == Some("asset-foo")
+                });
+            }
+        }
+    }
+    assert!(serde_found, "expected SPDX 3 externalIdentifier on matching Package");
+}
+
+#[test]
+fn component_id_warns_on_zero_match() {
+    // US4 §2, SC-008 / FR-010: zero-match selector → scan exits 0;
+    // warn-level log surfaces the unmatched selector.
+    let fake_home = tempfile::tempdir().unwrap();
+    let (_, stderr) = run_scan(
+        fake_home.path(),
+        &fixture_root(),
+        &[
+            "--component-id",
+            "pkg:cargo/nonexistent@0.0.0=acme:foo",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    // The scan succeeded (run_scan asserts). Check the warn surfaced.
+    let lower = stderr.to_lowercase();
+    assert!(
+        lower.contains("matched zero components")
+            || lower.contains("nonexistent"),
+        "expected warn about zero-match selector; got stderr={stderr}"
+    );
+}
+
+#[test]
+fn component_id_rejects_builtin_scheme_at_parse() {
+    // US4 §4 / FR-009 / SC-007: built-in schemes rejected at clap
+    // parse time. We exercise this through the `parse_component_id_flag`
+    // adapter (the value_parser clap calls); a clap parse failure
+    // exits non-zero before any scan work happens.
+    let err = parse_component_id_flag("pkg:cargo/foo@1.0=subject:sha256:abc")
+        .unwrap_err();
+    assert!(
+        err.contains("reserved") || err.contains("subject"),
+        "expected `reserved` / `subject` in error; got {err}"
+    );
+    // Same check via the binary itself — clap parse failure emits
+    // non-zero exit. We only check exit status here; stderr text is
+    // shaped by clap, not us.
+    let mut cmd = Command::new(bin());
+    let fake_home = tempfile::tempdir().unwrap();
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("out.cdx.json");
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(fixture_root())
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(format!("cyclonedx-json={}", out_path.to_string_lossy()))
+        .arg("--no-deep-hash")
+        .arg("--component-id")
+        .arg("pkg:cargo/foo@1.0=subject:sha256:abc");
+    let out = cmd.output().unwrap();
+    assert!(
+        !out.status.success(),
+        "expected clap parse failure on built-in scheme; status={:?} stdout={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn component_id_rejects_malformed_input_at_parse() {
+    // US4 §5: clear errors for several malformed inputs.
+    // No `=`.
+    let err = parse_component_id_flag("pkg:cargo/foo@1.0").unwrap_err();
+    assert!(err.contains("missing `=`"), "{err}");
+    // Empty PURL.
+    let err = parse_component_id_flag("=acme:foo").unwrap_err();
+    assert!(err.contains("PURL") && err.contains("empty"), "{err}");
+    // No `:` on RHS.
+    let err = parse_component_id_flag("pkg:cargo/foo@1.0=acme").unwrap_err();
+    assert!(err.contains("missing `:`"), "{err}");
+    // Empty scheme.
+    let err = parse_component_id_flag("pkg:cargo/foo@1.0=:value").unwrap_err();
+    assert!(err.contains("scheme is empty"), "{err}");
+    // Empty value.
+    let err = parse_component_id_flag("pkg:cargo/foo@1.0=acme:").unwrap_err();
+    assert!(err.contains("value is empty"), "{err}");
+}
+
+#[test]
+fn component_id_lexical_order_within_new_entries() {
+    // FR-012 + research §6: when two --component-id flags match the
+    // same component, the new entries appear in lexical order by
+    // (scheme, value) — not supply order.
+    let fake_home = tempfile::tempdir().unwrap();
+    let (cdx, _) = run_scan(
+        fake_home.path(),
+        &fixture_root(),
+        &[
+            "--component-id",
+            "pkg:cargo/serde@1.0.197=zzz-scheme:foo",
+            "--component-id",
+            "pkg:cargo/serde@1.0.197=aaa-scheme:bar",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comps = cdx["components"].as_array().expect("components[]");
+    let mut new_props_in_order: Vec<&str> = Vec::new();
+    for c in comps {
+        if c["purl"].as_str() == Some("pkg:cargo/serde@1.0.197") {
+            if let Some(arr) = c["properties"].as_array() {
+                for p in arr {
+                    if let Some(name) = p["name"].as_str() {
+                        if name == "zzz-scheme" || name == "aaa-scheme" {
+                            new_props_in_order.push(name);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    assert_eq!(
+        new_props_in_order,
+        vec!["aaa-scheme", "zzz-scheme"],
+        "expected new properties in lex order; got {new_props_in_order:?}"
+    );
+}
+
+#[test]
+fn component_id_deterministic_across_reruns() {
+    // SC-004: re-emission with identical inputs is byte-identical.
+    let fake_home_a = tempfile::tempdir().unwrap();
+    let fake_home_b = tempfile::tempdir().unwrap();
+    let extra = &[
+        "--component-id",
+        "pkg:cargo/serde@1.0.197=kusari-id:asset-foo",
+    ];
+    let workspace = common::workspace_root();
+    let run = |home: &Path, fmt: &str, fname: &str| -> String {
+        let out_dir = tempfile::tempdir().unwrap();
+        let out_path = out_dir.path().join(fname);
+        let mut cmd = Command::new(bin());
+        apply_fake_home_env(&mut cmd, home);
+        cmd.arg("--offline")
+            .arg("sbom")
+            .arg("scan")
+            .arg("--path")
+            .arg(fixture_root())
+            .arg("--format")
+            .arg(fmt)
+            .arg("--output")
+            .arg(format!("{fmt}={}", out_path.to_string_lossy()))
+            .arg("--no-deep-hash");
+        for a in extra {
+            cmd.arg(a);
+        }
+        let out = cmd.output().unwrap();
+        assert!(out.status.success(), "rerun scan failed: {:?}", String::from_utf8_lossy(&out.stderr));
+        let raw = std::fs::read_to_string(&out_path).unwrap();
+        // Normalize away volatile fields (serialNumber, timestamps,
+        // workspace paths, file hashes) so byte-identity is meaningful.
+        match fmt {
+            "cyclonedx-json" => common::normalize::normalize_cdx_for_golden(&raw, &workspace),
+            "spdx-2.3-json" => {
+                common::normalize::normalize_spdx23_for_golden(&raw, &workspace)
+            }
+            "spdx-3-json" => {
+                common::normalize::normalize_spdx3_for_golden(&raw, &workspace)
+            }
+            other => panic!("unknown format {other}"),
+        }
+    };
+    for (fmt, fname) in &[
+        ("cyclonedx-json", "out.cdx.json"),
+        ("spdx-2.3-json", "out.spdx.json"),
+        ("spdx-3-json", "out.spdx3.json"),
+    ] {
+        let a = run(fake_home_a.path(), fmt, fname);
+        let b = run(fake_home_b.path(), fmt, fname);
+        assert_eq!(
+            a, b,
+            "format {fmt}: re-emission must be byte-identical with --component-id (after normalize)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// Compile-time error-variant exhaustiveness sanity check.
+//
+// Exercises every variant of ComponentIdentifierFlagError so a future
+// addition forces a refresh.
+// ---------------------------------------------------------------------
+
+type ErrCase = (&'static str, fn(&ComponentIdentifierFlagError) -> bool);
+
+#[test]
+fn component_id_error_variants_exhaustive() {
+    use ComponentIdentifierFlagError::*;
+    let cases: &[ErrCase] = &[
+        ("no_eq", |e| matches!(e, MissingEquals(_))),
+        ("=foo:bar", |e| matches!(e, EmptyPurl(_))),
+        ("p=noscheme", |e| matches!(e, MissingColon(_))),
+        ("p=:value", |e| matches!(e, EmptyScheme)),
+        ("p=acme:", |e| matches!(e, EmptyValue)),
+        ("p=Acme:foo", |e| matches!(e, InvalidSchemeName(_, _))),
+        ("p=repo:foo", |e| matches!(e, BuiltinSchemeRejected(_))),
+    ];
+    for (raw, predicate) in cases {
+        let err = ComponentIdentifierFlag::parse(raw).unwrap_err();
+        assert!(
+            predicate(&err),
+            "input {raw:?} did not match expected variant; got {err:?}"
+        );
+    }
+}

--- a/specs/076-subject-component-ids/T001-audit.md
+++ b/specs/076-subject-component-ids/T001-audit.md
@@ -1,0 +1,133 @@
+# T001 audit — milestone 076 pre-flight
+
+Captured for T010 / T013 / T014 / T015 wiring.
+
+## (a) Existing build-tier fixtures
+
+No integration tests invoke `mikebom trace run` end-to-end against an
+in-toto subject set. `mikebom trace run` requires Linux + eBPF +
+privileges, so unit/integration tests that exercise the trace pipeline
+are gated on those preconditions. Tests that touch
+`auto_detect_build_tier_identifiers` (milestone 074) build synthetic
+git-fixture tempdirs and never go near the trace pipeline.
+
+Implication for T010: synthetic-subject-set fixtures + direct calls to
+`subject_identifiers_from_attestation_subjects` are the only way to
+exercise the build-tier subject auto-detect path on macOS/CI.
+
+## (b) Trace subject-set field
+
+The trace's subject set is **not held in long-lived in-process state**
+inside `cli/run.rs::execute`. The flow is:
+
+1. `super::scan::execute(scan_args).await?` writes the in-toto
+   attestation (DSSE envelope) to disk at `args.attestation_output`.
+2. `super::generate::execute(generate_args, false).await?` reads it
+   back via `crate::attestation::serializer::read_attestation`, yielding
+   an `InTotoStatement { subject: Vec<ResourceDescriptor>, … }`.
+
+`ResourceDescriptor` lives at `mikebom_common::attestation::statement`:
+
+```rust
+pub struct ResourceDescriptor {
+    pub name: String,
+    pub digest: BTreeMap<String, String>,
+}
+```
+
+The post-trace, in-process subject collection is therefore
+`statement.subject: &Vec<ResourceDescriptor>`. The internal
+`mikebom_cli::attestation::subject::Subject` enum exists but is the
+pre-serialization in-process resolver type; by the time `run.rs` is
+ready to merge subjects into identifiers, the canonical form is
+`ResourceDescriptor`.
+
+**T010 wiring decision**: read the attestation file once in
+`cli/run.rs::execute` between `scan::execute` and `generate::execute`,
+extract `statement.subject`, call
+`subject_identifiers_from_attestation_subjects(&statement.subject)`,
+and merge into the existing `assembled_ids` flow. This adds one
+additional disk read but keeps all subject parsing in the
+already-canonical wire form.
+
+`subject_identifiers_from_attestation_subjects`'s parameter type is
+`&[ResourceDescriptor]` accordingly.
+
+## (c) Per-format component-emission sites
+
+| Format | File | Function | Per-component carrier |
+|---|---|---|---|
+| CDX 1.6 | `mikebom-cli/src/generate/cyclonedx/builder.rs` | `CycloneDxBuilder::build_components` (~line 206) | `properties: Vec<serde_json::Value>` (~line 420), set on `entry` at line 649 |
+| SPDX 2.3 | `mikebom-cli/src/generate/spdx/packages.rs` | `component_to_package` (~line 341) | `external_refs: Vec<SpdxExternalRef>` (~line 369) |
+| SPDX 3 | `mikebom-cli/src/generate/spdx/v3_packages.rs` | `build_packages` (~line 52) | `externalIdentifier` array assembled via `super::v3_external_ids::build_external_identifiers_for(c)` then set at line 151 |
+
+Both SPDX 2.3 (`packages.rs::build_packages`) and SPDX 3
+(`v3_packages.rs::build_packages`) currently take `&[ResolvedComponent]`
+or a `&ScanArtifacts<'_>` directly. To wire `--component-id`,
+`v3_packages::build_packages` needs the `&[ComponentIdentifierFlag]`
+slice threaded through. Easiest path: extend its signature to take
+`scan: &ScanArtifacts<'_>` (or just the `component_identifiers` slice)
+and update the single call site in `v3_document::build_document`.
+
+For CDX, `CycloneDxBuilder` already stores most cross-cutting state
+as member fields (`identifiers`, `source_document_binding`, etc.) —
+add `component_identifiers: Vec<ComponentIdentifierFlag>` plus a
+`with_component_identifiers` setter, populated in `cyclonedx/mod.rs`
+serializer alongside `with_identifiers`.
+
+## (d) Pre-existing per-component entries (preserve at original positions)
+
+### CDX `components[].properties[]`
+Built by `builder.rs::build_components` in supply order:
+- `mikebom:cpe-candidates` (when len > 1)
+- `mikebom:source-files` (when include_source_files set)
+- `mikebom:lifecycle-scope` (non-runtime + include_dev)
+- `mikebom:requirement-range`
+- `mikebom:source-type`
+- `mikebom:co-owned-by`
+- evidence-derived properties (variable list)
+- `mikebom:sbom-tier`
+- `mikebom:npm-role`
+- `mikebom:raw-version`
+- `mikebom:buildinfo-status`
+- `mikebom:evidence-kind`
+- `mikebom:confidence`
+- `mikebom:binary-class`
+- `mikebom:binary-stripped`
+- `mikebom:linkage-kind`
+- `mikebom:detected-go`
+- `mikebom:shade-relocation`
+- `mikebom:binary-packed`
+- All `extra_annotations` entries (incl. `mikebom:not-linked`,
+  `mikebom:component-role`, `mikebom:shade-relocation`, etc.)
+
+T013 must append `--component-id` entries AFTER all of the above, in
+lexical order by `(scheme, value)`.
+
+### SPDX 2.3 `Package.externalRefs[]`
+Built by `packages.rs::component_to_package` in supply order:
+- `purl` (PACKAGE-MANAGER, always first)
+- `cpe23Type` (SECURITY, when CPE present)
+- `homepage`/`vcs`/`distribution` etc. from
+  `external_references` (OTHER)
+- Milestone-073 built-in identifiers (PERSISTENT-ID; only on
+  main-module)
+
+T014 must append `--component-id` entries AFTER all of the above, as
+PERSISTENT-ID rows, in lexical order by `(scheme, value)`.
+
+### SPDX 3 `Element.externalIdentifier[]`
+Built by `v3_external_ids::build_external_identifiers_for(c)` in supply
+order — typically the PURL row first then CPEs. T015 must append
+`--component-id` entries AFTER, in lexical order by `(scheme, value)`.
+
+## Implementation summary
+
+- T010: read `statement.subject: &Vec<ResourceDescriptor>` in
+  `run.rs::execute` after `scan::execute` returns; wire into
+  `assembled_ids`.
+- T013/T014/T015: thread `&[ComponentIdentifierFlag]` through
+  builder/packages/v3_packages; iterate flags, match by
+  `purl == component.purl.as_str()` byte-equality, append per-format
+  entries lex-sorted by `(scheme, value)` after pre-existing entries;
+  warn on zero match after the per-component loop completes.

--- a/specs/076-subject-component-ids/checklists/requirements.md
+++ b/specs/076-subject-component-ids/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Subject identifier scheme + per-component user-defined identifiers
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Two-deliverable milestone: (1) document-level `subject:` identifier scheme + build-tier auto-detect, (2) per-component user-defined identifiers via `--component-id` flag. Bundled because both serve the same goal — completing the cross-tier content-addressable correlation chain that milestones 072–075 began.
+- Constitution Principle V "native-first" audit: spec asserts both deliverables ride standards-native carriers (FR-004 for `subject:`, FR-008 for per-component identifiers). Specifically calls out that no new `mikebom:*` annotations are introduced. The `subject:` scheme uses the same per-document carrier set milestone 073 established. Per-component user-defined identifiers use CDX `components[].properties[]` or `externalReferences[]` (Phase 0 research will pin which), SPDX 2.3 `Package.externalRefs[PERSISTENT-ID]`, SPDX 3 `Element.externalIdentifier[]`.
+- Bounded scope: per-component built-in schemes (e.g., per-component `subject:`) are explicitly out. Glob/wildcard component selectors are out (exact PURL match only). `bom-ref`-based selection is out. Hash algos beyond sha256/sha512 are out. These are deliberate MVP cuts; future milestones can revisit each.
+- US3 (cross-tier handshake) is verified by an end-to-end harness rather than a built-in mikebom subcommand — keeps the milestone focused on emission contract correctness, not on building a new resolver/walker.
+- All items pass on first iteration; spec is ready for `/speckit.clarify` or `/speckit.plan`. Recommend `/speckit.clarify` for one likely-worth-pinning decision: the CDX 1.6 carrier choice for per-document `subject:` identifiers (which existing `externalReferences[].type` enum value best fits the "binary subject hash" semantic — `provenance`, `attestation`, or a different existing value). Phase 0 research can absorb that decision if `/speckit.clarify` is skipped.
+- **Post-`/speckit.clarify` integration (2026-05-06)**: applied one clarification — multi-digest subject behavior pinned to "sha256-only auto-emit; non-sha256 algos require manual `--subject-hash`." Updated FR-002 to make the rule explicit and added an edge-case bullet covering "Subject with no sha256 digest." See spec.md `## Clarifications` section. CDX type-enum-value choice for `subject:` was deliberately deferred to Phase 0 research §1 rather than asked as a clarify (decision is "reuse `attestation` per research §1").
+- **Post-`/speckit.analyze` remediation pass (2026-05-06)**: applied finding-driven edits to address C1 (added `component_id_deterministic_across_reruns` test in T016 (j) covering SC-004), C2 (added `manual_subject_hash_flag_works_on_image_tier` test in T011 (e) covering image-tier `--subject-hash`), U1 (tightened T001 to enumerate four explicit deliverables — fixture audit, trace's subject-set field name, per-format component-emission sites, pre-existing per-component entries — that T010/T013/T014/T015 depend on), I1 (T002 now lists the known exhaustive-match call sites with line numbers). All findings resolved; no `[NEEDS CLARIFICATION]` markers remain.

--- a/specs/076-subject-component-ids/contracts/per-component-id.md
+++ b/specs/076-subject-component-ids/contracts/per-component-id.md
@@ -1,0 +1,220 @@
+# Contract — milestone 076 per-component user-defined identifiers
+
+Public API for the new `--component-id` flag.
+
+## CLI surface
+
+### New flag (on both `mikebom sbom scan` and `mikebom trace run`)
+
+```
+--component-id <PURL>=<scheme>:<value>
+```
+
+- Type: repeatable (`Vec<ComponentIdentifierFlag>` in the parsed `Args` after CLI-level parse via the new `component_id::ComponentIdentifierFlag::parse` value parser)
+- LHS (`<PURL>`): exact PURL string for byte-identical match against `components[].purl` per research §5
+- RHS scheme: any string passing milestone 073's `SchemeName` regex (`^[a-z][a-z0-9_-]*$`), excluding the five built-in names (`repo`, `git`, `image`, `attestation`, `subject`)
+- RHS value: any non-empty string passing milestone 073's `IdentifierValue` rules
+
+### Help-text shape (clap-derived)
+
+```
+--component-id <PURL>=<SCHEME>:<VALUE>
+        Attach a user-defined identifier to a specific component in the
+        emitted SBOM. The PURL must byte-equal a component's `purl` field
+        in the emitted output; the SCHEME must be a non-built-in scheme
+        name (built-in schemes `repo`, `git`, `image`, `attestation`,
+        `subject` are reserved for document-level use). Examples:
+
+          --component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-shared-lib-v2"
+          --component-id "pkg:cargo/myapp@0.5.1=acme-asset:myapp-prod-001"
+
+        Repeatable. If a selector PURL matches multiple components
+        (same PURL across different bom-ref values), the identifier is
+        attached to ALL matching components. If a selector matches zero
+        components, the scan logs a warning and continues.
+```
+
+## Library surface (`mikebom-cli` crate)
+
+### New module `component_id`
+
+```rust
+// In mikebom-cli/src/binding/identifiers/component_id.rs (NEW)
+
+pub struct ComponentIdentifierFlag {
+    pub selector_purl: String,
+    pub scheme: SchemeName,
+    pub value: IdentifierValue,
+}
+
+impl ComponentIdentifierFlag {
+    /// Parse a flag value of form `PURL=scheme:value`.
+    /// Splits on the FIRST `=` (LHS = selector, RHS = scheme:value).
+    /// Splits the RHS on the FIRST `:` (scheme on left, value on right).
+    /// Rejects built-in scheme names per FR-009.
+    /// Used as a clap `value_parser`.
+    pub fn parse(raw: &str) -> Result<Self, ComponentIdentifierFlagError>;
+}
+
+// pub fn for clap::value_parser
+pub fn parse_component_id_flag(raw: &str) -> Result<ComponentIdentifierFlag, String>;
+```
+
+### Updated `ScanArtifacts` shape
+
+```rust
+// In mikebom-cli/src/generate/mod.rs
+
+pub struct ScanArtifacts<'a> {
+    // ... existing fields ...
+    /// Milestone 076: per-component user-defined identifiers from
+    /// --component-id flags. Threaded to per-format emitters which
+    /// match selector_purl against emitted components.
+    pub component_identifiers: Vec<ComponentIdentifierFlag>,
+}
+```
+
+## Integration boundary
+
+### Where flags are parsed
+
+```rust
+// In ScanArgs / RunArgs:
+#[arg(
+    long = "component-id",
+    value_name = "PURL=SCHEME:VALUE",
+    action = clap::ArgAction::Append,
+    value_parser = parse_component_id_flag,
+)]
+pub component_id: Vec<ComponentIdentifierFlag>,
+```
+
+### Where matching happens
+
+Per-format emitters consume `ScanArtifacts.component_identifiers: &[ComponentIdentifierFlag]`. Each format emitter does:
+
+1. After emitting the `components[]` array (or per-format equivalent), iterate through the supplied `component_identifiers`.
+2. For each flag, find all components whose emitted `purl` byte-equals `flag.selector_purl`.
+3. For each matching component, append the identifier to the component's per-format native carrier (CDX `properties[]`, SPDX 2.3 `externalRefs[PERSISTENT-ID]`, SPDX 3 `externalIdentifier[]`).
+4. After all flags are processed, sort each component's NEW entries lexically by `(scheme, value)`. Pre-existing properties/externalRefs are preserved at their original positions.
+5. After all components are processed, emit a `tracing::warn!` for any flag whose `selector_purl` matched zero components.
+
+The emitter logic must be identical across CDX / SPDX 2.3 / SPDX 3 modulo the per-format carrier name. Phase 1 may extract a small shared helper.
+
+## Per-format wire mapping (per research §2)
+
+### CDX 1.6
+
+`components[].properties[]` with `name = <scheme>` and `value = <value>`:
+
+```json
+{
+  "type": "library",
+  "name": "serde",
+  "version": "1.0.0",
+  "purl": "pkg:cargo/serde@1.0.0",
+  "properties": [
+    {"name": "kusari-id", "value": "asset-shared-lib-v2"},
+    {"name": "acme-asset", "value": "shared-001"}
+  ]
+}
+```
+
+Pre-existing properties (e.g., `mikebom:not-linked`) preserved at original positions; new entries appended in lexical order.
+
+### SPDX 2.3
+
+`Package.externalRefs[]` with `referenceCategory = "PERSISTENT-ID"`:
+
+```json
+{
+  "name": "serde",
+  "versionInfo": "1.0.0",
+  "externalRefs": [
+    {"referenceCategory": "PACKAGE-MANAGER", "referenceType": "purl", "referenceLocator": "pkg:cargo/serde@1.0.0"},
+    {"referenceCategory": "PERSISTENT-ID", "referenceType": "kusari-id", "referenceLocator": "asset-shared-lib-v2"},
+    {"referenceCategory": "PERSISTENT-ID", "referenceType": "acme-asset", "referenceLocator": "shared-001"}
+  ]
+}
+```
+
+### SPDX 3
+
+`Element.externalIdentifier[]` with `type = <scheme>`:
+
+```json
+{
+  "type": "software_Package",
+  "name": "serde",
+  "externalIdentifier": [
+    {"type": "purl", "identifier": "pkg:cargo/serde@1.0.0"},
+    {"type": "kusari-id", "identifier": "asset-shared-lib-v2"},
+    {"type": "acme-asset", "identifier": "shared-001"}
+  ]
+}
+```
+
+Native open-typed identifier list — Principle V audit passes.
+
+## Observable contract from outside the binary
+
+### Default behavior (no `--component-id` flags)
+
+```bash
+$ mikebom sbom scan --path . --output out.cdx.json
+... (no per-component identifier handling fires; SBOM byte-identical to alpha.17)
+```
+
+### Single match
+
+```bash
+$ mikebom sbom scan --path . \
+    --component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-shared-lib-v2" \
+    --output out.cdx.json
+
+$ jq '.components[] | select(.purl == "pkg:cargo/serde@1.0.0") | .properties' out.cdx.json
+[{"name": "kusari-id", "value": "asset-shared-lib-v2"}]
+```
+
+### Zero match
+
+```bash
+$ mikebom sbom scan --path . \
+    --component-id "pkg:cargo/nonexistent@0.0.0=asset:foo" \
+    --output out.cdx.json
+WARN --component-id selector `pkg:cargo/nonexistent@0.0.0` matched zero components; identifier `asset:foo` not attached
+... (scan exits 0; SBOM emitted with no extra annotations)
+```
+
+### Built-in scheme rejection
+
+```bash
+$ mikebom sbom scan --path . \
+    --component-id "pkg:cargo/foo@1.0=subject:sha256:abc"
+error: invalid value 'pkg:cargo/foo@1.0=subject:sha256:abc' for '--component-id <PURL=SCHEME:VALUE>': scheme 'subject' is reserved for document-level built-in usage
+```
+
+## Test contract
+
+The integration-test file `mikebom-cli/tests/identifiers_subject_and_component.rs` MUST cover (per-component portion):
+
+| Test | Acceptance scenario | Validates |
+|------|--------------------|-----------|
+| `component_id_attaches_to_matching_component_cdx` | US4 §1, SC-003 | FR-007, FR-008 (CDX) |
+| `component_id_attaches_to_matching_component_spdx23` | US4 §1, SC-003 | FR-008 (SPDX 2.3) |
+| `component_id_attaches_to_matching_component_spdx3` | US4 §1, SC-003 | FR-008 (SPDX 3) |
+| `component_id_warns_on_zero_match` | US4 §2, SC-008 | FR-010 |
+| `component_id_attaches_to_all_matching_when_multiple` | US4 §3 | FR-011 |
+| `component_id_rejects_builtin_scheme_at_parse` | US4 §4, SC-007 | FR-009 |
+| `component_id_rejects_malformed_input_at_parse` | US4 §5 | parse contract |
+| `component_id_lexical_order_within_new_entries` | FR-012 + research §6 | determinism |
+| `component_id_preserves_existing_properties` | research §6 | no churn |
+
+Plus unit tests on `ComponentIdentifierFlag::parse` for the parse-error edge cases.
+
+## Determinism contract (per FR-012, SC-005)
+
+- Per-component identifier matching is deterministic: byte-equality match.
+- Per-component emission order: pre-existing entries preserved at their positions; new entries appended in lexical order by `(scheme, value)`.
+- Multi-component fan-out: each matching component independently sees the new entry in its own properties/externalRefs.
+- Re-running with identical inputs produces byte-identical output.

--- a/specs/076-subject-component-ids/contracts/subject-identifier.md
+++ b/specs/076-subject-component-ids/contracts/subject-identifier.md
@@ -1,0 +1,185 @@
+# Contract — milestone 076 document-level `subject:` identifier
+
+Public API for the new `BuiltinScheme::Subject` variant + `--subject-hash` flag.
+
+## CLI surface
+
+### New flag (on both `mikebom sbom scan` and `mikebom trace run`)
+
+```
+--subject-hash <ALGO:HEX>
+```
+
+- Type: repeatable (`Vec<String>` in the parsed `Args`)
+- Each occurrence parses as a single `subject:` identifier
+- Algo: must be `sha256` or `sha512` per research §4
+- Hex: must be lowercase hex of correct length (64 chars for sha256, 128 for sha512)
+
+### Help-text shape (clap-derived)
+
+```
+--subject-hash <ALGO:HEX>
+        Attach a `subject:` identifier declaring "this SBOM describes
+        the artifact with the given content hash." Format:
+        `sha256:<64-lowercase-hex>` or `sha512:<128-lowercase-hex>`.
+        Repeatable for multi-subject SBOMs. On build-tier scans
+        (`mikebom trace run`), subject identifiers are auto-detected
+        from the in-toto attestation envelope's subject set; manual
+        flags augment auto-detected entries (deduplicated by exact
+        match per milestone 073). On source-tier and image-tier
+        scans, no auto-detect runs; manual flags are the only
+        source of `subject:` identifiers.
+```
+
+## Library surface (`mikebom-cli` crate)
+
+### New `BuiltinScheme::Subject` variant
+
+```rust
+// In mikebom-cli/src/binding/identifiers/mod.rs
+
+pub enum BuiltinScheme {
+    Repo,
+    Git,
+    Image,
+    Attestation,
+    Subject,        // NEW
+}
+```
+
+The variant is part of the public surface for scheme classification. External consumers reading mikebom's emitted SBOMs match on `subject` as a scheme name; the `Subject` variant is the in-process correspondent.
+
+### New `validate_subject` function
+
+```rust
+// In mikebom-cli/src/binding/identifiers/validators.rs
+
+/// Validate a `subject:` value (`<algo>:<hex>`). Accepts `sha256:` and
+/// `sha512:` prefixes only. Hex MUST be lowercase, length must match
+/// algo (64 chars for sha256, 128 for sha512). Anything else returns
+/// IdentifierError triggering soft-fail to UserDefined per FR-005.
+pub fn validate_subject(value: &str) -> Result<(), IdentifierError>;
+```
+
+### New auto-detect helper
+
+```rust
+// In mikebom-cli/src/binding/identifiers/auto_detect.rs
+
+/// Convert an in-toto subject set into a Vec of `subject:`
+/// `Identifier` instances. Subjects without a sha256 digest are
+/// skipped with `tracing::info!` per FR-002 + 2026-05-06 clarification.
+///
+/// Caller passes the subject set already collected by the trace
+/// pipeline (no I/O happens inside this function).
+pub fn subject_identifiers_from_attestation_subjects(
+    subjects: &[Subject],
+) -> Vec<Identifier>;
+```
+
+The exact `Subject` type comes from the existing in-toto witness-v0.1 attestation builder; the function signature is shaped to take a slice of whatever in-process struct represents subjects today.
+
+## Per-format wire mapping
+
+### CDX 1.6
+
+Document-level `subject:` identifiers ride `metadata.component.externalReferences[]` with `type = "attestation"` (research §1):
+
+```json
+{
+  "type": "attestation",
+  "url": "sha256:abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+  "comment": "auto-detected from build-tier in-toto subject `myapp`"
+}
+```
+
+For multi-output builds, multiple entries appear in the array (one per subject), in witness-v0.1 lexical order.
+
+This co-exists with milestone 073's `attestation:` IRI emissions in the same `externalReferences[]` array (they share `type` but differ by URL form: digest vs IRI).
+
+### SPDX 2.3
+
+`subject:` identifiers ride `Package.externalRefs[]` on the main-module package with `referenceCategory = "PERSISTENT-ID"`:
+
+```json
+{
+  "referenceCategory": "PERSISTENT-ID",
+  "referenceType": "subject",
+  "referenceLocator": "sha256:abc1234567890..."
+}
+```
+
+Plus the `creationInfo.creators[]` redundant text line per milestone 073 (extends the same dual-carrier pattern).
+
+### SPDX 3
+
+`subject:` identifiers ride `SpdxDocument.externalIdentifier[]`:
+
+```json
+{
+  "type": "subject",
+  "identifier": "sha256:abc1234567890..."
+}
+```
+
+Native open-typed `externalIdentifier[].type` — no Principle V parity issue.
+
+## Observable contract from outside the binary
+
+### Build-tier auto-detect (default — no flags)
+
+```bash
+$ mikebom trace run --signing-key ./key -- ./build.sh
+INFO build-tier auto-detected `subject:sha256:abc1234567890...` from in-toto subject `myapp`
+INFO build-tier auto-detected `subject:sha256:def5678901234...` from in-toto subject `myapp-debug`
+... (rest of trace flow unchanged)
+```
+
+The emitted build SBOM carries the `subject:` identifiers in its native carriers. The wrapping `.attestation.dsse.json` envelope continues to carry the same subjects in its `subjects[]` field; the SBOM-body identifiers are an additive duplicate optimized for SBOM-only consumption.
+
+### Manual `--subject-hash` (source-tier or override)
+
+```bash
+$ mikebom sbom scan --path . \
+    --subject-hash sha256:custom1234567890... \
+    --output out.cdx.json
+... (no auto-detect log line; manual values flow through)
+```
+
+### Skipped subject (no sha256 digest)
+
+```bash
+$ mikebom trace run -- ./build-with-only-sha512-subjects.sh
+INFO subject `myapp` has no sha256 digest (available algos: [sha512]); skipping subject: identifier auto-emit. Pass --subject-hash sha512:<hex> manually if needed.
+... (the subject does NOT appear in the emitted SBOM as a `subject:` identifier)
+```
+
+## Test contract
+
+A new integration-test file `mikebom-cli/tests/identifiers_subject_and_component.rs` MUST cover (subject-identifier portion):
+
+| Test | Acceptance scenario | Validates |
+|------|--------------------|-----------|
+| `build_tier_autodetects_subject_from_in_toto_subjects` | US1 §1 | FR-002, SC-001 |
+| `build_tier_autodetect_skips_subject_without_sha256` | US1 §3 + 2026-05-06 clarification | FR-002 + edge case |
+| `build_tier_autodetect_emits_one_subject_per_in_toto_subject` | US1 §2 | FR-002 + multi-output |
+| `manual_subject_hash_flag_works_on_source_tier` | US2 §1 | FR-003, FR-006 |
+| `manual_subject_hash_flag_repeatable` | US2 §2 | FR-003 |
+| `subject_value_validation_soft_fails_to_user_defined` | US2 §3 | FR-005 |
+| `subject_identifier_emits_in_all_three_formats` | FR-004 | per-format wire mapping |
+| `cross_tier_handshake_image_digest_matches_build_subject` | US3 §1, SC-002 | FR-014 |
+
+Plus unit tests on `validate_subject` for the regex edge cases per research §4.
+
+## Performance contract (per FR-012, SC-001)
+
+- `subject_identifiers_from_attestation_subjects` is a tight loop over the in-process subject set. O(N) in number of subjects; bounded by witness-v0.1's per-attestation cap.
+- No I/O. No subprocess. <1ms even for N=100 subjects.
+- Validation regex compiles once per scan invocation (lazy_static or once_cell pattern). Match is O(L) in value length.
+
+## Determinism contract (per FR-012, SC-005)
+
+- Auto-detected `subject:` identifier order matches the in-toto subject set's lexical order (already deterministic per witness-v0.1).
+- Manual `--subject-hash` order matches operator supply order.
+- Composition order in the build-tier identifier vec: `repo:` → `git:` → auto-detected `subject:` entries → manual `--subject-hash` entries → existing manual `--repo` / `--git-ref` / etc.
+- Re-running with identical inputs produces byte-identical output.

--- a/specs/076-subject-component-ids/data-model.md
+++ b/specs/076-subject-component-ids/data-model.md
@@ -1,0 +1,203 @@
+# Data Model — milestone 076 subject identifier + per-component identifiers
+
+The milestone adds one new variant to the existing `BuiltinScheme` enum and one small new struct (`ComponentIdentifierFlag`) for the per-component flag's parsed shape. Otherwise composes existing milestone-073 types.
+
+## Entities
+
+### `BuiltinScheme::Subject` (extension to existing enum)
+
+```rust
+// In mikebom-cli/src/binding/identifiers/mod.rs
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BuiltinScheme {
+    Repo,
+    Git,
+    Image,
+    Attestation,
+    Subject,        // NEW
+}
+
+impl BuiltinScheme {
+    pub fn from_scheme_name(name: &SchemeName) -> Option<Self> {
+        match name.as_str() {
+            "repo" => Some(Self::Repo),
+            "git" => Some(Self::Git),
+            "image" => Some(Self::Image),
+            "attestation" => Some(Self::Attestation),
+            "subject" => Some(Self::Subject),    // NEW
+            _ => None,
+        }
+    }
+
+    pub fn cdx_external_reference_type(self) -> &'static str {
+        match self {
+            Self::Repo | Self::Git => "vcs",
+            Self::Image => "distribution",
+            Self::Attestation | Self::Subject => "attestation",  // Subject reuses per research §1
+        }
+    }
+
+    pub fn spdx23_reference_category(self) -> &'static str { "PERSISTENT-ID" }
+    // Same uniform mapping as existing schemes.
+}
+```
+
+### `SubjectIdentifier` (conceptual; materialized as `Identifier` instance)
+
+A document-level `Identifier` with `scheme = SchemeName("subject")`, `value = IdentifierValue("<algo>:<hex>")`, `kind = IdentifierKind::Builtin(BuiltinScheme::Subject)` (or `UserDefined` on validation failure per research §4).
+
+Multiple SubjectIdentifiers may attach to one SBOM (multi-output builds). Auto-detected ones carry `source_label = "auto-detected from build-tier in-toto subject `<subject-name>`"`. Manual ones from `--subject-hash` carry `source_label = "manual --subject-hash"`.
+
+### `ComponentIdentifierFlag` (NEW, public struct)
+
+```rust
+// In mikebom-cli/src/binding/identifiers/component_id.rs (NEW module)
+#[derive(Debug, Clone)]
+pub struct ComponentIdentifierFlag {
+    /// Exact PURL string the operator typed; matched byte-identically
+    /// against `components[].purl` per research §5.
+    pub selector_purl: String,
+    /// User-defined scheme name. MUST NOT be a built-in (parser
+    /// rejects per FR-009).
+    pub scheme: SchemeName,
+    /// The identifier value. No format constraint beyond the existing
+    /// IdentifierValue rules (non-empty).
+    pub value: IdentifierValue,
+}
+
+impl ComponentIdentifierFlag {
+    /// Parse a `--component-id PURL=scheme:value` flag value.
+    /// Splits on the FIRST `=` (PURL containing `=` is invalid input).
+    /// Splits the RHS on the FIRST `:` (scheme:value).
+    /// Rejects built-in scheme names per FR-009.
+    pub fn parse(raw: &str) -> Result<Self, ComponentIdentifierFlagError>;
+}
+```
+
+Lifetime: parsed at CLI parse time, stored in `ScanArgs.component_id: Vec<ComponentIdentifierFlag>` and `RunArgs.component_id: Vec<ComponentIdentifierFlag>`, threaded through `ScanArtifacts.component_identifiers` to per-format emitters.
+
+### `ComponentIdentifierFlagError` (NEW)
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum ComponentIdentifierFlagError {
+    #[error("--component-id missing `=` separator: {0:?}")]
+    MissingEquals(String),
+
+    #[error("--component-id PURL (LHS of `=`) is empty")]
+    EmptyPurl,
+
+    #[error("--component-id RHS missing `:` separator: {0:?}")]
+    MissingColon(String),
+
+    #[error("--component-id scheme is empty")]
+    EmptyScheme,
+
+    #[error("--component-id value is empty")]
+    EmptyValue,
+
+    #[error("--component-id scheme {0:?} is reserved for document-level built-in usage")]
+    BuiltinSchemeRejected(String),
+
+    #[error("--component-id scheme {0:?} fails the FR-004 regex from milestone 073: {1}")]
+    InvalidSchemeName(String, IdentifierError),
+}
+```
+
+### `ScanArtifacts.component_identifiers: Vec<ComponentIdentifierFlag>` (extension)
+
+Located at `mikebom-cli/src/generate/mod.rs`. Add a new field:
+
+```rust
+pub struct ScanArtifacts<'a> {
+    // ... existing fields including identifiers (073) ...
+    /// Milestone 076: per-component user-defined identifiers from
+    /// `--component-id` flags. Threaded to per-format emitters which
+    /// match `selector_purl` against emitted components and attach
+    /// the identifier to matches.
+    pub component_identifiers: Vec<ComponentIdentifierFlag>,
+}
+```
+
+Existing `ScanArtifacts` constructions get an additional `component_identifiers: vec![]` field (back-compat default).
+
+## Functions (public surface added by this milestone)
+
+### `validate_subject` (NEW, in `validators.rs`)
+
+```rust
+pub fn validate_subject(value: &str) -> Result<(), IdentifierError>;
+```
+
+Behavior per research §4: accepts `^(sha256:[0-9a-f]{64}|sha512:[0-9a-f]{128})$` exactly; otherwise `Err(IdentifierError::BuiltinValidation { ... })` triggering soft-fail.
+
+### `subject_identifiers_from_attestation_subjects` (NEW, in `auto_detect.rs`)
+
+```rust
+pub fn subject_identifiers_from_attestation_subjects(
+    subjects: &[Subject],
+) -> Vec<Identifier>;
+```
+
+Behavior:
+1. Iterate `subjects` (already in lexically-sorted witness-v0.1 order).
+2. For each subject, extract the sha256 digest from the digest map. If sha256 is absent, log `tracing::info!` with subject name + available algos and skip per FR-002 + 2026-05-06 clarification.
+3. Construct an `Identifier` with scheme `subject`, value `sha256:<hex>`, kind `Builtin(Subject)`, source_label `"auto-detected from build-tier in-toto subject `<subject-name>`"`.
+4. Append to result vec.
+
+Never panics, never returns `Result`. Failures collapse to "skip this subject."
+
+### Updated `auto_detect_build_tier_identifiers` flow
+
+The existing milestone-074 helper continues to return `repo:` and `git:` identifiers. The new `subject:` identifiers come from `subject_identifiers_from_attestation_subjects` called at the build-tier emission site. Build-tier identifier vec ordering: `repo:` first, then `git:`, then `subject:` entries (in witness-v0.1 lexical order), then any manual `--subject-hash` entries (in supply order), then existing manual `--repo` / `--git-ref` etc.
+
+## Validation rules
+
+- **VR-076-001**: `BuiltinScheme::Subject` value MUST pass the `validate_subject` regex per research §4. Failures soft-fail to `IdentifierKind::UserDefined` per FR-005.
+- **VR-076-002**: Auto-detected `subject:` identifiers MUST emit only when the source subject has a sha256 digest in its `digest` map. Subjects with only non-sha256 digests are skipped with an info-log per FR-002.
+- **VR-076-003**: `ComponentIdentifierFlag::parse` MUST reject inputs whose LHS is empty, whose `=` separator is missing, whose RHS lacks `:`, whose scheme is empty, whose value is empty, or whose scheme matches a built-in name (`repo`, `git`, `image`, `attestation`, `subject`). Reject at CLI parse time with a clear, actionable error message.
+- **VR-076-004**: When a `--component-id` selector matches zero components in the emitted SBOM, the system MUST emit a `tracing::warn!` listing the unmatched selector and continue. The scan MUST NOT fail.
+- **VR-076-005**: When a `--component-id` selector matches multiple components (same PURL across different `bom-ref` values), the identifier MUST be attached to ALL matching components.
+- **VR-076-006**: Per-component identifier emission MUST preserve existing per-component property/externalRef ordering and append new entries at the end, in lexical order by `(scheme, value)` per research §6. No churn for components that don't match any `--component-id` selector.
+
+## Relationships
+
+```text
+mikebom sbom scan / mikebom trace run
+    │
+    ├── --subject-hash <algo>:<hex> (repeatable) ──┐
+    │                                              ├── ScanArgs/RunArgs
+    └── --component-id PURL=scheme:value (rep.) ──┘     │
+                                                         ▼
+                                  ┌──────────────────────────────┐
+                                  │ ScanArtifacts                │
+                                  │   .identifiers (incl.        │
+                                  │    --subject-hash + auto-    │
+                                  │    detected subject:)        │
+                                  │   .component_identifiers     │
+                                  └────────────┬─────────────────┘
+                                               │
+                                               ▼
+                              Per-format emitters
+                                ├── CDX        → metadata.component.externalReferences[type:attestation]
+                                │                + components[].properties[name=scheme,value=value]
+                                ├── SPDX 2.3   → Package.externalRefs[PERSISTENT-ID]
+                                │                (both subject: and per-component user-defined)
+                                └── SPDX 3     → Element.externalIdentifier[type=scheme,identifier=value]
+                                                 (both subject: and per-component user-defined)
+
+                              External SBOM-store consumer
+                                ├── reads image SBOM components[].hashes[].sha256 == X
+                                ├── searches store for SBOM with subject:sha256:X identifier
+                                ├── correlates ✓
+                                └── walks build SBOM's git: → matching source SBOM
+```
+
+## Backward compatibility
+
+- No new `Cargo.toml` deps; no MSRV change; no nightly required.
+- `BuiltinScheme` enum gains a new variant; existing `match` exhaustiveness in mikebom-cli is updated as part of this milestone (compile-time check).
+- `ScanArtifacts` gains a new field with `default = vec![]`; existing struct-update-syntax callers continue to compile via `..Default::default()`.
+- Existing milestone-073/074/075 byte-identity goldens stay byte-identical: no fixtures pass `--subject-hash` or `--component-id`, and the build-tier auto-detect is gated on having a non-empty subject set (which existing test fixtures don't have, since they're source-tier scans).
+- The CDX `externalReferences[type=attestation]` carrier reuse is additive — milestone 073's `attestation:` IRI emissions are unchanged. Multi-entry arrays (one for IRI, one for subject hash) are valid CDX 1.6 per spec.
+- New CLI flags (`--subject-hash`, `--component-id`) are opt-in; operators not passing them see no behavior change.

--- a/specs/076-subject-component-ids/plan.md
+++ b/specs/076-subject-component-ids/plan.md
@@ -1,0 +1,187 @@
+# Implementation Plan: Subject identifier scheme + per-component user-defined identifiers
+
+**Branch**: `076-subject-component-ids` | **Date**: 2026-05-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/076-subject-component-ids/spec.md`
+
+## Summary
+
+Closes the cross-tier content-addressable correlation chain that milestones 072–075 began. Two deliverables in one milestone, both small additive changes on top of milestone 073's identifier substrate:
+
+1. **Document-level `subject:` identifier scheme.** Adds `subject:<algo>:<hex>` as a fifth `BuiltinScheme` variant (alongside `Repo`, `Git`, `Image`, `Attestation`). Build-tier auto-detects from the in-toto attestation envelope's already-captured subject set. Source-tier and image-tier accept manual `--subject-hash` flags. The cross-tier handshake becomes automatic when the build's `subject:sha256:X` matches the image scan's `image:` digest portion — pure string match by external tools.
+
+2. **Per-component user-defined identifiers.** Adds a new `--component-id <PURL>=<scheme>:<value>` repeatable flag that attaches operator-supplied identifiers to specific components. Identifiers ride standards-native per-component carriers (CDX `components[].properties[]`, SPDX 2.3 `Package.externalRefs[PERSISTENT-ID]`, SPDX 3 `Element.externalIdentifier[]`) — Constitution Principle V audit confirms zero new `mikebom:*` annotations. Built-in scheme names rejected at CLI parse time on `--component-id` (reserved for future native-field usage).
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–075; no nightly).
+**Primary Dependencies**: Existing only — `serde`/`serde_json`, `tracing`, `anyhow`, `clap` (the two new flags via derive), `thiserror`. The build-tier subject extraction reuses the in-toto witness-v0.1 subject set the existing trace pipeline already collects in-process; no new subprocess calls, no new I/O, no new crates. **No additions to the dependency tree at the lockfile level.**
+**Storage**: N/A — identifier emission is a pure metadata transform; no caches, no persistence.
+**Testing**: `cargo +stable test --workspace`. New integration tests in `mikebom-cli/tests/identifiers_subject_and_component.rs` exercise the document-level `subject:` emission across all three formats and the per-component user-defined identifier emission across all three formats.
+**Target Platform**: Linux (CI primary), macOS (developer workstations). Logic is OS-agnostic; depends only on existing in-process attestation subject set and string manipulation.
+**Project Type**: CLI tool — single workspace, three crates (`mikebom-cli` is the only one touched).
+**Performance Goals**: Subject identifier emission adds <1ms per build-tier scan (one in-process subject-set read, one identifier-construction loop). Per-component identifier matching adds <5ms even for thousand-component SBOMs (linear scan against a hash-set of supplied PURLs).
+**Constraints**: Determinism per FR-012 (same input → byte-identical output, including identifier order). Soft-fail per FR-005 (validation failure routes to milestone 073's `UserDefined` path). No regression on existing milestone-073/074/075 byte-identity goldens per FR-013/SC-005.
+**Scale/Scope**: One new `BuiltinScheme::Subject` variant + value validator (~50 LOC); one helper to extract subjects from in-toto state (~40 LOC); two new CLI flags on `ScanArgs` and `RunArgs` (~20 LOC each); per-component identifier emission in 3 format emitters (~50 LOC each); one new integration-test file (~400 LOC, ~14 tests across 4 user stories); one docs update.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution v1.4.0 (last amended 2026-05-01). All 12 principles + 4 strict boundaries:
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| I. Pure Rust, Zero C | ✅ Pass | Pure-Rust extension of existing pure-Rust types. |
+| II. eBPF-Only Observation | ✅ Pass / N/A | This milestone touches identifier metadata, not dependency discovery. The eBPF trace is unchanged; the in-toto subject set is consumed at SBOM-emit time, not as a discovery source. |
+| III. Fail Closed | ✅ Pass | Soft-fail per FR-005 routes through milestone 073's `UserDefined` rule for malformed values. The trace + scan pipeline that produces the SBOM continues to fail closed exactly as before. |
+| IV. Type-Driven Correctness | ✅ Pass | Reuses existing `Identifier`, `SchemeName`, `IdentifierValue`, `BuiltinScheme`, `IdentifierKind` newtypes from milestone 073. New `BuiltinScheme::Subject` variant, new `validate_subject` validator following the existing pattern. Production code uses `anyhow::Result`/`IdentifierError`. Tests guard `#[cfg_attr(test, allow(clippy::unwrap_used))]` per the established convention. No new raw `String` boundary crossings. |
+| V. Specification Compliance | ✅ Pass | **Native-first audit (constitution v1.4.0 5th bullet):** Both deliverables ride standards-native carriers. Document-level `subject:` rides CDX `metadata.component.externalReferences[]` (Phase 0 research §1 pins which existing CDX 1.6 enum value), SPDX 2.3 `Package.externalRefs[].referenceCategory = PERSISTENT-ID`, SPDX 3 `Element.externalIdentifier[]` — same per-document carrier set milestone 073 established. Per-component user-defined identifiers ride CDX `components[].properties[]`, SPDX 2.3 `Package.externalRefs[PERSISTENT-ID]`, SPDX 3 `Element.externalIdentifier[]` — all existing standards-native fields per format (Phase 0 research §2 confirms). **Zero new `mikebom:*` annotations introduced.** |
+| VI. Three-Crate Architecture | ✅ Pass | All changes inside `mikebom-cli`. No new crates. |
+| VII. Test Isolation | ✅ Pass | Identifier emission and validation are pure user-space logic; tests need no privilege. New integration tests use the same tempdir-based fixture pattern from milestones 073/074/075. |
+| VIII. Completeness | ✅ Pass / N/A | Doesn't affect dependency discovery. |
+| IX. Accuracy | ✅ Pass | The 073 soft-fail-to-`UserDefined` rule applies (FR-005): malformed `subject:` values downgrade to user-defined classification rather than producing a falsely-`Builtin` emission. Per-component identifiers are user-defined-only (no built-in classification possible at the per-component layer in this milestone). |
+| X. Transparency | ✅ Pass | Both deliverables fire audibly: `subject:` auto-detect emits one info-level log per detected subject (and one info-level log per skipped non-sha256 subject, per the 2026-05-06 clarification); `--component-id` selectors that match zero components log `tracing::warn!` per FR-010. The auto-detected `subject:` `source_label` documents the origin per milestone 073 conventions. |
+| XI. Enrichment | ✅ Pass / N/A | Not enrichment. |
+| XII. External Data Source Enrichment | ✅ Pass / N/A | The in-toto attestation subject set is in-process state from the trace pipeline, not an external data source. |
+
+| Strict Boundary | Status |
+|-----------------|--------|
+| 1. No lockfile-based dependency discovery | ✅ Pass |
+| 2. No MITM proxy | ✅ Pass |
+| 3. No C code | ✅ Pass |
+| 4. No `.unwrap()` in production | ✅ Pass — extending production code that already complies; tests use the standard `#[cfg_attr(test, allow(clippy::unwrap_used))]` guard |
+
+**Gate result: PASS.** No violations; no Complexity Tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/076-subject-component-ids/
+├── plan.md                         # This file
+├── spec.md                         # /speckit.specify output (with /speckit.clarify integration)
+├── research.md                     # Phase 0 output
+├── data-model.md                   # Phase 1 output
+├── quickstart.md                   # Phase 1 output
+├── contracts/
+│   ├── subject-identifier.md       # Phase 1 — document-level `subject:` contract
+│   └── per-component-id.md         # Phase 1 — per-component identifier contract
+├── checklists/
+│   └── requirements.md             # Already passing
+└── tasks.md                        # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+The milestone touches the identifier module + 3 format emitters + 2 CLI entry points. No new modules, no new crates (one tiny new submodule `component_id.rs` for the flag-value parser).
+
+```text
+mikebom-cli/
+├── src/
+│   ├── binding/
+│   │   └── identifiers/
+│   │       ├── mod.rs                          # MODIFY — add `BuiltinScheme::Subject`
+│   │       │                                   # variant; extend cdx/spdx
+│   │       │                                   # type-mapping methods.
+│   │       ├── validators.rs                   # MODIFY — add `validate_subject`
+│   │       │                                   # for `<algo>:<hex>` form.
+│   │       ├── auto_detect.rs                  # MODIFY — add new helper
+│   │       │                                   # `subject_identifiers_from_
+│   │       │                                   # attestation_subjects(...)`
+│   │       │                                   # called by build-tier flow.
+│   │       └── component_id.rs                 # NEW — types + parser for
+│   │                                           # --component-id flag values
+│   │                                           # (PURL=scheme:value).
+│   ├── cli/
+│   │   ├── scan_cmd.rs                         # MODIFY — add --subject-hash
+│   │   │                                       # and --component-id flags to
+│   │   │                                       # ScanArgs; thread through to
+│   │   │                                       # ScanArtifacts.
+│   │   └── run.rs                              # MODIFY — same flags on
+│   │                                           # RunArgs + wire build-tier
+│   │                                           # subject auto-detect from the
+│   │                                           # trace's collected subjects.
+│   ├── generate/
+│   │   ├── mod.rs                              # MODIFY — ScanArtifacts gains
+│   │   │                                       # `component_identifiers:
+│   │   │                                       # Vec<ComponentIdentifierFlag>`
+│   │   │                                       # field threaded to emitters.
+│   │   ├── cyclonedx/
+│   │   │   ├── metadata.rs                     # MODIFY — emit `subject:`
+│   │   │   │                                   # under externalReferences.
+│   │   │   └── components.rs (or equiv.)       # MODIFY — emit per-component
+│   │   │                                       # identifiers under properties[].
+│   │   └── spdx/
+│   │       ├── packages.rs                     # MODIFY — emit `subject:` and
+│   │       │                                   # per-component user-defined
+│   │       │                                   # identifiers under
+│   │       │                                   # externalRefs[PERSISTENT-ID].
+│   │       └── v3_*.rs                         # MODIFY — emit both via
+│   │                                           # Element.externalIdentifier[].
+│   └── parity/
+│       └── extractors/                          # MODIFY — new catalog row(s)
+│                                                # for subject: and per-component
+│                                                # identifier extraction. Per-tier
+│                                                # symmetric carrier mapping.
+└── tests/
+    └── identifiers_subject_and_component.rs     # NEW — integration tests for
+                                                  # SC-001..SC-009.
+
+docs/reference/identifiers.md                    # MODIFY — document new
+                                                  # scheme + new flag.
+```
+
+**Structure Decision**: Single project. Extends `mikebom-cli` with one new tiny module (`component_id.rs` for the flag-value parser). Smallest-possible-surface-change consistent with milestones 074/075.
+
+## Phase 0 — Research questions
+
+Six implementation-level decisions to pin in `research.md` before Phase 1 design.
+
+1. **CDX 1.6 `externalReferences[].type` enum value for document-level `subject:`** — pick the existing enum value that best fits "binary subject hash" semantics. Candidates: `attestation` (reuse 073's attestation: scheme's type), `formulation` (build-output semantic), `evidence`, `other` (semantic-poor fallback). Decide based on (a) downstream tool compatibility, (b) Principle V native-fit, (c) symmetry with milestone 073's existing mappings.
+2. **CDX 1.6 carrier choice for per-component user-defined identifiers** — `components[].properties[]` (key-value) vs `components[].externalReferences[]` (URI-shaped). The CDX spec describes `properties[]` as "name-value store … flexibility to include data not officially supported in the standard" — a clean fit for arbitrary `(scheme, value)` pairs. `externalReferences[]` is described as "external references … not included with the BOM" — semantically about external systems/sites, not arbitrary identifiers. Decide and justify.
+3. **In-toto subject extraction site** — where in `mikebom trace run`'s flow does the SBOM-emit code read the collected subject set? Currently the subject set is captured by the attestation-builder at trace-completion time. Identify the exact in-process state object and confirm it's accessible at the point where `auto_detect_build_tier_identifiers` runs (or wherever the new `subject_identifiers_from_attestation_subjects` helper plugs in).
+4. **`subject:` value validation regex** — exact form `^(sha256|sha512):[0-9a-f]+$` plus length checks (64 chars hex for sha256, 128 chars hex for sha512). Pin the validator's behavior on uppercase hex (reject — RFC 6234 canonical hex is lowercase), on whitespace (reject), on missing algo prefix (reject), on prefix-only-no-hex (reject). Soft-fail-to-`UserDefined` per FR-005.
+5. **Per-component identifier matching algorithm** — for `--component-id "PURL=scheme:value"`, exact-PURL-match against `components[].purl`. Decide what "exact" means: byte-equality of the canonical PURL string, or PURL-spec-aware semantic equality (e.g., URL-encoding tolerance)? Recommend byte-equality for determinism + simplicity.
+6. **Determinism contract for multi-component matches** — when one `--component-id` selector matches N components (different `bom-ref` values, same PURL), all N receive the identifier (FR-011). Pin the per-component emission ordering: same as the surrounding `components[]` array order, with the per-component identifier appearing at the end of the existing `properties[]` (or equivalent) array, in lexical order by `(scheme, value)` for stable serialization.
+
+## Phase 1 — Design & contracts
+
+### data-model.md
+
+Two new entities:
+- `SubjectIdentifier`: a document-level `Identifier` with scheme `subject:` and value `<algo>:<hex>`. Composes `Identifier` + `SchemeName` + `IdentifierValue` + `IdentifierKind` (existing 073 types). Multiple SubjectIdentifiers may attach to one SBOM (multi-output builds).
+- `ComponentIdentifierFlag`: an operator-supplied per-component identifier from `--component-id PURL=scheme:value`. Composed of: `selector_purl: String`, `scheme: SchemeName`, `value: IdentifierValue`. Materialized as a `Vec<ComponentIdentifierFlag>` on `ScanArtifacts` / `TraceArtifacts`, consumed by per-format emitters.
+
+Plus one extension to existing `BuiltinScheme` enum (new `Subject` variant) and one extension to `ScanArtifacts` (new field `component_identifiers: Vec<ComponentIdentifierFlag>`).
+
+Validation rules VR-076-001..006 captured per the FR list.
+
+### contracts/
+
+Two contracts:
+- `subject-identifier.md` — public API for the new `BuiltinScheme::Subject`, the value validator, the `subject_identifiers_from_attestation_subjects` helper, and the per-format wire mapping (CDX externalReferences type per Phase 0 research §1; SPDX 2.3 PERSISTENT-ID; SPDX 3 externalIdentifier).
+- `per-component-id.md` — public CLI contract for `--component-id`, the parser shape, the matching algorithm, the per-format wire mapping (CDX properties[]; SPDX 2.3 externalRefs[PERSISTENT-ID]; SPDX 3 externalIdentifier[]). Contract specifies that built-in scheme names are rejected at parse time.
+
+### quickstart.md
+
+Operator-facing recipes:
+1. **Build-tier subject auto-detect** — the headline (no flags needed; `mikebom trace run` produces a build SBOM with `subject:` for each artifact).
+2. **Cross-tier digest handshake** — the SC-002 walkthrough: image SBOM's component hash matches build SBOM's `subject:` value, external tool correlates by string match.
+3. **Manual `--subject-hash`** — for source-tier or for opting into non-sha256 subjects.
+4. **Per-component identifier attachment** — operator pipes `--component-id` flags to mark internal asset IDs.
+5. **Reading per-component identifiers in each format** — CDX `properties[]`, SPDX 2.3 `externalRefs[PERSISTENT-ID]`, SPDX 3 `externalIdentifier[]`.
+
+### Agent context update
+
+Run `.specify/scripts/bash/update-agent-context.sh claude` after Phase 1 docs land.
+
+## Phase 2 — Out of scope for this command
+
+`/speckit.plan` ends here. `/speckit.tasks` consumes plan.md + spec.md + Phase 1 docs and emits `tasks.md`. Estimated task count: ~18-20 (larger than 074/075 because per-component identifier emission flows through 3 format emitters; smaller than 073 because no new module + no new flag for users on the document-level path beyond `--subject-hash`).
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified.**
+
+Not applicable — Constitution Check passes on all 12 principles + 4 strict boundaries with zero violations.

--- a/specs/076-subject-component-ids/quickstart.md
+++ b/specs/076-subject-component-ids/quickstart.md
@@ -1,0 +1,211 @@
+# Quickstart — milestone 076 subject identifier + per-component identifiers
+
+Five operator-facing recipes covering the milestone's two deliverables: document-level `subject:` identifiers and per-component user-defined identifiers.
+
+## Recipe 1 — Build-tier `subject:` auto-detect
+
+The headline. No flags needed beyond a normal `mikebom trace run` invocation.
+
+```bash
+mikebom trace run --signing-key ./signing.key \
+    --sbom-output build.cdx.json \
+    --attestation-output build.attestation.dsse.json \
+    -- cargo install ripgrep
+# INFO build-tier auto-detected `subject:sha256:abc1234567890...` from in-toto subject `ripgrep`
+```
+
+Inspect the build SBOM:
+
+```bash
+jq '.metadata.component.externalReferences[] | select(.type == "attestation")' build.cdx.json
+# [
+#   {
+#     "type": "attestation",
+#     "url": "sha256:abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+#     "comment": "auto-detected from build-tier in-toto subject `ripgrep`"
+#   }
+# ]
+```
+
+The build SBOM body now carries the build-output hash as a first-class `subject:` identifier. External tools can read it without unwrapping the `.attestation.dsse.json` envelope.
+
+For multi-output builds (e.g., `make all`), multiple entries appear:
+
+```bash
+jq '.metadata.component.externalReferences[] | select(.type == "attestation") | .url' build.cdx.json
+# "sha256:abc1234567890..."
+# "sha256:def5678901234..."
+# "sha256:fed9876543210..."
+```
+
+## Recipe 2 — Cross-tier digest handshake
+
+The end-to-end correlation flow milestone 076 enables. Build a binary, scan the resulting image, then walk the chain by string match alone.
+
+```bash
+# Step 1: Source-tier scan
+cd ~/projects/my-app
+mikebom sbom scan --path . --output source.cdx.json
+# (auto-detects repo:git@github.com:acme/my-app.git from milestone 073)
+
+# Step 2: Build-tier scan
+mikebom trace run --signing-key ./key.pem \
+    --sbom-output build.cdx.json \
+    --attestation-output build.attestation.dsse.json \
+    -- docker build -t my-app:v1 .
+# (auto-detects repo:, git:, AND subject:sha256:<image-digest>)
+
+# Step 3: Image-tier scan
+mikebom sbom scan --image my-app:v1 --output image.cdx.json
+# (auto-detects image:my-app:v1@sha256:<image-digest>)
+```
+
+Now correlate without invoking mikebom:
+
+```bash
+# Extract the build's subject hashes
+build_subjects=$(jq -r '.metadata.component.externalReferences[]
+                          | select(.type == "attestation")
+                          | select(.url | startswith("sha256:"))
+                          | .url' build.cdx.json)
+
+# Extract the image's identifier digest
+image_digest_full=$(jq -r '.metadata.component.externalReferences[]
+                              | select(.type == "distribution")
+                              | .url' image.cdx.json)
+# my-app:v1@sha256:abc1234567890...
+
+# The handshake: build subject's hex equals image digest's hex
+echo "Build subjects: $build_subjects"
+echo "Image: $image_digest_full"
+# → match by string: "sha256:abc1234..." appears in both
+```
+
+External SBOM-store tools can do this lookup automatically. The chain `image → build → source` is recoverable by walking identifiers across SBOMs in the store, no mikebom-side coordination required.
+
+## Recipe 3 — Manual `--subject-hash` (source-tier or override)
+
+For source-tier scans that have an externally-known content hash, or for non-sha256 digests, pass the value manually.
+
+```bash
+mikebom sbom scan --path . \
+    --subject-hash sha256:abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab \
+    --output source.cdx.json
+```
+
+Inspect:
+
+```bash
+jq '.metadata.component.externalReferences[] | select(.type == "attestation")' source.cdx.json
+# [
+#   {
+#     "type": "attestation",
+#     "url": "sha256:abc1234567890...",
+#     "comment": "manual --subject-hash"
+#   }
+# ]
+```
+
+For non-sha256 algos (the auto-detect path skips these per the 2026-05-06 clarification):
+
+```bash
+mikebom trace run \
+    --subject-hash sha512:def5678901234abc... \
+    -- ./build.sh
+# (manual sha512 entry rides through; auto-detect of any sha256 entries on the same subject still fires)
+```
+
+## Recipe 4 — Per-component user-defined identifiers
+
+Attach internal asset IDs to specific components.
+
+```bash
+mikebom sbom scan --path . \
+    --component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-shared-lib-v2" \
+    --component-id "pkg:cargo/myapp@0.5.1=acme-asset:myapp-prod-001" \
+    --output out.cdx.json
+```
+
+The matching components carry the user-defined identifiers in standards-native CDX `properties[]`:
+
+```bash
+jq '.components[] | select(.purl == "pkg:cargo/serde@1.0.0") | .properties' out.cdx.json
+# [
+#   {"name": "kusari-id", "value": "asset-shared-lib-v2"}
+# ]
+```
+
+Multiple identifiers per component:
+
+```bash
+mikebom sbom scan --path . \
+    --component-id "pkg:cargo/foo@1.0.0=kusari-id:asset-foo" \
+    --component-id "pkg:cargo/foo@1.0.0=internal-ticket:PROJ-456" \
+    --output out.cdx.json
+
+jq '.components[] | select(.purl == "pkg:cargo/foo@1.0.0") | .properties' out.cdx.json
+# [
+#   {"name": "internal-ticket", "value": "PROJ-456"},
+#   {"name": "kusari-id", "value": "asset-foo"}
+# ]
+# (lexical order by (scheme, value) per research §6)
+```
+
+If a selector matches zero components:
+
+```bash
+mikebom sbom scan --path . \
+    --component-id "pkg:cargo/nonexistent@0.0.0=asset:foo"
+# WARN --component-id selector `pkg:cargo/nonexistent@0.0.0` matched zero components; identifier `asset:foo` not attached
+```
+
+The scan still exits 0; the SBOM is emitted without the unmatched identifier.
+
+## Recipe 5 — Reading per-component identifiers in each format
+
+Per-component user-defined identifiers ride native fields per format. Operators / external tools read them like this:
+
+### CDX 1.6
+
+```bash
+jq '.components[]
+      | {purl, identifiers: [
+          .properties[]?
+          | select(.name | test("^[a-z][a-z0-9_-]*$"))
+          | {scheme: .name, value: .value}
+        ]}' out.cdx.json
+# {
+#   "purl": "pkg:cargo/serde@1.0.0",
+#   "identifiers": [{"scheme": "kusari-id", "value": "asset-shared-lib-v2"}]
+# }
+```
+
+### SPDX 2.3
+
+```bash
+jq '.packages[]
+      | {name, identifiers: [
+          .externalRefs[]?
+          | select(.referenceCategory == "PERSISTENT-ID")
+          | select(.referenceType != "purl")
+          | {scheme: .referenceType, value: .referenceLocator}
+        ]}' out.spdx.json
+# {
+#   "name": "serde",
+#   "identifiers": [{"scheme": "kusari-id", "value": "asset-shared-lib-v2"}]
+# }
+```
+
+### SPDX 3
+
+```bash
+jq '.elements[]
+      | select(.type == "software_Package")
+      | {name, identifiers: [
+          .externalIdentifier[]?
+          | select(.type != "purl")
+          | {scheme: .type, value: .identifier}
+        ]}' out.spdx3.json
+```
+
+All three formats expose the identifiers via existing standards-native fields. No mikebom-specific decoders required.

--- a/specs/076-subject-component-ids/research.md
+++ b/specs/076-subject-component-ids/research.md
@@ -1,0 +1,171 @@
+# Research — milestone 076 subject identifier + per-component identifiers
+
+Six implementation-level decisions to pin before Phase 1 design.
+
+## §1 — CDX 1.6 `externalReferences[].type` enum value for document-level `subject:`
+
+**Decision**: Use `attestation`. Same enum value milestone 073 already uses for the `attestation:` scheme (the IRI form). External tools disambiguate by inspecting the URL value: an IRI shape (`https://...`) means an attestation reference; a `<algo>:<hex>` shape means a subject hash.
+
+**Rationale**: Three reasons stack:
+1. **Supply-chain mental model fit.** A subject hash IS what an attestation cryptographically commits to. Calling it `attestation` in the externalReferences type tells consumers "this is part of the supply-chain attestation story" without inventing a new enum value.
+2. **No new mikebom-specific subtype hint needed.** Operators reading the SBOM will see `attestation`-typed entries and recognize them as supply-chain-related; the value form (IRI vs digest) is the per-entry disambiguator.
+3. **Consistency with 073's existing precedent.** `attestation:` IRIs already ride `attestation`; extending the same type to subject hashes preserves the symmetric mapping that the project's verification harness expects.
+
+The downside — that consumers naively expecting an IRI in every `attestation`-typed entry will see a digest string instead — is the smaller cost compared to inventing a new enum value (which would force every consumer to be updated to recognize the new value) or using `other` (which throws away the supply-chain semantic hint entirely).
+
+**Alternatives considered**:
+- `formulation` — semantically about how a component is *built*, which is adjacent but not identical to "this IS the build output." Subjects are outputs, not formulation descriptions.
+- `evidence` — too generic; loses the supply-chain-attestation hint.
+- `other` — semantic-poor fallback. Forces every consumer to read the comment field to interpret the entry. Loses interop value.
+- New CDX enum value — would require a CDX spec PR with cross-vendor consensus before mikebom could use it. Out of scope for this milestone.
+
+**Wire shape consequence**: a build-tier SBOM with one auto-detected subject emits:
+```json
+{
+  "type": "attestation",
+  "url": "sha256:abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+  "comment": "auto-detected from build-tier in-toto subject `myapp`"
+}
+```
+
+Co-existing with the milestone 073 attestation: IRI form when both are present:
+```json
+[
+  {
+    "type": "attestation",
+    "url": "https://example.com/myapp-build-001",
+    "comment": "manual --attestation"
+  },
+  {
+    "type": "attestation",
+    "url": "sha256:abc1234567890...",
+    "comment": "auto-detected from build-tier in-toto subject `myapp`"
+  }
+]
+```
+
+## §2 — CDX 1.6 carrier choice for per-component user-defined identifiers
+
+**Decision**: `components[].properties[]` with `name = "<scheme>"` and `value = "<value>"`.
+
+**Rationale**: The CDX 1.6 spec describes `properties` as *"a name-value store … flexibility to include data not officially supported in the standard without having to use additional namespaces"*. That is the literal use case: arbitrary user-defined `(scheme, value)` pairs whose semantics aren't in the CDX type taxonomy. By contrast, `externalReferences[]` is described as *"external references … to systems, sites, and information"* — semantically about pointing OUT to other systems, not about arbitrary local identifiers attached to the component in question.
+
+For Constitution Principle V's native-precedence rule:
+- `properties[]` is a native CDX field that exactly matches the semantic ("arbitrary key-value identifier scoped to this component"). Native fit: high.
+- `externalReferences[]` would force fitting into a URL/URI-shaped slot (the `url` field is required). Native fit: poor, requires shoe-horning.
+
+Per-component user-defined identifiers fit `properties[]` naturally. Use it.
+
+**Wire shape consequence**: a `--component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-shared-lib-v2"` flag produces, on the matching component:
+```json
+{
+  "type": "library",
+  "name": "serde",
+  "version": "1.0.0",
+  "purl": "pkg:cargo/serde@1.0.0",
+  "properties": [
+    {"name": "kusari-id", "value": "asset-shared-lib-v2"}
+  ]
+}
+```
+
+If the operator passes multiple `--component-id` flags matching the same component, each becomes a separate `properties[]` entry, in lexical order by `(name, value)` for stable serialization.
+
+**Symmetric per-format mapping**:
+| Format | Carrier |
+|--------|---------|
+| CDX 1.6 | `components[].properties[]` with `name=<scheme>`, `value=<value>` |
+| SPDX 2.3 | `Package.externalRefs[]` with `referenceCategory=PERSISTENT-ID`, `referenceType=<scheme>`, `referenceLocator=<value>` |
+| SPDX 3 | `Element.externalIdentifier[]` with `type=<scheme>`, `identifier=<value>` |
+
+All three are existing native fields per format. Zero new mikebom:* annotations introduced. Constitution Principle V audit passes.
+
+**Alternatives considered**:
+- `components[].externalReferences[]` with `type=other`, `url=<scheme>:<value>`, `comment=...` — Rejected: forces non-URI values into a URI-shaped slot; CDX validators may flag non-URI `url` values. The `other` type is also semantic-poor for what is conceptually an identifier, not an external reference.
+- New `mikebom:component-identifiers` annotation — Rejected: violates Principle V's native-precedence requirement. Native fields exist for all three formats; use them.
+- Mixed: `properties[]` for CDX, `externalRefs[PERSISTENT-ID]` for SPDX — Accepted (this is what the recommended decision encodes). The per-format symmetry isn't perfect (CDX's `properties[]` is structurally different from SPDX's `externalRefs[PERSISTENT-ID]`) but each format uses its idiomatic native field for the semantic.
+
+## §3 — In-toto subject extraction site
+
+**Decision**: Read the subject set at the same point in `mikebom trace run` where the attestation envelope is being assembled — specifically at `cli/run.rs` after `super::scan::execute(scan_args).await?` completes (i.e., after the trace + scan flow has populated the in-process subject collection). The new helper `subject_identifiers_from_attestation_subjects(...)` takes the subject set as input and produces `Vec<Identifier>` for the build-tier identifier vec.
+
+**Rationale**: The trace pipeline already produces a `Vec<Subject>` (or equivalent in-process collection) as part of the witness-v0.1 attestation builder before signing/serializing the envelope. Reading from this collection at SBOM-emit time is a single in-process state transfer; no re-computation, no I/O, no subprocess.
+
+The trace-completion-time read site is the right one because:
+- Subjects are deterministically known once the trace is complete (no race with running build).
+- The collected subject set is already deduplicated and lexically ordered per witness-v0.1 conventions; we don't need to re-sort.
+- The SBOM emission pipeline runs after this point, so the build-tier identifier vec can absorb subjects before any per-format emission begins.
+
+**Implementation note**: The exact field name on the trace-completion in-process state is TBD until implementation; the agent driving T002+ will identify the right field by reading `cli/scan.rs` and `cli/run.rs`. The contract between the helper and its caller is `fn subject_identifiers_from_attestation_subjects(subjects: &[Subject]) -> Vec<Identifier>` regardless of where the input slice is sourced from.
+
+**Alternatives considered**:
+- Re-parse the witness-v0.1 attestation JSON after it's serialized — Rejected: round-trips through JSON, slower, lossy if the witness-v0.1 format ever changes.
+- Hook into the eBPF event stream directly — Rejected: out of scope; the attestation builder is the canonical post-trace state.
+- Have the operator pass `--subject-hash` manually for build-tier too — Rejected: defeats the purpose of auto-detection (one of the milestone's headline values).
+
+## §4 — `subject:` value validation regex
+
+**Decision**: `validate_subject` accepts inputs matching `^(sha256:[0-9a-f]{64}|sha512:[0-9a-f]{128})$` exactly. Anything else fails validation and triggers the FR-005 soft-fail-to-`UserDefined` path.
+
+Specific rejection rules:
+- Uppercase hex (`SHA256:ABCD...`) — Reject. RFC 6234 canonical encoding is lowercase; mikebom enforces lowercase for determinism + downstream tool compatibility.
+- Mixed-case hex — Reject (same reason).
+- Whitespace anywhere — Reject.
+- Other algo prefixes (`sha1:`, `blake2b:`, `md5:`, etc.) — Reject; explicitly out of scope per spec assumptions. Future milestone can extend the regex.
+- Missing algo prefix (bare hex) — Reject; the value must be self-describing.
+- Algo prefix without colon-hex tail — Reject.
+- Wrong-length hex (e.g., sha256 algo with 63 hex chars) — Reject.
+
+**Rationale**: A strict, deterministic validator is the right shape for an identifier scheme that downstream tools are expected to string-match against. Loose acceptance (e.g., case-insensitive) creates ambiguity about canonical form and breaks correlation. The two algos covered (sha256, sha512) are the only ones the witness-v0.1 attestation framework canonically emits.
+
+The soft-fail-to-`UserDefined` path means malformed values still ride through the SBOM (under `mikebom:identifiers`-equivalent emission), so operators don't lose data — they just lose the `Builtin` classification + the per-format native carrier.
+
+**Alternatives considered**:
+- Case-insensitive hex acceptance (normalize to lowercase before storing) — Rejected: hides operator errors; an operator who typed uppercase may have intended uppercase for a reason. Strict-reject + soft-fail surfaces the issue while preserving the data.
+- Accept any algo prefix that matches `[a-z0-9]+` — Rejected: lets typos pass (`shaa256:...` would be accepted as user-defined). Closed enum is safer.
+- Algo whitelist via runtime config — Rejected: complexity for no concrete user benefit.
+
+## §5 — Per-component identifier matching algorithm
+
+**Decision**: Byte-equality match against the emitted `components[].purl` field. The operator's `--component-id` selector (the LHS of `=`) must be byte-identical to a component's emitted PURL string for the match to fire.
+
+**Rationale**:
+- **Determinism**: byte-equality is unambiguous. PURL-spec-aware semantic equality (e.g., URL-encoding tolerance, version-range matching, type-namespace canonicalization) introduces edge cases and varies by PURL spec version. Byte-equality side-steps these.
+- **Operator predictability**: the operator can run a scan first (`mikebom sbom scan --path . --output preview.cdx.json`), `jq -r '.components[].purl'` to see the exact PURLs mikebom emits, and copy those into `--component-id` selectors. Round-trip works trivially.
+- **MVP scope**: spec assumptions explicitly call out exact-PURL-match as the MVP; glob/wildcard is future work.
+
+**Edge case handling**:
+- PURL with URL-encoded characters: the operator must supply the URL-encoded form that mikebom emits. If mikebom's PURL emission has any non-canonical encoding, the operator's selector must match the non-canonical form. This is fine — byte-equality.
+- Multiple components share the same PURL (different `bom-ref` values): all matching components receive the identifier per FR-011.
+- Selector matches zero components: warn + continue per FR-010.
+
+**Alternatives considered**:
+- PURL-spec semantic equality — Rejected: see Determinism + Operator predictability above. Plus, the `packageurl` crate's normalization rules differ across versions; byte-equality is version-independent.
+- `bom-ref`-based selection — Rejected for MVP: bom-refs are derived (not operator-typed) and require running a scan before the operator can supply selectors. PURL is the more user-facing identifier.
+- Glob/wildcard PURL matching — Rejected for MVP: scope cut.
+
+## §6 — Determinism contract for multi-component matches
+
+**Decision**: When one `--component-id` selector matches N components, all N receive the identifier in their respective `properties[]` (or per-format equivalent) array. Per-component, the new identifier entries are appended at the end of the existing `properties[]` array, in lexical order by `(name, value)` against any other identifier entries this milestone emits to the same component.
+
+Pre-existing `properties[]` entries on the component (e.g., `mikebom:not-linked` from milestone 049, `mikebom:shade-relocation` from milestone 009) are preserved unchanged; the new entries appear after them.
+
+**Rationale**:
+- **Stable serialization**: lexical ordering of new entries gives byte-identical output across re-runs for fixed input.
+- **No churn for existing properties**: appending to the existing array preserves byte-identity for components with no `--component-id` flags. Existing 073/074/075 goldens stay byte-identical because no `--component-id` is passed in those fixtures.
+- **Multi-component fan-out**: when a single selector matches 5 components, each of the 5 components independently gets the identifier in its own `properties[]` — there's no "shared" entry. The 5 emissions are independent, each lexically sorted within its own component.
+
+**Wire-shape implications**:
+- A component with one pre-existing property `mikebom:not-linked=true` plus two new `--component-id` entries `kusari-id:asset-foo` and `acme-asset:bar-prod-001` ends up with:
+  ```json
+  "properties": [
+    {"name": "mikebom:not-linked", "value": "true"},          // pre-existing, position preserved
+    {"name": "acme-asset", "value": "bar-prod-001"},          // new, lexically first of new entries
+    {"name": "kusari-id", "value": "asset-foo"}               // new, lexically second
+  ]
+  ```
+
+**Alternatives considered**:
+- Sort the entire `properties[]` array (including pre-existing entries) lexically — Rejected: would churn existing goldens that have stable `properties[]` ordering encoded today.
+- Insert new entries at array start — Rejected: same churn problem, plus arbitrary placement.
+- Per-component identifiers in a separate `mikebom:component-identifiers` array — Rejected: violates Principle V (would be a new `mikebom:*` annotation when the native field works fine).

--- a/specs/076-subject-component-ids/spec.md
+++ b/specs/076-subject-component-ids/spec.md
@@ -1,0 +1,174 @@
+# Feature Specification: Subject identifier scheme + per-component user-defined identifiers
+
+**Feature Branch**: `076-subject-component-ids`
+**Created**: 2026-05-06
+**Status**: Draft
+**Input**: User description: "Add `subject:` as a fifth built-in identifier scheme so build SBOMs can declare their build-output hash as a first-class identifier in the SBOM body (auto-detected from the trace's subject set, or manually supplied via flag). Additionally, allow operators to attach user-defined identifiers (e.g., `kusari-id:asset-foo-prod-v2`) to specific components within an SBOM via a new `--component-id <PURL>=<scheme>:<value>` flag, so external tools can correlate components across SBOMs even when content hashes aren't available."
+
+## Overview
+
+Milestones 072–075 established document-level identifiers (`repo:`, `git:`, `image:`, `attestation:`) and cross-tier binding. The remaining gap in the cross-tier correlation story has two parts:
+
+1. **Build SBOMs don't declare their build-output hash as a first-class identifier in the SBOM body.** The hash exists in the wrapping in-toto attestation envelope's `subjects[]`, but a consumer holding only the `.cdx.json` file (without the `.attestation.dsse.json` wrapper) can't walk from "binary X in this image" → "the SBOM whose subject is X." This breaks the content-addressable correlation pattern external SBOM-stores want to support.
+
+2. **Operators can't attach their own per-component identifiers to specific components.** Today's user-defined `--id` flag attaches at the document level. When an operator wants to say "this specific binary in the image SBOM is also known as `kusari-id:asset-foo-prod-v2` in our internal asset DB," they have no first-class way to do it.
+
+This milestone closes both gaps:
+
+1. Adds `subject:<algo>:<hex>` as a fifth built-in identifier scheme. Auto-detected on build-tier scans from the trace's already-captured subject set (no manual flag needed for the common case); manually settable via `--subject-hash <algo>:<hex>` flag for source-tier and image-tier and overrides.
+2. Adds a `--component-id <PURL>=<scheme>:<value>` repeatable flag that attaches user-defined identifiers to specific components within an SBOM. Identifiers ride standards-native per-component fields where they exist (CDX `components[].properties[]` or `externalReferences[]`, SPDX 2.3 `Package.externalRefs[PERSISTENT-ID]`, SPDX 3 `Element.externalIdentifier[]`).
+
+Together, these complete the chain: external SBOM-stores can walk `image-SBOM.components[].hashes[].sha256 == X → SBOM whose subject:sha256:X matches → that build SBOM's git: commit → matching source SBOM` purely by string-match, with no mikebom-side resolver. And operators on internal-asset-tracking pipelines can layer their own per-component IDs on top without a separate annotation overlay.
+
+## Clarifications
+
+### Session 2026-05-06
+
+- Q: When the trace's subject set carries multi-digest subjects (e.g., both sha256 and sha512 in a single subject's `digest` map), what should the auto-detect path emit? → A: sha256-only auto-emit. Drop other algos from auto-detection; operators who need sha512 (or other algos) pass `--subject-hash sha512:<hex>` manually. Subjects lacking a sha256 digest auto-emit nothing for that subject (info-log records the skip).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Build-tier auto-detects `subject:` from trace output (Priority: P1)
+
+A developer or CI runner invokes `mikebom trace run -- ./build.sh`. The build produces a binary at `target/release/myapp` with SHA-256 `X`. The emitted build SBOM's body carries a `subject:sha256:X` identifier alongside the existing `repo:` and `git:` identifiers (from milestone 074). No manual flag required — mikebom reads the same subject set the in-toto attestation envelope already captures.
+
+**Why this priority**: This is the primary value-delivery for the milestone. Without auto-detect, the build-tier subject hash continues to live only in the attestation envelope and the cross-tier walk requires unwrapping the DSSE envelope to find it. Auto-detect makes the SBOM body self-sufficient for content-addressable correlation. P1 because the build-tier is the only tier where content-addressable subject hashes exist naturally and are auto-detectable; it's the tier where this milestone delivers concrete value.
+
+**Independent Test**: Run `mikebom trace run -- /usr/bin/true` (a wrapped command that produces no real artifacts but the trace still records what was observed). Inspect the emitted SBOM's `metadata.component.externalReferences[type:provenance]` (or whichever native carrier the implementation uses) and verify that, when the trace captured a subject, a corresponding `subject:sha256:<hex>` identifier appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a build that produces one output binary at hash `X`, **When** `mikebom trace run -- ./build.sh` is invoked, **Then** the emitted build SBOM body contains a `subject:sha256:X` identifier; the value matches the hash in the attestation envelope's `subjects[]` byte-for-byte.
+2. **Given** a multi-output build (e.g., `make all` produces 5 binaries with hashes X, Y, Z, W, V), **When** `mikebom trace run -- make all` is invoked, **Then** the emitted SBOM contains 5 `subject:` identifiers (one per output), in deterministic order.
+3. **Given** a build that produces no output (e.g., `mikebom trace run -- echo hello` — wrapped command produced no observable artifact), **When** the SBOM is emitted, **Then** no `subject:` identifier is emitted (the slot is omitted; the SBOM body is otherwise unchanged).
+4. **Given** the operator passes `--subject-hash sha256:Y` manually alongside an auto-detected `subject:sha256:X`, **When** the SBOM is emitted, **Then** both identifiers appear in the output (manual augments rather than overrides; `subject:` is multi-valued by design). If the manual value duplicates the auto-detected one, deduplication collapses them per milestone 073's `(scheme, value)` rule.
+
+---
+
+### User Story 2 — Source-tier and image-tier accept manual `subject:` (Priority: P2)
+
+For source-tier scans (where the source tree isn't natively content-addressable) and image-tier scans (where the `image:` identifier already encodes the digest, but operators may want a redundant `subject:` for cross-tier consistency), the operator can pass `--subject-hash sha256:<hex>` on the command line. The flag is repeatable for multi-subject SBOMs.
+
+**Why this priority**: Lower-priority because the use cases are narrower than US1: source-tier scans don't have an obvious "subject hash" (source trees are mutable), and image-tier scans already get `image:` (which encodes the digest natively). The manual flag exists for completeness and for operators with custom workflows that need `subject:` on these tiers.
+
+**Independent Test**: Run `mikebom sbom scan --path . --subject-hash sha256:abc123... --output out.cdx.json` and verify `subject:sha256:abc123...` appears in the emitted identifier set.
+
+**Acceptance Scenarios**:
+
+1. **Given** a source-tier scan with `--subject-hash sha256:X`, **When** the SBOM is emitted, **Then** the `subject:sha256:X` identifier is present alongside the auto-detected `repo:` from milestone 073.
+2. **Given** the operator passes `--subject-hash` repeatedly (e.g., `--subject-hash sha256:X --subject-hash sha256:Y`), **Then** both identifiers are emitted, in supply order.
+3. **Given** the operator passes a malformed hash like `--subject-hash banana`, **Then** the value soft-fails through milestone 073's `UserDefined` path: emitted under the user-defined namespace with a `tracing::warn!`; the scan does not fail.
+
+---
+
+### User Story 3 — Cross-tier digest handshake by string match (Priority: P1)
+
+An external SBOM-store consumer holds:
+- `image.cdx.json` with `components[]` listing binaries, each carrying `hashes[].sha256`.
+- `build-myapp.cdx.json` with a `subject:sha256:X` identifier (from US1).
+
+Without invoking mikebom, the consumer correlates: for each image-SBOM component with `hashes[].sha256 == X`, find any SBOM in the store whose document-level identifier set contains `subject:sha256:X`. The match resolves to `build-myapp.cdx.json`. From there the consumer reads the build SBOM's `git:` identifier to find the matching source SBOM. Pure content-addressable string-match correlation across tiers.
+
+**Why this priority**: This is the headline value the milestone delivers. Without it, the chain established by milestones 072–075 has a gap at the build-tier-to-image-tier hop. P1 because the entire previous arc (072+073+074+075) was about getting *to* this point.
+
+**Independent Test**: Build a tempdir fixture: a "source" git repo, a "build" SBOM produced manually with a known `subject:sha256:X`, an "image" SBOM listing one component whose hash is `X`. Write a small Python or jq harness that performs the walk: extract image components' hashes, search the store for SBOMs whose `subject:` identifier matches, surface the chain. Assert the harness recovers the source/build/image SBOMs in the right order.
+
+**Acceptance Scenarios**:
+
+1. **Given** an image SBOM listing a component with hash `X`, and a build SBOM in the same store with `subject:sha256:X`, **When** an external consumer walks the chain, **Then** the consumer correlates the image component to the build SBOM with no mikebom intervention.
+2. **Given** the same setup plus a source SBOM with `repo:R` matching the build SBOM's `repo:R`, **When** the consumer continues the walk, **Then** the source SBOM is correlated to the build SBOM.
+3. **Given** a multi-output build (build SBOM has 3 `subject:` identifiers), **When** the image SBOM has components matching 2 of those 3 hashes, **Then** the consumer correlates 2 of 3; the third subject (unused by this image) is benign.
+
+---
+
+### User Story 4 — Per-component user-defined identifier attachment (Priority: P1)
+
+An operator runs:
+
+```
+mikebom sbom scan --path . \
+    --component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-shared-lib-v2" \
+    --component-id "pkg:cargo/myapp@0.5.1=acme-asset:myapp-prod-001" \
+    --output out.cdx.json
+```
+
+The emitted SBOM has those two specific components carrying the user-defined identifiers in standards-native fields. An external consumer reads the per-component identifiers and correlates against the operator's internal asset DB without needing mikebom-specific decoders.
+
+**Why this priority**: Closes the operator-facing gap in cross-SBOM correlation. Many enterprise SBOM-store users have internal asset-tracking systems where components are referenced by org-specific IDs, not by content hashes. Letting them attach those IDs as first-class per-component fields means their SBOMs become useful inside their org's tooling immediately. P1 because it's the second deliverable the user explicitly asked for in the same milestone.
+
+**Independent Test**: Scan a project with two components and a `--component-id` flag matching one of them. Verify the matching component carries the identifier in its native per-component carrier (CDX `properties[]` / SPDX 2.3 `externalRefs[]` / SPDX 3 `externalIdentifier[]`); the non-matching component is unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with components `pkg:cargo/serde@1.0.0` and `pkg:cargo/foo@0.1.0`, **When** the operator passes `--component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-shared-lib-v2"`, **Then** the emitted SBOM has `serde@1.0.0` carrying a `kusari-id` identifier with value `asset-shared-lib-v2`; `foo@0.1.0` is unchanged.
+2. **Given** the same project, **When** the operator passes `--component-id "pkg:cargo/nonexistent@0.0.0=asset-id:foo"` (no matching component), **Then** the scan emits a `tracing::warn!` listing the unmatched selector; the scan does not fail.
+3. **Given** a project where multiple components match a single PURL (rare but possible across different `bom-ref` values), **When** the operator passes `--component-id` with that PURL, **Then** ALL matching components receive the identifier (deliberate broadcast; matches the spec's "by PURL" semantics).
+4. **Given** the operator passes `--component-id "pkg:cargo/foo@1.0=subject:sha256:X"` (built-in scheme name in a per-component context), **Then** the CLI rejects the flag at parse time with a clear error: per-component built-in schemes are reserved for future native-field usage; user-defined schemes only.
+5. **Given** the operator passes `--component-id` with a malformed selector or value (empty PURL, missing `=`, empty scheme, empty value), **Then** the CLI rejects at parse time with a clear, actionable error message.
+
+---
+
+### Edge Cases
+
+- **Build with no identifiable output** (e.g., `mikebom trace run -- echo hello`): no `subject:` identifier emitted; SBOM body is otherwise identical to alpha.16 build behavior.
+- **Subject with no sha256 digest** (e.g., a build that only produced a sha1 or sha512 entry — rare but possible for legacy ecosystems): auto-detect emits nothing for that subject and logs a `tracing::info!` with the subject name + available algos so operators can decide whether to fall back to manual `--subject-hash` for the non-sha256 case (per the 2026-05-06 clarification).
+- **Multi-output build with one output also matching the image digest** (e.g., the wrapped command was `docker build -t foo:v1 .` and the emitted image is `foo:v1@sha256:X`): the build SBOM emits `subject:sha256:X`; an image scan of `foo:v1` emits `image:foo:v1@sha256:X`. The X portion matches across the two tiers without any operator coordination — this is the cleanest possible cross-tier handshake.
+- **`subject:` value validation failure**: malformed `<algo>:<hex>` (wrong length, non-hex chars, unknown algo) soft-fails to `IdentifierKind::UserDefined` per milestone 073's FR-010 rule. The scan does not fail.
+- **Auto-detected and manual `--subject-hash` with same value**: deduplicated to one entry attributed to the manual flag (per milestone 073 FR-006 dedup rule).
+- **`--component-id` with a built-in scheme** (`subject:`, `repo:`, `git:`, `image:`, `attestation:`): rejected at CLI parse time. Per-component identifiers are user-defined-only in this milestone; the built-in schemes are reserved for the document level (where their semantics are well-defined). A future milestone may reconsider.
+- **`--component-id` selector that matches zero components**: warn + continue. Operators may pass selectors speculatively (e.g., across multiple scan runs of different projects); failing the scan would be too strict.
+- **`--component-id` selector that's not a valid PURL**: reject at parse time. The selector is contract-shape — non-PURL inputs aren't ambiguity, they're errors.
+- **Component selector matches a component that already has a same-`(scheme, value)` identifier**: deduplicated. The same identifier value attached twice produces one entry, not two.
+- **CDX 1.6 vs SPDX 2.3 vs SPDX 3 emission semantics**: all three formats have native per-component fields suitable for user-defined identifiers (per Constitution Principle V's native-precedence rule). No `mikebom:component-identifiers` annotation is introduced; the implementation rides existing native carriers per format.
+- **`subject:` on source-tier scans**: source trees are mutable and not content-addressable; `subject:` is omitted by default. The manual `--subject-hash` flag works if operators have an external content-addressing scheme they want to attach.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Add `subject:<algo>:<hex>` as a fifth built-in identifier scheme. Algo MUST be one of `sha256`, `sha512` (lowercase). Hex MUST be lowercase, of length matching the algo (64 chars for sha256, 128 chars for sha512).
+- **FR-002**: When `mikebom trace run` produces a non-empty subject set (the same set the in-toto attestation envelope captures in `statement.subject[]`), the build-tier SBOM body MUST emit one `subject:sha256:<hex>` identifier per subject that has a sha256 digest in its `digest` map. Identifiers are emitted in the same deterministic order the attestation uses (lexical sort by `(name, digest)` per witness-v0.1 conventions). Subjects with multi-algo digest maps (e.g., both sha256 and sha512) auto-emit only the sha256 form; other algos are dropped from auto-detection per the 2026-05-06 clarification. Subjects lacking a sha256 digest auto-emit nothing for that subject and the system MUST log a `tracing::info!` recording the skip with the subject's name and the available algos. Operators who need a non-sha256 form pass `--subject-hash sha512:<hex>` (or other) manually.
+- **FR-003**: Add `--subject-hash <algo>:<hex>` flag, repeatable, to both `mikebom sbom scan` and `mikebom trace run`. Manual `--subject-hash` values augment auto-detected ones (per US1 scenario 4); deduplication by `(scheme, value)` collapses exact matches per milestone 073 FR-006.
+- **FR-004**: `subject:` identifiers MUST ride standards-native per-document carriers consistent with milestone 073: CDX `metadata.component.externalReferences[]` (with an appropriate `type` value, e.g., `provenance` or another existing CDX 1.6 enum value that fits the "binary subject" semantic), SPDX 2.3 `Package.externalRefs[].referenceCategory = PERSISTENT-ID`, SPDX 3 `Element.externalIdentifier[]` with `type` matching the scheme name (`subject`).
+- **FR-005**: When the `subject:` value fails validation (FR-001's regex rule), the identifier MUST soft-fail to `IdentifierKind::UserDefined` per milestone 073 FR-010, with a `tracing::warn!` log. The scan MUST NOT fail.
+- **FR-006**: Source-tier scans (`mikebom sbom scan --path`) MUST NOT auto-detect a `subject:` identifier. The manual `--subject-hash` flag works on source-tier; the auto-detect path is reserved for tiers where content-addressing is natively available (build-tier; image-tier already covers it via `image:`).
+- **FR-007**: Add `--component-id <PURL>=<scheme>:<value>` flag, repeatable, to both `mikebom sbom scan` and `mikebom trace run`. The `<PURL>` is exact-match (no glob) and selects components by their emitted `purl` field. The `<scheme>:<value>` follows milestone 073's identifier-pair format.
+- **FR-008**: Per-component user-defined identifiers MUST ride standards-native per-component carriers per Constitution Principle V: CDX `components[].properties[]` with `name = "<scheme>"` and `value = "<value>"` (or `components[].externalReferences[]` if the component-level shape is more idiomatic — Phase 0 research pins the choice), SPDX 2.3 `Package.externalRefs[].referenceCategory = PERSISTENT-ID` with `referenceType = <scheme>` and `referenceLocator = <value>`, SPDX 3 `Element.externalIdentifier[].type = <scheme>` with `identifier = <value>`. No new `mikebom:*` annotations introduced (audit per Principle V's 5th bullet).
+- **FR-009**: `--component-id` MUST reject built-in scheme names (`subject`, `repo`, `git`, `image`, `attestation`) at CLI parse time with a clear error. Per-component built-in schemes are reserved for future native-field usage; user-defined schemes only at this layer.
+- **FR-010**: When a `--component-id` selector matches zero components in the emitted SBOM, the system MUST emit a `tracing::warn!` listing the unmatched selector and continue. The scan MUST NOT fail.
+- **FR-011**: When a `--component-id` selector matches multiple components (e.g., the same PURL appears under different `bom-ref` values), the identifier MUST be attached to ALL matching components.
+- **FR-012**: All emission MUST be deterministic per milestone 073's contract: same input → byte-identical output. Per-component identifiers are emitted in lexical order by `(scheme, value)` for stable serialization.
+- **FR-013**: Cross-format byte-identity goldens for fixtures with no `--component-id` flags and no auto-detected `subject:` (i.e., all existing 073/074/075 fixtures since none had build outputs flowing through the auto-detect path) MUST stay byte-identical to alpha.17. Goldens for fixtures that do exercise the new paths gain additive entries — that is the expected golden regen for this milestone.
+- **FR-014**: The image-tier handshake described in US3 (build SBOM's `subject:sha256:X` matches image SBOM's `image:` digest) MUST work without any mikebom-side coordination — purely string-match correlation by external tools. The `subject:` value's hex portion equals the digest portion of the corresponding `image:` value when they refer to the same artifact.
+
+### Key Entities
+
+- **SubjectIdentifier**: A document-level identifier of form `subject:<algo>:<hex>` declaring "this SBOM describes the artifact with the given content hash." Composed of: scheme name (always `subject`), algo (sha256 or sha512), hex digest. Multiple subject identifiers may attach to one SBOM (multi-output builds). Carries a `source_label` per milestone 073's pattern indicating origin (auto-detected from trace subject set / manual `--subject-hash` flag).
+- **ComponentIdentifier**: A per-component user-defined identifier attached via `--component-id`. Composed of: a PURL selector that picks components, a scheme name (any string passing the FR-004 regex from milestone 073, but rejected if it equals a built-in), a value. Materialized in the emitted SBOM as a per-component native field per format.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For a `mikebom trace run -- ./build.sh` invocation that produces a known binary at hash `X`, the emitted build SBOM body contains a `subject:sha256:X` identifier without any manual flag. Verified by integration test against a tempdir fixture that builds a small Rust crate and asserts on the emitted SBOM's identifier set.
+- **SC-002**: An external SBOM-store consumer (a small Python or jq harness) holding a build SBOM with `subject:sha256:X` and an image SBOM listing a component with `hashes[].sha256 == X` can correlate the two by string match alone, without invoking mikebom. Verified by an end-to-end integration test that runs the harness and asserts the correlation succeeds.
+- **SC-003**: A `mikebom sbom scan` invocation with `--component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-foo"` produces an SBOM where exactly one component (the matching one) carries the per-component identifier in standards-native carriers; non-matching components are unchanged. Verified by integration test asserting on per-component fields across CDX, SPDX 2.3, and SPDX 3 outputs.
+- **SC-004**: When the same SBOM is emitted twice with identical inputs (same scan target, same flags, same fixture state), both emissions are byte-identical. Verified by determinism integration test re-running scan against a fixed fixture.
+- **SC-005**: Source-tier scans of fixtures without `--component-id` and without `--subject-hash` produce SBOMs byte-identical to alpha.17 (no regression). Verified by the existing parity-check golden suite continuing to pass unchanged.
+- **SC-006**: A multi-output build (5 binaries) produces a build SBOM with 5 distinct `subject:` identifiers in deterministic lexical order. Verified by integration test on a synthetic multi-output fixture.
+- **SC-007**: `--component-id` with a built-in scheme name (e.g., `subject:`, `repo:`) fails at CLI parse time with a clear error message. Verified by negative integration tests asserting on exit code and error text.
+- **SC-008**: `--component-id` with a selector matching zero components emits a warning and the scan exits 0. Verified by integration test running a scan with a non-matching selector.
+- **SC-009**: All three SBOM formats (CDX 1.6, SPDX 2.3, SPDX 3) carry the per-component user-defined identifier in their respective standards-native per-component fields. Constitution Principle V audit passes — no new `mikebom:*` annotations introduced.
+
+## Assumptions
+
+- The build-tier subject set comes from the same in-toto witness-v0.1 attestation collection that already runs as part of `mikebom trace run`. Reading these subjects at SBOM-emit time is a small additional read of in-process state, not a new subprocess or filesystem touch.
+- The `subject:<algo>:<hex>` value validator restricts the algo to `sha256` or `sha512` initially. Other hash algos (sha1, blake2, etc.) are out of scope; they can be added incrementally if downstream demand emerges.
+- The `--component-id` selector is exact-PURL-match in the MVP. Glob/wildcard support, version-range matching, and `bom-ref`-based selection are explicit future-milestone work.
+- Per-component identifiers ride existing standards-native per-component fields. The implementation MUST NOT introduce a new `mikebom:component-identifiers` annotation. Constitution Principle V's native-first rule applies; per-format native carriers exist for all three formats and are sufficient.
+- Per-component built-in schemes (e.g., a per-component `subject:` identifier attached to a specific component) are out of scope. Only document-level `subject:` and per-component user-defined are in this milestone. The CLI rejects per-component built-in schemes to keep the boundary clear.
+- Image-tier scans don't introduce new automatic `subject:` emission since the image digest is already encoded in the `image:` identifier (per milestone 073 FR-008). Operators who want a redundant `subject:` on image-tier scans can pass `--subject-hash` manually.
+- Operators on alpha.16 / alpha.17 who want the per-component identifier behavior can mitigate today by post-processing emitted SBOMs with `mikebom sbom enrich` or another JSON-Patch-based tool. This milestone makes the behavior first-class.
+- Backward compatibility: existing flag set is unchanged; only two new flags (`--subject-hash`, `--component-id`) are added. Operators not using either get byte-identical output to alpha.17 (per FR-013 + SC-005).
+- The cross-tier digest handshake (US3, FR-014) does not require any new mikebom-side infrastructure. It works because the build-tier subject hash and the image-tier image-manifest digest happen to be the same string when the build produced an image that was later scanned. The handshake is a property of how the inputs flow through; mikebom merely ensures both ends emit the digest in stable, parseable identifier slots.
+- "Kusari-id" as a scheme name in the user description is a placeholder; mikebom does not bake in any vendor-specific scheme name. Operators choose their own scheme names (e.g., `kusari-id`, `acme-asset-id`, `internal_ticket`, etc.) — anything passing milestone 073's FR-004 regex is accepted as a user-defined scheme on `--component-id`.

--- a/specs/076-subject-component-ids/tasks.md
+++ b/specs/076-subject-component-ids/tasks.md
@@ -1,0 +1,232 @@
+---
+description: "Task list for milestone 076 — subject identifier scheme + per-component user-defined identifiers"
+---
+
+# Tasks: Subject identifier scheme + per-component user-defined identifiers
+
+**Input**: Design documents from `/specs/076-subject-component-ids/`
+**Prerequisites**: plan.md, spec.md (with /speckit.clarify integration), research.md, data-model.md, contracts/{subject-identifier,per-component-id}.md, quickstart.md
+
+**Tests**: Spec references SC-001 through SC-009 plus the test matrices in both contract documents. Test tasks are included.
+
+**Organization**: Four user stories. US1 (build-tier subject auto-detect) and US3 (cross-tier handshake) are P1 — the headline value. US4 (per-component identifiers) is also P1 — the second deliverable. US2 (manual `--subject-hash` on source/image tiers) is P2. Phases group by what blocks what; both deliverables share the foundational identifier-substrate work.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different files, no incomplete-task dependencies)
+- **[Story]**: US1 / US2 / US3 / US4 (user-story phase tasks only)
+- File paths are absolute or repository-relative
+
+## Path Conventions
+
+Single workspace; all 076 changes inside `mikebom-cli` plus `docs/reference/identifiers.md`. One small new module file (`component_id.rs`); no new crates.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Pre-flight reconnaissance before touching code.
+
+- [X] T001 Audit four explicit deliverables and capture each in this PR's commit message or a checked-in scratchpad. T010 / T013 / T014 / T015 depend on the named outputs. (a) **Existing build-tier fixtures**: enumerate any tempdir or git-fixture-based test that exercises `mikebom trace run` end-to-end against an in-toto subject set. Per milestone 074's T001, the answer is likely "none" since `mikebom trace run` requires Linux + eBPF + privileges; confirm. (b) **Trace's in-process subject-set field name**: identify the exact struct + field on the in-process state object (post `super::scan::execute` completion) that holds `Vec<Subject>` (or whatever the in-toto subject collection is typed as). Document the type path (e.g., `mikebom::trace::AttestationBuilder.subjects: &Vec<Subject>`) so T010 can read it directly. (c) **Per-format component-emission sites**: identify the exact file path + function name where each format builds the per-component arrays — CDX `components[].properties[]` (likely `mikebom-cli/src/generate/cyclonedx/components.rs` or `mikebom-cli/src/generate/cyclonedx/mod.rs`), SPDX 2.3 `Package.externalRefs[]` (likely `mikebom-cli/src/generate/spdx/packages.rs`), SPDX 3 `Element.externalIdentifier[]` (likely `mikebom-cli/src/generate/spdx/v3_*.rs`). T013 / T014 / T015 each plug into one of these sites. (d) **Pre-existing per-component entries**: enumerate any pre-existing properties / externalRefs / externalIdentifier entries the existing emitters produce (e.g., `mikebom:not-linked` from milestone 049, `mikebom:shade-relocation` from milestone 009, the `purl` externalRef in SPDX 2.3). T013/T014/T015 must preserve these at their current array positions per research §6 — the audit produces the regression-test surface for that constraint.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the new types, helpers, flags, and `ScanArtifacts` field that both deliverables depend on. After this phase the production code is sanitization-aware but no story-specific tests have been written.
+
+**⚠️ CRITICAL**: Both user-story tracks (subject + per-component) depend on this phase.
+
+- [X] T002 Add `BuiltinScheme::Subject` variant to `mikebom-cli/src/binding/identifiers/mod.rs`. Update `from_scheme_name` (around `mod.rs:161`) to map `"subject"` → `Some(Self::Subject)`. Update `cdx_external_reference_type` (around `mod.rs:178`) to return `"attestation"` for `Self::Subject` per research §1. `spdx23_reference_category` already returns `"PERSISTENT-ID"` uniformly; no change needed. Update existing exhaustive-match call sites; the known sites identified at planning time are: (i) `cdx_external_reference_type` itself, (ii) `from_scheme_name` itself, (iii) the per-scheme test `builtin_scheme_cdx_external_reference_type_per_scheme` around `mod.rs:565`, (iv) any milestone 072/073/074/075 call site that pattern-matches on `BuiltinScheme` (`grep -rn 'BuiltinScheme::' mikebom-cli/src/` to enumerate). The compile-time exhaustiveness check catches any missed match arm. Add unit test asserting `BuiltinScheme::Subject.cdx_external_reference_type() == "attestation"` and `BuiltinScheme::Subject.spdx23_reference_category() == "PERSISTENT-ID"`.
+
+- [X] T003 Add `pub fn validate_subject(value: &str) -> Result<(), IdentifierError>` to `mikebom-cli/src/binding/identifiers/validators.rs`. Behavior per research §4: accept `^(sha256:[0-9a-f]{64}|sha512:[0-9a-f]{128})$` exactly; reject uppercase hex, mixed-case hex, whitespace, missing algo prefix, prefix-only-no-hex, wrong-length hex, other algos. Return `IdentifierError::BuiltinValidation` on rejection so soft-fail-to-`UserDefined` triggers per FR-005. Wire `validate_subject` into the existing `validate_for_scheme` dispatcher so `BuiltinScheme::Subject` routes through it. Add 8 unit tests covering: valid sha256, valid sha512, uppercase rejection, missing prefix, wrong-length sha256 (63/65 chars), wrong-length sha512 (127/129 chars), unknown algo (`sha1:`), whitespace.
+
+- [X] T004 Add `pub fn subject_identifiers_from_attestation_subjects(subjects: &[Subject]) -> Vec<Identifier>` to `mikebom-cli/src/binding/identifiers/auto_detect.rs`. Implementation per data-model.md "Functions": iterate subjects in input order (already lexically sorted per witness-v0.1); for each, extract `sha256` digest from the digest map (key lookup); on absent sha256, log `tracing::info!` with subject name + available algo list and skip per FR-002 + 2026-05-06 clarification; on present sha256, construct `Identifier` with scheme `subject`, value `sha256:<hex>`, kind `Builtin(Subject)` (after `validate_for_scheme` round-trip; the value should always validate but the call provides defense-in-depth), source_label `"auto-detected from build-tier in-toto subject `<name>`"`. Apply VR-076-001 + VR-076-002. Add unit tests for: single-subject sha256 happy path, multi-subject lexical order, subject-without-sha256 skip + log, subject with both sha256 and sha512 emits sha256-only, empty subject set returns empty vec.
+
+- [X] T005 [P] Create new module `mikebom-cli/src/binding/identifiers/component_id.rs`. Implement `pub struct ComponentIdentifierFlag { selector_purl: String, scheme: SchemeName, value: IdentifierValue }`, `pub enum ComponentIdentifierFlagError` per data-model.md, `pub fn parse(raw: &str) -> Result<Self, ComponentIdentifierFlagError>` per contracts/per-component-id.md, and `pub fn parse_component_id_flag(raw: &str) -> Result<ComponentIdentifierFlag, String>` (the clap `value_parser` adapter). The `parse` function: split on FIRST `=`, reject empty LHS, split RHS on FIRST `:`, reject empty scheme, reject empty value, validate scheme via `SchemeName::new` (uses 073's regex), reject built-in scheme names (`repo`, `git`, `image`, `attestation`, `subject`) per FR-009. Apply VR-076-003. Add `pub mod component_id;` to `mikebom-cli/src/binding/identifiers/mod.rs`. Add 10 unit tests for parse-error paths + happy paths.
+
+- [X] T006 Extend `ScanArtifacts` in `mikebom-cli/src/generate/mod.rs` with new field `pub component_identifiers: Vec<ComponentIdentifierFlag>`. Update existing struct-literal call sites (look for `ScanArtifacts { ... }` constructions) to pass `component_identifiers: vec![]` for back-compat. Update derive/impl blocks if needed. Add a brief module-level doc comment referencing data-model.md.
+
+- [X] T007 Add `#[arg(long = "subject-hash", value_name = "ALGO:HEX", action = clap::ArgAction::Append)] pub subject_hash: Vec<String>` and `#[arg(long = "component-id", value_name = "PURL=SCHEME:VALUE", action = clap::ArgAction::Append, value_parser = component_id::parse_component_id_flag)] pub component_id: Vec<ComponentIdentifierFlag>` to `ScanArgs` in `mikebom-cli/src/cli/scan_cmd.rs`. Help text per contracts/{subject-identifier,per-component-id}.md "Help-text shape" sections. In the call site that constructs `ScanArtifacts`, build `subject:` `Identifier`s from `args.subject_hash` (reuse `Identifier::parse(format!("subject:{val}"))`-equivalent path; soft-fail per 073 contract on validation failure) and merge into the resolution pipeline; pass `args.component_id` directly to `ScanArtifacts.component_identifiers`.
+
+- [X] T008 Add the same two flags to `RunArgs` in `mikebom-cli/src/cli/run.rs`. Wire them into the existing identifier-resolution flow at `run.rs::execute` (the `assembled_ids` block from milestone 074). Manual `--subject-hash` values become `Identifier`s appended after milestone-074's auto-detected `repo:`/`git:` entries. The build-tier auto-detect from the trace's subject set is wired separately in T010 — this task only handles flag plumbing.
+
+**Checkpoint**: production code compiles. All foundational types + helpers + flag plumbing in place. No integration tests yet; no auto-detect wired. Both user-story tracks can proceed.
+
+---
+
+## Phase 3: User Story 1 — Build-tier auto-detects `subject:` from trace output (Priority: P1)
+
+**Goal**: `mikebom trace run -- ./build.sh` produces a build SBOM body with `subject:sha256:<hex>` identifiers for each in-toto attestation subject — no manual flag required.
+
+**Independent Test**: Build a tempdir fixture with a synthetic in-toto subject set (the test calls `auto_detect_build_tier_identifiers` or its successor directly, since `mikebom trace run` requires eBPF). Assert the resulting `Vec<Identifier>` contains a `subject:` identifier per subject with sha256, and skips subjects without sha256.
+
+### Tests for User Story 1
+
+- [X] T009 [US1] Create new integration test file `mikebom-cli/tests/identifiers_subject_and_component.rs` with: (a) a synthetic-subject-set fixture builder helper (constructs `Vec<Subject>` matching the in-toto witness-v0.1 shape — name + digest map); (b) test `build_tier_autodetects_subject_from_in_toto_subjects` (US1 §1: one subject with sha256 → one `subject:` identifier); (c) test `build_tier_autodetect_emits_one_subject_per_in_toto_subject` (US1 §2: 3 subjects → 3 identifiers in lexical order); (d) test `build_tier_autodetect_skips_subject_without_sha256` (US1 §3 + 2026-05-06 clarification: subject with only sha512 in digest map → no identifier emitted; info-log captured); (e) test `build_tier_autodetect_emits_sha256_only_when_multi_digest` (research-§4-aligned: subject with both sha256 AND sha512 → only `subject:sha256:...` emits); (f) test `build_tier_autodetect_empty_subject_set` (no subjects → empty vec). All tests guarded with `#[cfg_attr(test, allow(clippy::unwrap_used))]`.
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Wire build-tier subject auto-detect in `mikebom-cli/src/cli/run.rs::execute`. After `super::scan::execute(scan_args).await?` completes (which is when the in-toto attestation subject set has been collected by the trace pipeline), read the subject set from the in-process state (T001's audit identified the exact field) and call `subject_identifiers_from_attestation_subjects(subjects)`. Merge the resulting `Vec<Identifier>` into the existing `assembled_ids` flow per data-model.md "Updated `auto_detect_build_tier_identifiers` flow": `repo:` first, then `git:`, then auto-detected `subject:` entries (in witness-v0.1 lexical order), then manual `--subject-hash` from T008, then existing manual `--repo` / `--git-ref` etc. Verify all T009 tests pass.
+
+**Checkpoint**: US1 passes. Build-tier `mikebom trace run` (when invoked in a real eBPF-capable environment) emits `subject:` identifiers in the SBOM body automatically.
+
+---
+
+## Phase 4: User Story 2 — Source-tier and image-tier accept manual `--subject-hash` (Priority: P2)
+
+**Goal**: Operators on source-tier and image-tier scans can attach `subject:` identifiers manually via `--subject-hash`. Repeatable, augments rather than overrides auto-detected entries.
+
+**Independent Test**: Run `mikebom sbom scan --path . --subject-hash sha256:<hex> --output out.cdx.json` and verify the emitted SBOM contains `subject:sha256:<hex>` in its identifier set.
+
+### Tests for User Story 2
+
+- [X] T011 [US2] Add to `mikebom-cli/tests/identifiers_subject_and_component.rs`: (a) `manual_subject_hash_flag_works_on_source_tier` — `mikebom sbom scan --path` against a tempdir with `--subject-hash sha256:abc...`; assert emitted CDX `metadata.component.externalReferences[]` contains the entry with type `attestation` and url `sha256:abc...`. (b) `manual_subject_hash_flag_repeatable` — pass `--subject-hash` twice with different values; assert both appear in the emitted SBOM in supply order. (c) `subject_value_validation_soft_fails_to_user_defined` — pass `--subject-hash banana`; assert the value rides through under user-defined namespace per FR-005; the scan exits 0. (d) `subject_identifier_emits_in_all_three_formats` — same scan with `--subject-hash`, emit CDX + SPDX 2.3 + SPDX 3; assert all three carry the value in the per-format carrier (CDX externalReferences[type:attestation], SPDX 2.3 externalRefs[PERSISTENT-ID][referenceType:subject], SPDX 3 externalIdentifier[type:subject]). (e) `manual_subject_hash_flag_works_on_image_tier` — `mikebom sbom scan --image <fixture-tar> --subject-hash sha256:def...`; assert `subject:sha256:def...` appears alongside the auto-detected `image:` identifier in the emitted SBOM. Verifies FR-003's "on `mikebom sbom scan` and `mikebom trace run`" coverage extends to image-tier scans, not just source-tier.
+
+**Checkpoint**: US2 passes. Manual `--subject-hash` works on source-tier; per-format wire mapping correct.
+
+---
+
+## Phase 5: User Story 3 — Cross-tier digest handshake by string match (Priority: P1)
+
+**Goal**: An external SBOM-store consumer holding a build SBOM with `subject:sha256:X` and an image SBOM listing a component with `hashes[].sha256 == X` can correlate them by string match alone — no mikebom-side resolver.
+
+**Independent Test**: Construct a tempdir fixture with: a build SBOM (synthetic, with a known `subject:sha256:X` identifier), an image SBOM (synthetic, with one component whose hash equals X). Write a small jq harness in the test that performs the lookup and asserts the correlation succeeds.
+
+### Tests for User Story 3
+
+- [X] T012 [US3] Add to `mikebom-cli/tests/identifiers_subject_and_component.rs`: `cross_tier_handshake_image_digest_matches_build_subject` — build a fixture with two synthetic SBOMs sharing a hash; run a jq-shaped extraction (in Rust, using `serde_json::Value` to navigate) and assert that for each image-SBOM `components[].hashes[].sha256 == X`, the build SBOM with `subject:sha256:X` is found. The test does not call mikebom; it tests that the wire format mikebom emits is consumable by string-match correlation. Verifies SC-002.
+
+**Checkpoint**: US3 passes. The cross-tier digest handshake is end-to-end-testable without mikebom infrastructure.
+
+---
+
+## Phase 6: User Story 4 — Per-component user-defined identifier attachment (Priority: P1)
+
+**Goal**: Operators can attach user-defined identifiers (e.g., `kusari-id:asset-foo-prod-v2`) to specific components via `--component-id <PURL>=<scheme>:<value>`. The identifier emits in standards-native per-component carriers across all three formats.
+
+**Independent Test**: Run `mikebom sbom scan --path . --component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-foo" --output out.cdx.json`. Verify the matching component in the emitted CDX has `properties[]` entry `{name: "kusari-id", value: "asset-foo"}`. Verify zero matches produces a warn + scan-success.
+
+### Implementation for User Story 4
+
+- [X] T013 [US4] CDX emission: in `mikebom-cli/src/generate/cyclonedx/` (the components-emission module identified in T001's audit), after the `components[]` array is built, iterate `scan_artifacts.component_identifiers`. For each flag, find matching components by byte-equality of `purl` field per research §5. Append a new property `{name: scheme, value: value}` to each matching component's `properties[]` (preserving pre-existing entries at their original positions). After processing all flags, lexical-sort the NEW per-component entries by `(name, value)` per research §6. After the loop, call `tracing::warn!` for any flag whose selector_purl matched zero components (FR-010). Implementation must preserve existing milestone-073/074/075 byte-identity goldens (verify via existing parity-check golden suite).
+
+- [X] T014 [US4] [P] SPDX 2.3 emission: in `mikebom-cli/src/generate/spdx/packages.rs`, mirror T013's logic — match by PURL, append `{referenceCategory: "PERSISTENT-ID", referenceType: scheme, referenceLocator: value}` entries to `Package.externalRefs[]`, lexical-sort new entries, warn on zero match.
+
+- [X] T015 [US4] [P] SPDX 3 emission: in `mikebom-cli/src/generate/spdx/v3_*.rs` (the package/element module identified in T001's audit), mirror T013's logic — match by PURL, append `{type: scheme, identifier: value}` entries to `Element.externalIdentifier[]`, lexical-sort new entries, warn on zero match.
+
+### Tests for User Story 4
+
+- [X] T016 [US4] Add to `mikebom-cli/tests/identifiers_subject_and_component.rs`: (a) `component_id_attaches_to_matching_component_cdx` — `--component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-foo"` against a project with `serde@1.0.0`; assert CDX `components[]` matching component has `properties[{name:"kusari-id",value:"asset-foo"}]`; non-matching components unchanged. (b) `component_id_attaches_to_matching_component_spdx23` — same scan emits SPDX 2.3; assert `Package.externalRefs[{referenceCategory:"PERSISTENT-ID",referenceType:"kusari-id",referenceLocator:"asset-foo"}]`. (c) `component_id_attaches_to_matching_component_spdx3` — same scan emits SPDX 3; assert `Element.externalIdentifier[{type:"kusari-id",identifier:"asset-foo"}]`. (d) `component_id_warns_on_zero_match` — `--component-id` with non-matching PURL; assert scan exits 0; assert warn-level log contains the unmatched selector. (e) `component_id_attaches_to_all_matching_when_multiple` — fixture with 2 components having same PURL different bom-refs; assert BOTH receive the identifier per FR-011. (f) `component_id_rejects_builtin_scheme_at_parse` — `--component-id "pkg:cargo/foo@1.0=subject:sha256:abc"`; assert clap parse error mentioning "reserved" or similar; non-zero exit. (g) `component_id_rejects_malformed_input_at_parse` — try several malformed inputs (no `=`, empty PURL, no `:`, empty scheme, empty value); assert each fails at parse with clear error. (h) `component_id_lexical_order_within_new_entries` — pass two `--component-id` flags matching same PURL with schemes `zzz:foo` and `aaa:bar`; assert emitted properties order has `aaa` first, `zzz` second per research §6. (i) `component_id_preserves_existing_properties` — fixture with a component carrying pre-existing `mikebom:not-linked=true` property; pass `--component-id` adding a new entry; assert pre-existing property at its original position; new entry appended after. (j) `component_id_deterministic_across_reruns` — invoke `mikebom sbom scan` twice with identical `--component-id` flags against the same fixture; emit CDX + SPDX 2.3 + SPDX 3 from each run; assert byte-equality of every emitted file across the two runs. Verifies SC-004 (deterministic re-emission) — analogous to milestone 074's `build_tier_autodetect_deterministic_across_reruns` test. Tests guarded with `#[cfg_attr(test, allow(clippy::unwrap_used))]`.
+
+**Checkpoint**: US4 passes. Per-component user-defined identifiers emit in all three formats; matching, broadcast, ordering, and parse-error behavior all verified.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [X] T017 [P] Update `docs/reference/identifiers.md`: add a new section "Subject identifier scheme (`subject:`)" documenting the value form (`sha256:<hex>` or `sha512:<hex>`), the build-tier auto-detect path, the `--subject-hash` manual flag, and the per-format wire mapping (CDX externalReferences[type:attestation], SPDX 2.3 externalRefs[PERSISTENT-ID][referenceType:subject], SPDX 3 externalIdentifier[type:subject]). Add a separate section "Per-component user-defined identifiers" documenting the `--component-id` flag, the byte-equality PURL matching rule, the per-format carriers (CDX properties[], SPDX 2.3 externalRefs[PERSISTENT-ID], SPDX 3 externalIdentifier[]), the built-in scheme rejection rule, and the zero-match warn behavior. Cross-link to quickstart.md Recipes 1–5.
+
+- [X] T018 [P] Update `mikebom-cli/src/parity/extractors/`: add new catalog row(s) for `subject:` identifier extraction (per-format carriers from contracts/subject-identifier.md) and per-component identifier extraction (per-format carriers from contracts/per-component-id.md). Use the existing `Directionality::SymmetricEqual` for both rows since the carriers are symmetric across CDX/SPDX 2.3/SPDX 3 (modulo per-format native field naming). Document the new rows in `parity/extractors/mod.rs`'s catalog comment block.
+
+- [X] T019 Run pre-PR gate per CLAUDE.md: (a) `cargo +stable clippy --workspace --all-targets -- -D warnings` zero warnings; (b) `cargo +stable test --workspace` every target reports `0 failed`. Convenience: `./scripts/pre-pr.sh`. A failing per-crate `cargo test -p mikebom` does NOT discharge this requirement.
+
+- [X] T020 Manually validate quickstart.md recipes 1, 2, 3, 4, 5 end-to-end against a real local build of milestone 076 (Recipe 1 requires Linux + eBPF; on macOS, the pre-trace flag-wiring portion can still be exercised). Confirm log-line phrasing matches contracts/{subject-identifier,per-component-id}.md exactly. Confirm jq snippets in the recipes work against actual emitted SBOMs.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: T001 has no dependencies; survey task.
+- **Phase 2 (Foundational)**: T002 → T003 → T004 sequential (same file, building up). T005 [P] independent (different file). T006 depends on T005 (uses `ComponentIdentifierFlag` type). T007 depends on T002, T005, T006. T008 depends on T002, T004, T005, T006 (uses `subject_identifiers_from_attestation_subjects` and `ComponentIdentifierFlag`).
+- **Phase 3 (US1)**: T009 (test file creation) before T010 (wiring) per TDD; T010 depends on T004 (Phase 2).
+- **Phase 4 (US2)**: T011 depends on T007 (flag wiring), can run in parallel with Phase 3.
+- **Phase 5 (US3)**: T012 depends on US1 implementation (T010) since US3 verifies the build-tier emission output.
+- **Phase 6 (US4)**: T013 / T014 [P] / T015 [P] are different files (CDX emitter vs SPDX 2.3 emitter vs SPDX 3 emitter); they share no state and can run in parallel. T016 depends on all three implementation tasks.
+- **Phase 7 (Polish)**: T017 [P] (docs) parallel with T018 [P] (parity catalog); T019 (pre-PR gate) depends on Phases 1-6 complete; T020 depends on T019 (need a clean build to smoke-test).
+
+### Parallel Opportunities
+
+- T005 [P] in Phase 2: independent of T002-T004 (different file).
+- T011 in Phase 4: parallel with T010 (different concern; different test functions).
+- T014 [P] and T015 [P] in Phase 6: parallel with each other and with T013 (three independent format emitters).
+- T017 [P] and T018 [P] in Phase 7: parallel docs/catalog work.
+
+### Within Each User Story
+
+- US1 / US3 share the build-tier code path; US3 depends on US1 wiring.
+- US2 / US4 are independent of each other; both depend on Phase 2 flag plumbing.
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```bash
+# Sequential — same file (auto_detect.rs / mod.rs / validators.rs intermixed):
+Task: "T002 Add BuiltinScheme::Subject variant in mod.rs"
+Task: "T003 Add validate_subject in validators.rs"
+Task: "T004 Add subject_identifiers_from_attestation_subjects in auto_detect.rs"
+
+# Parallel with the above — different file:
+Task: "T005 Create component_id.rs new module"
+
+# After T002 + T005:
+Task: "T006 Extend ScanArtifacts with component_identifiers field"
+
+# After T002 + T005 + T006:
+Task: "T007 Add flags to ScanArgs in scan_cmd.rs"
+Task: "T008 Add flags to RunArgs in run.rs"
+```
+
+## Parallel Example: Phase 6 (US4 implementation)
+
+```bash
+# All three are different files, run in parallel:
+Task: "T013 [US4] CDX per-component emission"
+Task: "T014 [US4] [P] SPDX 2.3 per-component emission"
+Task: "T015 [US4] [P] SPDX 3 per-component emission"
+
+# After all three complete:
+Task: "T016 [US4] Add per-component integration tests across all 3 formats"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (Phases 1-3 = US1 alone)
+
+1. Phase 1 setup (T001).
+2. Phase 2 foundational (T002–T008).
+3. Phase 3 US1 (T009 + T010).
+4. **STOP and VALIDATE**: at this checkpoint, build-tier subject auto-detect works end-to-end. The wire-format works for the cross-tier handshake (US3) even without US3-specific tests. Per-component identifiers (US4) are not yet wired into format emitters but flag plumbing exists.
+5. Continue to Phases 4-7 to complete the milestone.
+
+### Incremental Delivery
+
+The milestone is small enough (estimated <1 week) that a single PR covering Phases 1-7 is the natural shape. Splitting the subject-identifier half (Phases 2-5) from the per-component half (Phase 6) is technically possible but creates a transient state where one operator-visible feature ships in alpha-X without the other; recommend single PR.
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Developer A: Phase 2 T002–T004 in `auto_detect.rs` / `mod.rs` / `validators.rs`.
+2. Developer B: Phase 2 T005 (new `component_id.rs` module) in parallel.
+3. Developer A or C: Phase 2 T006 / T007 / T008 (sequential after foundations).
+4. Developer A: Phase 3 T009 + T010 (US1 test + wiring).
+5. Developer B: Phase 6 T013 (CDX emitter), Developer C: Phase 6 T014 (SPDX 2.3 emitter), Developer D: Phase 6 T015 (SPDX 3 emitter) — three-way parallel.
+6. Anyone: Phase 4 T011, Phase 5 T012, Phase 6 T016, Phase 7 T017–T020.
+
+Single developer fits comfortably in <1 week. Parallel staffing is overkill for this size.
+
+---
+
+## Notes
+
+- [P] = different files, no incomplete-task dependencies.
+- All four user stories share Phase 2 production code. Test surface splits by user story; per-format emitter splits by format.
+- Per CLAUDE.md: pre-PR gate REQUIRES both `cargo +stable clippy --workspace --all-targets -- -D warnings` clean AND `cargo +stable test --workspace` clean. Cite both in the PR description.
+- Tests in `identifiers_subject_and_component.rs` MUST guard their `mod tests` items with `#[cfg_attr(test, allow(clippy::unwrap_used))]` per CLAUDE.md.
+- Total estimated tasks: 20. Total estimated effort: <1 person-week.


### PR DESCRIPTION
## Summary

Closes the cross-tier content-addressable correlation chain that milestones 072–075 began. Two deliverables:

1. **Document-level `subject:` identifier scheme** (fifth `BuiltinScheme` variant). Build-tier `mikebom trace run` auto-detects from the in-toto attestation subject set (sha256-only per the 2026-05-06 clarification). Source-tier and image-tier accept manual `--subject-hash sha256:<hex>`. Cross-tier handshake becomes automatic: build's `subject:sha256:X` matches image's `image:foo:v1@sha256:X` digest portion → external SBOM-store tools correlate by string match.
2. **Per-component user-defined identifiers** via `--component-id <PURL>=<scheme>:<value>`. Operator examples: `--component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-shared-lib-v2"`. Built-in scheme names rejected at parse time.

Both deliverables ride standards-native carriers per Constitution Principle V — **zero new `mikebom:*` annotations introduced**.

## Per-format wire mapping

| Surface | CDX 1.6 | SPDX 2.3 | SPDX 3 |
|---------|---------|----------|--------|
| Document `subject:` | `externalReferences[type:attestation]` | `externalRefs[PERSISTENT-ID][type:subject]` | `externalIdentifier[type:subject]` |
| Per-component user-defined | `components[].properties[name,value]` | `externalRefs[PERSISTENT-ID][type:scheme,locator:value]` | `externalIdentifier[type:scheme,identifier:value]` |

## Spec

- [`specs/076-subject-component-ids/spec.md`](specs/076-subject-component-ids/spec.md) — 4 user stories, 14 FRs, 9 SCs, 1 clarification (multi-digest sha256-only)
- [`specs/076-subject-component-ids/research.md`](specs/076-subject-component-ids/research.md) — 6 implementation decisions
- [`specs/076-subject-component-ids/data-model.md`](specs/076-subject-component-ids/data-model.md) — `BuiltinScheme::Subject`, `ComponentIdentifierFlag`, VR-076-001..006
- [`specs/076-subject-component-ids/T001-audit.md`](specs/076-subject-component-ids/T001-audit.md) — implementation-time audit findings (the trace's subject set is read from the just-emitted in-toto attestation file)

## Test plan

- [x] Pre-PR gate clean: `cargo +stable clippy --workspace --all-targets -- -D warnings` (zero warnings); `cargo +stable test --workspace` — all 49 test targets `0 failed`
- [x] 20 new integration tests in `mikebom-cli/tests/identifiers_subject_and_component.rs` cover all 4 user stories; all pass
- [x] 25+ new unit tests in `validators.rs` (validate_subject), `auto_estimate.rs` (subject_identifiers_from_attestation_subjects), and the new `component_id.rs` module
- [x] Existing milestone-073/074/075 byte-identity goldens stay byte-identical (no fixtures pass `--component-id`; no fixtures exercise build-tier subject auto-detect under eBPF)
- [x] All three formats emit the new identifiers in their respective standards-native carriers (verified by per-format integration tests in T011d, T016a/b/c)
- [x] Determinism verified per SC-004: `component_id_deterministic_across_reruns` test (T016j) re-runs scan with identical flags and asserts byte-equality across CDX/SPDX 2.3/SPDX 3
- [ ] Reviewer sanity-check: `mikebom trace run -- ./build.sh` in a real Linux + eBPF environment produces a build SBOM with `subject:` identifier(s) auto-detected from the attestation envelope's subjects
- [ ] Reviewer sanity-check: `--component-id "pkg:cargo/foo@1.0=subject:sha256:abc"` (built-in scheme) fails clean at clap parse with a clear error message

## Notable design decisions

1. **CDX type for `subject:` reuses `attestation`** (research §1). Same enum value milestone 073 uses for `attestation:` IRIs; disambiguated by URL value shape (digest vs IRI). Avoided inventing a new CDX enum value.
2. **Per-component CDX carrier is `properties[]`** (research §2). Native fit for `(name, value)` pairs; `externalReferences[]` would have forced URI-shape on non-URI values.
3. **Subject set source**: between `scan::execute` (which writes the in-toto attestation file) and `generate::execute` (which writes the SBOM), `cli/run.rs::execute` reads the just-emitted attestation file once via `read_attestation` and extracts `statement.subject: Vec<ResourceDescriptor>`. Soft-fails on read error per FR-005.
4. **Per-component identifiers attach to ALL matching components** (FR-011) — broadcast semantics, not main-module-gated.
5. **Built-in scheme rejection** runs at clap parse time via the new `parse_component_id_flag` value_parser — non-zero exit before any scan work happens.
6. **Multi-output build** produces multiple `subject:` identifiers in lex-sorted order (FR-002 + research §6).

## Deviations from plan

- **T001 audit**: identified that the trace's subject set is NOT in shared in-process state between `scan::execute` and `generate::execute` — it's persisted to disk in the attestation file. Implementation reads it from disk between phases (one `read_attestation` call). T001-audit.md captures the four explicit deliverables in detail.
- **T018 (parity catalog)**: did NOT add new catalog rows because both new identifier surfaces ride standards-native carriers (not `mikebom:*` annotation envelopes). Added a module-level documentation block in `parity/extractors/mod.rs` explaining the rationale instead.
- **`large_enum_variant` clippy lint**: adding two `Vec<...>` fields to `ScanArgs`/`RunArgs` tipped `SbomSubcommand`/`TraceSubcommand` past clippy's threshold. Allowed via `#[allow(clippy::large_enum_variant)]` rather than boxing variants (which would have rippled through the dispatch layer).

## Constitution check

All 12 principles + 4 strict boundaries pass per [`plan.md`](specs/076-subject-component-ids/plan.md#constitution-check). Specifically:
- Principle V native-first audit: zero new `mikebom:*` annotations; both deliverables ride existing native fields per format
- Principle X (Transparency): info-level logs for auto-detected subjects, info-level skip logs for non-sha256 subjects, warn-level logs for unmatched `--component-id` selectors

## Release notes (for changelog when alpha.18 is cut)

- **Subject identifier scheme**: build-tier `mikebom trace run` now auto-detects build-output hashes as first-class `subject:sha256:<hex>` identifiers in the SBOM body. Cross-tier correlation between source/build/image SBOMs no longer requires unwrapping the in-toto attestation envelope.
- **Per-component user-defined identifiers**: operators can attach internal asset IDs (e.g., `kusari-id:asset-foo`) to specific components via `--component-id <PURL>=<scheme>:<value>`. Identifiers ride standards-native per-component fields across all three SBOM formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)