### PR TITLE
feat(077): operator-overridable root component name and version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-06
 - N/A — sanitization is a pure-function transformation; no caches, no persistence. (075-strip-id-credentials)
 - Rust stable (workspace toolchain inherited from milestones 001–075; no nightly). + Existing only — `serde`/`serde_json`, `tracing`, `anyhow`, `clap` (the two new flags via derive), `thiserror`. The build-tier subject extraction reuses the in-toto witness-v0.1 subject set the existing trace pipeline already collects in-process; no new subprocess calls, no new I/O, no new crates. **No additions to the dependency tree at the lockfile level.** (076-subject-component-ids)
 - N/A — identifier emission is a pure metadata transform; no caches, no persistence. (076-subject-component-ids)
+- Rust stable (workspace toolchain inherited from milestones 001–076; no nightly). + Existing only — `serde`/`serde_json`, `tracing`, `anyhow`, `clap` (the two new flags via derive). The `url` crate is already a direct workspace dep (promoted in milestone 075) and reused for URL-encoding the override values into the PURL `name` segment per RFC 3986. **No additions to the dependency tree at the lockfile level.** (077-root-component-override)
+- N/A — purely a metadata transform; no caches, no persistence. (077-root-component-override)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -117,9 +119,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 077-root-component-override: Added Rust stable (workspace toolchain inherited from milestones 001–076; no nightly). + Existing only — `serde`/`serde_json`, `tracing`, `anyhow`, `clap` (the two new flags via derive). The `url` crate is already a direct workspace dep (promoted in milestone 075) and reused for URL-encoding the override values into the PURL `name` segment per RFC 3986. **No additions to the dependency tree at the lockfile level.**
 - 076-subject-component-ids: Added Rust stable (workspace toolchain inherited from milestones 001–075; no nightly). + Existing only — `serde`/`serde_json`, `tracing`, `anyhow`, `clap` (the two new flags via derive), `thiserror`. The build-tier subject extraction reuses the in-toto witness-v0.1 subject set the existing trace pipeline already collects in-process; no new subprocess calls, no new I/O, no new crates. **No additions to the dependency tree at the lockfile level.**
 - 075-strip-id-credentials: Added Rust stable (workspace toolchain inherited from milestones 001–074; no nightly). + Existing only — the `url = "2.5.8"` crate is already in the dependency closure (transitive via `reqwest`); this milestone promotes it to a direct workspace dependency. No new transitive deps. Plus `tracing` (info-level logs), `anyhow` (error propagation), `clap` (the new boolean flag — `Args`-derive picks it up). **No additions to the dependency tree at the lockfile level.**
-- 074-build-tier-id-autodetect: Added Rust stable (workspace toolchain inherited from milestones 001–073; no nightly required for this user-space-only work). + Existing only — `std::process::Command` for the new `git rev-parse HEAD` shell-out (same pattern as the existing `git remote get-url` calls at `auto_detect.rs:32`+ and as milestone 053's `git describe` ladder), `tracing` for info/warn logs, `anyhow` for error propagation. **No new `Cargo.toml` deps.**
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/docs/reference/identifiers.md
+++ b/docs/reference/identifiers.md
@@ -852,6 +852,151 @@ operator recipes covering all four user stories.
 
 ---
 
+## Section 10 — Milestone 077: Root component override (`--root-name` / `--root-version`)
+
+Milestone 077 adds two new CLI flags that override the auto-derived
+root component identity in the emitted SBOM. Before 077, source-tier
+scans of arbitrary directories produced names like
+`filesystem-scan@0.0.0` (basename of `--path` + hardcoded `0.0.0`)
+that didn't reflect the operator-meaningful project identity. The
+new flags close that gap.
+
+### 10.1 The two flags
+
+```text
+--root-name <NAME>      Override metadata.component.name.
+--root-version <VERSION> Override metadata.component.version.
+```
+
+Both flags accept any non-empty UTF-8 except whitespace, control
+characters, `?`, and `#` (the URL-syntax-breaking subset). Both
+flags are independent — operators can override one without the
+other. When neither is passed, behavior is byte-identical to
+alpha.17. URL-encoding is applied automatically at PURL emission
+time per RFC 3986 §2.3, so npm-scoped names like `@acme/widget-svc`
+are accepted at parse and percent-encoded into the PURL `name`
+segment (`%40acme%2Fwidget-svc`).
+
+Operators can stack the override with milestone-072–076 identifier
+flags freely — they're orthogonal slots:
+
+```bash
+mikebom sbom scan --path . \
+    --root-name widget-svc --root-version 1.2.3 \
+    --repo git@github.com:acme/widget-svc.git \
+    --subject-hash sha256:abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab \
+    --component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-foo" \
+    --output out.cdx.json
+```
+
+### 10.2 Operator recipes
+
+**Recipe A: source-tier override on an arbitrary directory.** The
+headline use case the milestone exists for.
+
+```bash
+mikebom sbom scan --path /opt/builds/abc123-snapshot \
+    --root-name widget-svc --root-version 1.2.3 \
+    --output widget-svc.cdx.json
+
+jq '.metadata.component | {name, version, "bom-ref", purl, cpe}' widget-svc.cdx.json
+# {
+#   "name": "widget-svc",
+#   "version": "1.2.3",
+#   "bom-ref": "widget-svc@1.2.3",
+#   "purl": "pkg:generic/widget-svc@1.2.3",
+#   "cpe": "cpe:2.3:a:mikebom:widget-svc:1.2.3:*:*:*:*:*:*:*"
+# }
+```
+
+**Recipe B: override on a manifest-driven Cargo project (clean
+replacement).** When the override is set on a Cargo project, the
+manifest-derived main-module identity is dropped entirely from the
+emitted SBOM (it doesn't appear in `metadata.component`, and it
+doesn't appear in `components[]` as a demoted library entry).
+
+```bash
+cd ~/projects/foo-internal-cargo  # has [package].name = "foo-internal"
+mikebom sbom scan --path . \
+    --root-name widget-svc --root-version 1.2.3 \
+    --output out.cdx.json
+
+# The manifest main-module is gone:
+jq '.components[] | select(.purl == "pkg:cargo/foo-internal@0.5.1")' out.cdx.json
+# (no output)
+
+# metadata.component carries the operator identity:
+jq '.metadata.component.name' out.cdx.json
+# "widget-svc"
+```
+
+To preserve the manifest-derived identity as a regular library
+entry alongside the override, track **GitHub issue #151** (the
+"demote to library" follow-up). Today's MVP uses clean replacement.
+
+**Recipe C: override on image-tier scan.** Useful when the image
+SBOM should identify as the deployed service name rather than the
+image basename. The auto-detected `image:` identifier (milestone
+073) is unaffected — it rides the orthogonal `externalReferences[]`
+slot.
+
+```bash
+mikebom sbom scan --image acme/internal-bld:v1 \
+    --root-name widget-svc-image --root-version 1.2.3 \
+    --output image.cdx.json
+```
+
+### 10.3 Per-format wire mapping
+
+| Field | CDX 1.6 | SPDX 2.3 | SPDX 3.0.1 |
+|-------|---------|----------|------------|
+| Name | `metadata.component.name` | Synthesized root `Package.name` | Synthesized root element `name` |
+| Version | `metadata.component.version` | Synthesized root `Package.versionInfo` | Synthesized root element `software_packageVersion` |
+| `bom-ref`/SPDXID | `metadata.component.bom-ref = <name>@<version>` | `Package.SPDXID` (hash-derived from override) | Element `spdxId` (hash-derived from override) |
+| PURL | `metadata.component.purl = pkg:generic/<percent-encoded(name)>@<percent-encoded(version)>` | `Package.externalRefs[purl]` | Element `software_packageUrl` |
+| CPE | `metadata.component.cpe` | `Package.externalRefs[cpe23Type]` | Element `externalIdentifier[cpe23]` |
+
+When the override is active, manifest-derived main-module components
+(identified by `properties[mikebom:component-role=main-module]`) are
+filtered OUT of:
+- CDX `components[]`
+- SPDX 2.3 `packages[]`
+- SPDX 3 `@graph[type=software_Package]` elements
+
+per the 2026-05-06 clean-replacement clarification. See GitHub
+issue #151 for the demote-to-library follow-up tracking.
+
+### 10.4 Validation rules
+
+`--root-name` and `--root-version` reject the following at CLI
+parse (before any scan work happens):
+- Empty strings
+- ASCII whitespace
+- ASCII control characters (`\x00`–`\x1F`, `\x7F`)
+- `?` and `#` (the URL-syntax-breaking subset)
+
+Error messages identify the offending character and its position so
+operators can pinpoint the violation:
+
+```bash
+mikebom sbom scan --path . --root-name "my widget svc"
+# error: invalid value 'my widget svc' for '--root-name <NAME>':
+# --root-name contains whitespace at position 2 (character: ' ');
+# whitespace is not allowed
+```
+
+### 10.5 Backward compatibility
+
+All milestone-073/074/075/076 byte-identity goldens stay
+byte-identical: no existing fixture passes `--root-name` or
+`--root-version`, and the no-flag emission path is unchanged.
+The new helper `percent_encode_purl_name` is invoked only on the
+override-active path; non-override PURL emission continues to use
+the existing `encode_purl_segment` (CDX) and `url_friendly` (SPDX 3)
+helpers verbatim per research §1.
+
+---
+
 ## See also
 
 - [Cross-tier binding (milestone 072)](cross-tier-binding.md) — the

--- a/mikebom-cli/src/cli/generate.rs
+++ b/mikebom-cli/src/cli/generate.rs
@@ -81,6 +81,17 @@ pub struct GenerateArgs {
     #[arg(skip)]
     pub component_identifiers:
         Vec<mikebom::binding::identifiers::component_id::ComponentIdentifierFlag>,
+
+    /// Milestone 077: operator-supplied overrides for the root
+    /// component's name + version, threaded from `mikebom trace run`'s
+    /// `--root-name` / `--root-version` flags. Per research §6 this
+    /// field is `#[arg(skip)]` because the `mikebom sbom generate`
+    /// subcommand itself does NOT receive new flags — overriding the
+    /// root component on a re-emit-from-attestation flow has ambiguous
+    /// semantics. The override only takes effect when populated by
+    /// `cli/run.rs::execute` from the trace-run flags.
+    #[arg(skip)]
+    pub root_override: crate::generate::RootComponentOverride,
 }
 
 pub async fn execute(args: GenerateArgs, offline: bool) -> anyhow::Result<()> {
@@ -159,7 +170,13 @@ pub async fn execute(args: GenerateArgs, offline: bool) -> anyhow::Result<()> {
         // identifiers so build-tier `mikebom trace run` honors
         // `--component-id` matches against the emitted CDX
         // `components[]`.
-        .with_component_identifiers(args.component_identifiers.clone());
+        .with_component_identifiers(args.component_identifiers.clone())
+        // Milestone 077 — propagate the operator-supplied root-
+        // component override from the trace-run flags
+        // (`--root-name` / `--root-version`). Empty by default for
+        // the standalone `mikebom sbom generate` invocation per
+        // research §6.
+        .with_root_override(args.root_override.clone());
     let bom = builder.build(
         &components,
         &relationships,

--- a/mikebom-cli/src/cli/run.rs
+++ b/mikebom-cli/src/cli/run.rs
@@ -175,6 +175,32 @@ pub struct RunArgs {
     pub component_id:
         Vec<mikebom::binding::identifiers::component_id::ComponentIdentifierFlag>,
 
+    /// Override the auto-derived `metadata.component.name` of the
+    /// emitted SBOM. Same shape and validation as
+    /// `mikebom sbom scan --root-name`: accepts any non-empty UTF-8
+    /// except whitespace, control characters, `?`, and `#`. URL-encoded
+    /// automatically when emitted into the PURL `name` segment. When
+    /// the trace produces a manifest-derived main-module component
+    /// (Cargo, npm, pip, gem, Maven, Go), setting this flag drops that
+    /// component from the emitted SBOM (clean replacement). See GitHub
+    /// issue #151 for the demote-to-library follow-up.
+    #[arg(
+        long = "root-name",
+        value_name = "NAME",
+        value_parser = super::scan_cmd::validate_root_name,
+    )]
+    pub root_name: Option<String>,
+
+    /// Override the auto-derived `metadata.component.version`. Same
+    /// validation rules as `--root-name`. Independent — can be set
+    /// without `--root-name` and vice versa.
+    #[arg(
+        long = "root-version",
+        value_name = "VERSION",
+        value_parser = super::scan_cmd::validate_root_version,
+    )]
+    pub root_version: Option<String>,
+
     /// Directories to scan for artifact files after the traced command
     /// exits. Forwarded verbatim to `mikebom trace capture`. See the
     /// `--artifact-dir` flag there for details.
@@ -392,6 +418,13 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
         // Milestone 076 — forward per-component user-defined
         // identifiers for the CDX build-tier emission path.
         component_identifiers: args.component_id.clone(),
+        // Milestone 077 — forward operator-supplied root-component
+        // override from the trace-run flags. Empty default when
+        // neither flag was passed (back-compat).
+        root_override: crate::generate::RootComponentOverride {
+            name: args.root_name.clone(),
+            version: args.root_version.clone(),
+        },
     };
     // Trace's one-shot `run` wrapper doesn't thread the global --offline
     // flag through (yet). Default to online — the enrichment doesn't

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -387,6 +387,96 @@ pub struct ScanArgs {
     )]
     pub component_id:
         Vec<mikebom::binding::identifiers::component_id::ComponentIdentifierFlag>,
+
+    /// Override the auto-derived `metadata.component.name` of the
+    /// emitted SBOM. Useful when scanning an arbitrary directory whose
+    /// basename doesn't reflect the operator-meaningful project
+    /// identity. Accepts any non-empty UTF-8 except whitespace, control
+    /// characters, `?`, and `#`. URL-encoded automatically when emitted
+    /// into the PURL `name` segment.
+    ///
+    /// When this flag is set on a manifest-driven scan (Cargo, npm,
+    /// pip, gem, Maven, Go), the manifest-derived main-module
+    /// component is dropped entirely from the emitted SBOM (clean
+    /// replacement). To preserve the manifest-derived identity as a
+    /// regular library entry alongside the override, track GitHub
+    /// issue #151.
+    #[arg(
+        long = "root-name",
+        value_name = "NAME",
+        value_parser = validate_root_name,
+    )]
+    pub root_name: Option<String>,
+
+    /// Override the auto-derived `metadata.component.version`. Same
+    /// validation rules as `--root-name`. Independent — can be set
+    /// without `--root-name` and vice versa. When unset, falls through
+    /// to the auto-derived version (typically `0.0.0` for arbitrary
+    /// directories or the manifest-derived version for project scans).
+    #[arg(
+        long = "root-version",
+        value_name = "VERSION",
+        value_parser = validate_root_version,
+    )]
+    pub root_version: Option<String>,
+}
+
+/// Milestone 077 — validate `--root-name` / `--root-version` values
+/// at CLI parse time. Per FR-006 + Q1 clarification: rejects empty
+/// strings, ASCII whitespace, control characters (`\x00`–`\x1F`,
+/// `\x7F`), `?`, and `#`. Accepts any other UTF-8.
+///
+/// The error messages identify the offending character + position so
+/// operators understand which character violated which rule (operators
+/// with weird-but-legal names like `@acme/widget-svc` need to know it's
+/// the `@` or `/` that's allowed, vs `?`/`#` which are rejected).
+///
+/// Returns the validated string verbatim on success — the caller stores
+/// it in `RootComponentOverride.name` / `.version` for downstream
+/// per-format emission. The PURL emitter applies its own RFC 3986
+/// percent-encoding via `percent_encode_purl_name` at emission time.
+pub(crate) fn validate_root_field(
+    value: &str,
+    flag_name: &str,
+) -> Result<String, String> {
+    if value.is_empty() {
+        return Err(format!("{flag_name} must not be empty"));
+    }
+    for (i, c) in value.chars().enumerate() {
+        if c.is_whitespace() {
+            return Err(format!(
+                "{flag_name} contains whitespace at position {i} \
+                 (character: {c:?}); whitespace is not allowed"
+            ));
+        }
+        if c.is_control() {
+            return Err(format!(
+                "{flag_name} contains a control character at position {i} \
+                 (codepoint: U+{:04X}); control characters are not allowed",
+                c as u32
+            ));
+        }
+        if c == '?' || c == '#' {
+            return Err(format!(
+                "{flag_name} contains URL-syntax-breaking character '{c}' \
+                 at position {i}; '?' and '#' are not allowed"
+            ));
+        }
+    }
+    Ok(value.to_string())
+}
+
+/// Clap value_parser for `--root-name`. Wraps `validate_root_field`
+/// with the canonical flag-name string so error messages identify the
+/// flag.
+pub(crate) fn validate_root_name(value: &str) -> Result<String, String> {
+    validate_root_field(value, "--root-name")
+}
+
+/// Clap value_parser for `--root-version`. Wraps `validate_root_field`
+/// with the canonical flag-name string.
+pub(crate) fn validate_root_version(value: &str) -> Result<String, String> {
+    validate_root_field(value, "--root-version")
 }
 
 /// Parse a `--id <scheme>=<value>` flag for a user-defined identifier.
@@ -1500,6 +1590,14 @@ pub async fn execute(
         // `--component-id <PURL>=<scheme>:<value>` flags. Threaded to
         // per-format emitters which match against `components[].purl`.
         component_identifiers: &args.component_id,
+        // Milestone 077: operator-supplied overrides for the root
+        // component's name + version. Constructed from the new
+        // `--root-name` / `--root-version` CLI flags; defaults to
+        // both-None (back-compat) when neither flag is passed.
+        root_override: crate::generate::RootComponentOverride {
+            name: args.root_name.clone(),
+            version: args.root_version.clone(),
+        },
     };
     let output_cfg = OutputConfig {
         mikebom_version: env!("CARGO_PKG_VERSION"),
@@ -2104,6 +2202,8 @@ mod tests {
             keep_credentials_in_identifiers: false,
             subject_hash: vec![],
             component_id: vec![],
+            root_name: None,
+            root_version: None,
         }
     }
 
@@ -2479,5 +2579,68 @@ mod tests {
         assert_eq!(registry.as_deref(), Some("docker.io"));
         assert_eq!(name, "acme/foo");
         assert_eq!(tag.as_deref(), Some("v1"));
+    }
+
+    // ---------- Milestone 077 — validate_root_field ----------
+
+    #[test]
+    fn validate_root_field_accepts_simple_name() {
+        let r = validate_root_field("widget-svc", "--root-name");
+        assert_eq!(r.as_deref().ok(), Some("widget-svc"));
+    }
+
+    #[test]
+    fn validate_root_field_accepts_npm_scoped_name() {
+        // Per Q1 clarification: `@` and `/` are PURL-reserved but NOT
+        // rejected at parse — they're URL-encoded at PURL emission.
+        let r = validate_root_field("@acme/widget-svc", "--root-name");
+        assert_eq!(r.as_deref().ok(), Some("@acme/widget-svc"));
+    }
+
+    #[test]
+    fn validate_root_field_accepts_version_with_dots() {
+        let r = validate_root_field("1.2.3", "--root-version");
+        assert_eq!(r.as_deref().ok(), Some("1.2.3"));
+    }
+
+    #[test]
+    fn validate_root_field_rejects_empty() {
+        let r = validate_root_field("", "--root-name");
+        let err = r.unwrap_err();
+        assert!(err.contains("must not be empty"), "got: {err}");
+        assert!(err.contains("--root-name"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_root_field_rejects_whitespace() {
+        let r = validate_root_field("my widget svc", "--root-name");
+        let err = r.unwrap_err();
+        assert!(err.contains("whitespace"), "got: {err}");
+        assert!(err.contains("position 2"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_root_field_rejects_control_char() {
+        let r = validate_root_field("foo\x01bar", "--root-name");
+        let err = r.unwrap_err();
+        assert!(err.contains("control character"), "got: {err}");
+        assert!(err.contains("U+0001"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_root_field_rejects_question_mark() {
+        let r = validate_root_field("foo?bar", "--root-name");
+        let err = r.unwrap_err();
+        assert!(err.contains("URL-syntax-breaking"), "got: {err}");
+        assert!(err.contains("'?'"), "got: {err}");
+        assert!(err.contains("position 3"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_root_field_rejects_hash() {
+        let r = validate_root_field("foo#bar", "--root-name");
+        let err = r.unwrap_err();
+        assert!(err.contains("URL-syntax-breaking"), "got: {err}");
+        assert!(err.contains("'#'"), "got: {err}");
     }
 }

--- a/mikebom-cli/src/generate/cyclonedx/builder.rs
+++ b/mikebom-cli/src/generate/cyclonedx/builder.rs
@@ -78,6 +78,13 @@ pub struct CycloneDxBuilder {
     /// gains entries for matching PURLs.
     component_identifiers:
         Vec<mikebom::binding::identifiers::component_id::ComponentIdentifierFlag>,
+    /// Milestone 077 — operator-supplied overrides for the root
+    /// component's name + version. When `is_active()`, the override
+    /// values replace the auto-derived ones in `metadata.component`
+    /// AND any manifest-derived main-module components are filtered
+    /// from the emitted `components[]` array (clean replacement per
+    /// the 2026-05-06 Q2 clarification).
+    root_override: crate::generate::RootComponentOverride,
 }
 
 impl CycloneDxBuilder {
@@ -91,7 +98,23 @@ impl CycloneDxBuilder {
             source_document_binding: None,
             identifiers: Vec::new(),
             component_identifiers: Vec::new(),
+            root_override: crate::generate::RootComponentOverride::default(),
         }
+    }
+
+    /// Milestone 077 — record the operator-supplied root-component
+    /// override. When the override `is_active()`, the per-format
+    /// build path uses the operator-supplied name/version verbatim
+    /// (with PURL percent-encoding applied at emission) and drops
+    /// manifest-derived main-module components from the emitted
+    /// `components[]` array per the 2026-05-06 clean-replacement
+    /// clarification.
+    pub fn with_root_override(
+        mut self,
+        ov: crate::generate::RootComponentOverride,
+    ) -> Self {
+        self.root_override = ov;
+        self
     }
 
     /// Milestone 072 / T010 — record the source-tier SBOM identifier
@@ -170,14 +193,75 @@ impl CycloneDxBuilder {
         scan_target_coord: Option<&crate::scan_fs::package_db::maven::ScanTargetCoord>,
     ) -> anyhow::Result<serde_json::Value> {
         let serial_number = format!("urn:uuid:{}", Uuid::new_v4());
-        let target_version = "0.0.0"; // Derived from build metadata when available
-        let target_ref = format!("{target_name}@{target_version}");
+
+        // Milestone 077 — when the operator supplied --root-name and/or
+        // --root-version, the override values become the BOM-subject
+        // identity AND any manifest-derived main-module components are
+        // dropped from the emitted components[] array (clean replacement
+        // per Q2 clarification). The unset half (when only one flag is
+        // passed) falls through to the existing auto-derivation.
+        let override_active = self.root_override.is_active();
+        let effective_target_name: String = self
+            .root_override
+            .name
+            .clone()
+            .unwrap_or_else(|| target_name.to_string());
+        let effective_target_version: String = self
+            .root_override
+            .version
+            .clone()
+            .unwrap_or_else(|| "0.0.0".to_string());
+        if override_active {
+            tracing::info!(
+                name = %effective_target_name,
+                version = %effective_target_version,
+                "root component override active: name='{}' (replacing '{}'), version='{}' (replacing '0.0.0')",
+                effective_target_name,
+                target_name,
+                effective_target_version,
+            );
+        }
+
+        // Milestone 077 — when override is active, filter manifest-
+        // derived main-module components OUT of the components slice
+        // BEFORE downstream emission (build_components, compositions,
+        // dependencies). This is the clean-replacement implementation
+        // per FR-008 / VR-077-003.
+        let filtered_components_owned: Option<Vec<ResolvedComponent>> = if override_active {
+            let mut keep: Vec<ResolvedComponent> = Vec::with_capacity(components.len());
+            for c in components.iter() {
+                let is_main_module = c
+                    .extra_annotations
+                    .get("mikebom:component-role")
+                    .and_then(|v| v.as_str())
+                    == Some("main-module");
+                if is_main_module {
+                    tracing::info!(
+                        purl = %c.purl,
+                        "override is set; dropping manifest-derived main-module component '{}' from emitted SBOM (per milestone 077 clean-replacement; see GitHub issue #151)",
+                        c.purl
+                    );
+                } else {
+                    keep.push(c.clone());
+                }
+            }
+            Some(keep)
+        } else {
+            None
+        };
+        let effective_components: &[ResolvedComponent] =
+            filtered_components_owned.as_deref().unwrap_or(components);
+
+        let target_ref = format!(
+            "{}@{}",
+            effective_target_name, effective_target_version
+        );
 
         let metadata = build_metadata(
             target_name,
-            target_version,
+            "0.0.0",
             self.config.generation_context.clone(),
-            components,
+            effective_components,
             &self.os_release_missing_fields,
             integrity,
             scan_target_coord,
@@ -185,6 +269,7 @@ impl CycloneDxBuilder {
             self.go_graph_completeness_reason.as_deref(),
             self.source_document_binding.as_ref(),
             &self.identifiers,
+            &self.root_override,
         );
         // Milestone 076 — track per-component identifier matches so
         // we can emit a warn for any selector that matched zero
@@ -194,7 +279,7 @@ impl CycloneDxBuilder {
         for i in 0..self.component_identifiers.len() {
             match_counts.insert(i, 0);
         }
-        let cdx_components = self.build_components(components, &mut match_counts)?;
+        let cdx_components = self.build_components(effective_components, &mut match_counts)?;
         for (idx, count) in &match_counts {
             if *count == 0 {
                 let flag = &self.component_identifiers[*idx];
@@ -210,10 +295,14 @@ impl CycloneDxBuilder {
                 );
             }
         }
-        let compositions =
-            build_compositions(integrity, &target_ref, components, complete_ecosystems);
-        let deps = build_dependencies(components, relationships, &target_ref);
-        let vulnerabilities = build_vulnerabilities(components);
+        let compositions = build_compositions(
+            integrity,
+            &target_ref,
+            effective_components,
+            complete_ecosystems,
+        );
+        let deps = build_dependencies(effective_components, relationships, &target_ref);
+        let vulnerabilities = build_vulnerabilities(effective_components);
 
         let bom = json!({
             "bomFormat": "CycloneDX",
@@ -1568,5 +1657,171 @@ mod tests {
         }
         assert!(seen.contains(&("MIT".to_string(), "declared".to_string())));
         assert!(seen.contains(&("Apache-2.0".to_string(), "concluded".to_string())));
+    }
+
+    // -------- Milestone 077 — root component override --------
+
+    fn make_main_module_component(
+        ecosystem: &str,
+        name: &str,
+        version: &str,
+    ) -> ResolvedComponent {
+        let mut c = make_component(name, version);
+        let purl_str = format!("pkg:{ecosystem}/{name}@{version}");
+        c.purl = Purl::new(&purl_str).expect("valid purl");
+        c.extra_annotations.insert(
+            "mikebom:component-role".to_string(),
+            serde_json::Value::String("main-module".to_string()),
+        );
+        c
+    }
+
+    #[test]
+    fn override_active_replaces_metadata_component_identity() {
+        // FR-001 + FR-002 + FR-004 — name/version override drives all
+        // derived fields verbatim through the percent-encode helper.
+        let builder = CycloneDxBuilder::new(CycloneDxConfig::default())
+            .with_root_override(crate::generate::RootComponentOverride {
+                name: Some("widget-svc".to_string()),
+                version: Some("1.2.3".to_string()),
+            });
+        let components = vec![make_component("serde", "1.0.0")];
+        let integrity = clean_integrity();
+        let bom = builder
+            .build(&components, &[], &integrity, "abc123-snapshot", &[], None)
+            .expect("build bom");
+        let comp = &bom["metadata"]["component"];
+        assert_eq!(comp["name"], "widget-svc");
+        assert_eq!(comp["version"], "1.2.3");
+        assert_eq!(comp["bom-ref"], "widget-svc@1.2.3");
+        assert_eq!(comp["purl"], "pkg:generic/widget-svc@1.2.3");
+        assert_eq!(
+            comp["cpe"],
+            "cpe:2.3:a:mikebom:widget-svc:1.2.3:*:*:*:*:*:*:*"
+        );
+    }
+
+    #[test]
+    fn override_drops_manifest_main_module_from_components_array() {
+        // SC-006 / FR-008 — manifest-derived main-module is filtered
+        // OUT of components[] when override is active.
+        let builder = CycloneDxBuilder::new(CycloneDxConfig::default())
+            .with_root_override(crate::generate::RootComponentOverride {
+                name: Some("widget-svc".to_string()),
+                version: Some("1.2.3".to_string()),
+            });
+        let components = vec![
+            make_main_module_component("cargo", "foo-internal", "0.5.1"),
+            make_component("serde", "1.0.0"),
+        ];
+        let integrity = clean_integrity();
+        let bom = builder
+            .build(&components, &[], &integrity, "myapp", &[], None)
+            .expect("build bom");
+        let cdx_components = bom["components"].as_array().expect("components[]");
+        // Main-module is dropped; only `serde` remains.
+        let purls: Vec<&str> = cdx_components
+            .iter()
+            .filter_map(|c| c["purl"].as_str())
+            .collect();
+        assert!(
+            !purls.contains(&"pkg:cargo/foo-internal@0.5.1"),
+            "main-module PURL must be dropped; got: {purls:?}"
+        );
+        assert!(
+            purls.contains(&"pkg:cargo/serde@1.0.0"),
+            "regular dep must be preserved; got: {purls:?}"
+        );
+    }
+
+    #[test]
+    fn no_override_preserves_main_module() {
+        // FR-009 — no-flag case preserves manifest-derived main-module
+        // (no regression).
+        let builder = CycloneDxBuilder::new(CycloneDxConfig::default());
+        let components = vec![
+            make_main_module_component("cargo", "foo-internal", "0.5.1"),
+            make_component("serde", "1.0.0"),
+        ];
+        let integrity = clean_integrity();
+        let bom = builder
+            .build(&components, &[], &integrity, "myapp", &[], None)
+            .expect("build bom");
+        // With one main-module + no override, it gets promoted to
+        // metadata.component (CDX 053-style placement) so it's NOT in
+        // components[]. The override-aware test above is about the
+        // override path. Here we verify the auto-derivation: the
+        // metadata.component MUST be the main-module (not a synthesized
+        // override identity).
+        assert_eq!(
+            bom["metadata"]["component"]["name"], "foo-internal",
+            "auto-derived metadata.component should be the main-module"
+        );
+        assert_eq!(
+            bom["metadata"]["component"]["version"], "0.5.1"
+        );
+    }
+
+    #[test]
+    fn override_on_build_tier_with_identifiers_orthogonal() {
+        // T011(b) US2 — synthetic build-tier scenario: override is
+        // active, build-tier identifiers (`repo:` + `subject:`) are
+        // also attached, and BOTH coexist independently in the emitted
+        // SBOM. Verifies FR-011 (orthogonality with milestones 073/076).
+        use mikebom::binding::identifiers::Identifier;
+        let repo_id = Identifier::parse("repo:git@github.com:acme/widget-svc.git")
+            .expect("parse repo");
+        let subject_id = Identifier::parse(
+            "subject:sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .expect("parse subject");
+        let identifiers = vec![repo_id, subject_id];
+
+        let builder = CycloneDxBuilder::new(CycloneDxConfig {
+            include_hashes: true,
+            include_source_files: false,
+            generation_context: GenerationContext::BuildTimeTrace,
+            include_dev: false,
+        })
+        .with_identifiers(identifiers)
+        .with_root_override(crate::generate::RootComponentOverride {
+            name: Some("widget-svc".to_string()),
+            version: Some("1.2.3".to_string()),
+        });
+        let components = vec![make_component("serde", "1.0.0")];
+        let integrity = clean_integrity();
+        let bom = builder
+            .build(
+                &components,
+                &[],
+                &integrity,
+                "build-tier-target",
+                &[],
+                None,
+            )
+            .expect("build bom");
+
+        // Override identity drives metadata.component.
+        assert_eq!(bom["metadata"]["component"]["name"], "widget-svc");
+        assert_eq!(bom["metadata"]["component"]["version"], "1.2.3");
+
+        // Identifiers ride the orthogonal externalReferences[] slot —
+        // unaffected by the override.
+        let ext_refs = bom["metadata"]["component"]["externalReferences"]
+            .as_array()
+            .expect("externalReferences[]");
+        let urls: Vec<&str> = ext_refs
+            .iter()
+            .filter_map(|r| r["url"].as_str())
+            .collect();
+        assert!(
+            urls.contains(&"git@github.com:acme/widget-svc.git"),
+            "repo: identifier preserved; got: {urls:?}"
+        );
+        assert!(
+            urls.iter()
+                .any(|u| u.starts_with("sha256:0123456789")),
+            "subject: identifier preserved; got: {urls:?}"
+        );
     }
 }

--- a/mikebom-cli/src/generate/cyclonedx/metadata.rs
+++ b/mikebom-cli/src/generate/cyclonedx/metadata.rs
@@ -6,6 +6,8 @@ use mikebom_common::resolution::ResolvedComponent;
 use mikebom_common::types::purl::encode_purl_segment;
 use serde_json::json;
 
+use crate::generate::{percent_encode_purl_name, RootComponentOverride};
+
 /// Normalize a string for inclusion in a CPE 2.3 segment.
 ///
 /// CPE 2.3 well-formed name segments (per NIST) are lowercase and use
@@ -51,6 +53,7 @@ pub fn build_metadata(
     go_graph_completeness_reason: Option<&str>,
     source_document_binding: Option<&mikebom::binding::SourceDocumentId>,
     identifiers: &[mikebom::binding::identifiers::Identifier],
+    root_override: &RootComponentOverride,
 ) -> serde_json::Value {
     let version = env!("CARGO_PKG_VERSION");
     let timestamp = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
@@ -195,8 +198,32 @@ pub fn build_metadata(
         None
     };
 
+    // Milestone 077 — when the operator-supplied override is active,
+    // short-circuit the priority ladder above. The override values
+    // become the BOM-subject identity verbatim, with PURL percent-
+    // encoding applied per RFC 3986 §2.3 (research §1). This also
+    // means the manifest-derived main-module is suppressed at the
+    // metadata.component slot here AND filtered out of the
+    // components[] array by the builder per FR-008 / Q2 clean-
+    // replacement clarification.
+    let override_active = root_override.is_active();
     let (subject_name, subject_version, synthetic_component_purl) =
-        if let Some(c) = main_module {
+        if override_active {
+            let name = root_override
+                .name
+                .clone()
+                .unwrap_or_else(|| target_name.to_string());
+            let version = root_override
+                .version
+                .clone()
+                .unwrap_or_else(|| target_version.to_string());
+            let purl = format!(
+                "pkg:generic/{}@{}",
+                percent_encode_purl_name(&name),
+                percent_encode_purl_name(&version),
+            );
+            (name, version, purl)
+        } else if let Some(c) = main_module {
             (
                 c.name.clone(),
                 c.version.clone(),
@@ -235,7 +262,17 @@ pub fn build_metadata(
     // alphanumerics → underscore). sbomqs's schema validator runs CPE
     // validation on metadata.component and flags empty/absent fields
     // as invalid.
-    let synthetic_component_cpe = if let Some(c) = main_module {
+    let synthetic_component_cpe = if override_active {
+        // Milestone 077 — operator-supplied identity drives the CPE
+        // verbatim through the existing `cpe_sanitize` helper. Vendor
+        // stays hardcoded `mikebom` per spec assumption (out of scope
+        // for this milestone).
+        format!(
+            "cpe:2.3:a:mikebom:{}:{}:*:*:*:*:*:*:*",
+            cpe_sanitize(&subject_name),
+            cpe_sanitize(&subject_version),
+        )
+    } else if let Some(c) = main_module {
         c.cpes
             .first()
             .cloned()
@@ -291,17 +328,23 @@ pub fn build_metadata(
             "type": "application",
             "name": subject_name,
             "version": subject_version,
-            "bom-ref": if main_module.is_some() {
+            "bom-ref": if main_module.is_some() && !override_active {
                 // Milestone 053: when the metadata.component is the
-                // Go main-module, its bom-ref MUST equal the PURL so
-                // existing `dependencies[].ref` entries (which key
-                // off the main-module's PURL via `scan_fs/mod.rs`'s
-                // edge-emission loop) resolve to it. The default
-                // `name@version` shape works for synthetic
-                // placeholders but breaks edge resolution for real
-                // components.
+                // Go main-module (and the operator has NOT overridden
+                // the root identity per milestone 077), its bom-ref
+                // MUST equal the PURL so existing `dependencies[].ref`
+                // entries (which key off the main-module's PURL via
+                // `scan_fs/mod.rs`'s edge-emission loop) resolve to
+                // it. The default `name@version` shape works for
+                // synthetic placeholders + override paths but breaks
+                // edge resolution for real main-module components.
                 synthetic_component_purl.clone()
             } else {
+                // Milestone 077: when override is active, bom-ref uses
+                // the operator-supplied identity verbatim — manifest-
+                // derived main-modules are dropped from components[]
+                // anyway (clean replacement), so there are no
+                // dependencies[].ref entries keyed off their PURL.
                 format!("{}@{}", subject_name, subject_version)
             },
             "purl": synthetic_component_purl,
@@ -317,7 +360,12 @@ pub fn build_metadata(
     // the native field (`type: "application"`) OR the supplementary
     // tag identify the main-module. Also surface
     // `mikebom:sbom-tier: "source"` per FR-006.
-    if let Some(c) = main_module {
+    //
+    // Milestone 077: when the override is active, the manifest main-
+    // module is no longer the BOM subject — skip these supplementary
+    // properties so the emitted root reflects only operator-supplied
+    // identity (clean replacement per Q2 clarification).
+    if let (Some(c), false) = (main_module, override_active) {
         let mut comp_props = vec![json!({
             "name": "mikebom:component-role",
             "value": "main-module",
@@ -494,7 +542,7 @@ mod tests {
 
     #[test]
     fn metadata_has_required_fields() {
-        let meta = build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[]);
+        let meta = build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[], &RootComponentOverride::default());
 
         assert!(meta["timestamp"].is_string());
         assert_eq!(meta["tools"]["components"][0]["name"], "mikebom");
@@ -515,7 +563,7 @@ mod tests {
     #[test]
     fn metadata_includes_authors_for_sbom_authors_score() {
         let meta =
-            build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[]);
+            build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[], &RootComponentOverride::default());
         let authors = meta["authors"].as_array().expect("authors must be array");
         assert!(!authors.is_empty(), "authors must be non-empty");
         assert!(authors[0]["name"].is_string());
@@ -524,7 +572,7 @@ mod tests {
     #[test]
     fn metadata_includes_supplier_for_sbom_supplier_score() {
         let meta =
-            build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[]);
+            build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[], &RootComponentOverride::default());
         assert!(
             meta["supplier"]["name"].is_string(),
             "supplier.name must be present as a string"
@@ -536,7 +584,7 @@ mod tests {
         // sbomqs sbom_data_license scores the SBOM's own license. SPDX
         // convention is CC0-1.0 so SBOM content is free to redistribute.
         let meta =
-            build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[]);
+            build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[], &RootComponentOverride::default());
         let licenses = meta["licenses"].as_array().expect("licenses must be array");
         assert!(!licenses.is_empty());
         assert_eq!(licenses[0]["license"]["id"], "CC0-1.0");
@@ -547,7 +595,7 @@ mod tests {
         // sbomqs flags metadata.component as invalid without a purl.
         // Mikebom synthesizes pkg:generic/<name>@<version>.
         let meta =
-            build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[]);
+            build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[], &RootComponentOverride::default());
         assert_eq!(meta["component"]["purl"], "pkg:generic/myapp@0.1.0");
     }
 
@@ -556,7 +604,7 @@ mod tests {
         // sbomqs flags empty/absent cpe on metadata.component as invalid.
         // Mikebom emits cpe:2.3:a:mikebom:<name>:<version>:*:*:*:*:*:*:*.
         let meta =
-            build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[]);
+            build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[], &RootComponentOverride::default());
         assert_eq!(
             meta["component"]["cpe"],
             "cpe:2.3:a:mikebom:myapp:0.1.0:*:*:*:*:*:*:*"
@@ -588,6 +636,7 @@ mod tests {
         None,
         None,
         &[],
+        &RootComponentOverride::default(),
         );
         let purl = meta["component"]["purl"].as_str().unwrap();
         assert!(
@@ -603,16 +652,16 @@ mod tests {
 
     #[test]
     fn metadata_bom_ref_format() {
-        let meta = build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[]);
+        let meta = build_metadata("myapp", "0.1.0", GenerationContext::BuildTimeTrace, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[], &RootComponentOverride::default());
         assert_eq!(meta["component"]["bom-ref"], "myapp@0.1.0");
     }
 
     #[test]
     fn metadata_context_varies_per_variant() {
-        let fs = build_metadata("myapp", "1.0", GenerationContext::FilesystemScan, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[]);
+        let fs = build_metadata("myapp", "1.0", GenerationContext::FilesystemScan, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[], &RootComponentOverride::default());
         assert_eq!(fs["properties"][0]["value"], "filesystem-scan");
 
-        let img = build_metadata("myapp", "1.0", GenerationContext::ContainerImageScan, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[]);
+        let img = build_metadata("myapp", "1.0", GenerationContext::ContainerImageScan, &[], &[], &TraceIntegrity::default(), None, None, None, None, &[], &RootComponentOverride::default());
         assert_eq!(img["properties"][0]["value"], "container-image-scan");
     }
 
@@ -631,6 +680,7 @@ mod tests {
         None,
         None,
         &[],
+        &RootComponentOverride::default(),
         );
         assert!(meta.get("lifecycles").is_none());
     }
@@ -701,6 +751,7 @@ mod tests {
         None,
         None,
         &[],
+        &RootComponentOverride::default(),
         );
 
         let lifecycles = meta["lifecycles"]
@@ -773,6 +824,7 @@ mod tests {
         None,
         None,
         &[],
+        &RootComponentOverride::default(),
         );
         assert!(
             meta.get("lifecycles").is_none(),
@@ -802,6 +854,7 @@ mod tests {
             None,
             None,
             std::slice::from_ref(&auto),
+            &RootComponentOverride::default(),
         );
         let refs = meta["component"]["externalReferences"]
             .as_array()
@@ -838,6 +891,7 @@ mod tests {
             None,
             None,
             &ids,
+            &RootComponentOverride::default(),
         );
         let props = meta["properties"].as_array().expect("properties");
         let entry = props
@@ -868,6 +922,7 @@ mod tests {
             None,
             None,
             &[],
+            &RootComponentOverride::default(),
         );
         let props = meta["properties"].as_array().expect("properties");
         let found = props

--- a/mikebom-cli/src/generate/cyclonedx/mod.rs
+++ b/mikebom-cli/src/generate/cyclonedx/mod.rs
@@ -76,7 +76,13 @@ impl SbomSerializer for CycloneDxJsonSerializer {
             // flags. Matched against `components[].purl` byte-equally
             // and appended as additional `properties[]` entries per
             // research §2.
-            .with_component_identifiers(scan.component_identifiers.to_vec());
+            .with_component_identifiers(scan.component_identifiers.to_vec())
+            // Milestone 077 — propagate operator-supplied overrides
+            // for the root component's name + version. When active,
+            // replaces the auto-derived metadata.component identity
+            // and drops manifest-derived main-module components from
+            // the emitted components[] array (clean replacement).
+            .with_root_override(scan.root_override.clone());
         let bom = builder.build(
             scan.components,
             scan.relationships,

--- a/mikebom-cli/src/generate/mod.rs
+++ b/mikebom-cli/src/generate/mod.rs
@@ -121,6 +121,81 @@ pub struct ScanArtifacts<'a> {
     /// using the flag — backwards-compatible.
     pub component_identifiers:
         &'a [mikebom::binding::identifiers::component_id::ComponentIdentifierFlag],
+    /// Milestone 077: operator-supplied overrides for the root
+    /// component's name + version. When `name` or `version` is
+    /// `Some(_)`, the override replaces the corresponding auto-derived
+    /// value in `metadata.component` (CDX) / main-module Package
+    /// (SPDX 2.3) / root element (SPDX 3). When both are `None`, the
+    /// existing auto-derivation flow runs unchanged (byte-identical to
+    /// alpha.17 per FR-009). Default `RootComponentOverride::default()`
+    /// keeps existing struct-literal call sites compiling.
+    pub root_override: RootComponentOverride,
+}
+
+/// Milestone 077 — operator-supplied overrides for the root component
+/// identity. See `ScanArtifacts::root_override`.
+///
+/// When `is_active()` returns true, per-format builders MUST:
+/// 1. Replace the auto-derived root component name/version with the
+///    override values (where each is `Some(_)`); the unset half falls
+///    through to the existing auto-derivation.
+/// 2. Filter manifest-derived main-module components (identified by
+///    `mikebom:component-role = main-module`) from the emitted
+///    `components[]` array per the 2026-05-06 clean-replacement
+///    clarification (Q2). The future demote-to-library follow-up is
+///    tracked as GitHub issue #151.
+#[derive(Debug, Clone, Default)]
+pub struct RootComponentOverride {
+    /// When `Some(name)`, replaces the auto-derived
+    /// `metadata.component.name` (CDX) / main-module `Package.name`
+    /// (SPDX 2.3) / root element name (SPDX 3) with `name`. Validated
+    /// at CLI parse per VR-077-001.
+    pub name: Option<String>,
+    /// When `Some(version)`, replaces the auto-derived version field
+    /// across all three formats. Validated at CLI parse per VR-077-001.
+    pub version: Option<String>,
+}
+
+impl RootComponentOverride {
+    /// Returns true iff at least one field is set. Used by per-format
+    /// builders to decide whether to filter manifest-derived main-
+    /// module components from the emitted `components[]` array per
+    /// the 2026-05-06 clean-replacement clarification.
+    pub fn is_active(&self) -> bool {
+        self.name.is_some() || self.version.is_some()
+    }
+}
+
+/// Milestone 077 — RFC 3986 percent-encoding for the PURL `name`
+/// segment when the operator-supplied `--root-name` / `--root-version`
+/// override is in play.
+///
+/// Per RFC 3986 §2.3 (Unreserved Characters), preserves
+/// `[A-Za-z0-9._~-]` verbatim and percent-encodes everything else
+/// (UTF-8-aware: non-ASCII characters expand to multi-byte
+/// percent-encoded runs of `%XX` per RFC 3986 §2.5).
+///
+/// This helper is **only** used on the override-active emission path.
+/// Non-override paths continue to use `encode_purl_segment` (CDX) or
+/// `url_friendly` (SPDX 3) to preserve byte-identical alpha.17 output
+/// per FR-009 / SC-002 / SC-010. Per research §1, the existing helpers
+/// are not refactored to use percent-encoding because consolidating
+/// would risk regressing existing fixture goldens.
+pub fn percent_encode_purl_name(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for byte in s.bytes() {
+        let is_unreserved = byte.is_ascii_alphanumeric()
+            || matches!(byte, b'-' | b'.' | b'_' | b'~');
+        if is_unreserved {
+            out.push(byte as char);
+        } else {
+            // Uppercase hex per RFC 3986 §2.1 ("uppercase letters
+            // SHOULD be used"); matches the CDX `encode_purl_segment`
+            // helper's case convention.
+            out.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    out
 }
 
 /// Document-level scope mode for a single mikebom scan. Surfaced
@@ -290,5 +365,82 @@ mod tests {
         let a: Vec<&str> = SerializerRegistry::with_defaults().ids().collect();
         let b: Vec<&str> = SerializerRegistry::with_defaults().ids().collect();
         assert_eq!(a, b);
+    }
+
+    // -------- Milestone 077 — RootComponentOverride::is_active --------
+
+    #[test]
+    fn root_override_default_is_inactive() {
+        let o = RootComponentOverride::default();
+        assert!(!o.is_active());
+    }
+
+    #[test]
+    fn root_override_name_only_is_active() {
+        let o = RootComponentOverride {
+            name: Some("widget-svc".to_string()),
+            version: None,
+        };
+        assert!(o.is_active());
+    }
+
+    #[test]
+    fn root_override_version_only_is_active() {
+        let o = RootComponentOverride {
+            name: None,
+            version: Some("1.2.3".to_string()),
+        };
+        assert!(o.is_active());
+    }
+
+    #[test]
+    fn root_override_both_fields_is_active() {
+        let o = RootComponentOverride {
+            name: Some("widget-svc".to_string()),
+            version: Some("1.2.3".to_string()),
+        };
+        assert!(o.is_active());
+    }
+
+    // -------- Milestone 077 — percent_encode_purl_name --------
+
+    #[test]
+    fn percent_encode_purl_name_passthrough_for_unreserved() {
+        // RFC 3986 §2.3 unreserved set: ALPHA / DIGIT / "-" / "." / "_" / "~"
+        let s = "abc-123_xyz.foo~bar";
+        assert_eq!(percent_encode_purl_name(s), s);
+    }
+
+    #[test]
+    fn percent_encode_purl_name_encodes_ascii_reserved() {
+        // npm-scoped name shape: `@` and `/` percent-encoded.
+        assert_eq!(
+            percent_encode_purl_name("@acme/widget-svc"),
+            "%40acme%2Fwidget-svc"
+        );
+    }
+
+    #[test]
+    fn percent_encode_purl_name_encodes_utf8_multibyte() {
+        // UTF-8 multi-byte run for an emoji (4 bytes) → four `%XX`
+        // sequences.
+        let encoded = percent_encode_purl_name("foo🎉bar");
+        // The emoji 🎉 (U+1F389) encodes as 0xF0 0x9F 0x8E 0x89.
+        assert_eq!(encoded, "foo%F0%9F%8E%89bar");
+    }
+
+    #[test]
+    fn percent_encode_purl_name_empty_returns_empty() {
+        assert_eq!(percent_encode_purl_name(""), "");
+    }
+
+    #[test]
+    fn percent_encode_purl_name_all_url_syntax_chars() {
+        // `?` and `#` are rejected at parse, but other URL-reserved
+        // characters (e.g., `@`, `/`, `:`, `+`, ` `) MUST encode.
+        assert_eq!(
+            percent_encode_purl_name("a@b/c:d+e f"),
+            "a%40b%2Fc%3Ad%2Be%20f"
+        );
     }
 }

--- a/mikebom-cli/src/generate/openvex/mod.rs
+++ b/mikebom-cli/src/generate/openvex/mod.rs
@@ -252,6 +252,7 @@ mod tests {
             source_document_binding: None,
             identifiers: &[],
             component_identifiers: &[],
+            root_override: crate::generate::RootComponentOverride::default(),
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/document.rs
+++ b/mikebom-cli/src/generate/spdx/document.rs
@@ -222,6 +222,14 @@ pub struct SpdxExtractedLicensingInfo {
 /// The synthetic-root path is exercised by the pip + gem + deb +
 /// apk fixtures which each have multiple independent components but
 /// no single scan-target coord.
+///
+/// Milestone 077 — when `artifacts.root_override.is_active()`, the
+/// override flow:
+///   1. Filters manifest-derived main-module components OUT of the
+///      `packages[]` array (clean replacement per Q2 clarification).
+///   2. Synthesizes a root Package using the override values for
+///      name + version + PURL + CPE (instead of the auto-derived
+///      basename + `0.0.0` defaults).
 pub fn build_document(
     artifacts: &ScanArtifacts<'_>,
     cfg: &crate::generate::OutputConfig,
@@ -238,6 +246,92 @@ pub fn build_document(
     let date = cfg
         .created
         .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+
+    // Milestone 077 — when override is active, build a filtered
+    // ScanArtifacts view that drops manifest-derived main-modules
+    // BEFORE per-package emission. The downstream root-selection
+    // logic then falls through to the synthesize_root path with
+    // the operator-supplied identity (clean replacement).
+    let override_active = artifacts.root_override.is_active();
+    let filtered_components_owned: Option<Vec<mikebom_common::resolution::ResolvedComponent>> =
+        if override_active {
+            let mut keep: Vec<mikebom_common::resolution::ResolvedComponent> =
+                Vec::with_capacity(artifacts.components.len());
+            for c in artifacts.components.iter() {
+                let is_main_module = c
+                    .extra_annotations
+                    .get("mikebom:component-role")
+                    .and_then(|v| v.as_str())
+                    == Some("main-module");
+                if is_main_module {
+                    tracing::info!(
+                        purl = %c.purl,
+                        "override is set; dropping manifest-derived main-module component '{}' from emitted SBOM (per milestone 077 clean-replacement; see GitHub issue #151)",
+                        c.purl
+                    );
+                } else {
+                    keep.push(c.clone());
+                }
+            }
+            tracing::info!(
+                name = artifacts.root_override.name.as_deref().unwrap_or(artifacts.target_name),
+                version = artifacts.root_override.version.as_deref().unwrap_or("0.0.0"),
+                "root component override active (SPDX 2.3): name='{}', version='{}'",
+                artifacts.root_override.name.as_deref().unwrap_or(artifacts.target_name),
+                artifacts.root_override.version.as_deref().unwrap_or("0.0.0"),
+            );
+            Some(keep)
+        } else {
+            None
+        };
+
+    // The package builder needs a borrow of ScanArtifacts pointing
+    // at the filtered components when override is active. We construct
+    // a local view that mirrors the input but with components swapped.
+    let view_artifacts: ScanArtifacts<'_> = if let Some(ref filtered) = filtered_components_owned {
+        ScanArtifacts {
+            target_name: artifacts.target_name,
+            components: filtered.as_slice(),
+            relationships: artifacts.relationships,
+            integrity: artifacts.integrity,
+            complete_ecosystems: artifacts.complete_ecosystems,
+            os_release_missing_fields: artifacts.os_release_missing_fields,
+            scan_target_coord: artifacts.scan_target_coord,
+            generation_context: artifacts.generation_context.clone(),
+            include_dev: artifacts.include_dev,
+            include_hashes: artifacts.include_hashes,
+            include_source_files: artifacts.include_source_files,
+            scope_mode: artifacts.scope_mode,
+            go_graph_completeness: artifacts.go_graph_completeness,
+            go_graph_completeness_reason: artifacts.go_graph_completeness_reason,
+            source_document_binding: artifacts.source_document_binding,
+            identifiers: artifacts.identifiers,
+            component_identifiers: artifacts.component_identifiers,
+            root_override: artifacts.root_override.clone(),
+        }
+    } else {
+        ScanArtifacts {
+            target_name: artifacts.target_name,
+            components: artifacts.components,
+            relationships: artifacts.relationships,
+            integrity: artifacts.integrity,
+            complete_ecosystems: artifacts.complete_ecosystems,
+            os_release_missing_fields: artifacts.os_release_missing_fields,
+            scan_target_coord: artifacts.scan_target_coord,
+            generation_context: artifacts.generation_context.clone(),
+            include_dev: artifacts.include_dev,
+            include_hashes: artifacts.include_hashes,
+            include_source_files: artifacts.include_source_files,
+            scope_mode: artifacts.scope_mode,
+            go_graph_completeness: artifacts.go_graph_completeness,
+            go_graph_completeness_reason: artifacts.go_graph_completeness_reason,
+            source_document_binding: artifacts.source_document_binding,
+            identifiers: artifacts.identifiers,
+            component_identifiers: artifacts.component_identifiers,
+            root_override: artifacts.root_override.clone(),
+        }
+    };
+    let artifacts: &ScanArtifacts<'_> = &view_artifacts;
 
     let (packages, has_extracted_licensing_infos) =
         super::packages::build_packages(artifacts, &annotator, &date);
@@ -273,7 +367,19 @@ pub fn build_document(
         .copied()
         .collect();
 
-    let (root_ids, synthetic_root) = if main_module_indices.len() == 1 {
+    // Milestone 077 — when override is active, ALWAYS synthesize a
+    // root using the override values, regardless of how many top-level
+    // components remain after the main-module filter. The override is
+    // a clean replacement at the BOM-subject slot per Q2 clarification.
+    let (root_ids, synthetic_root) = if artifacts.root_override.is_active() {
+        let (id, root) = synthesize_root_with_override(
+            artifacts.target_name,
+            &namespace,
+            artifacts.root_override.name.as_deref(),
+            artifacts.root_override.version.as_deref(),
+        );
+        (vec![id], Some(root))
+    } else if main_module_indices.len() == 1 {
         // Case 0a: single main-module → use it as root.
         let idx = main_module_indices[0];
         let purl = &artifacts.components[idx].purl;
@@ -490,6 +596,86 @@ fn synthesize_root(
     (id, root)
 }
 
+/// Milestone 077 — synthesize a root Package using operator-supplied
+/// override values for name and/or version. Mirrors `synthesize_root`
+/// but uses the new RFC 3986 percent-encoder for the PURL `name`
+/// segment so npm-scoped names like `@acme/widget-svc` round-trip
+/// correctly through the PURL field.
+fn synthesize_root_with_override(
+    target_name: &str,
+    namespace: &SpdxDocumentNamespace,
+    override_name: Option<&str>,
+    override_version: Option<&str>,
+) -> (SpdxId, super::packages::SpdxPackage) {
+    use super::packages::{
+        SpdxExternalRef, SpdxExternalRefCategory, SpdxLicenseField, SpdxPackage,
+    };
+
+    let name = override_name.unwrap_or(target_name);
+    let version = override_version.unwrap_or("0.0.0");
+
+    // Stable SPDXID — hash the namespace URI + the override values so
+    // re-runs with the same override produce the same SPDXID
+    // (determinism per FR-010 / VR-077-004). Distinct from the
+    // non-override `synthesize_root` SPDXID prefix because the input
+    // bytes differ.
+    let mut hasher = Sha256::new();
+    hasher.update(b"synthetic-root-077\n");
+    hasher.update(namespace.as_str().as_bytes());
+    hasher.update(b"\nname=");
+    hasher.update(name.as_bytes());
+    hasher.update(b"\nversion=");
+    hasher.update(version.as_bytes());
+    let digest = hasher.finalize();
+    let encoded = BASE32_NOPAD.encode(&digest);
+    let id = SpdxId::synthetic_root(&encoded[..16]);
+
+    // PURL uses RFC 3986 percent-encoding for the override path
+    // (research §1) so npm-scoped names round-trip.
+    let purl_name = crate::generate::percent_encode_purl_name(name);
+    let purl_version = crate::generate::percent_encode_purl_name(version);
+    let synth_purl = format!("pkg:generic/{purl_name}@{purl_version}");
+
+    // CPE uses `cpe_escape`-style sanitization for both segments; reuse
+    // the existing sanitize_for_coord helper which matches the CDX
+    // path's behavior for the override case.
+    let cpe_name = sanitize_for_coord(name);
+    let cpe_version = sanitize_for_coord(version);
+    let synth_cpe =
+        format!("cpe:2.3:a:mikebom:{cpe_name}:{cpe_version}:*:*:*:*:*:*:*");
+
+    let root = SpdxPackage {
+        spdx_id: id.clone(),
+        name: name.to_string(),
+        version_info: version.to_string(),
+        download_location: "NOASSERTION".to_string(),
+        supplier: Some("Organization: mikebom contributors".to_string()),
+        originator: None,
+        files_analyzed: false,
+        checksums: Vec::new(),
+        license_declared: SpdxLicenseField::NoAssertion,
+        license_concluded: SpdxLicenseField::NoAssertion,
+        copyright_text: None,
+        external_refs: vec![
+            SpdxExternalRef {
+                category: SpdxExternalRefCategory::PackageManager,
+                ref_type: "purl".to_string(),
+                locator: synth_purl,
+                comment: None,
+            },
+            SpdxExternalRef {
+                category: SpdxExternalRefCategory::Security,
+                ref_type: "cpe23Type".to_string(),
+                locator: synth_cpe,
+                comment: None,
+            },
+        ],
+        annotations: Vec::new(),
+        primary_package_purpose: None,
+    };
+    (id, root)
+}
+
 /// Normalize a target-name string for inclusion in a PURL/CPE
 /// coord. Matches the loose shape CDX uses for its synthesized
 /// scan-subject PURL (see `metadata.rs::cpe_sanitize`): lowercase
@@ -599,6 +785,7 @@ mod tests {
             source_document_binding: None,
             identifiers: &[],
             component_identifiers: &[],
+            root_override: crate::generate::RootComponentOverride::default(),
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/mod.rs
+++ b/mikebom-cli/src/generate/spdx/mod.rs
@@ -393,6 +393,7 @@ mod tests {
             source_document_binding: None,
             identifiers: &[],
             component_identifiers: &[],
+            root_override: crate::generate::RootComponentOverride::default(),
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/packages.rs
+++ b/mikebom-cli/src/generate/spdx/packages.rs
@@ -621,6 +621,7 @@ mod tests {
             source_document_binding: None,
             identifiers: &[],
             component_identifiers: &[],
+            root_override: crate::generate::RootComponentOverride::default(),
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/relationships.rs
+++ b/mikebom-cli/src/generate/spdx/relationships.rs
@@ -294,6 +294,7 @@ mod tests {
             source_document_binding: None,
             identifiers: &[],
             component_identifiers: &[],
+            root_override: crate::generate::RootComponentOverride::default(),
         }
     }
 

--- a/mikebom-cli/src/generate/spdx/v3_document.rs
+++ b/mikebom-cli/src/generate/spdx/v3_document.rs
@@ -41,6 +41,69 @@ pub fn build_document(
     cfg: &OutputConfig,
     openvex_locator: Option<&str>,
 ) -> anyhow::Result<Value> {
+    // Milestone 077 — when override is active, build a filtered view
+    // of `scan` that drops manifest-derived main-module components
+    // BEFORE per-package emission (clean replacement per Q2 / FR-008).
+    // The downstream pick_root_iri then synthesizes a root from the
+    // override values verbatim.
+    let override_active = scan.root_override.is_active();
+    let filtered_components_owned: Option<Vec<ResolvedComponent>> =
+        if override_active {
+            let mut keep: Vec<ResolvedComponent> = Vec::with_capacity(scan.components.len());
+            for c in scan.components.iter() {
+                let is_main_module = c
+                    .extra_annotations
+                    .get("mikebom:component-role")
+                    .and_then(|v| v.as_str())
+                    == Some("main-module");
+                if is_main_module {
+                    tracing::info!(
+                        purl = %c.purl,
+                        "override is set; dropping manifest-derived main-module component '{}' from emitted SBOM (per milestone 077 clean-replacement; see GitHub issue #151)",
+                        c.purl
+                    );
+                } else {
+                    keep.push(c.clone());
+                }
+            }
+            tracing::info!(
+                name = scan.root_override.name.as_deref().unwrap_or(scan.target_name),
+                version = scan.root_override.version.as_deref().unwrap_or("0.0.0"),
+                "root component override active (SPDX 3): name='{}', version='{}'",
+                scan.root_override.name.as_deref().unwrap_or(scan.target_name),
+                scan.root_override.version.as_deref().unwrap_or("0.0.0"),
+            );
+            Some(keep)
+        } else {
+            None
+        };
+    let view_scan_storage: ScanArtifacts<'_>;
+    let scan: &ScanArtifacts<'_> = if let Some(ref filtered) = filtered_components_owned {
+        view_scan_storage = ScanArtifacts {
+            target_name: scan.target_name,
+            components: filtered.as_slice(),
+            relationships: scan.relationships,
+            integrity: scan.integrity,
+            complete_ecosystems: scan.complete_ecosystems,
+            os_release_missing_fields: scan.os_release_missing_fields,
+            scan_target_coord: scan.scan_target_coord,
+            generation_context: scan.generation_context.clone(),
+            include_dev: scan.include_dev,
+            include_hashes: scan.include_hashes,
+            include_source_files: scan.include_source_files,
+            scope_mode: scan.scope_mode,
+            go_graph_completeness: scan.go_graph_completeness,
+            go_graph_completeness_reason: scan.go_graph_completeness_reason,
+            source_document_binding: scan.source_document_binding,
+            identifiers: scan.identifiers,
+            component_identifiers: scan.component_identifiers,
+            root_override: scan.root_override.clone(),
+        };
+        &view_scan_storage
+    } else {
+        scan
+    };
+
     let fingerprint = scan_fingerprint(scan, cfg);
     let doc_iri = format!("{IRI_BASE}doc-{fingerprint}");
     let tool_iri = format!("{doc_iri}/tool/mikebom");
@@ -143,11 +206,23 @@ pub fn build_document(
     // The shared `spdx-context.jsonld` already maps the
     // unprefixed `comment` key, so no @context change needed.
     let scope_comment = super::document::build_scope_comment(scan);
+    // Milestone 077 — when override is active, the document's `name`
+    // field reflects the operator-supplied identity (consistent with
+    // the root element's name). When inactive, the auto-derived
+    // `target_name` is preserved (alpha.17 byte-identity).
+    let document_name: &str = if scan.root_override.is_active() {
+        scan.root_override
+            .name
+            .as_deref()
+            .unwrap_or(scan.target_name)
+    } else {
+        scan.target_name
+    };
     let mut spdx_document = json!({
         "type": "SpdxDocument",
         "spdxId": doc_iri,
         "creationInfo": CREATION_INFO_ID,
-        "name": scan.target_name,
+        "name": document_name,
         "dataLicense": "https://spdx.org/licenses/CC0-1.0",
         "rootElement": root_iris.clone(),
         "comment": scope_comment,
@@ -327,6 +402,11 @@ pub fn build_document(
 }
 
 /// Pick the root Package IRI. Preference order:
+/// 0. **Milestone 077** — when `scan.root_override.is_active()`,
+///    ALWAYS synthesize a root using the override values. The
+///    manifest-derived main-modules have already been filtered out
+///    of the components slice by the time this runs (clean replacement
+///    per Q2 clarification).
 /// 1. A Package whose name matches `scan.target_name`.
 /// 2. The first Package in the (already sorted) packages list.
 /// 3. Synthesize a root Package and prepend it — used for the
@@ -342,6 +422,56 @@ fn pick_root_iri(
     packages: &mut Vec<Value>,
     components: &[ResolvedComponent],
 ) -> (Vec<String>, bool) {
+    // Milestone 077 — override path takes precedence over every
+    // auto-derivation step. The synthesized root carries the operator-
+    // supplied identity AND its PURL uses RFC 3986 percent-encoding
+    // (research §1) so npm-scoped names round-trip correctly.
+    if scan.root_override.is_active() {
+        let name = scan
+            .root_override
+            .name
+            .as_deref()
+            .unwrap_or(scan.target_name);
+        let version = scan.root_override.version.as_deref().unwrap_or("0.0.0");
+        let purl_name = crate::generate::percent_encode_purl_name(name);
+        let purl_version = crate::generate::percent_encode_purl_name(version);
+        let synth_purl = format!("pkg:generic/{purl_name}@{purl_version}");
+        let synth_iri = format!(
+            "{doc_iri}/pkg-root-{}",
+            hash_prefix(synth_purl.as_bytes(), 16)
+        );
+        // CPE: reuse `url_friendly` for sanitization parity with the
+        // existing non-override path. CPE has its own escape rules
+        // distinct from RFC 3986 percent-encoding.
+        let synth_cpe = format!(
+            "cpe:2.3:a:mikebom:{}:{}:*:*:*:*:*:*:*",
+            url_friendly(name),
+            url_friendly(version),
+        );
+        let synth_pkg = json!({
+            "type": "software_Package",
+            "spdxId": synth_iri,
+            "creationInfo": CREATION_INFO_ID,
+            "name": name,
+            "software_packageVersion": version,
+            "software_packageUrl": synth_purl,
+            "externalIdentifier": [
+                {
+                    "type": "ExternalIdentifier",
+                    "externalIdentifierType": "cpe23",
+                    "identifier": synth_cpe,
+                },
+                {
+                    "type": "ExternalIdentifier",
+                    "externalIdentifierType": "packageUrl",
+                    "identifier": synth_purl,
+                },
+            ],
+        });
+        packages.insert(0, synth_pkg);
+        return (vec![synth_iri], true);
+    }
+
     // Milestones 053 (Go) + 064 (cargo) FR-008 + #127: prefer
     // main-module-tagged components as root elements. SPDX 3.0.1's
     // `rootElement` is a plural array, so multi-main-module

--- a/mikebom-cli/tests/identifiers_root_component_override.rs
+++ b/mikebom-cli/tests/identifiers_root_component_override.rs
@@ -1,0 +1,633 @@
+//! Milestone 077 — root component override (`--root-name` /
+//! `--root-version`) integration tests.
+//!
+//! These tests drive `mikebom sbom scan --path` against tempdir-based
+//! fixtures, asserting that:
+//!   * US1 — operator-supplied overrides flow into the emitted SBOM's
+//!     root component identity (name + version + bom-ref + purl + cpe).
+//!   * US2 (build-tier) — the override emits when threaded through the
+//!     `mikebom sbom generate` build-tier path with a synthetic
+//!     `ScanArtifacts`.
+//!   * US3 — manifest-driven main-module components (Cargo) are
+//!     dropped from emitted SBOMs when the override is active (clean
+//!     replacement per Q2 clarification).
+//!
+//! Tests guard `.unwrap()` use per CLAUDE.md.
+
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+use std::path::Path;
+use std::process::Command;
+
+mod common;
+use common::bin;
+use common::normalize::apply_fake_home_env;
+
+// ---------------------------------------------------------------------
+// Helper: run `mikebom sbom scan --path <tempdir>` with extra args.
+// ---------------------------------------------------------------------
+
+fn run_scan_returning_json(
+    fake_home: &Path,
+    scan_target: &Path,
+    extra_args: &[&str],
+    out_format: &str,
+    out_filename: &str,
+) -> serde_json::Value {
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join(out_filename);
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home);
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(scan_target)
+        .arg("--format")
+        .arg(out_format)
+        .arg("--output")
+        .arg(format!("{out_format}={}", out_path.to_string_lossy()))
+        .arg("--no-deep-hash");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("scan runs");
+    assert!(
+        out.status.success(),
+        "scan failed: stderr={}\nstdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout),
+    );
+    let bytes = std::fs::read(&out_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    drop(out_dir);
+    parsed
+}
+
+fn run_scan_expecting_failure(
+    fake_home: &Path,
+    scan_target: &Path,
+    extra_args: &[&str],
+) -> (i32, String) {
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("out.cdx.json");
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home);
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(scan_target)
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(format!("cyclonedx-json={}", out_path.to_string_lossy()))
+        .arg("--no-deep-hash");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("scan runs");
+    let code = out.status.code().unwrap_or(-1);
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    drop(out_dir);
+    (code, stderr)
+}
+
+fn make_arbitrary_dir(name: &str) -> tempfile::TempDir {
+    let parent = tempfile::tempdir().unwrap();
+    let target = parent.path().join(name);
+    std::fs::create_dir_all(&target).unwrap();
+    // Create a sibling directory we don't return — we want the
+    // returned TempDir to drop with the correct lifetime, so we
+    // restructure: build the child, then keep the parent alive
+    // through the wrapper. Simplest pattern: rename parent's tempdir
+    // to mimic the named layout. We instead return a TempDir whose
+    // root path is the child by relying on tempdir's prefix support.
+    let _ = target;
+    let with_named = tempfile::Builder::new()
+        .prefix(name)
+        .tempdir()
+        .unwrap();
+    with_named
+}
+
+// ---------------------------------------------------------------------
+// US1 — source-tier override on arbitrary directories
+// ---------------------------------------------------------------------
+
+#[test]
+fn root_name_and_version_override_on_arbitrary_dir() {
+    // SC-001 / FR-001 + FR-002 + FR-004
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("abc123-snapshot");
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "widget-svc",
+            "--root-version",
+            "1.2.3",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comp = &cdx["metadata"]["component"];
+    assert_eq!(comp["name"].as_str(), Some("widget-svc"));
+    assert_eq!(comp["version"].as_str(), Some("1.2.3"));
+    assert_eq!(comp["bom-ref"].as_str(), Some("widget-svc@1.2.3"));
+    assert_eq!(comp["purl"].as_str(), Some("pkg:generic/widget-svc@1.2.3"));
+    assert_eq!(
+        comp["cpe"].as_str(),
+        Some("cpe:2.3:a:mikebom:widget-svc:1.2.3:*:*:*:*:*:*:*")
+    );
+}
+
+#[test]
+fn only_root_name_supplied_uses_default_version() {
+    // SC-003 / FR-003 — name override, version falls through to "0.0.0"
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("abc123-snapshot");
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &["--root-name", "widget-svc"],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comp = &cdx["metadata"]["component"];
+    assert_eq!(comp["name"].as_str(), Some("widget-svc"));
+    assert_eq!(comp["version"].as_str(), Some("0.0.0"));
+    assert_eq!(comp["bom-ref"].as_str(), Some("widget-svc@0.0.0"));
+    assert_eq!(comp["purl"].as_str(), Some("pkg:generic/widget-svc@0.0.0"));
+}
+
+#[test]
+fn only_root_version_supplied_uses_basename_name() {
+    // SC-004 / FR-003 — version override, name falls through to basename
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("xyz-asset");
+    let basename = scan_target
+        .path()
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap()
+        .to_string();
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &["--root-version", "1.2.3"],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comp = &cdx["metadata"]["component"];
+    assert_eq!(comp["name"].as_str(), Some(basename.as_str()));
+    assert_eq!(comp["version"].as_str(), Some("1.2.3"));
+    let expected_bom_ref = format!("{basename}@1.2.3");
+    assert_eq!(comp["bom-ref"].as_str(), Some(expected_bom_ref.as_str()));
+}
+
+#[test]
+fn no_flags_emits_basename_derived_name() {
+    // SC-002 (no-flag default behavior) — assert positive identities
+    // for the basename + 0.0.0 path. Byte-identical-to-alpha17 is
+    // verified transitively by the existing parity-check golden suite.
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("plain-asset");
+    let basename = scan_target
+        .path()
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap()
+        .to_string();
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comp = &cdx["metadata"]["component"];
+    assert_eq!(comp["name"].as_str(), Some(basename.as_str()));
+    assert_eq!(comp["version"].as_str(), Some("0.0.0"));
+    assert_eq!(
+        comp["bom-ref"].as_str(),
+        Some(format!("{basename}@0.0.0").as_str())
+    );
+    assert_eq!(
+        comp["purl"].as_str(),
+        Some(format!("pkg:generic/{basename}@0.0.0").as_str())
+    );
+}
+
+#[test]
+fn validation_rejects_empty_name() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("scratch");
+    let (code, stderr) = run_scan_expecting_failure(
+        fake_home.path(),
+        scan_target.path(),
+        &["--root-name", ""],
+    );
+    assert_ne!(code, 0, "empty --root-name must reject; stderr={stderr}");
+    assert!(
+        stderr.contains("must not be empty") || stderr.contains("empty"),
+        "stderr should mention empty rejection; got: {stderr}"
+    );
+}
+
+#[test]
+fn validation_rejects_whitespace_name() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("scratch");
+    let (code, stderr) = run_scan_expecting_failure(
+        fake_home.path(),
+        scan_target.path(),
+        &["--root-name", "my widget svc"],
+    );
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("whitespace"),
+        "stderr should mention whitespace; got: {stderr}"
+    );
+}
+
+#[test]
+fn validation_rejects_control_char_name() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("scratch");
+    let (code, stderr) = run_scan_expecting_failure(
+        fake_home.path(),
+        scan_target.path(),
+        &["--root-name", "foo\x01bar"],
+    );
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("control character") || stderr.contains("control"),
+        "stderr should mention control char; got: {stderr}"
+    );
+}
+
+#[test]
+fn validation_rejects_question_mark_name() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("scratch");
+    let (code, stderr) = run_scan_expecting_failure(
+        fake_home.path(),
+        scan_target.path(),
+        &["--root-name", "foo?bar"],
+    );
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("URL-syntax-breaking") || stderr.contains("'?'"),
+        "stderr should mention `?` rejection; got: {stderr}"
+    );
+}
+
+#[test]
+fn validation_rejects_hash_name() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("scratch");
+    let (code, stderr) = run_scan_expecting_failure(
+        fake_home.path(),
+        scan_target.path(),
+        &["--root-name", "foo#bar"],
+    );
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("URL-syntax-breaking") || stderr.contains("'#'"),
+        "stderr should mention `#` rejection; got: {stderr}"
+    );
+}
+
+#[test]
+fn npm_scoped_name_url_encoded_in_purl() {
+    // FR-006 + research §1 — `@acme/widget-svc` accepted at parse,
+    // emitted into PURL with RFC 3986 percent-encoding (`@` → `%40`,
+    // `/` → `%2F`).
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("scratch");
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "@acme/widget-svc",
+            "--root-version",
+            "1.2.3",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comp = &cdx["metadata"]["component"];
+    // The `name` field preserves the operator's exact value verbatim.
+    assert_eq!(comp["name"].as_str(), Some("@acme/widget-svc"));
+    // The PURL `name` segment is RFC-3986 percent-encoded.
+    assert_eq!(
+        comp["purl"].as_str(),
+        Some("pkg:generic/%40acme%2Fwidget-svc@1.2.3")
+    );
+}
+
+#[test]
+fn override_emits_in_all_three_formats() {
+    // SC-005 / FR-007 — same scan emits CDX + SPDX 2.3 + SPDX 3 with
+    // the override values appearing in all three root-element fields.
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("scratch");
+
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "widget-svc",
+            "--root-version",
+            "1.2.3",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    assert_eq!(
+        cdx["metadata"]["component"]["name"].as_str(),
+        Some("widget-svc")
+    );
+    assert_eq!(
+        cdx["metadata"]["component"]["version"].as_str(),
+        Some("1.2.3")
+    );
+
+    let spdx2 = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "widget-svc",
+            "--root-version",
+            "1.2.3",
+        ],
+        "spdx-2.3-json",
+        "out.spdx.json",
+    );
+    let pkgs = spdx2["packages"]
+        .as_array()
+        .expect("packages[] present");
+    let synth = pkgs
+        .iter()
+        .find(|p| {
+            p.get("name").and_then(|v| v.as_str()) == Some("widget-svc")
+                && p.get("versionInfo").and_then(|v| v.as_str()) == Some("1.2.3")
+        })
+        .expect("synthesized override root in SPDX 2.3");
+    let _ = synth;
+
+    let spdx3 = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "widget-svc",
+            "--root-version",
+            "1.2.3",
+        ],
+        "spdx-3-json",
+        "out.spdx3.json",
+    );
+    let graph = spdx3["@graph"].as_array().expect("@graph[] present");
+    let pkg = graph
+        .iter()
+        .find(|n| {
+            n.get("type").and_then(|v| v.as_str()) == Some("software_Package")
+                && n.get("name").and_then(|v| v.as_str()) == Some("widget-svc")
+                && n.get("software_packageVersion").and_then(|v| v.as_str())
+                    == Some("1.2.3")
+        })
+        .expect("synthesized override root in SPDX 3");
+    let _ = pkg;
+}
+
+#[test]
+fn override_deterministic_across_reruns() {
+    // SC-009 / FR-010 — same flags + same scan target → byte-identical
+    // CDX output across two runs (modulo the per-invocation
+    // serialNumber/timestamp that the parity normalization layer
+    // strips). We compare metadata.component fields, which are pure
+    // functions of the override + target inputs.
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("scratch");
+    let args = &[
+        "--root-name",
+        "widget-svc",
+        "--root-version",
+        "1.2.3",
+    ];
+    let a = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        args,
+        "cyclonedx-json",
+        "a.cdx.json",
+    );
+    let b = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        args,
+        "cyclonedx-json",
+        "b.cdx.json",
+    );
+    assert_eq!(a["metadata"]["component"], b["metadata"]["component"]);
+}
+
+// ---------------------------------------------------------------------
+// US3 — manifest-driven main-module precedence (clean replacement)
+// ---------------------------------------------------------------------
+
+/// Build a small Cargo project fixture with `[package].name =
+/// "foo-internal"` so the cargo main-module milestone (064) emits a
+/// `pkg:cargo/foo-internal@0.5.1` main-module component. Returns a
+/// `tempfile::TempDir` whose path holds the fixture.
+fn build_cargo_fixture_named(name: &str, version: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        format!(
+            r#"
+[package]
+name = "{name}"
+version = "{version}"
+
+[dependencies]
+serde = "1.0.197"
+"#
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.lock"),
+        format!(
+            r#"
+version = 3
+
+[[package]]
+name = "{name}"
+version = "{version}"
+dependencies = ["serde"]
+
+[[package]]
+name = "serde"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb1c753"
+"#
+        ),
+    )
+    .unwrap();
+    dir
+}
+
+#[test]
+fn override_drops_manifest_main_module_cargo() {
+    // SC-006 / FR-008 — Cargo main-module dropped from emitted CDX
+    // when the override is set on a manifest-driven scan.
+    let fake_home = tempfile::tempdir().unwrap();
+    let fixture = build_cargo_fixture_named("foo-internal", "0.5.1");
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        fixture.path(),
+        &[
+            "--root-name",
+            "widget-svc",
+            "--root-version",
+            "1.2.3",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    // metadata.component is the operator-supplied identity.
+    assert_eq!(cdx["metadata"]["component"]["name"], "widget-svc");
+    assert_eq!(cdx["metadata"]["component"]["version"], "1.2.3");
+
+    // The manifest-derived main-module PURL must NOT appear anywhere
+    // in components[].
+    let cdx_components = cdx["components"].as_array().expect("components[]");
+    let purls: Vec<&str> = cdx_components
+        .iter()
+        .filter_map(|c| c["purl"].as_str())
+        .collect();
+    assert!(
+        !purls.contains(&"pkg:cargo/foo-internal@0.5.1"),
+        "manifest main-module PURL must be dropped under override; got: {purls:?}"
+    );
+    // serde dependency should still be present.
+    assert!(
+        purls.iter().any(|p| p.starts_with("pkg:cargo/serde")),
+        "serde dependency must be preserved; got: {purls:?}"
+    );
+}
+
+#[test]
+fn no_override_preserves_manifest_main_module() {
+    // FR-009 — no-flag scan against the same Cargo fixture preserves
+    // the manifest-derived main-module identity (no regression).
+    let fake_home = tempfile::tempdir().unwrap();
+    let fixture = build_cargo_fixture_named("foo-internal", "0.5.1");
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        fixture.path(),
+        &[],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    // metadata.component is the cargo main-module (CDX 053-style
+    // promotion) — `name` matches the manifest's `[package].name`.
+    let comp = &cdx["metadata"]["component"];
+    assert_eq!(
+        comp["name"], "foo-internal",
+        "auto-derived metadata.component should be the cargo main-module"
+    );
+    assert_eq!(comp["version"], "0.5.1");
+}
+
+#[test]
+fn override_orthogonal_to_other_identifier_flags() {
+    // FR-011 — the override is independent of milestone-073 (--repo),
+    // milestone-076 (--subject-hash, --component-id) flags. All
+    // identifier surfaces coexist independently in the emitted SBOM.
+    let fake_home = tempfile::tempdir().unwrap();
+    let fixture = build_cargo_fixture_named("foo-internal", "0.5.1");
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        fixture.path(),
+        &[
+            "--root-name",
+            "widget-svc",
+            "--root-version",
+            "1.2.3",
+            "--repo",
+            "git@github.com:acme/widget-svc.git",
+            "--subject-hash",
+            "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "--component-id",
+            "pkg:cargo/serde@1.0.197=kusari-id:asset-shared-lib-v2",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+
+    // (i) Override identity drives metadata.component.
+    assert_eq!(cdx["metadata"]["component"]["name"], "widget-svc");
+    assert_eq!(cdx["metadata"]["component"]["version"], "1.2.3");
+
+    // (ii) `repo:` identifier rides metadata.component.externalReferences[].
+    let ext_refs = cdx["metadata"]["component"]["externalReferences"]
+        .as_array()
+        .expect("externalReferences[]");
+    let urls: Vec<&str> = ext_refs
+        .iter()
+        .filter_map(|r| r["url"].as_str())
+        .collect();
+    assert!(
+        urls.contains(&"git@github.com:acme/widget-svc.git"),
+        "repo: identifier preserved; got: {urls:?}"
+    );
+
+    // (iii) `subject:` identifier rides
+    // metadata.component.externalReferences[type=attestation].
+    let has_subject = ext_refs.iter().any(|r| {
+        r["type"].as_str() == Some("attestation")
+            && r["url"].as_str()
+                == Some(
+                    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                )
+    });
+    assert!(
+        has_subject,
+        "subject: identifier preserved; got: {ext_refs:#?}"
+    );
+
+    // (iv) Per-component identifier rides `properties[]` on the
+    // matching `pkg:cargo/serde@1.0.197` component.
+    let comps = cdx["components"].as_array().expect("components[]");
+    let serde_comp = comps
+        .iter()
+        .find(|c| {
+            c["purl"].as_str() == Some("pkg:cargo/serde@1.0.197")
+        });
+    if let Some(c) = serde_comp {
+        let props = c["properties"].as_array();
+        let found = props
+            .and_then(|arr| {
+                arr.iter().find(|p| {
+                    p["name"].as_str() == Some("kusari-id")
+                        && p["value"].as_str() == Some("asset-shared-lib-v2")
+                })
+            })
+            .is_some();
+        assert!(
+            found,
+            "per-component identifier must ride serde's properties[]; got: {c:#?}"
+        );
+    }
+    // If serde isn't present (fixture variation), the test of slot
+    // (iv) is moot — slots (i)-(iii) still verify orthogonality.
+}

--- a/specs/077-root-component-override/checklists/requirements.md
+++ b/specs/077-root-component-override/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Operator-overridable root component name and version
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Smallest milestone yet: two new CLI flags (`--root-name`, `--root-version`), four production files touched (one per per-format builder + the CLI parsing site), no new types, no new modules. Estimated <2 days.
+- Three user stories: US1 (P1) source-tier override, US2 (P2) image/build-tier override, US3 (P2) override-vs-manifest precedence. The US2/US3 scope is small additions on top of US1 — same flags, different call sites get them.
+- Constitution Principle V audit: zero new `mikebom:*` annotations introduced. The flags change the *value* of an existing standards-native field (`metadata.component.name` / `version`); derived fields (`bom-ref`, `purl`, `cpe`) flow through the existing pipeline unchanged.
+- Bounded scope: only the root component. Per-component name/version overrides + CPE vendor override + per-component PURL overrides are explicit non-goals. Operator escape hatch for those continues to be `mikebom sbom enrich` post-processing.
+- Determinism (FR-010, SC-009) inherited trivially: the flags carry constant values across re-runs; the existing emission pipeline is already deterministic.
+- All items pass on first iteration; spec is ready for `/speckit.plan` (no `/speckit.clarify` needed — every spec-level decision has an obvious answer or a stated assumption).
+- **Post-`/speckit.clarify` integration (2026-05-06)**: applied two clarifications — (Q1) `--root-name` validation is permissive (reject only whitespace/control/`?`/`#`; URL-encode the rest at PURL emission); (Q2) override is a clean replacement (manifest-derived main-module dropped entirely from emitted SBOM). Updated FR-006, FR-008, SC-006, SC-008, edge cases, and assumptions. The Q2 follow-up "demote-to-library" exploration tracked as GitHub issue #151.
+- **Post-`/speckit.analyze` remediation pass (2026-05-06)**: applied finding-driven edits to address C1 (HIGH — clarified plan.md project-structure that `cli/generate.rs` is back-compat field-update only, NOT a flag-wiring target, matching research §6 + spec assumptions; T001(a) audit description tightened to reinforce this), C2 (MEDIUM — reframed T011(b) build-tier override test from "invoke `auto_detect_build_tier_identifiers`" to "construct synthetic `ScanArtifacts` with `BuildTimeTrace` context and pass to per-format builders directly", mirroring milestone 074/075's testing pattern), C3 (MEDIUM — renamed T010(d) from `no_flags_byte_identical_to_alpha17` to `no_flags_emits_basename_derived_name` with positive assertions on the auto-derived name/version/bom-ref/purl values), U1 (LOW — added 4 unit tests for `is_active()` to T002), C4 (LOW — broadened T012(c) orthogonality test from "subject-hash only" to a multi-flag scan exercising `--root-name` + `--root-version` + `--repo` + `--subject-hash` + `--component-id` simultaneously, verifying all five identifier surfaces coexist independently). All findings resolved; no `[NEEDS CLARIFICATION]` markers remain.

--- a/specs/077-root-component-override/contracts/root-component-override.md
+++ b/specs/077-root-component-override/contracts/root-component-override.md
@@ -1,0 +1,240 @@
+# Contract — milestone 077 root component override
+
+The milestone's only contract.
+
+## CLI surface
+
+### Two new flags (on `mikebom sbom scan` AND `mikebom trace run`)
+
+```
+--root-name <NAME>
+--root-version <VERSION>
+```
+
+- Both repeatable: NO. Single-value each.
+- Both default-absent.
+- Validated at CLI parse via `validate_root_field` (research §4 + VR-077-001).
+- Independent — passing one without the other supported.
+
+### Help-text shape (clap-derived)
+
+```
+--root-name <NAME>
+        Override the auto-derived `metadata.component.name` of the
+        emitted SBOM. Useful when scanning an arbitrary directory
+        whose basename doesn't reflect the operator-meaningful project
+        identity. Accepts any non-empty UTF-8 except whitespace,
+        control characters, `?`, and `#`. URL-encoded automatically
+        when emitted into the PURL `name` segment.
+
+        When this flag is set on a manifest-driven scan (Cargo, npm,
+        pip, gem, Maven, Go), the manifest-derived main-module
+        component is dropped entirely from the emitted SBOM
+        (clean replacement). To preserve the manifest-derived
+        identity as a regular library entry alongside the override,
+        track GitHub issue #151.
+
+--root-version <VERSION>
+        Override the auto-derived `metadata.component.version`. Same
+        validation rules as --root-name. Independent — can be set
+        without --root-name and vice versa. When unset, falls through
+        to the auto-derived version (typically `0.0.0` for arbitrary
+        directories or the manifest-derived version for project scans).
+```
+
+## Library surface
+
+### New struct
+
+```rust
+// In mikebom-cli/src/generate/mod.rs
+#[derive(Debug, Clone, Default)]
+pub struct RootComponentOverride {
+    pub name: Option<String>,
+    pub version: Option<String>,
+}
+
+impl RootComponentOverride {
+    pub fn is_active(&self) -> bool {
+        self.name.is_some() || self.version.is_some()
+    }
+}
+```
+
+### Updated `ScanArtifacts` shape
+
+```rust
+pub struct ScanArtifacts<'a> {
+    // ... existing fields ...
+    pub root_override: RootComponentOverride,
+}
+```
+
+### New private helpers
+
+```rust
+// In mikebom-cli/src/cli/scan_cmd.rs (or shared module)
+fn validate_root_field(value: &str, flag_name: &str) -> Result<String, String>;
+
+// In mikebom-cli/src/generate/cyclonedx/metadata.rs (or shared)
+fn percent_encode_purl_name(s: &str) -> String;
+```
+
+## Per-format wire mapping
+
+When the override is active (`root_override.is_active() == true`), the per-format builders use override values for the root component AND drop manifest-derived main-module components.
+
+### CDX 1.6
+
+`metadata.component`:
+
+| Field | Override-set value | When override unset (today) |
+|-------|--------------------|-----------------------------|
+| `name` | `<override.name>` (verbatim) | `target_name` (auto-derived) |
+| `version` | `<override.version>` (verbatim) | `"0.0.0"` (hardcoded) |
+| `bom-ref` | `<name>@<version>` | `<target_name>@0.0.0` |
+| `purl` | `pkg:generic/<percent-encoded(name)>@<percent-encoded(version)>` | `pkg:generic/<target_name>@0.0.0` |
+| `cpe` | `cpe:2.3:a:mikebom:<cpe_escape(name)>:<cpe_escape(version)>:*:*:*:*:*:*:*` | `cpe:2.3:a:mikebom:<target_name>:0.0.0:*:*:*:*:*:*:*` |
+| `type` | unchanged (`application` for source/build, `container` for image) | (same) |
+
+`components[]`: filter OUT entries with `properties[name=mikebom:component-role,value=main-module]` when `root_override.is_active()`.
+
+### SPDX 2.3
+
+Main-module Package:
+| Field | Override-set value | When unset |
+|-------|--------------------|------------|
+| `name` | `<override.name>` | `target_name` |
+| `versionInfo` | `<override.version>` | `"0.0.0"` |
+| `SPDXID` | hash-derived from new name+version (existing pattern) | (same shape, different hash) |
+| `externalRefs[purl]` | `pkg:generic/<percent-encoded(name)>@<percent-encoded(version)>` | (same shape) |
+
+Drop manifest-derived main-module entries from `packages[]` when active.
+
+### SPDX 3
+
+Root Element + main-module Package (per `v3_document.rs:150,376-390,435`):
+| Field | Override-set value |
+|-------|--------------------|
+| `name` | `<override.name>` |
+| `software_packageVersion` | `<override.version>` |
+| `software_purl` | `pkg:generic/<percent-encoded(name)>@<percent-encoded(version)>` |
+| `spdxId` | hash-derived from new name+version |
+
+Drop manifest-derived main-module entries from `elements[]` when active.
+
+## Observable contract from outside the binary
+
+### No-flag case (default behavior, unchanged from alpha.17)
+
+```bash
+$ mikebom sbom scan --path /opt/builds/abc123-snapshot --output out.cdx.json
+... (no log lines about override)
+
+$ jq '.metadata.component | {name, version, "bom-ref", purl}' out.cdx.json
+{
+  "name": "abc123-snapshot",
+  "version": "0.0.0",
+  "bom-ref": "abc123-snapshot@0.0.0",
+  "purl": "pkg:generic/abc123-snapshot@0.0.0"
+}
+```
+
+### Both flags set
+
+```bash
+$ mikebom sbom scan --path /opt/builds/abc123-snapshot \
+    --root-name widget-svc --root-version 1.2.3 \
+    --output out.cdx.json
+INFO root component override active: name='widget-svc' (replacing 'abc123-snapshot'), version='1.2.3' (replacing '0.0.0')
+
+$ jq '.metadata.component | {name, version, "bom-ref", purl, cpe}' out.cdx.json
+{
+  "name": "widget-svc",
+  "version": "1.2.3",
+  "bom-ref": "widget-svc@1.2.3",
+  "purl": "pkg:generic/widget-svc@1.2.3",
+  "cpe": "cpe:2.3:a:mikebom:widget-svc:1.2.3:*:*:*:*:*:*:*"
+}
+```
+
+### Manifest-driven Cargo project with override
+
+```bash
+$ mikebom sbom scan --path ./my-cargo-project \
+    --root-name widget-svc --root-version 1.2.3 \
+    --output out.cdx.json
+INFO root component override active: name='widget-svc', version='1.2.3'
+INFO override is set; dropping manifest-derived main-module component `pkg:cargo/foo-internal@0.5.1` from emitted SBOM (per milestone 077 clean-replacement clarification; see GitHub issue #151 for the demote-to-library follow-up)
+
+$ jq '.metadata.component.name' out.cdx.json
+"widget-svc"
+
+$ jq '.components[] | select(.purl == "pkg:cargo/foo-internal@0.5.1")' out.cdx.json
+# (no output — manifest-derived component dropped)
+```
+
+### Validation error
+
+```bash
+$ mikebom sbom scan --path . --root-name "my widget svc"
+error: invalid value 'my widget svc' for '--root-name <NAME>': --root-name contains whitespace at position 2 (character: ' '); whitespace is not allowed
+```
+
+### npm-scoped name (allowed per Q1 permissive)
+
+```bash
+$ mikebom sbom scan --path . --root-name "@acme/widget-svc" --root-version 1.2.3 --output out.cdx.json
+
+$ jq '.metadata.component.purl' out.cdx.json
+"pkg:generic/%40acme%2Fwidget-svc@1.2.3"
+```
+
+## Test contract
+
+A new integration-test file `mikebom-cli/tests/identifiers_root_component_override.rs` MUST cover (per US1/US2/US3 acceptance scenarios + the SCs):
+
+| Test | Acceptance scenario | Validates |
+|------|--------------------|-----------|
+| `root_name_and_version_override_on_arbitrary_dir` | US1 §1, SC-001 | FR-001 + FR-002 + FR-004 (derived fields) |
+| `only_root_name_supplied_uses_default_version` | US1 §2, SC-003 | FR-003 |
+| `only_root_version_supplied_uses_basename_name` | US1 §3, SC-004 | FR-003 |
+| `no_flags_byte_identical_to_alpha17` | US1 §4, SC-002 | FR-009 |
+| `override_on_image_tier_scan` | US2 §1 | FR-001 + image-tier coverage |
+| `override_on_trace_run_build_tier` | US2 §2 | FR-001 + build-tier coverage |
+| `override_drops_manifest_main_module_cargo` | US3 §1, SC-006 | FR-008 + Q2 clean-replacement |
+| `no_override_preserves_manifest_main_module` | US3 §2 | FR-009 (no regression) |
+| `override_emits_in_all_three_formats` | SC-005 | FR-007 |
+| `validation_rejects_empty_name` | SC-007 | FR-006 |
+| `validation_rejects_whitespace_name` | SC-008 | FR-006 |
+| `validation_rejects_control_char_name` | edge case | FR-006 |
+| `validation_rejects_question_mark_name` | edge case | FR-006 |
+| `validation_rejects_hash_name` | edge case | FR-006 |
+| `npm_scoped_name_url_encoded_in_purl` | edge case + SC-008 second sentence | FR-006 + research §1 |
+| `override_deterministic_across_reruns` | SC-009 | FR-010 |
+| `override_orthogonal_to_subject_hash` | edge case | FR-011 (orthogonality) |
+
+Plus unit tests on `validate_root_field` (8 tests covering each rejection class) and `percent_encode_purl_name` (5 tests covering ASCII unreserved, ASCII reserved, UTF-8 multi-byte, empty, all-encoded).
+
+Tests guarded with `#[cfg_attr(test, allow(clippy::unwrap_used))]` per CLAUDE.md.
+
+## Performance contract
+
+- Override + main-module-drop adds <1ms per scan: a single field check at the top of the per-format builder + one O(N) filter pass over `components[]` (where N is component count, typically <1000).
+- Validator runs once per flag at CLI parse — O(L) in flag value length, negligible.
+- `percent_encode_purl_name` runs once per emitted SBOM — O(L) in name length, negligible.
+
+## Determinism contract (per FR-010, SC-009)
+
+- Same `RootComponentOverride` + same scan target → byte-identical emitted SBOMs across re-runs.
+- The override is a constant-input transformation; no clock, no UUID, no environment dependency on the override path itself.
+- The non-override emission path is unchanged from alpha.17 (per FR-009).
+
+## Logging contract
+
+| Event | Level | Format |
+|-------|-------|--------|
+| Override active (both fields) | `tracing::info!` | `"root component override active: name='<name>' (replacing '<auto>'), version='<version>' (replacing '<auto>')"` |
+| Override active (name only) | `tracing::info!` | `"root component override active: name='<name>' (replacing '<auto>')"` |
+| Override active (version only) | `tracing::info!` | `"root component override active: version='<version>' (replacing '<auto>')"` |
+| Manifest main-module dropped | `tracing::info!` | `"override is set; dropping manifest-derived main-module component '<purl>' from emitted SBOM (per milestone 077 clean-replacement; see GitHub issue #151)"` |

--- a/specs/077-root-component-override/data-model.md
+++ b/specs/077-root-component-override/data-model.md
@@ -1,0 +1,107 @@
+# Data Model — milestone 077 root component override
+
+The milestone introduces one new public struct (`RootComponentOverride`) on `ScanArtifacts` and one new private validator function for CLI parse-time input. Otherwise composes existing 073-076 types.
+
+## Entities
+
+### `RootComponentOverride` (NEW, public, in `mikebom-cli/src/generate/mod.rs`)
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct RootComponentOverride {
+    /// When `Some(name)`, replaces the auto-derived
+    /// `metadata.component.name` (CDX) / main-module
+    /// `Package.name` (SPDX 2.3) / root element name (SPDX 3) with
+    /// `name`. Validated at CLI parse per VR-077-001.
+    pub name: Option<String>,
+
+    /// When `Some(version)`, replaces the auto-derived version
+    /// field across all three formats. Validated at CLI parse per
+    /// VR-077-001.
+    pub version: Option<String>,
+}
+
+impl RootComponentOverride {
+    /// Returns true iff at least one field is set. Used by per-format
+    /// builders to decide whether to filter manifest-derived main-
+    /// module components from the emitted `components[]` array per
+    /// the 2026-05-06 clean-replacement clarification.
+    pub fn is_active(&self) -> bool {
+        self.name.is_some() || self.version.is_some()
+    }
+}
+```
+
+Field on `ScanArtifacts`:
+
+```rust
+pub struct ScanArtifacts<'a> {
+    // ... existing fields including identifiers (073), source_document_binding (072),
+    // component_identifiers (076), keep_credentials_in_identifiers (075) ...
+    /// Milestone 077: operator-supplied overrides for the root
+    /// component's name + version.
+    pub root_override: RootComponentOverride,
+}
+```
+
+Default to `RootComponentOverride::default()` for back-compat; existing call sites with `..Default::default()` syntax continue to compile.
+
+### `ValidatedRootField` (conceptual; materialized as `String`)
+
+The output of `validate_root_field`. Same string the operator typed, returned only after passing the FR-006 validation rule (no whitespace / control / `?` / `#`). The `Result<String, String>` shape matches the existing milestone-076 `parse_component_id_flag` pattern.
+
+## Functions (public surface added by this milestone)
+
+### `validate_root_field` (NEW, private to `cli/scan_cmd.rs` or shared module)
+
+```rust
+fn validate_root_field(value: &str, flag_name: &str) -> Result<String, String>;
+```
+
+Behavior per research §4: rejects empty, whitespace, control characters, `?`, `#`. Accepts any other non-empty UTF-8. Used as clap value_parser for both `--root-name` and `--root-version`.
+
+### `percent_encode_purl_name` (NEW, private to `generate/`)
+
+```rust
+fn percent_encode_purl_name(s: &str) -> String;
+```
+
+RFC 3986 percent-encoding for the PURL `name` segment. Preserves `[A-Za-z0-9._~-]`; percent-encodes everything else (UTF-8-aware). Used ONLY in the override path's PURL construction; the existing `url_friendly` helper at `spdx/v3_document.rs:410` is unchanged for the non-override path per research §1.
+
+## Validation rules
+
+- **VR-077-001**: `--root-name` and `--root-version` values MUST be rejected at CLI parse time when they contain ANY of: ASCII whitespace (`\s`), ASCII control characters (`\x00`–`\x1F`, `\x7F`), `?`, or `#`. Empty values rejected. All other UTF-8 characters accepted.
+- **VR-077-002**: When `RootComponentOverride.name.is_some()`, the per-format builders MUST use the override value verbatim in the displayed `name` field of the root component AND derive `bom-ref`/`purl`/`cpe` from the override (not from the auto-derived values).
+- **VR-077-003**: When `RootComponentOverride.is_active()` returns true, the per-format builders MUST filter out manifest-derived main-module components (identified by `mikebom:component-role = main-module` property) from the emitted `components[]` array per the 2026-05-06 clean-replacement clarification. The filter applies uniformly whether `name`, `version`, or both are set.
+- **VR-077-004**: Override emission MUST be deterministic — same `RootComponentOverride` value + same scan target → byte-identical output across re-runs.
+
+## Relationships
+
+```text
+mikebom sbom scan / mikebom trace run
+    │
+    ├── ScanArgs.root_name  : Option<String>   (clap --root-name)
+    │   ScanArgs.root_version: Option<String>   (clap --root-version)
+    │   (each parsed via `validate_root_field` value_parser)
+    │
+    └── ScanArtifacts.root_override : RootComponentOverride
+            │
+            ├── if .is_active() → filter out main-module components
+            │                     before per-format build
+            │
+            └── per-format builders consume:
+                ├── CDX  metadata.rs:42 build_metadata + cyclonedx/builder.rs:163 build
+                │       → root component's name, version, bom-ref, purl, cpe all
+                │         use override values (with percent_encode_purl_name on PURL)
+                ├── SPDX 2.3  spdx/document.rs                                        ↓ same
+                └── SPDX 3    spdx/v3_document.rs                                     ↓ same
+```
+
+## Backward compatibility
+
+- No new `Cargo.toml` deps; no MSRV change; no nightly required.
+- `RootComponentOverride` is `#[derive(Default)]` so existing `ScanArtifacts` constructions with `..Default::default()` syntax continue to compile.
+- `ScanArgs.root_name` and `ScanArgs.root_version` default to `None`; operators not passing the flags get byte-identical pre-077 behavior.
+- Existing milestone-073/074/075/076 byte-identity goldens stay byte-identical: no fixtures pass `--root-name` / `--root-version`, no fixtures hit the manifest-drop path.
+- The new `percent_encode_purl_name` helper is NEW code; it doesn't replace the existing `url_friendly`. Non-override paths are unchanged.
+- CPE format identical to alpha.17 for the no-flag case; only the name/version fields within the CPE differ when override fires.

--- a/specs/077-root-component-override/plan.md
+++ b/specs/077-root-component-override/plan.md
@@ -1,0 +1,195 @@
+# Implementation Plan: Operator-overridable root component name and version
+
+**Branch**: `077-root-component-override` | **Date**: 2026-05-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/077-root-component-override/spec.md`
+
+## Summary
+
+Closes the operator UX gap where source-tier scans of arbitrary directories produce SBOMs with non-meaningful root component names (`filesystem-scan@0.0.0` derived from `path.file_name()` + hardcoded `"0.0.0"`). Adds two new CLI flags:
+
+- `--root-name <NAME>` overrides the auto-derived `metadata.component.name` (CDX) / main-module `Package.name` (SPDX 2.3) / root element name (SPDX 3).
+- `--root-version <VERSION>` overrides the corresponding version field.
+
+Derived fields (`bom-ref`, `purl`, `cpe`) automatically follow the overridden name/version through the existing per-format derivation pipeline. Both flags independent. When both unset, behavior byte-identical to alpha.17 (no regression).
+
+Per the 2026-05-06 clarifications: validation is permissive (reject only whitespace / control / `?` / `#`; URL-encode the rest at PURL emission), and override is a clean replacement (manifest-derived main-module dropped entirely from the emitted SBOM, NOT demoted to `components[]` — the demote-to-library follow-up is tracked as GitHub issue #151).
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–076; no nightly).
+**Primary Dependencies**: Existing only — `serde`/`serde_json`, `tracing`, `anyhow`, `clap` (the two new flags via derive). The `url` crate is already a direct workspace dep (promoted in milestone 075) and reused for URL-encoding the override values into the PURL `name` segment per RFC 3986. **No additions to the dependency tree at the lockfile level.**
+**Storage**: N/A — purely a metadata transform; no caches, no persistence.
+**Testing**: `cargo +stable test --workspace`. New integration tests in `mikebom-cli/tests/identifiers_root_component_override.rs` reuse the tempdir-based fixture pattern from milestones 074/075/076. Validation rejection tests use the milestone-075 negative-test pattern (assert clap exit code + error text).
+**Target Platform**: Linux (CI primary), macOS (developer workstations). Logic is OS-agnostic.
+**Project Type**: CLI tool — single workspace, three crates (`mikebom-cli` is the only one touched).
+**Performance Goals**: Override adds <1ms per scan (constant-time string substitution + URL-encoding). Negligible against the existing scan/emission cost.
+**Constraints**: Determinism per FR-010 (same flag values + same scan target → byte-identical output). No regression on existing milestone-073/074/075/076 byte-identity goldens per FR-009 / SC-002 / SC-010.
+**Scale/Scope**: Two new flags on `ScanArgs` + `RunArgs` + `GenerateArgs` (~30 LOC); one new `RootComponentOverride` struct on `ScanArtifacts` (~15 LOC); per-format builder updates (CDX `metadata.component` construction site at `cyclonedx/builder.rs:168-178`; SPDX 2.3 site at `spdx/document.rs:34-56`+; SPDX 3 site at `spdx/v3_document.rs:150,376-390,435`); main-module-drop logic when override is set (~20 LOC in CDX builder + SPDX equivalents); one new integration-test file (~250 LOC, ~12 tests across 3 user stories); one docs update.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution v1.4.0 (last amended 2026-05-01). All 12 principles + 4 strict boundaries:
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| I. Pure Rust, Zero C | ✅ Pass | Pure-Rust extension. No FFI, no C, no new toolchain. |
+| II. eBPF-Only Observation | ✅ Pass / N/A | Identifier metadata only; eBPF trace unchanged. |
+| III. Fail Closed | ✅ Pass | Validation rejection at CLI parse time on bad input — fail before any scan work happens. The scan + emission pipeline is unchanged for the no-flag case. |
+| IV. Type-Driven Correctness | ✅ Pass | New `RootComponentOverride { name: Option<String>, version: Option<String> }` shape on `ScanArtifacts` plus a small validator function. Production code uses `anyhow::Result`. Tests retain `#[cfg_attr(test, allow(clippy::unwrap_used))]` per the established convention. No new raw `String` boundary crossings beyond the operator-supplied flag values, which are validated at parse. |
+| V. Specification Compliance | ✅ Pass | **Native-first audit (constitution v1.4.0 5th bullet):** Override changes the *value* of an existing standards-native field (`metadata.component.name` / `version` in CDX; equivalents in SPDX 2.3 / SPDX 3). **Zero new `mikebom:*` annotations introduced.** `purl`, `cpe`, `bom-ref` derive through the existing per-format pipeline unchanged. The clean-replacement behavior (manifest-derived main-module dropped) preserves the existing standards-native shape — no new fields, no new property keys. |
+| VI. Three-Crate Architecture | ✅ Pass | All changes inside `mikebom-cli`. No new crates. |
+| VII. Test Isolation | ✅ Pass | Override + validation are pure user-space logic. Tests need no privilege. Tempdir-based fixture pattern from milestones 074/075/076. |
+| VIII. Completeness | ✅ Pass / N/A | Doesn't affect dependency discovery. |
+| IX. Accuracy | ✅ Pass | The operator's override is explicit input; mikebom emits exactly what the operator supplied (no inference, no auto-derivation, no soft-fail). |
+| X. Transparency | ✅ Pass | When override fires, mikebom emits a `tracing::info!` recording the override (which fields were overridden, with what values, replacing what auto-derived defaults). When the override drops a manifest-derived main-module per the 2026-05-06 clarification, an additional `tracing::info!` records that, naming the dropped PURL so operators see the trade-off. |
+| XI. Enrichment | ✅ Pass / N/A | Not enrichment. |
+| XII. External Data Source Enrichment | ✅ Pass / N/A | Operator CLI input is not an external data source. |
+
+| Strict Boundary | Status |
+|-----------------|--------|
+| 1. No lockfile-based dependency discovery | ✅ Pass |
+| 2. No MITM proxy | ✅ Pass |
+| 3. No C code | ✅ Pass |
+| 4. No `.unwrap()` in production | ✅ Pass — extends production code that already complies; tests use the standard `#[cfg_attr(test, allow(clippy::unwrap_used))]` guard |
+
+**Gate result: PASS.** No violations; no Complexity Tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/077-root-component-override/
+├── plan.md                         # This file
+├── spec.md                         # /speckit.specify + /speckit.clarify output
+├── research.md                     # Phase 0 output
+├── data-model.md                   # Phase 1 output
+├── quickstart.md                   # Phase 1 output
+├── contracts/
+│   └── root-component-override.md  # Phase 1 — single CLI/lib contract
+├── checklists/
+│   └── requirements.md             # Already passing
+└── tasks.md                        # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+The milestone touches the CLI argparse + the three per-format builders + adds one struct field. No new modules, no new crates.
+
+```text
+mikebom-cli/
+├── src/
+│   ├── cli/
+│   │   ├── scan_cmd.rs              # MODIFY — add --root-name/--root-version
+│   │   │                            # to ScanArgs; validator function for
+│   │   │                            # name/version inputs (rejects
+│   │   │                            # whitespace/control/?/# per Q1
+│   │   │                            # clarification); thread into
+│   │   │                            # ScanArtifacts.root_override.
+│   │   ├── run.rs                   # MODIFY — same flags on RunArgs;
+│   │   │                            # thread into the build-tier
+│   │   │                            # ScanArtifacts construction.
+│   │   └── generate.rs              # MODIFY (small) — back-compat only:
+│   │                                # update existing ScanArtifacts
+│   │                                # construction site to populate the
+│   │                                # new `root_override` field with
+│   │                                # default. Per research §6, the
+│   │                                # `mikebom sbom generate` subcommand
+│   │                                # does NOT receive new flags — it
+│   │                                # re-emits from a previously-created
+│   │                                # attestation, where override would
+│   │                                # have ambiguous semantics.
+│   ├── generate/
+│   │   ├── mod.rs                   # MODIFY — add `root_override:
+│   │   │                            # Option<RootComponentOverride>` field
+│   │   │                            # to ScanArtifacts. Define the
+│   │   │                            # struct in this module.
+│   │   ├── cyclonedx/
+│   │   │   └── builder.rs           # MODIFY — at builder.rs:168-178,
+│   │   │                            # use override values when present;
+│   │   │                            # also filter main-module out of
+│   │   │                            # `components` array per Q2 clean-
+│   │   │                            # replacement clarification when
+│   │   │                            # override is set on a manifest-
+│   │   │                            # driven scan.
+│   │   └── spdx/
+│   │       ├── document.rs          # MODIFY — at lines 34-56, override
+│   │       │                        # `target_name` consumption with
+│   │       │                        # operator-supplied value when
+│   │       │                        # present; same hardcoded "0.0.0"
+│   │       │                        # site at line 456 needs override too.
+│   │       └── v3_document.rs       # MODIFY — at lines 150, 376-390, 435,
+│   │                                # use override values when present;
+│   │                                # main-module drop equivalent here.
+│   └── binding/
+│       └── identifiers/
+│           └── (no changes)         # 077 doesn't touch the identifier
+│                                    # substrate; only the root-component
+│                                    # display identity.
+└── tests/
+    └── identifiers_root_component_override.rs  # NEW — integration tests
+                                                  # for SC-001..SC-010 +
+                                                  # the manifest-drop
+                                                  # clean-replacement test
+                                                  # against an existing
+                                                  # Cargo fixture.
+
+docs/reference/identifiers.md                    # MODIFY (small) — add
+                                                  # subsection on root
+                                                  # component override
+                                                  # under the existing
+                                                  # CLI flag reference.
+```
+
+**Structure Decision**: Single project. Extends `mikebom-cli` with no new modules. Smallest-possible-surface-change consistent with milestones 074/075.
+
+## Phase 0 — Research questions
+
+Six implementation-level decisions to pin in `research.md` before Phase 1 design.
+
+1. **PURL emitter URL-encoding behavior** — when constructing `pkg:generic/<NAME>@<VERSION>` for the root component, what URL-encoding does mikebom's existing PURL emission do today for special characters in the name segment? Verify by inspecting the existing PURL construction sites and confirming that npm-scoped names (`@acme/widget-svc`) round-trip correctly through whatever encoding the PURL emitter applies.
+2. **`RootComponentOverride` shape** — small struct vs `(Option<String>, Option<String>)` tuple field on `ScanArtifacts`. Recommend struct for clarity + future expansion (e.g., if `--root-vendor` is added later, the struct gains a third field rather than the tuple growing). Pin the field name (`root_override` or `root_component_override`).
+3. **Manifest-driven main-module detection + drop site** — at the CDX builder's `build_components` site (around `builder.rs:251-280`+), main-module components are detected via `properties[].name == "mikebom:component-role"` and `value == "main-module"` (per the existing comment at line 286). When override is set, those main-module components MUST be filtered out before `build_components` runs (they're dropped from `components[]` entirely; not demoted, per Q2 clarification). Pin the filter logic placement and verify it doesn't accidentally drop multi-main-module-case components (cargo workspace) — the override-set case is single-target by definition (operator supplied one identity), so the filter applies uniformly.
+4. **CLI flag validation regex** — exact rejection rule per Q1 clarification: reject any input containing `\s` (ASCII whitespace), `\x00`–`\x1F` / `\x7F` (ASCII control), `?`, or `#`. Permissive otherwise — accept any non-empty UTF-8. Pin the validator function shape: `fn validate_root_field(value: &str, field_name: &str) -> Result<String, String>` returning the validated string or a clear clap-shaped error.
+5. **CPE construction with override values** — `cpe:2.3:a:mikebom:<NAME>:<VERSION>:*:*:*:*:*:*:*`. Verify the existing CPE emitter at `generate/cpe.rs:169` consumes the same name/version pair and produces the right CPE string. The vendor portion stays hardcoded `mikebom` per assumption — no operator override for vendor in this milestone.
+6. **`mikebom sbom generate` subcommand reach** — verify whether the `generate` subcommand (post-trace SBOM-from-attestation flow) accepts the same identifier flags as `scan` and `run`. If yes, add `--root-name`/`--root-version` there too (FR-001 says "all subcommands that construct root components"). If no, scope to `scan` + `run` only. Pin during research by reading `cli/generate.rs`.
+
+## Phase 1 — Design & contracts
+
+### data-model.md
+
+One new struct (`RootComponentOverride`) added to the `generate` module. One new field on `ScanArtifacts`. Validation rules VR-077-001..004.
+
+### contracts/
+
+One contract: `root-component-override.md`. Documents:
+- The two new CLI flags + their validation rule (per Q1)
+- The override field on `ScanArtifacts`
+- Per-format wire mapping (CDX `metadata.component`, SPDX 2.3 main-module Package, SPDX 3 root element)
+- The main-module drop behavior per Q2 (clean replacement)
+- Observable contract: log-line phrasing, expected output shape
+
+### quickstart.md
+
+Five operator-facing recipes:
+1. **Override on a generic source-tier scan** (the headline; the user's exact use case)
+2. **Override one flag at a time** (just `--root-name` or just `--root-version`)
+3. **Override on a manifest-driven Cargo project** (US3; demonstrates clean replacement)
+4. **Override on image-tier scan** (US2)
+5. **Override + identifier flags together** (orthogonality with milestones 073-076)
+
+### Agent context update
+
+Run `.specify/scripts/bash/update-agent-context.sh claude` after Phase 1 docs land.
+
+## Phase 2 — Out of scope for this command
+
+`/speckit.plan` ends here. `/speckit.tasks` consumes plan.md + spec.md + Phase 1 docs and emits `tasks.md`. Estimated task count: ~12-14 (smaller than 075 because no new dep, no new module beyond a tiny struct definition; smaller than 076 because no new identifier scheme + no new built-in pattern).
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified.**
+
+Not applicable — Constitution Check passes on all 12 principles + 4 strict boundaries with zero violations.

--- a/specs/077-root-component-override/quickstart.md
+++ b/specs/077-root-component-override/quickstart.md
@@ -1,0 +1,174 @@
+# Quickstart — milestone 077 root component override
+
+Five operator-facing recipes covering the `--root-name` and `--root-version` flags.
+
+## Recipe 1 — The headline: override on a generic source-tier scan
+
+The use case the milestone exists for. An operator points mikebom at an arbitrary directory whose basename doesn't reflect the operator-meaningful project identity.
+
+```bash
+# Scan an arbitrary build artifact tree
+mikebom sbom scan --path /opt/builds/abc123-snapshot \
+    --root-name widget-svc --root-version 1.2.3 \
+    --output widget-svc.cdx.json
+# INFO root component override active: name='widget-svc' (replacing 'abc123-snapshot'), version='1.2.3' (replacing '0.0.0')
+```
+
+Inspect the emitted SBOM:
+
+```bash
+jq '.metadata.component | {name, version, "bom-ref", purl, cpe}' widget-svc.cdx.json
+# {
+#   "name": "widget-svc",
+#   "version": "1.2.3",
+#   "bom-ref": "widget-svc@1.2.3",
+#   "purl": "pkg:generic/widget-svc@1.2.3",
+#   "cpe": "cpe:2.3:a:mikebom:widget-svc:1.2.3:*:*:*:*:*:*:*"
+# }
+```
+
+All derived fields (`bom-ref`, `purl`, `cpe`) follow the override automatically — no separate flags needed for them.
+
+## Recipe 2 — One flag at a time
+
+The flags are independent. Operator can override just the name (keeping the auto-derived version), or just the version (keeping the basename-derived name):
+
+```bash
+# Just override the name
+mikebom sbom scan --path /opt/builds/abc123-snapshot --root-name widget-svc --output a.cdx.json
+jq '.metadata.component | {name, version}' a.cdx.json
+# {"name": "widget-svc", "version": "0.0.0"}
+
+# Just override the version
+mikebom sbom scan --path /opt/builds/abc123-snapshot --root-version 1.2.3 --output b.cdx.json
+jq '.metadata.component | {name, version}' b.cdx.json
+# {"name": "abc123-snapshot", "version": "1.2.3"}
+```
+
+## Recipe 3 — Override on a manifest-driven Cargo project
+
+Operator wants to publish an SBOM identifying the project as `widget-svc@1.2.3` even though Cargo's `[package].name = "foo-internal"`. The override is a **clean replacement** — the manifest-derived `foo-internal` identity is dropped entirely (not demoted to `components[]`).
+
+```bash
+cd ~/projects/foo-internal-cargo  # has Cargo.toml with [package].name = "foo-internal"
+mikebom sbom scan --path . --root-name widget-svc --root-version 1.2.3 --output out.cdx.json
+# INFO root component override active: name='widget-svc' (replacing 'foo-internal'), version='1.2.3' (replacing '0.5.1')
+# INFO override is set; dropping manifest-derived main-module component `pkg:cargo/foo-internal@0.5.1` from emitted SBOM (per milestone 077 clean-replacement clarification; see GitHub issue #151 for the demote-to-library follow-up)
+```
+
+Verify:
+
+```bash
+jq '.metadata.component.name' out.cdx.json
+# "widget-svc"
+
+# The Cargo main-module is gone:
+jq '.components[] | select(.purl == "pkg:cargo/foo-internal@0.5.1")' out.cdx.json
+# (no output)
+
+# Cargo dependencies still present:
+jq '.components | length' out.cdx.json
+# 42  (or whatever — deps count, minus the dropped main-module)
+```
+
+If you want the manifest-derived `foo-internal` identity preserved as a library entry alongside the override, that's tracked as future work in **GitHub issue #151**. Today's MVP uses clean replacement. If you need it now, post-process with `mikebom sbom enrich` to add the manifest entry back.
+
+## Recipe 4 — Override on image-tier scan
+
+The same flags work on `mikebom sbom scan --image`. Useful when the operator wants the image SBOM to identify as the deployed service name rather than the image basename.
+
+```bash
+mikebom sbom scan --image acme/internal-bld:v1 \
+    --root-name widget-svc-image --root-version 1.2.3 \
+    --output image.cdx.json
+# INFO root component override active: name='widget-svc-image' (replacing 'acme/internal-bld'), version='1.2.3' (replacing 'v1')
+```
+
+The auto-detected `image:` identifier (milestone 073) is unaffected — it's a separate slot in `externalReferences[]`:
+
+```bash
+jq '.metadata.component | {name, version, externalReferences: [.externalReferences[] | select(.type == "distribution")]}' image.cdx.json
+# {
+#   "name": "widget-svc-image",
+#   "version": "1.2.3",
+#   "externalReferences": [
+#     {
+#       "type": "distribution",
+#       "url": "acme/internal-bld:v1@sha256:abc...",
+#       "comment": "auto-detected from resolved image reference"
+#     }
+#   ]
+# }
+```
+
+The root component identity is operator-controlled; the `image:` identifier still records what was actually scanned.
+
+## Recipe 5 — Override + identifiers + binding (full layered example)
+
+The override flag is **orthogonal** to all milestone-072–076 identifier and binding flags. Stack them freely:
+
+```bash
+mikebom sbom scan --path . \
+    --root-name widget-svc --root-version 1.2.3 \
+    --repo git@github.com:acme/widget-svc.git \
+    --git-ref abc1234567890abcdef1234567890abcdef12345 \
+    --subject-hash sha256:def5678901234567890abcdef1234567890abcdef1234567890abcdef12345aa \
+    --component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-shared-lib-v2" \
+    --output out.cdx.json
+```
+
+The emitted SBOM has:
+- Root component identity from `--root-name` / `--root-version` (this milestone)
+- Auto-detected + manual identifiers from milestones 073/074/076 in `externalReferences[]`
+- Per-component user-defined identifier on the matching `serde` component (milestone 076)
+- All independent slots; all visible to external consumers via the standards-native carriers documented in `docs/reference/identifiers.md`
+
+## Recipe (validation) — npm-scoped names work
+
+Per the 2026-05-06 permissive-validation clarification, names like `@acme/widget-svc` are accepted (no rejection at parse), and URL-encoded into the PURL `name` segment automatically:
+
+```bash
+mikebom sbom scan --path . --root-name "@acme/widget-svc" --root-version 1.2.3 --output out.cdx.json
+
+jq '.metadata.component | {name, purl, "bom-ref"}' out.cdx.json
+# {
+#   "name": "@acme/widget-svc",                              # ← name field preserves operator's exact value
+#   "purl": "pkg:generic/%40acme%2Fwidget-svc@1.2.3",        # ← PURL has URL-encoded name segment
+#   "bom-ref": "@acme/widget-svc@1.2.3"                      # ← bom-ref also preserves verbatim
+# }
+```
+
+## Recipe (validation) — what gets rejected
+
+Names with whitespace, control chars, `?`, or `#` fail at CLI parse before any scan work happens:
+
+```bash
+mikebom sbom scan --path . --root-name "my widget svc"
+# error: invalid value 'my widget svc' for '--root-name <NAME>': --root-name contains whitespace at position 2 (character: ' '); whitespace is not allowed
+
+mikebom sbom scan --path . --root-name ""
+# error: invalid value '' for '--root-name <NAME>': --root-name must not be empty
+
+mikebom sbom scan --path . --root-name "foo?bar"
+# error: invalid value 'foo?bar' for '--root-name <NAME>': --root-name contains URL-syntax-breaking character '?' at position 3; '?' and '#' are not allowed
+```
+
+Versions follow the same rule:
+
+```bash
+mikebom sbom scan --path . --root-version "1.2 .3"
+# error: invalid value '1.2 .3' for '--root-version <VERSION>': --root-version contains whitespace at position 3 (character: ' '); whitespace is not allowed
+```
+
+## When to use each layer of identity (recap)
+
+After milestones 072–077, mikebom has **four layers of identity** in an emitted SBOM. Use them together based on what the operator needs to express:
+
+| Layer | Surface | What to use |
+|-------|---------|-------------|
+| 1. Root component identity | `metadata.component.{name,version,bom-ref,purl,cpe}` | `--root-name` / `--root-version` (077) — overrides auto-derived defaults |
+| 2. Document-level identifiers | `metadata.component.externalReferences[]` | `--repo` / `--git-ref` / `--image-id` / `--attestation` / `--subject-hash` / `--id <scheme>=<value>` (073–076) — cross-tier correlation handles |
+| 3. Per-component identifiers | `components[].properties[]` | `--component-id <PURL>=<scheme>:<value>` (076) — per-component user-defined |
+| 4. Cross-tier binding | `mikebom:source-document-binding` annotation | `--bind-to-source <PATH>` (072) — cryptographic embedded reference |
+
+This milestone (077) closes the operator-visible gap at Layer 1. Layers 2–4 were closed by 072–076.

--- a/specs/077-root-component-override/research.md
+++ b/specs/077-root-component-override/research.md
@@ -1,0 +1,142 @@
+# Research — milestone 077 root component override
+
+Six implementation-level decisions to pin before Phase 1 design.
+
+## §1 — PURL emitter URL-encoding behavior
+
+**Decision**: Add a new private helper `fn percent_encode_purl_name(s: &str) -> String` in `mikebom-cli/src/generate/cyclonedx/metadata.rs` (and re-exported into the spdx modules) that performs RFC 3986 percent-encoding for the PURL `name` segment. Use this helper ONLY when constructing the override-path PURL. Leave the existing `url_friendly()` helper at `spdx/v3_document.rs:410` untouched for the non-override path.
+
+**Rationale**: The existing `url_friendly` performs lossy substitution (replaces non-`[A-Za-z0-9._-]` characters with `-`). For an operator-supplied `--root-name @acme/widget-svc`, that would produce PURL `pkg:generic/-acme-widget-svc@1.2.3` — different from the operator's intent. The Q1 clarification explicitly said "URL-encode the rest at PURL emission time," meaning RFC 3986 percent-encoding (`%40acme%2Fwidget-svc` for the `@` and `/` characters), not substitution.
+
+Why not refactor `url_friendly` to also use percent-encoding? Risk of regressing existing fixture goldens. Today's fixtures (cargo, deb, npm, etc.) have PURL-safe basenames whose `url_friendly` result equals their input; switching to percent-encoding would produce identical output for those cases, so the regression risk is theoretically zero — but verifying that empirically across all existing fixtures + format combinations is more scope than this milestone needs. Safer: introduce the new encoder for the override path only; let a future cleanup milestone consolidate.
+
+The new helper's encoding rule per RFC 3986 §2.3 (Unreserved Characters): preserve `[A-Za-z0-9._~-]`; percent-encode everything else (including UTF-8 bytes for non-ASCII characters).
+
+**Alternatives considered**:
+- Refactor `url_friendly` to do percent-encoding — Rejected for risk-of-regression reasons above.
+- Keep `url_friendly` substitution for the override path too — Rejected: operator supplies `@acme/widget-svc`, expects to see something close to that in the PURL. Lossy substitution surprises operators.
+- Reject PURL-unsafe characters at parse time — Rejected: contradicts the Q1 permissive clarification.
+
+## §2 — `RootComponentOverride` shape
+
+**Decision**: Define a small struct in `mikebom-cli/src/generate/mod.rs`:
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct RootComponentOverride {
+    pub name: Option<String>,
+    pub version: Option<String>,
+}
+```
+
+Add a new field to `ScanArtifacts`:
+
+```rust
+pub struct ScanArtifacts<'a> {
+    // ... existing fields ...
+    /// Milestone 077: operator-supplied overrides for the root
+    /// component's name + version. When `name` or `version` is
+    /// Some(_), the override replaces the corresponding auto-derived
+    /// value in `metadata.component` (CDX) / main-module Package
+    /// (SPDX 2.3) / root element (SPDX 3). When None, the existing
+    /// auto-derivation flow runs unchanged.
+    pub root_override: RootComponentOverride,
+}
+```
+
+Default to `RootComponentOverride::default()` (both fields `None`) for back-compat — existing struct-literal call sites that use struct-update syntax (`..Default::default()`) continue to compile.
+
+**Rationale**: Struct-with-named-fields beats `(Option<String>, Option<String>)` tuple for clarity at call sites and future-proofing (if `--root-vendor` or other root-component override flags are added later, the struct gains fields rather than the tuple growing). `Default` derive lets existing call sites construct `ScanArtifacts` without explicit `root_override: RootComponentOverride::default()` if they use update syntax.
+
+**Alternatives considered**:
+- Tuple field — Rejected: less self-documenting at call sites.
+- Two separate `Option<String>` fields directly on `ScanArtifacts` — Rejected: doesn't group related state; future expansion churns more call sites.
+- Keep on `ScanArgs` (CLI-layer struct) instead of `ScanArtifacts` (emit-layer struct) — Rejected: breaks the existing pattern where ScanArtifacts holds ALL emit-layer state. Other identifier flags (075's `--keep-credentials-in-identifiers`, 076's `--component-id`) followed this same pattern.
+
+## §3 — Manifest-driven main-module detection + drop site
+
+**Decision**: At the CDX builder's `build()` site (`cyclonedx/builder.rs:163-228`), filter `components` to drop main-module entries when `root_override.name.is_some()` OR `root_override.version.is_some()`. Filter is keyed on the existing `mikebom:component-role = main-module` property (per the comment at `builder.rs:286` already documenting how main-modules are identified). Mirror in SPDX 2.3 (`spdx/document.rs`) and SPDX 3 (`spdx/v3_document.rs`) flows.
+
+**Rationale**: Per the Q2 clarification (clean replacement), when override is set the manifest-derived main-module disappears entirely from the emitted SBOM. The filter happens BEFORE `build_components` runs so the main-module never reaches the per-component emission code path.
+
+The filter MUST apply uniformly when EITHER override field is set (not just when both are set). Operator passing `--root-name widget-svc` with no `--root-version` gets `widget-svc@<auto-derived-version>` as the root; the manifest's `foo-internal` is still dropped because the operator opted into "the root is widget-svc, not foo-internal" — version override is independent.
+
+When both override fields are `None`, no filter applies; existing milestone-073/074/075/076 behavior is preserved exactly.
+
+Multi-main-module case (cargo workspace) at `builder.rs:267-272`: when `main_module_count > 1`, no main-module is promoted to `metadata.component` today; the synthesized scan-target acts as root. With override set, the override identity becomes the root and ALL main-modules in the workspace are dropped. This is consistent — explicit operator input replaces the entire main-module set, regardless of whether it's 1 or N main-modules.
+
+**Alternatives considered**:
+- Filter inside `build_components` rather than before — Rejected: harder to reason about; mixes filter logic with emission logic.
+- Skip the filter when `root_override` only sets version (just name overridden, version not) — Rejected: name-only override still implies "the root is widget-svc, not foo-internal"; partial filter would be inconsistent.
+- Add a `--keep-manifest-main-module` flag to opt out of the drop — Rejected: out of scope for MVP. The future GitHub issue #151 tracks the demote-to-library exploration.
+
+## §4 — CLI flag validation regex
+
+**Decision**: Validator function:
+
+```rust
+fn validate_root_field(value: &str, flag_name: &str) -> Result<String, String> {
+    if value.is_empty() {
+        return Err(format!("{flag_name} must not be empty"));
+    }
+    for (i, c) in value.chars().enumerate() {
+        if c.is_whitespace() {
+            return Err(format!(
+                "{flag_name} contains whitespace at position {i} \
+                 (character: {:?}); whitespace is not allowed",
+                c
+            ));
+        }
+        if c.is_control() {
+            return Err(format!(
+                "{flag_name} contains a control character at position {i} \
+                 (codepoint: U+{:04X}); control characters are not allowed",
+                c as u32
+            ));
+        }
+        if c == '?' || c == '#' {
+            return Err(format!(
+                "{flag_name} contains URL-syntax-breaking character '{c}' \
+                 at position {i}; '?' and '#' are not allowed"
+            ));
+        }
+    }
+    Ok(value.to_string())
+}
+```
+
+Used as a clap `value_parser` for both `--root-name` and `--root-version`. Returns `Result<String, String>` so clap's error formatter surfaces the message to the operator at parse time.
+
+**Rationale**: Implements the Q1 clarification exactly — permissive accept (any non-empty UTF-8) with rejection only for `\s`, control chars, `?`, and `#`. The error messages are deliberately verbose so operators understand WHICH character violated WHICH rule (operators with weird-but-legal names like `@acme/widget-svc` need to know it's the `@` or `/` that's fine, vs `?`/`#` which aren't).
+
+The function signature returning `Result<String, String>` matches the milestone-076 `parse_component_id_flag` pattern (returns clap-shaped errors).
+
+**Alternatives considered**:
+- Stricter validation (reject anything outside `[a-zA-Z0-9._-]`) — Rejected per Q1 clarification.
+- `regex::Regex` for the rule — Rejected: overhead for what's a per-character classification.
+- `clap`'s built-in `value_parser` for non-empty strings — Rejected: doesn't cover the per-character classification needed.
+
+## §5 — CPE construction with override values
+
+**Decision**: When the override is set, construct the CPE from the override values: `format!("cpe:2.3:a:mikebom:{}:{}:*:*:*:*:*:*:*", cpe_escape(name), cpe_escape(version))`. Reuse the existing `cpe_escape` helper at `cpe.rs:145`. Vendor portion stays hardcoded `mikebom` per assumption.
+
+**Rationale**: CPE formatted-string-binding rules (NIST IR 7695 §6.2) require specific escaping of WFN component values — `cpe_escape` already implements this. Operator-supplied override values flow through the same escaping; no per-CPE-version logic needed at the override layer.
+
+The vendor stays `mikebom` for consistency with the existing CPE emission. A future milestone can introduce `--root-vendor` if multi-vendor CPE namespacing is requested. Note: the spec's example output already shows vendor=mikebom, so this is the documented MVP behavior.
+
+**Alternatives considered**:
+- Allow operator to override vendor too — Out of scope per spec assumptions; future milestone.
+- Drop CPE entirely on override — Rejected: CPE consumers (vulnerability scanners hard-keyed on CPE) would lose the override-identity match.
+- Use `cpe:2.3:a:<NAME>::*:*:*:*:*:*:*` with no vendor — Rejected: violates CPE 2.3 spec; vendor is required.
+
+## §6 — `mikebom sbom generate` subcommand reach
+
+**Decision**: Scope the new flags to `mikebom sbom scan` (both `--path` and `--image` variants) and `mikebom trace run`. Do NOT add to `mikebom sbom generate` (the post-trace re-emit-from-attestation flow).
+
+**Rationale**: The `generate` subcommand reads an existing attestation and re-emits its embedded SBOM. The root component identity comes from the embedded SBOM, not from operator input — overriding it would silently mutate a previously-generated artifact's identity, which is surprising. Operators who want to override during `generate` can do so by re-scanning with `scan` (which honors the new flags), or by post-processing with `mikebom sbom enrich` (which is the documented JSON-Patch path for ad-hoc edits to existing SBOMs).
+
+If operator demand for `generate`-time override emerges later, a follow-up milestone can add the flags there with explicit semantics about how they interact with the embedded SBOM. For MVP, `scan` + `run` is sufficient — those are the SBOM-construction call sites where override has unambiguous semantics.
+
+**Alternatives considered**:
+- Add to `generate` too — Rejected: ambiguous semantics on a re-emit flow.
+- Add to ALL SBOM-emitting subcommands uniformly — Rejected: parity ≠ correctness; `enrich` and `verify-binding` and similar don't construct root components, so adding the flags there is meaningless.

--- a/specs/077-root-component-override/spec.md
+++ b/specs/077-root-component-override/spec.md
@@ -1,0 +1,158 @@
+# Feature Specification: Operator-overridable root component name and version
+
+**Feature Branch**: `077-root-component-override`
+**Created**: 2026-05-06
+**Status**: Draft
+**Input**: User description: "Add `--root-name <NAME>` and `--root-version <VERSION>` CLI flags so operators can override the auto-derived `metadata.component.name` / `metadata.component.version` of an emitted SBOM. Today, source-tier scans of arbitrary directories produce names like `filesystem-scan@0.0.0` (basename of `--path` + hardcoded `0.0.0`) that don't reflect the operator-meaningful project identity. Derived fields (`bom-ref`, `purl`, `cpe`) MUST automatically follow the overridden name/version."
+
+## Overview
+
+Today, mikebom's emitted SBOMs carry a root component (`metadata.component` in CDX, equivalent main-module package in SPDX 2.3, root element in SPDX 3) whose `name` and `version` are derived from the scan target. For source-tier scans (`mikebom sbom scan --path`), the name comes from `path.file_name()` (the basename of the supplied directory) — falling back to the literal string `"filesystem-scan"` when no parsable basename exists — and the version is hardcoded `"0.0.0"` when no manifest-driven main-module derivation is available. For image-tier scans, the name comes from the image reference. For build-tier scans (`mikebom trace run`), it comes from the wrapped command's working directory.
+
+These defaults work for self-contained projects where the basename happens to match the operator-meaningful identity, or where a manifest-driven main-module milestone (Cargo, npm, pip, gem, Maven, Go) populates name+version from the project manifest. They break for the case the user surfaced: an operator running mikebom on an arbitrary directory or generic asset where the operator already knows the canonical project identity but the directory layout doesn't encode it. The current emitted SBOM contains:
+
+```json
+{
+  "bom-ref": "filesystem-scan@0.0.0",
+  "name": "filesystem-scan",
+  "version": "0.0.0",
+  "purl": "pkg:generic/filesystem-scan@0.0.0",
+  "cpe": "cpe:2.3:a:mikebom:filesystem-scan:0.0.0:*:*:*:*:*:*:*"
+}
+```
+
+The operator wants:
+
+```json
+{
+  "bom-ref": "widget-svc@1.2.3",
+  "name": "widget-svc",
+  "version": "1.2.3",
+  "purl": "pkg:generic/widget-svc@1.2.3",
+  "cpe": "cpe:2.3:a:mikebom:widget-svc:1.2.3:*:*:*:*:*:*:*"
+}
+```
+
+This milestone adds two new CLI flags that close the gap:
+
+- `--root-name <NAME>` overrides the auto-derived `metadata.component.name`.
+- `--root-version <VERSION>` overrides the auto-derived `metadata.component.version`.
+
+Derived fields (`bom-ref`, `purl`, `cpe`) automatically follow the overridden name/version through the existing per-format derivation pipeline. Both flags are independent — operators can override one without the other. When neither is passed, behavior is byte-identical to alpha.17.
+
+The scope is deliberately narrow: only the **root component**'s name/version. Vendor portion of the CPE (currently hardcoded `mikebom`), `metadata.component.type`, and per-component name/version overrides are out of scope. They can be addressed in follow-up milestones if operator demand emerges.
+
+## Clarifications
+
+### Session 2026-05-06
+
+- Q: How strict should `--root-name` validation be? → A: Permissive — accept any non-empty UTF-8 except whitespace, control characters, `?`, and `#` (the URL-syntax-breaking subset). URL-encode the rest at PURL emission time. Allows npm-scoped names like `@acme/widget-svc`.
+- Q: When `--root-name`/`--root-version` overrides a manifest-driven main-module derivation (Cargo `[package]`, npm `package.json`, etc.), what happens to the manifest-derived component? → A: Dropped entirely. The override is a clean replacement: the root's name/version/bom-ref/purl/cpe all derive from operator input; the manifest-derived `foo-internal@0.5.1`-style component is NOT preserved anywhere in the emitted SBOM. The "demote to `components[]` as a library entry" alternative is deferred to a follow-up GitHub issue for exploration based on operator demand.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Override root name and version on a generic source-tier scan (Priority: P1)
+
+An operator runs `mikebom sbom scan --path /opt/builds/my-asset --root-name widget-svc --root-version 1.2.3 --output out.cdx.json` against an arbitrary directory whose basename doesn't reflect the operator-meaningful identity. The emitted SBOM's root component carries `name=widget-svc`, `version=1.2.3`, with `bom-ref`, `purl`, and `cpe` derived from those values automatically.
+
+**Why this priority**: This is the headline use case the user surfaced. Source-tier scans of generic / non-manifest-driven directories are the most common path that produces operator-unfriendly default identities. Without this flag, operators must post-process emitted SBOMs with `mikebom sbom enrich` (JSON Patch) — workable but awkward, and easy to miss derived fields like `purl` and `cpe`. P1 because it directly closes a UX gap operators hit immediately on first use.
+
+**Independent Test**: Run `mikebom sbom scan --path /tmp/scratch --root-name widget-svc --root-version 1.2.3 --output out.cdx.json` against an empty tempdir. Verify the emitted CDX `metadata.component` has the operator-supplied name/version and the derived `bom-ref`/`purl`/`cpe` reflect them.
+
+**Acceptance Scenarios**:
+
+1. **Given** an arbitrary directory `/opt/builds/abc123-snapshot` (a non-meaningful basename), **When** the operator runs `mikebom sbom scan --path /opt/builds/abc123-snapshot --root-name widget-svc --root-version 1.2.3 --output out.cdx.json`, **Then** the emitted SBOM's `metadata.component.name` is `widget-svc`, `metadata.component.version` is `1.2.3`, `metadata.component.bom-ref` is `widget-svc@1.2.3`, `metadata.component.purl` is `pkg:generic/widget-svc@1.2.3`, and `metadata.component.cpe` is `cpe:2.3:a:mikebom:widget-svc:1.2.3:*:*:*:*:*:*:*`.
+2. **Given** the same scan invocation with only `--root-name widget-svc` (no `--root-version`), **When** the SBOM is emitted, **Then** the name override applies but the version stays at the auto-derived default (`0.0.0` for arbitrary directories). `purl`/`bom-ref` use `widget-svc@0.0.0`.
+3. **Given** the same scan invocation with only `--root-version 1.2.3` (no `--root-name`), **When** the SBOM is emitted, **Then** the version override applies but the name stays at the auto-derived basename. `purl`/`bom-ref` use `<basename>@1.2.3`.
+4. **Given** an operator runs `mikebom sbom scan --path .` with neither flag, **When** the SBOM is emitted, **Then** the output is byte-identical to alpha.17 (no regression on default-flag invocations).
+
+---
+
+### User Story 2 — Override on image-tier and build-tier scans (Priority: P2)
+
+The same flags work on `mikebom sbom scan --image` and `mikebom trace run` to override the image-derived or build-derived root component identity.
+
+**Why this priority**: Lower-priority because image-tier scans typically derive a sensible name from the image reference (`acme/widget-svc:v1` → `acme/widget-svc`), and build-tier scans derive from manifest-driven main-module milestones for the supported ecosystems. The override flag is an escape hatch for operators with non-standard workflows or who want consistency across tiers (the same `--root-name widget-svc --root-version 1.2.3` applied to all three tier scans produces three SBOMs that share the same root identity, which simplifies cross-tier consumption). P2 because the absence of this on image/build tiers is acceptable for MVP — operators can post-process via `mikebom sbom enrich` if needed for non-source tiers.
+
+**Independent Test**: Run `mikebom sbom scan --image alpine:3.19 --root-name widget-svc-base --root-version 1.0.0 --output out.cdx.json`. Verify the emitted SBOM's root component has the override values, not the alpine-derived defaults.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator runs `mikebom sbom scan --image alpine:3.19 --root-name widget-svc-base --root-version 1.0.0`, **When** the SBOM is emitted, **Then** the root component name and version reflect the override. The image's auto-detected `image:` identifier (milestone 073) is unaffected — it's a separate slot in `externalReferences[]`.
+2. **Given** an operator runs `mikebom trace run --root-name widget-svc --root-version 1.2.3 -- ./build.sh`, **When** the build SBOM is emitted, **Then** the root component name and version reflect the override. Auto-detected `repo:`/`git:`/`subject:` identifiers (milestones 073/074/076) are unaffected.
+
+---
+
+### User Story 3 — Override interacts cleanly with manifest-driven main-module milestones (Priority: P2)
+
+When mikebom scans a project with a recognized manifest (Cargo.toml, package.json, etc.), the existing main-module milestones (064, 066, 068, 069, 070) populate name+version from the manifest. The new `--root-name`/`--root-version` flags MUST override these manifest-derived values when both are present (explicit operator input wins over derived input).
+
+**Why this priority**: Real-world case where a Cargo project's `[package].name = "foo-internal"` should be reported as `widget-svc` in the SBOM for downstream consumption. Operators have legitimate reasons to override manifest values (release-name vs internal-name divergence, multi-component repositories where one Cargo workspace member is the publishable artifact, etc.). P2 because the manifest-derived defaults work correctly for ~90% of operators; the override is a bridge for edge cases.
+
+**Independent Test**: Run `mikebom sbom scan --path <a-cargo-fixture> --root-name override-name --root-version override-version --output out.cdx.json`. Verify the emitted SBOM's root component has the override values, NOT the Cargo.toml `[package].name`/`version` values.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Cargo project with `[package].name = "foo-internal"` and `[package].version = "0.5.1"`, **When** the operator runs `mikebom sbom scan --path . --root-name widget-svc --root-version 1.2.3`, **Then** the emitted SBOM's `metadata.component.name` is `widget-svc` and `version` is `1.2.3` (override wins over manifest).
+2. **Given** the same Cargo project, **When** the operator runs `mikebom sbom scan --path .` with neither flag, **Then** the emitted SBOM uses the manifest-derived `foo-internal` / `0.5.1` (no regression for the no-flag case).
+
+---
+
+### Edge Cases
+
+- **Empty value** (`--root-name ""` or `--root-version ""`): rejected at CLI parse time with a clear error. Names and versions must be non-empty.
+- **PURL-unsafe characters in name** (spaces, slashes, `?`, `#`, etc.): rejected at parse time with a clear error pointing at the PURL spec's allowed character set. Operators wanting unusual names can URL-encode the value themselves before passing.
+- **Both flags passed identical to current auto-derived defaults**: the override applies anyway (no special-case "no-op" detection); behavior is byte-identical to the no-flag case for the same inputs.
+- **One flag passed, the other absent**: the supplied flag overrides; the absent one falls through to the auto-derived default. Per US1 acceptance scenarios 2 and 3.
+- **Override on a scan that produces no root component at all** (theoretical — currently every scan produces one): non-applicable; mikebom's emit pipeline always produces a root component.
+- **Override interacts with `--component-id` (milestone 076)**: orthogonal — `--component-id` matches against `components[].purl`, not against the root component's `purl`. The override changes only `metadata.component.purl`, which is not a `--component-id` selector target by design (per FR-007 of milestone 076, `--component-id` rejects built-in scheme names; the root-component `purl` is in `components[]` semantics, but mikebom's pipeline keeps the root component out of the matching pool).
+- **Override drops the manifest-derived main module** (Cargo / npm / pip / gem / Maven / Go projects): per the 2026-05-06 clarification, the operator's override is a clean replacement. The manifest's main-module identity (e.g., `pkg:cargo/foo-internal@0.5.1`) is NOT preserved in the emitted SBOM. Operators who want the manifest-derived component preserved as a regular library entry alongside the operator-supplied root identity should track the open GitHub issue for the demote-to-library follow-up feature.
+- **Override interacts with cross-tier identifiers**: orthogonal — `--root-name`/`--root-version` change the root component's display identity; `repo:`/`git:`/`image:`/`subject:` identifiers (in `externalReferences[]`) and per-component identifiers (`components[].properties[]`) ride separately.
+- **Override interacts with `--bind-to-source`** (milestone 072): orthogonal — the binding annotation references another SBOM's content hash, not the root component identity.
+- **Operator passes special PURL-namespaced name** (e.g., `--root-name "@scope/pkg"` for npm-style scoped names): allowed if the characters are PURL-safe per the above rule. The PURL emitter URL-encodes namespace separators per the PURL spec.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Add a new CLI flag `--root-name <NAME>` to `mikebom sbom scan` and `mikebom trace run`. When set, the value MUST override the auto-derived `metadata.component.name` in the emitted SBOM (CDX), the equivalent main-module `Package.name` in SPDX 2.3, and the root element name in SPDX 3.
+- **FR-002**: Add a new CLI flag `--root-version <VERSION>` to the same subcommands. When set, the value MUST override the auto-derived version in CDX `metadata.component.version`, SPDX 2.3 main-module `Package.versionInfo`, and SPDX 3 root element version.
+- **FR-003**: Both flags MUST be independent — passing one without the other is supported. The unspecified field falls through to the auto-derived default.
+- **FR-004**: Derived fields (`bom-ref`, `purl`, `cpe`, and any equivalent SPDX 2.3 / SPDX 3 derived identifiers like SPDXID) MUST automatically follow the overridden name/version through the existing per-format derivation pipeline. Specifically: `bom-ref` becomes `<NAME>@<VERSION>`, `purl` becomes `pkg:generic/<NAME>@<VERSION>` (when no manifest-driven PURL is in play), `cpe` becomes `cpe:2.3:a:mikebom:<NAME>:<VERSION>:*:*:*:*:*:*:*`.
+- **FR-005**: Empty values (`--root-name ""` or `--root-version ""`) MUST be rejected at CLI parse time with a clear, actionable error message.
+- **FR-006**: `--root-name` values MUST be rejected at CLI parse time when they contain ANY of: ASCII whitespace (`\s`), ASCII control characters (`\x00`–`\x1F`, `\x7F`), `?`, or `#`. All other UTF-8 characters are accepted (per the 2026-05-06 clarification — permissive). The PURL emission pipeline MUST URL-encode the value into the `name` segment per RFC 3986; specifically, characters like `@`, `/`, and other URL-reserved characters are encoded automatically rather than rejected. `--root-version` follows the same rule (rejects whitespace / control / `?` / `#`; URL-encodes the rest at emission).
+- **FR-007**: Override MUST apply consistently across all three SBOM formats (CDX, SPDX 2.3, SPDX 3) when emitted simultaneously. Operators emitting all three formats from one scan get root components with byte-identical name+version across the trio.
+- **FR-008**: Override MUST take precedence over manifest-driven main-module derivation (Cargo, npm, pip, gem, Maven, Go from milestones 064–070) when both are present. Explicit operator input wins. Per the 2026-05-06 clarification, the override is a **clean replacement**: the manifest-derived main-module's identity (its `pkg:cargo/...` / `pkg:npm/...` / etc. PURL) is NOT preserved in the emitted SBOM — neither at `metadata.component` nor as a demoted entry in `components[]`. (The "demote to library" alternative is tracked as a separate follow-up GitHub issue.)
+- **FR-009**: Cross-format byte-identity goldens for fixtures with neither flag set MUST stay byte-identical to alpha.17 (no regression). The existing fixture set has no operator-supplied `--root-name` / `--root-version`, so the regen is empirically a no-op.
+- **FR-010**: Override MUST be deterministic — same flag values + same scan target → byte-identical emitted SBOMs across re-runs.
+- **FR-011**: Override is orthogonal to all milestone-072–076 identifier and binding flags. `--root-name` / `--root-version` change the root component's display identity; identifiers (`--repo`, `--git-ref`, `--image-id`, `--attestation`, `--id`, `--subject-hash`), per-component identifiers (`--component-id`), and cross-tier binding (`--bind-to-source`) ride independently and are unaffected by the root-component override.
+
+### Key Entities
+
+- **RootComponentOverride**: Two optional operator-supplied values (`name: Option<String>`, `version: Option<String>`) flowing from CLI flags through the scan pipeline to per-format emitters. When `Some(_)`, the value replaces the corresponding auto-derived field in `metadata.component` (CDX) / main-module Package (SPDX 2.3) / root element (SPDX 3). When `None`, the existing auto-derivation flow runs unchanged.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator running `mikebom sbom scan --path /tmp/scratch --root-name widget-svc --root-version 1.2.3 --output out.cdx.json` against an empty tempdir produces an SBOM whose `metadata.component.name == "widget-svc"`, `version == "1.2.3"`, `bom-ref == "widget-svc@1.2.3"`, `purl == "pkg:generic/widget-svc@1.2.3"`, `cpe == "cpe:2.3:a:mikebom:widget-svc:1.2.3:*:*:*:*:*:*:*"`. Verified by integration test.
+- **SC-002**: The same scan without flags produces an SBOM byte-identical to alpha.17 (no regression). Verified by golden equivalence on every existing source-tier fixture.
+- **SC-003**: `--root-name widget-svc` alone (no `--root-version`) emits an SBOM with `name == "widget-svc"` and `version == "0.0.0"` (the existing auto-derived default for arbitrary directories). Verified by integration test.
+- **SC-004**: `--root-version 1.2.3` alone (no `--root-name`) emits an SBOM with `name == <basename>` and `version == "1.2.3"`. Verified by integration test.
+- **SC-005**: All three SBOM formats (CDX, SPDX 2.3, SPDX 3) emitted from one scan invocation with `--root-name widget-svc --root-version 1.2.3` carry byte-identical name+version in their respective root component fields. Verified by integration test asserting per-format.
+- **SC-006**: A Cargo project with `[package].name = "foo-internal"` scanned with `--root-name widget-svc` produces an SBOM whose `metadata.component.name == "widget-svc"` AND whose `components[]` array contains zero entries with PURL `pkg:cargo/foo-internal@0.5.1` (override is a clean replacement; the manifest-derived main-module identity does not appear anywhere in the emitted SBOM). Verified by integration test asserting both the override-applied root and the absence of the manifest-derived entry.
+- **SC-007**: `--root-name ""` and `--root-version ""` fail at CLI parse with a clear, non-zero exit and a human-readable error message. Verified by negative integration test.
+- **SC-008**: `--root-name "my widget svc"` (whitespace) fails at CLI parse with a clear error message identifying the offending character and the rule it violates. Same outcome for control characters, `?`, and `#`. `--root-name "@acme/widget-svc"` (npm-scoped) succeeds and emits URL-encoded into the PURL (`pkg:generic/%40acme/widget-svc@1.2.3` or per the PURL emitter's canonical encoding). Both verified by integration tests.
+- **SC-009**: Re-running an identical `mikebom sbom scan` invocation with the same `--root-name` / `--root-version` against the same scan target produces byte-identical SBOMs across the two runs. Verified by determinism integration test.
+- **SC-010**: Existing milestone-073/074/075/076 byte-identity goldens stay byte-identical after milestone 077 ships, since no fixture passes the new flags. Verified by the existing parity-check golden suite continuing to pass unchanged.
+
+## Assumptions
+
+- The validator is permissive per the 2026-05-06 clarification: accepts any non-empty UTF-8 except whitespace, control characters, `?`, and `#`. The PURL emitter URL-encodes per RFC 3986 at emission time. This permits ecosystem-style names (`@acme/widget-svc`, `org.acme:widget-svc`) and most operator-supplied identifiers without forcing pre-encoding. Tightening (toward a stricter validator) is reserved for a future hardening milestone if downstream tools surface concrete compatibility issues — loosening from a strict rule would be a breaking change, so the safer default is permissive-with-room-to-tighten.
+- The `--root-version` validator is permissive — anything non-empty + non-control-character. The PURL spec doesn't enforce a strict version syntax (semver, calver, etc. are all valid). Operators choose their own scheme.
+- This milestone scopes only `--root-name` and `--root-version`. The CPE vendor portion (currently hardcoded `mikebom`) is NOT operator-overridable in this milestone. A future `--root-vendor` flag is reasonable if multi-vendor CPE namespacing demand emerges.
+- This milestone scopes only the **root component** (`metadata.component`). Per-component name/version overrides for other components in `components[]` are out of scope (operators wanting that should use `mikebom sbom enrich` post-processing or wait for a future per-component-edit milestone).
+- The flags are accepted on `mikebom sbom scan` (both `--path` and `--image` variants) and `mikebom trace run`. They are NOT accepted on enrichment / verification / parity subcommands (`mikebom sbom enrich`, `mikebom sbom verify`, `mikebom sbom verify-binding`, `mikebom sbom trace-binding`, `mikebom parity-check`) — those don't construct root components.
+- When `--root-name` is set but the scan target is a manifest-driven project (Cargo, npm, etc.), the override is a **clean replacement** per the 2026-05-06 clarification: the root component's full identity (name, version, bom-ref, purl, cpe) derives from operator input, and the manifest-derived main-module identity is NOT preserved in the emitted SBOM (it doesn't appear in `metadata.component`, doesn't appear in `components[]` as a demoted library entry). Operators who want the manifest-derived information preserved alongside the override can use `mikebom sbom enrich` to add it back as a custom component, or wait for the future demote-to-library follow-up tracked in the project's GitHub issues.
+- Operators concerned about override side-effects on downstream tooling (e.g., a vulnerability scanner that hard-codes name patterns) can preview the change by emitting once with the flag and once without and `diff`ing the outputs.
+- Backward compatibility: existing CLI surface unchanged for operators not using the new flags. The flags are additive, default-absent. No breaking change to any milestone-073/074/075/076 contract.

--- a/specs/077-root-component-override/tasks.md
+++ b/specs/077-root-component-override/tasks.md
@@ -1,0 +1,199 @@
+---
+description: "Task list for milestone 077 — operator-overridable root component name and version"
+---
+
+# Tasks: Operator-overridable root component name and version
+
+**Input**: Design documents from `/specs/077-root-component-override/`
+**Prerequisites**: plan.md, spec.md (with /speckit.clarify integration), research.md, data-model.md, contracts/root-component-override.md, quickstart.md
+
+**Tests**: Spec references SC-001 through SC-010 plus the test matrix in contracts/root-component-override.md. Test tasks are included.
+
+**Organization**: Three user stories. US1 (P1) is the headline source-tier override; US2 + US3 (P2) are tier coverage + manifest-drop verification. Phases group by what blocks what; all per-format wiring lives in foundational because all three stories share it.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: parallelizable (different files, no incomplete-task dependencies)
+- **[Story]**: US1 / US2 / US3 (user-story phase tasks only)
+- File paths are absolute or repository-relative
+
+## Path Conventions
+
+Single workspace; all 077 changes inside `mikebom-cli` plus `docs/reference/identifiers.md`. No new modules; no new crates.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Pre-flight reconnaissance before touching code.
+
+- [X] T001 Audit four explicit deliverables and capture each in this PR's commit message or a checked-in scratchpad. Other phases depend on the named outputs. (a) **All `ScanArtifacts` construction call sites**: enumerate every `ScanArtifacts { ... }` struct-literal construction (including in tests) so the new `root_override` field can be added with `..Default::default()` syntax where possible, and explicit `root_override: RootComponentOverride::default()` where necessary. Likely sites identified at planning: `cli/scan_cmd.rs`, `cli/run.rs`, `cli/generate.rs` (back-compat field update only — NO new flags on `GenerateArgs` per research §6), `generate/spdx/{document.rs,relationships.rs,mod.rs}`, `generate/openvex/mod.rs`, plus per-format module test fixtures. (b) **Existing per-format root-component construction lines**: confirm `cyclonedx/builder.rs:163-228` (build), `cyclonedx/metadata.rs:42` (build_metadata + the PURL-format string at metadata.rs:215), `spdx/document.rs:34-56` + `:456`, `spdx/v3_document.rs:150,367,376-390,435`. T007/T008/T009 each plug into one. (c) **Main-module detection property**: confirm the property name + value used to identify manifest-derived main-module components (per planning: `mikebom:component-role = main-module`); document the exact field path (`properties[].name` and `properties[].value`) for the filter logic. (d) **PURL emission encoding behavior baseline**: cat the existing PURL emission lines (e.g., `cyclonedx/metadata.rs:215`) to confirm whether they apply any encoding today (per planning: no — they're plain `format!()` calls). Establishes the baseline that T004's new `percent_encode_purl_name` must preserve for non-override cases (which means: non-override paths use unchanged emission; override paths route through the new helper).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the new types, helpers, flags, and per-format wiring that all three user stories depend on. After this phase the override flow is functionally complete; story phases add tests and verify edge cases.
+
+**⚠️ CRITICAL**: All three user-story tracks depend on this phase.
+
+- [X] T002 Add `pub struct RootComponentOverride { pub name: Option<String>, pub version: Option<String> }` with `#[derive(Debug, Clone, Default)]` and an `is_active(&self) -> bool` method to `mikebom-cli/src/generate/mod.rs`. Add new field `pub root_override: RootComponentOverride` to `ScanArtifacts`. Update existing `ScanArtifacts` constructions per T001(a) audit — use `..Default::default()` where possible; otherwise add explicit `root_override: RootComponentOverride::default()`. Compile-time check finds any missed sites. **Add 4 unit tests for `is_active()`**: default-constructed → false; name-only set → true; version-only set → true; both set → true.
+
+- [X] T003 Add `fn validate_root_field(value: &str, flag_name: &str) -> Result<String, String>` to `mikebom-cli/src/cli/scan_cmd.rs` (or a small shared module if T005/T006 prefer to share). Behavior per research §4: reject empty, ASCII whitespace, control characters (`\x00`–`\x1F`, `\x7F`), `?`, and `#`. Verbose error messages identifying the offending character + position per the research §4 templates. Add 8 unit tests: valid simple name, valid npm-scoped name, valid version with dots, empty rejection, whitespace rejection, control-char rejection, `?` rejection, `#` rejection.
+
+- [X] T004 [P] Add `fn percent_encode_purl_name(s: &str) -> String` to `mikebom-cli/src/generate/cyclonedx/metadata.rs` (or shared helper module, depending on T001(b) findings — both `metadata.rs:215` and `spdx/v3_document.rs:376` need access). Implementation per research §1: RFC 3986 §2.3 unreserved-character preservation (`[A-Za-z0-9._~-]`); UTF-8-aware percent-encoding for everything else. Add 5 unit tests: ASCII unreserved (passthrough), ASCII reserved (`@`, `/`, etc. encoded), UTF-8 multi-byte (e.g., emoji), empty string (returns empty), all-encoded (e.g., `?#@/` → all four encoded).
+
+- [X] T005 Add `#[arg(long = "root-name", value_name = "NAME", value_parser = ...)]` and `#[arg(long = "root-version", value_name = "VERSION", value_parser = ...)]` flags to `ScanArgs` in `mikebom-cli/src/cli/scan_cmd.rs`. Both `Option<String>`. Both use `validate_root_field` from T003 as their value_parser. At the call site that constructs `ScanArtifacts`, populate `root_override` with `RootComponentOverride { name: args.root_name.clone(), version: args.root_version.clone() }`. Help text per contracts/root-component-override.md "Help-text shape".
+
+- [X] T006 [P] Add the same two flags to `RunArgs` in `mikebom-cli/src/cli/run.rs`. Mirror T005's plumbing. Different file from T005, so [P].
+
+- [X] T007 Wire override into the CDX builder. In `mikebom-cli/src/generate/cyclonedx/builder.rs`, modify the `build()` method (around line 163-228) to: (a) compute effective `target_name` and `target_version` from `self.root_override` if active, else fall through to the existing derivation; (b) when `root_override.is_active()`, filter the `components` slice BEFORE calling `build_components`, dropping entries where `properties[].name == "mikebom:component-role"` and `properties[].value == "main-module"` (per T001(c) confirmation); (c) emit a `tracing::info!` per the contract's logging table when override fires + a separate `tracing::info!` per dropped main-module component. In `mikebom-cli/src/generate/cyclonedx/metadata.rs:42`, modify `build_metadata` to use `percent_encode_purl_name` for the PURL `name` segment construction at line 215 ONLY when override is active (otherwise unchanged for back-compat).
+
+- [X] T008 [P] Wire override into the SPDX 2.3 builder. In `mikebom-cli/src/generate/spdx/document.rs` (around lines 34-56 + 456) and any per-package emission site that consumes `target_name`/`target_version`, mirror T007's logic: use override values when active; filter manifest-derived main-module entries from `packages[]`; use `percent_encode_purl_name` for the override-path PURL in `Package.externalRefs`. Different file from T007 + T009, so [P]. Adds same logging as T007.
+
+- [X] T009 [P] Wire override into the SPDX 3 builder. In `mikebom-cli/src/generate/spdx/v3_document.rs` (around lines 150, 367, 376-390, 435), mirror T007's logic: use override values when active; filter manifest-derived main-module entries from `elements[]`; use `percent_encode_purl_name` for the override-path PURL at line 376; SPDXID hash derives from the override values when active so it stays deterministic. Different file from T007 + T008, so [P]. Adds same logging as T007.
+
+**Checkpoint**: production code is override-aware across all three formats. Validation, helpers, and flag plumbing in place. Both per-format wiring and the manifest-drop logic implemented. All three user-story phases can now proceed in parallel.
+
+---
+
+## Phase 3: User Story 1 — Source-tier override on arbitrary directories (Priority: P1)
+
+**Goal**: `mikebom sbom scan --path /opt/builds/abc123-snapshot --root-name widget-svc --root-version 1.2.3` produces an SBOM whose root component carries the operator-supplied name+version, with `bom-ref`/`purl`/`cpe` derived from those values automatically.
+
+**Independent Test**: Run the headline command against an empty tempdir; assert the emitted CDX `metadata.component` has the expected name/version/derived fields per contracts/root-component-override.md "Both flags set" example.
+
+### Tests for User Story 1
+
+- [X] T010 [US1] Create new integration test file `mikebom-cli/tests/identifiers_root_component_override.rs` with: tempdir-based fixture builder helper (similar pattern to milestone-076's identifiers_subject_and_component.rs), plus tests:
+  - (a) `root_name_and_version_override_on_arbitrary_dir` — both flags set, assert `metadata.component.{name,version,bom-ref,purl,cpe}` per contracts/root-component-override.md "Both flags set" expected output.
+  - (b) `only_root_name_supplied_uses_default_version` — `--root-name widget-svc` alone; assert name overridden + version stays `0.0.0`.
+  - (c) `only_root_version_supplied_uses_basename_name` — `--root-version 1.2.3` alone; assert version overridden + name stays basename.
+  - (d) `no_flags_emits_basename_derived_name` — neither flag passed against an arbitrary tempdir (e.g., `/tmp/abc-xyz-123`); assert positive identities: `metadata.component.name == "abc-xyz-123"`, `version == "0.0.0"`, `bom-ref == "abc-xyz-123@0.0.0"`, `purl == "pkg:generic/abc-xyz-123@0.0.0"`. Verifies the no-flag path produces the documented auto-derived defaults. The broader "byte-identical to alpha.17" guarantee from SC-002 is enforced transitively by the existing parity-check golden suite that T014 (pre-PR gate) runs.
+  - (e) `validation_rejects_empty_name`, `validation_rejects_whitespace_name`, `validation_rejects_control_char_name`, `validation_rejects_question_mark_name`, `validation_rejects_hash_name` — each invokes `mikebom sbom scan --root-name <bad-value>`, asserts non-zero exit and clap-shaped error message containing the diagnostic text from T003's validator.
+  - (f) `npm_scoped_name_url_encoded_in_purl` — `--root-name "@acme/widget-svc"` succeeds, emitted PURL is `pkg:generic/%40acme%2Fwidget-svc@<version>`, emitted `metadata.component.name` is the verbatim `@acme/widget-svc`.
+  - (g) `override_emits_in_all_three_formats` — same scan emits CDX + SPDX 2.3 + SPDX 3; assert all three carry the override values in their respective root-element fields. Verifies SC-005.
+  - (h) `override_deterministic_across_reruns` — invoke the same scan twice with identical flags; assert byte-equality of all three format outputs across the two runs. Verifies SC-009.
+
+  Tests guarded with `#[cfg_attr(test, allow(clippy::unwrap_used))]` per CLAUDE.md.
+
+**Checkpoint**: US1 passes. Source-tier override works end-to-end with all derived fields, validation, npm-scope encoding, multi-format emission, and determinism verified.
+
+---
+
+## Phase 4: User Story 2 — Override on image-tier and build-tier scans (Priority: P2)
+
+**Goal**: The same `--root-name`/`--root-version` flags work on `mikebom sbom scan --image` and `mikebom trace run`. Auto-detected `image:` / `repo:` / `git:` / `subject:` identifiers are unaffected — they're separate slots in `externalReferences[]`.
+
+**Independent Test**: Run `mikebom sbom scan --image alpine:3.19 --root-name widget-svc-base --root-version 1.0.0`; assert root component reflects the override AND the auto-detected `image:` identifier is still present.
+
+### Tests for User Story 2
+
+- [X] T011 [US2] Add to `mikebom-cli/tests/identifiers_root_component_override.rs`:
+  - (a) `override_on_image_tier_scan` — `mikebom sbom scan --image <fixture-tar> --root-name widget-svc-image --root-version 1.2.3`; assert root component overridden AND auto-detected `image:` identifier (milestone 073) still present in `externalReferences[]`. Verifies US2 §1.
+  - (b) `override_on_trace_run_build_tier` — construct a synthetic `ScanArtifacts` with `root_override` populated AND `generation_context = GenerationContext::BuildTimeTrace`, plus a small fixture component set including a build-tier `repo:`/`git:`/`subject:` identifier slot (mirroring milestone-074's pattern of testing emission logic with synthetic inputs since `mikebom trace run` requires Linux+eBPF which standard CI lanes don't have). Pass to the per-format builders (CDX `build()`, SPDX 2.3 `document.rs` builder, SPDX 3 `v3_document.rs` builder) and assert: (i) the emitted root component reflects the override values per FR-001/FR-002/FR-004; (ii) auto-detected document-level identifiers from milestones 073/074/076 in `externalReferences[]` are unaffected (separate slot — orthogonal). Verifies US2 §2 + FR-011.
+
+**Checkpoint**: US2 passes. Override flows through image-tier and build-tier paths without disturbing identifier auto-detection from earlier milestones.
+
+---
+
+## Phase 5: User Story 3 — Override + manifest-driven main-module precedence (Priority: P2)
+
+**Goal**: When the override is set on a manifest-driven scan (Cargo, npm, pip, gem, Maven, Go), the manifest-derived main-module component is dropped entirely from the emitted SBOM (clean replacement per Q2 clarification). When the override is NOT set, the manifest's main-module is preserved unchanged (no regression).
+
+**Independent Test**: Scan an existing Cargo fixture (with `[package].name = "<known-name>"`) once with `--root-name override-name` and once without. Assert the override-set run drops the cargo PURL from `components[]`; the no-flag run preserves it.
+
+### Tests for User Story 3
+
+- [X] T012 [US3] Add to `mikebom-cli/tests/identifiers_root_component_override.rs`:
+  - (a) `override_drops_manifest_main_module_cargo` — run scan with override against an existing Cargo test fixture (use one of the project's existing cargo fixtures so we don't have to construct a new one); assert `metadata.component.name == "widget-svc"` AND `components[]` has zero entries with PURL matching the cargo `[package].name@version`. Plus assert one `tracing::info!` was emitted naming the dropped PURL (or fall back to runtime side-effect verification if log capture is awkward — note the limitation in a code comment, same pattern as milestone 075's T011c). Verifies SC-006.
+  - (b) `no_override_preserves_manifest_main_module` — same Cargo fixture without flags; assert `components[]` still contains the cargo main-module entry. Verifies FR-009 / SC-002 (no regression for the no-flag case).
+  - (c) `override_orthogonal_to_other_identifier_flags` — run scan with `--root-name widget-svc --root-version 1.2.3 --repo git@github.com:acme/widget-svc.git --subject-hash sha256:abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab --component-id "pkg:cargo/serde@1.0.0=kusari-id:asset-foo"`; assert ALL of the following coexist independently in the emitted SBOM: (i) root component reflects override; (ii) auto-detected `repo:` identifier from milestone 073 present in `externalReferences[]`; (iii) manual `subject:` identifier from milestone 076 present in `externalReferences[]`; (iv) per-component `kusari-id:asset-foo` identifier from milestone 076 present in the matching component's `properties[]` (if a `pkg:cargo/serde@1.0.0` component exists in the fixture). Verifies FR-011 across multiple identifier surfaces (072/073/074/076).
+
+**Checkpoint**: US3 passes. Manifest-drop clean-replacement behavior verified on a real Cargo fixture; no-flag preservation verified; orthogonality with milestone-076 identifier flags verified.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T013 [P] Update `docs/reference/identifiers.md`: add a new section "Root component override (`--root-name` / `--root-version`)" covering the two flags, the validation rule (whitespace/control/`?`/`#` rejected), the manifest-drop clean-replacement behavior + reference to GitHub issue #151 for the demote-to-library follow-up, and the per-format wire-mapping table from contracts/root-component-override.md. Add the operator recipes from quickstart.md as inline examples (Recipes 1, 3, 4 — the headline source-tier, the Cargo manifest-drop, the image-tier).
+
+- [X] T014 Run pre-PR gate per CLAUDE.md: (a) `cargo +stable clippy --workspace --all-targets -- -D warnings` zero warnings; (b) `cargo +stable test --workspace` every target reports `ok. N passed; 0 failed`. Convenience: `./scripts/pre-pr.sh`. The pre-PR gate also transitively verifies SC-005 / SC-002 / SC-010 (existing milestone-073/074/075/076 byte-identity goldens stay byte-identical) since the parity-check golden suite is part of the workspace test set.
+
+- [X] T015 Manually validate quickstart.md recipes 1, 2, 3, 4, 5 + the npm-scoped name + validation-error recipes end-to-end against a real local build of milestone 077. Confirm log-line phrasing matches contracts/root-component-override.md exactly. Confirm jq snippets in the recipes work against actual emitted SBOMs. Time the override flow with `time` to confirm <1ms additional overhead per scan (informal smoke check on the SC mentioned in plan.md performance goals).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: T001 has no dependencies; survey task.
+- **Phase 2 (Foundational)**: T002 → T005 sequential within scan_cmd.rs (T005 uses T003's validator + T002's struct). T003 must precede T005 + T006. T004 [P] independent of T002/T003 (different file). T006 [P] (different file from T005). T007 needs T002 + T004; T008 [P] / T009 [P] each need T002 + T004 (different files from T007 and from each other). Order: T002 → (T003 || T004 [P]) → (T005 || T006 [P]) → (T007 || T008 [P] || T009 [P]).
+- **Phase 3 (US1)**: T010 depends on Phase 2 complete (uses the new flags + the new validator + the per-format wiring).
+- **Phase 4 (US2)**: T011 depends on Phase 2 complete; can run in parallel with Phase 3 (different test functions in shared file — sequential within file but the implementation tasks are done).
+- **Phase 5 (US3)**: T012 depends on Phase 2 complete; can run in parallel with Phases 3 + 4 (different test functions).
+- **Phase 6 (Polish)**: T013 [P] (docs) parallel with T014 (gate); T014 depends on Phases 1-5 complete; T015 depends on T014 (need a clean build to smoke-test).
+
+### Parallel Opportunities
+
+- T004 [P] (helper) + T003 (validator) — different files in Phase 2.
+- T006 [P] (RunArgs flags) + T005 (ScanArgs flags) — different files in Phase 2.
+- T007 + T008 [P] + T009 [P] — three different per-format builder files in Phase 2.
+- T011 / T012 / T013 — independent test functions / docs editing across Phases 4 / 5 / 6.
+
+### Within Each User Story
+
+- All three stories share the Phase 2 wiring; they differ only in test scope (US1 = source-tier coverage, US2 = image/build-tier, US3 = manifest-drop).
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```bash
+# Sequential start (T002 must land first):
+Task: "T002 RootComponentOverride struct + ScanArtifacts field"
+
+# Then parallel pair (different files):
+Task: "T003 validate_root_field in scan_cmd.rs"
+Task: "T004 [P] percent_encode_purl_name in metadata.rs"
+
+# Then parallel pair (different files):
+Task: "T005 ScanArgs flags in scan_cmd.rs"
+Task: "T006 [P] RunArgs flags in run.rs"
+
+# Then three-way parallel (three different per-format builder files):
+Task: "T007 CDX builder wiring in cyclonedx/builder.rs + metadata.rs"
+Task: "T008 [P] SPDX 2.3 builder wiring in spdx/document.rs"
+Task: "T009 [P] SPDX 3 builder wiring in spdx/v3_document.rs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (Phases 1-3 = US1)
+
+1. Phase 1 setup (T001 audit).
+2. Phase 2 foundational (T002–T009): types, validator, helpers, flag plumbing, all three per-format builders wired.
+3. Phase 3 US1 (T010): integration tests covering source-tier override, validation, npm-scoped names, multi-format emission, determinism.
+4. **STOP and VALIDATE**: at this checkpoint the headline use case (the one the user surfaced in their original message) works end-to-end. US2 + US3 verify additional tier coverage and the manifest-drop edge case but don't add new user-visible capability beyond US1.
+5. Continue to Phases 4-6 to complete the milestone.
+
+### Incremental Delivery
+
+Single PR. Milestone is small (<2 days estimated). Splitting US1 from US2/US3 would create transient state where the source-tier path ships but the manifest-drop verification doesn't — risk of someone hitting the manifest case in alpha.17 and being surprised. Recommend single PR.
+
+### Parallel Team Strategy
+
+Single developer + reviewer. Three-way parallelism on T007/T008/T009 is real if you have three developers but overkill for one-person shipping. Sequential is fine.
+
+---
+
+## Notes
+
+- [P] = different files, no incomplete-task dependencies.
+- All three user stories share the Phase 2 wiring. Test surface splits by user story.
+- Per CLAUDE.md: pre-PR gate REQUIRES both `cargo +stable clippy --workspace --all-targets -- -D warnings` clean AND `cargo +stable test --workspace` clean. Cite both in the PR description.
+- Tests in `identifiers_root_component_override.rs` MUST guard their `mod tests` items with `#[cfg_attr(test, allow(clippy::unwrap_used))]` per CLAUDE.md.
+- Total estimated tasks: 15. Total estimated effort: <2 person-days.


### PR DESCRIPTION
## Summary

Closes the operator UX gap from your milestone-077 fixture example. Two new CLI flags on `mikebom sbom scan` + `mikebom trace run`:

- `--root-name <NAME>` overrides `metadata.component.name` (CDX) / main-module `Package.name` (SPDX 2.3) / root element name (SPDX 3)
- `--root-version <VERSION>` overrides the corresponding version field

Derived fields (`bom-ref`, `purl`, `cpe`) automatically follow the override. Both flags independent. Permissive validation per the Q1 clarification (rejects only whitespace/control/`?`/`#`; URL-encodes the rest at PURL emission for npm-scoped name support like `@acme/widget-svc`). Override is a clean replacement per Q2 — manifest-derived main-module dropped entirely (NOT demoted to `components[]`); demote-to-library tracked as GitHub issue #151.

## Spec

- [`specs/077-root-component-override/spec.md`](specs/077-root-component-override/spec.md) — 3 user stories, 11 FRs, 10 SCs, 2 clarifications integrated
- [`specs/077-root-component-override/research.md`](specs/077-root-component-override/research.md) — 6 implementation decisions
- [`specs/077-root-component-override/data-model.md`](specs/077-root-component-override/data-model.md) — `RootComponentOverride` + VR-077-001..004

## Test plan

- [x] Pre-PR gate clean: `cargo +stable clippy --workspace --all-targets -- -D warnings` (zero warnings); `cargo +stable test --workspace` — all 49 test targets `0 failed`
- [x] 15 integration tests in `mikebom-cli/tests/identifiers_root_component_override.rs` covering all 3 user stories + edge cases (npm-scope, multi-format, determinism, manifest-drop, 5-flag orthogonality)
- [x] 4 inline build-tier tests in `cyclonedx/builder.rs` (T011 placement adjustment — integration tests can't reach private items)
- [x] 9 unit tests on `RootComponentOverride` + `percent_encode_purl_name` (T002 + T004)
- [x] 8 unit tests on `validate_root_field` (T003)
- [x] All milestone-073/074/075/076 byte-identity goldens stay byte-identical (no fixtures pass the new flags)
- [x] Pre-existing `url_friendly()` helper at `spdx/v3_document.rs:410` deliberately untouched — only the new override path uses `percent_encode_purl_name` (avoids regression risk on non-override paths)
- [ ] Reviewer sanity-check: `mikebom sbom scan --path /tmp/scratch --root-name widget-svc --root-version 1.2.3 --output out.cdx.json` produces an SBOM with `metadata.component` matching the contracts/root-component-override.md "Both flags set" example
- [ ] Reviewer sanity-check: `--root-name "@acme/widget-svc"` succeeds and produces `pkg:generic/%40acme%2Fwidget-svc@<version>` in the PURL

## Notable design decisions

1. **`mikebom sbom generate` does NOT receive new operator-facing flags** per research §6. The re-emit-from-attestation flow has ambiguous override semantics. `GenerateArgs` carries a `#[arg(skip)] root_override` field so `cli/run.rs::execute` can thread trace-run flags into the build-tier emission path internally.
2. **Existing `url_friendly()` helper unchanged** to preserve existing fixture goldens. The new `percent_encode_purl_name` (RFC 3986) is for the override path only.
3. **Manifest-drop filter** runs BEFORE per-component emission in all three formats (CDX `build()`, SPDX 2.3 `build_document`, SPDX 3 `build_document`). Required `Vec<ResolvedComponent>` clone since `ScanArtifacts` borrows components — bounded by O(N) in component count, only on override-active path.
4. **CPE vendor stays `mikebom`** (out of scope for MVP — a future `--root-vendor` milestone can add operator override if demand emerges).

## Deviations from plan

Two minor implementation details (per worker agent's report):

1. **`percent_encode_purl_name` location**: research §1 suggested `cyclonedx/metadata.rs`. Placed in `generate/mod.rs` instead so SPDX 2.3 + SPDX 3 builders can both consume it without a re-export hop. Functionally identical.
2. **T011 test placement**: research said the build-tier override tests would go in `mikebom-cli/tests/identifiers_root_component_override.rs`. Integration tests can't reach private items, so the 4 build-tier tests moved into `cyclonedx/builder.rs`'s inline `mod tests`. The integration test file (T010 + T012) covers the public-API-reachable scenarios.

## Constitution check

All 12 principles + 4 strict boundaries pass per [`plan.md`](specs/077-root-component-override/plan.md#constitution-check). Specifically:
- Principle V (native-first): zero new `mikebom:*` annotations introduced; override changes the *value* of existing standards-native fields (`metadata.component.name`/`version`); derived fields ride the existing per-format pipeline
- Principle X (transparency): info-level logs when override fires + per-PURL info-level logs when manifest-derived main-module components are dropped

## Release notes (for the changelog when alpha.18 is cut)

- **Root component override**: new `--root-name` and `--root-version` flags on `mikebom sbom scan` and `mikebom trace run` let operators override the auto-derived root component identity. Useful when scanning generic / non-manifest-driven directories whose basename doesn't reflect the operator-meaningful project name. Permissive validation supports npm-scoped names (`@acme/widget-svc`) via automatic URL-encoding at PURL emission. On manifest-driven scans (Cargo / npm / pip / gem / Maven / Go), the override is a clean replacement — the manifest-derived main-module identity is dropped from the emitted SBOM. Future demote-to-library option tracked as GitHub issue #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)