### PR TITLE
fix(085): maven SPDX dep edges + parity-extractor scope-handling — milestone-070 follow-up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Auto-generated from all feature plans. Last updated: 2026-05-08
 - N/A — purely test infrastructure. The 9 vendored fixtures (~500 KB total) live in `mikebom-cli/tests/fixtures/transitive_parity/<ecosystem>/`. No caches, no persistence beyond test fixtures. (083-transitive-correctness)
 - Rust stable (workspace toolchain inherited from milestones 001–083; no nightly). + existing only — `serde`/`serde_json` (CDX JSON construction), `tracing`, `anyhow`, `thiserror`. **No new Cargo dependencies.** The `cyclonedx-bom` workspace dep is already in use; this milestone does not change which crates participate in CDX construction. (084-cdx-mainmod-collapse)
 - N/A — purely emission-time identifier-string transformation. No caches, no persistence. (084-cdx-mainmod-collapse)
+- Rust stable (workspace toolchain). + existing only — no new crates. (085-maven-spdx-dep-edges)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -132,9 +133,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 085-maven-spdx-dep-edges: Added Rust stable (workspace toolchain). + existing only — no new crates.
 - 084-cdx-mainmod-collapse: Added Rust stable (workspace toolchain inherited from milestones 001–083; no nightly). + existing only — `serde`/`serde_json` (CDX JSON construction), `tracing`, `anyhow`, `thiserror`. **No new Cargo dependencies.** The `cyclonedx-bom` workspace dep is already in use; this milestone does not change which crates participate in CDX construction.
 - 083-transitive-correctness: Added Rust stable (workspace toolchain inherited from milestones 001–082; no nightly). + Existing only — `serde`/`serde_json` (parsing emitted SBOM JSON), `tracing`, `anyhow`. The audit harness shells out to `trivy` and `syft` as external CLI tools (similar to milestone 078's `spdx3-validate` shell-out pattern). Source-format direct readers use existing per-ecosystem parsers in `mikebom-cli/src/scan_fs/package_db/` for tiebreaker comparisons (we don't re-implement; we re-invoke). For OS package managers, native tools (`dpkg-query`, `rpm`, `apk`) are shelled out. **No new Cargo dependencies.**
-- 082-docs-refresh: Added N/A — pure documentation work. No code paths touched. The Rust workspace continues to compile + test identically pre/post merge. + None new. The pre-PR gate uses the existing `cargo +stable clippy` + `cargo +stable test --workspace` pipeline; both remain stable across docs-only changes.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/generate/spdx/v3_relationships.rs
+++ b/mikebom-cli/src/generate/spdx/v3_relationships.rs
@@ -82,12 +82,28 @@ pub fn build_dependency_relationships(
             creation_info_id,
         );
         // Milestone 052/part-2: native LifecycleScopeType field.
+        // Milestone 085: corrected to use the SPDX 3.0.1
+        // `LifecycleScopedRelationship` element type (a subtype of
+        // `Relationship` per the SPDX 3 schema). The `scope` field
+        // is only valid on `LifecycleScopedRelationship`; pre-085
+        // the code emitted `scope` on a plain `Relationship` which
+        // failed JSON-Schema validation (the
+        // `LifecycleScopedRelationship_props` allOf branch wasn't
+        // selected, so `scope` was an unknown property). Pre-085
+        // this code path was untested by the SPDX 3 conformance
+        // gate (milestone 078) because cargo/gem/etc. fixtures only
+        // emit plain `DependsOn` — never the typed
+        // `Dev/Build/TestDependsOn` variants that would hit this
+        // branch. Maven (milestone 070 + 085) is the first
+        // ecosystem whose fixture has a TestDependsOn edge AND a
+        // SPDX 3 conformance check; surfaced the type-mismatch.
         if let Some(scope) = match rel.relationship_type {
             RelationshipType::DevDependsOn => Some("development"),
             RelationshipType::BuildDependsOn => Some("build"),
             RelationshipType::TestDependsOn => Some("test"),
             RelationshipType::DependsOn => None,
         } {
+            element["type"] = json!("LifecycleScopedRelationship");
             element["scope"] = json!(scope);
         }
         out.push(element);

--- a/mikebom-cli/src/parity/extractors/cdx.rs
+++ b/mikebom-cli/src/parity/extractors/cdx.rs
@@ -276,16 +276,26 @@ fn cdx_dependency_edges(doc: &Value, dev_only: bool) -> BTreeSet<String> {
             Some(p) => p.to_string(),
             None => continue,
         };
-        // Milestone 052/part-2: source-side dev classification via
-        // native CDX `scope: "excluded"` (any non-runtime). The
-        // legacy `mikebom:dev-dependency` property was removed.
+        // Milestone 052/part-2: dev classification via native CDX
+        // `scope: "excluded"` (any non-runtime).
+        //
+        // Milestone 085: classify per-edge using EITHER endpoint's
+        // scope, not just the source-side. Maven (and any future
+        // ecosystem that puts scope on the target rather than the
+        // source — e.g., pom.xml `<scope>test</scope>` lives on the
+        // dep declaration, attached to the target component) needs
+        // the target-side check or runtime-vs-dev parity against
+        // SPDX 2.3's typed `DEPENDS_ON`/`TEST_DEPENDENCY_OF` shape
+        // produces false positives in CDX's runtime bucket. Pre-085
+        // the source-side-only filter masked this for ecosystems
+        // (cargo etc.) where dev/test deps happened to be excluded
+        // from `dependencies[]` entirely; post-085 the per-edge
+        // check correctly classifies edges where any endpoint
+        // carries scope=excluded as non-runtime.
         let from_is_dev = from_comp
             .get("scope")
             .and_then(|v| v.as_str())
             == Some("excluded");
-        if dev_only != from_is_dev {
-            continue;
-        }
         let Some(targets) = d.get("dependsOn").and_then(|v| v.as_array()) else {
             continue;
         };
@@ -297,6 +307,11 @@ fn cdx_dependency_edges(doc: &Value, dev_only: bool) -> BTreeSet<String> {
             let Some(to_purl) = to_comp.get("purl").and_then(|v| v.as_str()) else {
                 continue;
             };
+            let to_is_dev = to_comp.get("scope").and_then(|v| v.as_str()) == Some("excluded");
+            let edge_is_dev = from_is_dev || to_is_dev;
+            if dev_only != edge_is_dev {
+                continue;
+            }
             out.insert(format!("{from_purl}->{to_purl}"));
         }
     }

--- a/mikebom-cli/src/parity/extractors/spdx2.rs
+++ b/mikebom-cli/src/parity/extractors/spdx2.rs
@@ -221,17 +221,24 @@ pub(super) fn spdx23_dev_deps(doc: &Value) -> BTreeSet<String> {
     // Per milestone-011 B2 + milestone-012 mapping, SPDX 2.3 emits
     // DEV_DEPENDENCY_OF (target-source swap). Reverse the pair to
     // align with CDX direction.
-    let raw = spdx_relationship_edges(doc, "DEV_DEPENDENCY_OF", "");
-    raw.into_iter()
-        .filter_map(|s| {
+    //
+    // Milestone 085: also include TEST_DEPENDENCY_OF and
+    // BUILD_DEPENDENCY_OF — milestone-052/part-2 added them as
+    // typed variants alongside DEV. For B2 (any non-runtime
+    // dep edge), all three count. Pre-085 this extractor under-
+    // counted maven test deps because junit→demo-app emits as
+    // TEST_DEPENDENCY_OF, not DEV_DEPENDENCY_OF.
+    let mut out = BTreeSet::new();
+    for rel_type in &["DEV_DEPENDENCY_OF", "BUILD_DEPENDENCY_OF", "TEST_DEPENDENCY_OF"] {
+        let raw = spdx_relationship_edges(doc, rel_type, "");
+        for s in raw {
             let parts: Vec<&str> = s.splitn(2, "->").collect();
             if parts.len() == 2 {
-                Some(format!("{}->{}", parts[1], parts[0]))
-            } else {
-                None
+                out.insert(format!("{}->{}", parts[1], parts[0]));
             }
-        })
-        .collect()
+        }
+    }
+    out
 }
 
 pub(super) fn spdx23_containment(doc: &Value) -> BTreeSet<String> {

--- a/mikebom-cli/src/parity/extractors/spdx3.rs
+++ b/mikebom-cli/src/parity/extractors/spdx3.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeSet;
 use serde_json::Value;
 
 use super::common::{
-    decode_envelope, extract_mikebom_annotation_values, normalize_alg, spdx_relationship_edges,
+    extract_mikebom_annotation_values, normalize_alg, spdx_relationship_edges,
     walk_spdx3_packages,
 };
 
@@ -217,13 +217,77 @@ pub(super) fn spdx3_supplier(doc: &Value) -> BTreeSet<String> {
 // ============================================================
 
 pub(super) fn spdx3_runtime_deps(doc: &Value) -> BTreeSet<String> {
-    spdx_relationship_edges(doc, "", "dependsOn")
+    // Milestone 085: SPDX 3 puts lifecycle classification on the
+    // Relationship itself via the `scope` parameter (per milestone
+    // 052/part-2 — `dev` / `build` / `test` / `runtime`). The
+    // generic `spdx_relationship_edges` walker can't see that
+    // because B2 (dev) is signaled by a separate annotation
+    // mechanism in this extractor file. For the runtime bucket,
+    // include only relationships whose scope is absent or runtime;
+    // exclude any with scope=dev/build/test so SPDX 3 matches CDX's
+    // post-085 per-edge classifier (which excludes edges where the
+    // target carries `scope: "excluded"`) and SPDX 2.3's typed
+    // relationshipType filter (which excludes DEV/BUILD/TEST_*_OF
+    // by counting only DEPENDS_ON).
+    let Some(graph) = doc.get("@graph").and_then(|v| v.as_array()) else {
+        return BTreeSet::new();
+    };
+    let mut purl_by_iri: std::collections::BTreeMap<String, String> =
+        std::collections::BTreeMap::new();
+    for el in graph {
+        if el.get("type").and_then(|v| v.as_str()) == Some("software_Package") {
+            if let (Some(iri), Some(purl)) = (
+                el.get("spdxId").and_then(|v| v.as_str()),
+                el.get("software_packageUrl").and_then(|v| v.as_str()),
+            ) {
+                purl_by_iri.insert(iri.to_string(), purl.to_string());
+            }
+        }
+    }
+    let mut out = BTreeSet::new();
+    for el in graph {
+        let el_type = el.get("type").and_then(|v| v.as_str());
+        if !matches!(el_type, Some("Relationship") | Some("LifecycleScopedRelationship")) {
+            continue;
+        }
+        if el.get("relationshipType").and_then(|v| v.as_str()) != Some("dependsOn") {
+            continue;
+        }
+        let scope = el.get("scope").and_then(|v| v.as_str());
+        if matches!(scope, Some("development") | Some("build") | Some("test")) {
+            continue;
+        }
+        let Some(from_iri) = el.get("from").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(to_arr) = el.get("to").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        let Some(from_purl) = purl_by_iri.get(from_iri) else {
+            continue;
+        };
+        for t in to_arr {
+            if let Some(t_iri) = t.as_str() {
+                if let Some(to_purl) = purl_by_iri.get(t_iri) {
+                    out.insert(format!("{from_purl}->{to_purl}"));
+                }
+            }
+        }
+    }
+    out
 }
 
-// SPDX 3 lacks `devDependencyOf`; the C6 annotation carries the
-// dev-vs-runtime distinction (mapping doc B2). The extractor walks
-// `dependsOn` edges and filters by C6 annotation on the source
-// Package.
+// SPDX 3 lacks `devDependencyOf`; per milestone-052/part-2 the
+// dev-vs-runtime distinction lives on the `Relationship` itself
+// via the `scope` parameter (`dev` / `build` / `test`).
+//
+// Milestone 085: walk `dependsOn` Relationships and include only
+// those whose `scope` is dev/build/test. Mirrors B1 (which
+// excludes the same scopes) and matches SPDX 2.3's typed
+// DEV/BUILD/TEST_DEPENDENCY_OF representation. The previous
+// implementation read a deprecated `mikebom:dev-dependency`
+// annotation on the source Package; that annotation was removed
+// when 052/part-2 promoted the native scope encoding.
 pub(super) fn spdx3_dev_deps(doc: &Value) -> BTreeSet<String> {
     let Some(graph) = doc.get("@graph").and_then(|v| v.as_array()) else {
         return BTreeSet::new();
@@ -240,42 +304,26 @@ pub(super) fn spdx3_dev_deps(doc: &Value) -> BTreeSet<String> {
             }
         }
     }
-    // Set of IRIs whose C6 annotation marks them dev.
-    let mut dev_iris: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-    for el in graph {
-        if el.get("type").and_then(|v| v.as_str()) != Some("Annotation") {
-            continue;
-        }
-        let Some(subject) = el.get("subject").and_then(|v| v.as_str()) else {
-            continue;
-        };
-        let Some(stmt) = el.get("statement").and_then(|v| v.as_str()) else {
-            continue;
-        };
-        if let Some(values) = decode_envelope(stmt, "mikebom:dev-dependency") {
-            if values.iter().any(|v| v == "true" || v == "\"true\"") {
-                dev_iris.insert(subject.to_string());
-            }
-        }
-    }
     let mut out = BTreeSet::new();
     for el in graph {
-        if el.get("type").and_then(|v| v.as_str()) != Some("Relationship") {
+        let el_type = el.get("type").and_then(|v| v.as_str());
+        if !matches!(el_type, Some("Relationship") | Some("LifecycleScopedRelationship")) {
             continue;
         }
         if el.get("relationshipType").and_then(|v| v.as_str()) != Some("dependsOn") {
             continue;
         }
-        let Some(from) = el.get("from").and_then(|v| v.as_str()) else {
-            continue;
-        };
-        if !dev_iris.contains(from) {
+        let scope = el.get("scope").and_then(|v| v.as_str());
+        if !matches!(scope, Some("development") | Some("build") | Some("test")) {
             continue;
         }
+        let Some(from_iri) = el.get("from").and_then(|v| v.as_str()) else {
+            continue;
+        };
         let Some(to_arr) = el.get("to").and_then(|v| v.as_array()) else {
             continue;
         };
-        let Some(from_purl) = purl_by_iri.get(from) else {
+        let Some(from_purl) = purl_by_iri.get(from_iri) else {
             continue;
         };
         for t in to_arr {

--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -373,9 +373,27 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
         for e in &db_entries {
             let ecosystem = e.purl.ecosystem().to_string();
             name_to_purl.insert(
-                (ecosystem, normalize_dep_name(e.purl.ecosystem(), &e.name)),
+                (ecosystem.clone(), normalize_dep_name(e.purl.ecosystem(), &e.name)),
                 e.purl.as_str().to_string(),
             );
+            // Milestone 085 — maven main-modules emit `entry.depends`
+            // entries in canonical `groupId:artifactId` form (per
+            // `package_db/maven.rs:3451-3455`), but `e.name` is just
+            // the artifact-id. Insert the disambiguated key so the
+            // edge-emission loop below can resolve maven main-module
+            // deps. Without this, every maven main-module → direct-dep
+            // lookup misses, and SPDX 2.3 + SPDX 3 emit zero
+            // DEPENDS_ON edges for maven (the gap milestone-084's
+            // closure-invariant test surfaced via parity_maven row B1).
+            if ecosystem == "maven" {
+                if let Some(group_id) = e.purl.namespace() {
+                    let gav_key = format!("{}:{}", group_id, e.name);
+                    name_to_purl.insert(
+                        (ecosystem, normalize_dep_name("maven", &gav_key)),
+                        e.purl.as_str().to_string(),
+                    );
+                }
+            }
         }
 
         // Milestone 039: build the apk per-package file-list map

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/maven.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/maven.spdx.json
@@ -276,6 +276,21 @@
       "relatedSpdxElement": "SPDXRef-Package-Q7X32JLRPGCHW46Q",
       "relationshipType": "DESCRIBES",
       "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-MVONQLC7NTCYCDSJ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-Q7X32JLRPGCHW46Q"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-BE4OZRGHG4BEYMYQ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-Q7X32JLRPGCHW46Q"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-Q7X32JLRPGCHW46Q",
+      "relationshipType": "TEST_DEPENDENCY_OF",
+      "spdxElementId": "SPDXRef-Package-B7B65U5T2YH5ZD5T"
     }
   ],
   "spdxVersion": "SPDX-2.3"

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/maven.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/maven.spdx3.json
@@ -190,6 +190,26 @@
     },
     {
       "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-HEW563Z6BBRY7VWC5ACXXYAY/pkg-Q7X32JLRPGCHW46Q",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-HEW563Z6BBRY7VWC5ACXXYAY/rel-E6USA3GX5OFSLTWA",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-HEW563Z6BBRY7VWC5ACXXYAY/pkg-MVONQLC7NTCYCDSJ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-HEW563Z6BBRY7VWC5ACXXYAY/pkg-Q7X32JLRPGCHW46Q",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-HEW563Z6BBRY7VWC5ACXXYAY/rel-JH4W2B7GN36M5Q7F",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-HEW563Z6BBRY7VWC5ACXXYAY/pkg-BE4OZRGHG4BEYMYQ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
       "from": "https://mikebom.kusari.dev/spdx3/doc-HEW563Z6BBRY7VWC5ACXXYAY",
       "relationshipType": "describes",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-HEW563Z6BBRY7VWC5ACXXYAY/rel-W2MVLDHLMFOGLTGI",
@@ -197,6 +217,17 @@
         "https://mikebom.kusari.dev/spdx3/doc-HEW563Z6BBRY7VWC5ACXXYAY/pkg-Q7X32JLRPGCHW46Q"
       ],
       "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-HEW563Z6BBRY7VWC5ACXXYAY/pkg-Q7X32JLRPGCHW46Q",
+      "relationshipType": "dependsOn",
+      "scope": "test",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-HEW563Z6BBRY7VWC5ACXXYAY/rel-ZNPESYZ6B7XH6WHF",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-HEW563Z6BBRY7VWC5ACXXYAY/pkg-B7B65U5T2YH5ZD5T"
+      ],
+      "type": "LifecycleScopedRelationship"
     },
     {
       "annotationType": "other",

--- a/mikebom-cli/tests/holistic_parity.rs
+++ b/mikebom-cli/tests/holistic_parity.rs
@@ -104,27 +104,12 @@ fn triple_scan_at_path(
 /// milestones rather than the one currently in flight. Each entry:
 /// `(ecosystem_label, row_id, justification)`.
 ///
-/// **`("maven", "B1", _)`**: milestone-070 (Maven main-module) added
-/// the project's main-module to `metadata.component` and to
-/// `components[]`, but did NOT add `Relationship` entries from the
-/// main-module PURL to its direct deps in `ScanArtifacts.relationships`.
-/// The CDX side fakes them via the `dependencies.rs:78-91` primary-dep
-/// fallback (synthesizing target_ref → roots-of-component-graph),
-/// which produces correct dep-graph edges in CDX `dependencies[]`.
-/// The SPDX 2.3 + SPDX 3 sides have no equivalent fallback and emit
-/// zero `DEPENDS_ON` relationships for maven. Pre-milestone-084 this
-/// was masked because the CDX-side parity extractor at
-/// `mikebom-cli/src/parity/extractors/cdx.rs:253` couldn't resolve
-/// the orphan `<short-name>@0.0.0` ref and skipped the entire dep set
-/// — both sides reported empty edge sets, so SymmetricEqual passed.
-/// Milestone-084's CDX fix exposes the gap. See follow-up issue: TBD.
-const KNOWN_PARITY_GAPS: &[(&str, &str, &str)] = &[(
-    "maven",
-    "B1",
-    "milestone-070 maven reader does not emit main-module → direct-dep \
-     Relationship entries; CDX uses primary-dep fallback, SPDX has none. \
-     Surfaced by milestone-084 CDX orphan-ref fix.",
-)];
+/// Empty after milestone 085 closed the maven `("maven", "B1", _)`
+/// gap by adding a `groupId:artifactId` lookup key for maven entries
+/// in `scan_fs/mod.rs`'s `name_to_purl` map. New gaps may be added
+/// here in the future when a CDX-side fix exposes a pre-existing
+/// SPDX-side parity divergence that needs its own follow-up.
+const KNOWN_PARITY_GAPS: &[(&str, &str, &str)] = &[];
 
 fn assert_holistic_parity(label: &str, scan: &TripleScan) {
     let rows = catalog::parse_mapping_doc(&mapping_doc_path());

--- a/specs/085-maven-spdx-dep-edges/checklists/requirements.md
+++ b/specs/085-maven-spdx-dep-edges/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Maven SPDX dep-edge emission
+
+**Purpose**: Validate spec completeness before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs) — spec references file paths + line numbers in "Root cause" section as diagnostic context (same pattern as milestone 084 spec); the actual fix shape lives in plan.md
+- [X] Focused on user value and business needs — opens with operator-facing SPDX-pipeline impact + Constitution Principle V framing
+- [X] Written for non-technical stakeholders — root cause explained in operator terms (key mismatch); semantic impact described as parity-gate failure
+- [X] All mandatory sections completed — User Scenarios, Requirements, Success Criteria, Assumptions, Out of scope, Dependencies all present
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain — none used; the fix shape is unambiguous (one additional `name_to_purl` insert per maven entry)
+- [X] Requirements are testable and unambiguous — FR-001 through FR-009 each name a measurable invariant: SPDX maven 3 DEPENDS_ON, CDX byte-identity, allowlist removal, parity test pass
+- [X] Success criteria are measurable — SC-001 through SC-007 each name a count or pass/fail check
+- [X] Success criteria are technology-agnostic — SC-001/SC-002 describe consumer-observable outcomes (relationship counts in emitted documents)
+- [X] All acceptance scenarios are defined — every user story has 2+ Given/When/Then scenarios
+- [X] Edge cases are identified — collision handling, property-substituted GAV, multi-module reactor, empty `<dependencies>` all covered
+- [X] Scope is clearly bounded — Out of Scope explicitly excludes per-ecosystem audit, name_to_purl refactor, CDX-side closure assertion, dep-management beyond milestone-070
+- [X] Dependencies and assumptions identified — Dependencies section names 4 prior milestones; Assumptions section documents 4 working assumptions
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria — FR-001 through FR-009 map to user-story acceptance scenarios or to explicit invariant checks
+- [X] User scenarios cover primary flows — US1 (SPDX maven dep edges), US2 (parity gate clean), US3 (CDX byte-identity preservation) cover the load-bearing observation surfaces
+- [X] Feature meets measurable outcomes defined in Success Criteria — every SC verifiable post-merge
+- [X] No implementation details leak into specification — file paths in "Root cause" are diagnostic context (showing why this is a one-line `scan_fs/mod.rs` change); the actual code change lives in plan.md per speckit ladder
+
+## Notes
+
+- This is a small follow-up milestone (one extra `name_to_purl` insert + golden regen + allowlist removal); the spec is intentionally tight.
+- Bug-fix-style milestones in this codebase routinely cite file paths + line numbers in their spec.md "Root cause" subsection (see milestones 054, 084) — this pattern is established and stakeholder-readable.
+- Items marked incomplete require spec updates before `/speckit.plan`.

--- a/specs/085-maven-spdx-dep-edges/plan.md
+++ b/specs/085-maven-spdx-dep-edges/plan.md
@@ -1,0 +1,59 @@
+# Implementation Plan: Maven SPDX dep-edge emission
+
+**Branch**: `085-maven-spdx-dep-edges` | **Date**: 2026-05-08 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/085-maven-spdx-dep-edges/spec.md`
+
+## Summary
+
+One extra `name_to_purl` insert per maven entry in `mikebom-cli/src/scan_fs/mod.rs:373-379` so maven main-module's `"groupId:artifactId"` depend names resolve to their target PURLs. Side effects: SPDX 2.3 + SPDX 3 maven goldens regenerate (3 new `DEPENDS_ON` / `software_dependsOn` edges per maven main-module). CDX maven golden stays byte-identical (the same 3 edges already came through the primary-dep fallback at `dependencies.rs:78-91`; post-085 they come through real `Relationship` entries instead). The `KNOWN_PARITY_GAPS` allowlist entry from milestone 084 is removed.
+
+Net code change: ~6 LOC in `scan_fs/mod.rs` + 1 line removed from `holistic_parity.rs` + maven SPDX 2.3 + SPDX 3 goldens regenerated.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain).
+**Primary Dependencies**: existing only — no new crates.
+**Storage**: N/A.
+**Testing**: existing `cdx_regression` / `spdx_regression` / `spdx3_regression` / `holistic_parity` / `cdx_ref_closure_invariant` test suites.
+**Target Platform**: Linux + macOS (same as rest of mikebom).
+**Project Type**: CLI extension (existing `mikebom-cli` crate).
+**Performance Goals**: emission stays within milestone-082 baseline (one extra HashMap insert per maven entry; negligible).
+**Constraints**: maven SPDX 2.3 + SPDX 3 goldens regenerate with diffs containing only the new `DEPENDS_ON` / `software_dependsOn` edges; CDX maven golden byte-identical; other ecosystems' goldens (CDX/SPDX/SPDX 3) all byte-identical.
+**Scale/Scope**: ~6 LOC in `scan_fs/mod.rs` + 1 LOC removed from `holistic_parity.rs` + 2 SPDX goldens regenerate.
+
+## Constitution Check
+
+| Principle | Compliance |
+|---|---|
+| **I. Pure Rust, Zero C** | ✅ pass |
+| **II. eBPF-Only Observation** | N/A — emission, not discovery |
+| **III. Fail Closed** | N/A |
+| **IV. Type-Driven Correctness** | ✅ pass — no new untyped boundaries; no `.unwrap()` in production |
+| **V. Specification Compliance** | ✅✅ — closes a per-format vocabulary divergence; standards-native dep-edge emission (SPDX 2.3 `DEPENDS_ON` + SPDX 3 `software_dependsOn`); no `mikebom:*` introduced |
+| **VI. Three-Crate Architecture** | ✅ pass |
+| **VII. Test Isolation** | ✅ pass |
+| **VIII. Completeness** | N/A — identifier resolution, not dep discovery |
+| **IX. Accuracy** | ✅ improves accuracy — closes dep-edge gap surfaced by milestone 084 |
+| **X. Transparency** | N/A |
+| **XI. Enrichment** | N/A |
+| **XII. External Data Source Enrichment** | N/A |
+
+Strict Boundaries: all preserved. Pre-PR gate per CLAUDE.md applies. **Decision: PASS.**
+
+## Project Structure
+
+```text
+mikebom-cli/
+├── src/
+│   └── scan_fs/
+│       └── mod.rs                       # MODIFY — name_to_purl dual-key insert for maven (~6 LOC at lines 373-379)
+├── tests/
+│   ├── holistic_parity.rs               # MODIFY — remove KNOWN_PARITY_GAPS entry for ("maven", "B1") (~5 LOC removed; allowlist becomes empty const &[])
+│   └── fixtures/golden/
+│       ├── spdx-2.3/maven.spdx.json     # REGEN — 3 new DEPENDS_ON
+│       └── spdx-3/maven.spdx3.json      # REGEN — 3 new software_dependsOn
+```
+
+## Complexity Tracking
+
+No violations. Section intentionally empty.

--- a/specs/085-maven-spdx-dep-edges/spec.md
+++ b/specs/085-maven-spdx-dep-edges/spec.md
@@ -1,0 +1,175 @@
+# Feature Specification: Maven SPDX dep-edge emission (milestone-070 follow-up)
+
+**Feature Branch**: `085-maven-spdx-dep-edges`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: "Fix maven SPDX dep edges from milestone-070 gap" — Maven main-module emits no `DEPENDS_ON` relationships in SPDX 2.3 / SPDX 3 (and CDX relies on the primary-dep fallback rather than real `Relationship` entries). Pre-existing milestone-070 gap surfaced by milestone-084 closing the CDX orphan-ref bug.
+
+## Overview
+
+Milestone 070 (Maven main-module) added the project's main-module to `metadata.component` and `components[]`, with `entry.depends` populated from the `<dependencies>` block as `"groupId:artifactId"` strings (per `mikebom-cli/src/scan_fs/package_db/maven.rs:3451-3455`). The intent was that the existing edge-emission machinery in `mikebom-cli/src/scan_fs/mod.rs:548-564` would resolve those depends names against `name_to_purl` and emit `Relationship { from: main-module-PURL, to: dep-PURL, type: DependsOn }` entries — same as cargo / npm / pip / gem / go.
+
+That resolution **silently fails for maven**:
+
+- `name_to_purl` is keyed by `(ecosystem, normalize_dep_name(ecosystem, e.name))` at `scan_fs/mod.rs:373-379`. For maven dep components, `e.name` is the **artifact-id** (e.g., `"guava"`), so the key is `("maven", "guava")`.
+- Maven main-module's `depends` list contains **`"groupId:artifactId"`** strings (e.g., `"com.google.guava:guava"`).
+- Lookup at `scan_fs/mod.rs:549` constructs key `("maven", "com.google.guava:guava")` — which is NOT in `name_to_purl`.
+- Every maven dep lookup misses → zero `Relationship` entries emitted from the maven main-module → SPDX 2.3 / SPDX 3 emit zero `DEPENDS_ON` for maven.
+
+The CDX side compensated via the `dependencies.rs:78-91` primary-dep fallback (synthesizing `target_ref → roots-of-component-graph`), which produced correct dep-graph edges in CDX `dependencies[]`. Milestone 084's closure-invariant test exposed the gap: the CDX side now correctly emits 3 edges from the demo-app PURL, but SPDX 2.3 + SPDX 3 still emit zero. Parity test `parity_maven` for row B1 (`dependency edge (runtime)`) failed; milestone 084 added a `KNOWN_PARITY_GAPS` allowlist entry as a temporary measure pointing at this milestone for the real fix.
+
+Empirical baseline (alpha.23 + milestone-084 fix):
+
+| Format | Maven main-module → guava/junit/commons-lang3 edges |
+|---|---|
+| CDX 1.6 | 3 (via fallback synthesis at `dependencies.rs:78-91`) |
+| SPDX 2.3 | 0 |
+| SPDX 3 | 0 |
+
+Post-085 target:
+
+| Format | Maven main-module → guava/junit/commons-lang3 edges |
+|---|---|
+| CDX 1.6 | 3 (via real `Relationship` entries; fallback no longer fires for maven) |
+| SPDX 2.3 | 3 (via the existing `DEPENDS_ON` emission at `spdx/relationships.rs:122-169`) |
+| SPDX 3 | 3 (via the existing emission at `spdx/v3_relationships.rs`) |
+
+## Why this matters — root cause
+
+One symbol mismatch in `mikebom-cli/src/scan_fs/mod.rs:373-379`:
+
+```rust
+for e in &db_entries {
+    let ecosystem = e.purl.ecosystem().to_string();
+    name_to_purl.insert(
+        (ecosystem, normalize_dep_name(e.purl.ecosystem(), &e.name)),
+        e.purl.as_str().to_string(),
+    );
+}
+```
+
+`e.name` for maven entries is just the artifact-id. But maven dep names are conventionally `"groupId:artifactId"` (the canonical disambiguation format). Cargo / npm / pip / gem don't have this issue because their dep names are package names that match `e.name` directly.
+
+The fix: for maven entries, ALSO insert a key under `"groupId:artifactId"` form. Both keys point at the same PURL. The maven main-module's `depends` lookups now resolve correctly.
+
+## Why this matters — semantic impact
+
+Per Constitution Principle V (Specification Compliance + standards-native precedence):
+
+> "**Standards-native fields take precedence over `mikebom:`-prefixed properties.**"
+
+The CDX primary-dep fallback at `dependencies.rs:78-91` is a `mikebom`-internal synthesis that compensates for missing real relationships. It produces correct CDX output but provides no signal to the SPDX path. SPDX 2.3 and SPDX 3 both have native `DEPENDS_ON` / `software_dependsOn` constructs that mikebom emits when it has real relationships (per cargo/gem/golang/npm/pip evidence). Maven's gap means the SPDX side can't represent the dep-graph edges that the CDX side has — a per-format vocabulary divergence that the format-parity gate (milestone 013) is designed to catch.
+
+This was masked pre-milestone-084 because:
+- The CDX-side parity extractor at `parity/extractors/cdx.rs:253` couldn't resolve the orphan `<short-name>@0.0.0` ref and skipped its dep edges in the comparison.
+- Both sides reported empty edge sets → `parity_maven` row B1 SymmetricEqual passed (false positive).
+
+Post-milestone-084: CDX correctly emits 3 edges, SPDX still has zero, parity test fails. The KNOWN_PARITY_GAPS allowlist in `holistic_parity.rs` papers over the divergence; this milestone removes the allowlist entry by closing the underlying gap.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — SPDX 2.3 maven document carries main-module dep edges (Priority: P1)
+
+A regulatory-compliance pipeline consuming a mikebom-emitted SPDX 2.3 document for a Maven project needs `DEPENDS_ON` relationships from the project Package to its direct deps so the dep graph is reconstructable from SPDX alone. Today these edges are missing for maven (zero `DEPENDS_ON` in any maven SPDX 2.3 golden); the consumer either falls back to the CDX-only pipeline (defeating SPDX parity) or treats the maven SBOM as having zero deps.
+
+**Why this priority**: Headline operator pain — SPDX 2.3 is the dominant deployed SPDX version per Constitution Principle V's prose, and federal procurement / sbomqs / syft|grype|trivy interop all expect it. A maven SPDX 2.3 with zero dep edges fails dep-tree-reconstruction expectations.
+
+**Independent Test**: Run `mikebom sbom scan --path tests/fixtures/maven/pom-three-deps --format spdx-2.3-json --output -` and assert the resulting document has 3 `DEPENDS_ON` relationships from the demo-app SPDXID to guava / junit / commons-lang3 SPDXIDs. Equivalently: assert `[.relationships[] | select(.relationshipType == "DEPENDS_ON")] | length == 3`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a maven scan with `<dependencies>` declaring guava + junit + commons-lang3, **When** mikebom emits SPDX 2.3, **Then** 3 `DEPENDS_ON` relationships exist with `spdxElementId` = main-module SPDXID and `relatedSpdxElement` = each dep's SPDXID.
+2. **Given** the same scan, **When** mikebom emits SPDX 3, **Then** the equivalent edges exist via `software_dependsOn` per the existing milestone-079 ID-vocab work.
+
+---
+
+### User Story 2 — Format-parity gate is clean without an allowlist (Priority: P1)
+
+The `KNOWN_PARITY_GAPS` allowlist entry in `mikebom-cli/tests/holistic_parity.rs` (added by milestone 084) papers over the SPDX-side divergence for maven. Post-085, the allowlist entry is removed; `parity_maven` passes for row B1 against unmodified holistic_parity infrastructure.
+
+**Why this priority**: A clean parity gate is more durable than an allowlist. Allowlists tend to grow over time and silently mask drift. P1 because removing the allowlist is the load-bearing milestone-085 deliverable that "closes the loop" on the milestone-084 → 085 chain.
+
+**Independent Test**: Remove the `("maven", "B1", _)` entry from `KNOWN_PARITY_GAPS` in `holistic_parity.rs`; run `cargo +stable test -p mikebom --test holistic_parity parity_maven`; assert exit 0.
+
+**Acceptance Scenarios**:
+
+1. **Given** the post-085 fix, **When** `holistic_parity::parity_maven` runs without the allowlist entry, **Then** the test passes.
+2. **Given** the same post-085 fix, **When** the closure-invariant test from milestone 084 (`cdx_ref_closure_invariant`) runs, **Then** it continues to pass for maven (no regression).
+
+---
+
+### User Story 3 — CDX maven output stays byte-identical post-085 (Priority: P2)
+
+The CDX side already has the 3 dep edges via the primary-dep fallback at `dependencies.rs:78-91`. Post-085 the same 3 edges come through real `Relationship` entries instead, but the CDX `dependencies[]` array contents are identical. The maven CDX golden MUST stay byte-identical pre/post 085.
+
+**Why this priority**: P2 because byte-identity is a property of the fix shape (relationships flow through the same `target_ref` entry whether from real edges or fallback synthesis), not a separate requirement. Verifying it explicitly catches over-correction.
+
+**Independent Test**: Run `cargo +stable test -p mikebom --test cdx_regression cdx_regression_maven` post-fix; assert exit 0 without `MIKEBOM_UPDATE_CDX_GOLDENS` env var.
+
+**Acceptance Scenarios**:
+
+1. **Given** the post-085 maven scan, **When** mikebom emits CDX 1.6, **Then** the resulting document is byte-identical to the milestone-084-regenerated maven golden.
+2. **Given** the same post-085 fix, **When** the closure-invariant test runs across all 6 ecosystems, **Then** maven continues to satisfy the closure invariant + reverse-walk + compositions-anchor assertions.
+
+---
+
+### Edge Cases
+
+- **Multiple maven entries sharing an artifact-id but different groupIds** (e.g., `org.foo:utils` and `org.bar:utils`): the post-085 fix inserts BOTH `("maven", "utils")` AND `("maven", "org.foo:utils")` keys. The artifact-id-only key collides between the two utils components — last-write-wins (existing behavior). The disambiguated `groupId:artifactId` key is unambiguous. Maven main-module depends are looked up via the disambiguated key, so they resolve correctly regardless of artifact-id collisions.
+- **Maven dep with property-substituted GAV** (e.g., `<groupId>${groupId.placeholder}</groupId>`): the maven reader at `maven.rs:3417-3434` already resolves properties via `resolve_pom_property_value`. If a property is unresolvable, the dep emission fails with a warn — no relationship emitted (current behavior; not regressed).
+- **Maven workspace / reactor with multi-module POM** (`<modules>` block): each child module emits its own main-module entry via `build_maven_main_module_entry`. Each module's `<dependencies>` produces its own depend-name list. No cross-module dep lookups beyond what milestone 070 already supports.
+- **Empty `<dependencies>` block**: maven main-module's `depends` list is empty; the edge-emission loop iterates zero times; zero relationships emitted (current behavior; correct).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: For every `db_entry` whose ecosystem is `"maven"`, `name_to_purl` MUST contain BOTH a key `("maven", artifact-id)` AND a key `("maven", "groupId:artifactId")` — both pointing at the entry's PURL string.
+- **FR-002**: Maven main-module's `depends` list (containing `"groupId:artifactId"` strings) MUST resolve via the `name_to_purl` lookup at `scan_fs/mod.rs:548-564`, producing one `Relationship { from: main-module-PURL, to: dep-PURL, type: DependsOn }` entry per direct dep.
+- **FR-003**: SPDX 2.3 maven emission MUST contain N `DEPENDS_ON` relationships where N = number of resolved direct deps from the maven main-module's pom.xml `<dependencies>` block. Verified by inspecting the regenerated maven SPDX 2.3 golden.
+- **FR-004**: SPDX 3 maven emission MUST contain N equivalent `software_dependsOn` edges via the existing milestone-079 ID-vocab path.
+- **FR-005**: CDX 1.6 maven emission MUST be byte-identical to the milestone-084-regenerated maven golden — the same 3 dep edges flow through real relationships rather than the primary-dep fallback, but the resulting `dependencies[]` array is unchanged.
+- **FR-006**: The `KNOWN_PARITY_GAPS` allowlist entry `("maven", "B1", _)` in `mikebom-cli/tests/holistic_parity.rs` MUST be removed; `holistic_parity::parity_maven` MUST pass without it.
+- **FR-007**: Existing milestone-070 main-module emission tests MUST pass unmodified (no behavioral change to the main-module component itself; only the relationships from it are added).
+- **FR-008**: Existing milestone-013 / 071 / 084 parity + closure-invariant tests MUST pass post-regen.
+- **FR-009**: SPDX 2.3 + SPDX 3 maven goldens MUST regenerate cleanly with diffs containing only the newly-added `DEPENDS_ON` / `software_dependsOn` edges (no other field changes). Other ecosystems' SPDX goldens MUST stay byte-identical.
+
+### Key Entities
+
+- **`name_to_purl` map** (existing internal at `scan_fs/mod.rs:371`): `HashMap<(String, String), String>` keyed by `(ecosystem, normalized-name)`, value is PURL string. Post-085: maven entries get TWO keys per entry (artifact-id + groupId:artifactId), both pointing at the same PURL.
+- **Maven main-module's `depends` field** (existing internal): `Vec<String>` of `"groupId:artifactId"` strings, populated at `maven.rs:3451-3455`. Unchanged by this milestone — it's already correct; the fix is on the consumer side.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: SPDX 2.3 maven golden post-085 contains exactly 3 `DEPENDS_ON` relationships from the demo-app Package to guava / junit / commons-lang3 Packages.
+- **SC-002**: SPDX 3 maven golden post-085 contains exactly 3 equivalent `software_dependsOn` edges.
+- **SC-003**: CDX 1.6 maven golden post-085 is byte-identical to the milestone-084-regenerated golden.
+- **SC-004**: `holistic_parity::parity_maven` passes after removing the `KNOWN_PARITY_GAPS` allowlist entry.
+- **SC-005**: Other ecosystems' goldens (CDX, SPDX 2.3, SPDX 3) all stay byte-identical post-085.
+- **SC-006**: Pre-PR gate clean (`./scripts/pre-pr.sh`): zero clippy warnings, every test suite `0 failed`.
+- **SC-007**: Closure-invariant test from milestone 084 (`cdx_ref_closure_invariant`) continues to pass for maven (no regression).
+
+## Assumptions
+
+- The existing maven dep-name extraction at `maven.rs:3451-3455` correctly produces `"groupId:artifactId"` strings. (Verified empirically — already shipping behavior.)
+- The existing SPDX 2.3 / SPDX 3 dep-edge emission at `spdx/relationships.rs:122-169` and `spdx/v3_relationships.rs` correctly converts mikebom-internal `Relationship` entries into format-native edges. (Verified — works for cargo / gem / golang / npm / pip with non-trivial DEPENDS_ON counts in their goldens.)
+- Maven artifact-ids are unique enough within a typical fixture that the additional `groupId:artifactId` key doesn't introduce collisions in real workloads. The test fixture `pom-three-deps` has no collision; future fixtures with intentional collisions would be caught by the new SPDX 2.3 maven golden's diff scope (3 expected edges; collisions would change the count).
+- No new Cargo dependencies needed.
+- The fix is safe to ship in a single PR. The change site is one block in `scan_fs/mod.rs`; no API surface change.
+
+## Out of scope
+
+- **SPDX-side per-ecosystem audit beyond maven**: cargo, gem, golang, npm, pip already emit SPDX `DEPENDS_ON` (per their non-zero golden counts). dpkg / apk / rpm don't have main-module promotion (fallback path); they emit zero `DEPENDS_ON` legitimately. No other ecosystem has a similar gap.
+- **Refactoring `name_to_purl` to a smarter per-ecosystem strategy**: the fix is the smallest change (one extra insert for maven entries). Refactoring `name_to_purl` to use a per-ecosystem dep-name-format adapter is a code-quality concern outside scope.
+- **Adding a CDX-side closure-invariant assertion that the primary-dep fallback no longer fires for maven**: byte-identity (FR-005 / SC-003) covers this implicitly — if the fallback fires the same way pre/post, byte-identity holds; if the fallback's behavior changes, the goldens drift and the audit catches it.
+- **Maven `<dependencyManagement>` resolution beyond what milestone 070 already supports**: the dep-name extraction inherits whatever GAV resolution milestone-070 produced. If a `<dependency>` has a property-substituted GAV that fails to resolve, no relationship is emitted (current behavior).
+
+## Dependencies
+
+- Milestone 070 (Maven main-module emission) — must continue to work; the fix is downstream of it.
+- Milestone 084 (CDX 1.6 main-module super-root collapse) — the trigger for this fix; PR #166 must merge before this milestone can land cleanly (the `KNOWN_PARITY_GAPS` allowlist entry that this milestone removes was added by 084).
+- Milestone 013 format-parity gate — gates the SPDX maven golden regen.
+- Milestone 071 annotation parity — unaffected by this fix (different parity rows).
+- Milestone 079 SPDX 3 ID-vocab — provides the `software_dependsOn` IRI form used by SPDX 3 dep edges.

--- a/specs/085-maven-spdx-dep-edges/tasks.md
+++ b/specs/085-maven-spdx-dep-edges/tasks.md
@@ -1,0 +1,49 @@
+---
+description: "Tasks: Maven SPDX dep-edge emission"
+---
+
+# Tasks: Maven SPDX dep-edge emission (milestone-070 follow-up)
+
+**Input**: Design documents from `/specs/085-maven-spdx-dep-edges/`
+**Prerequisites**: spec.md ✅, plan.md ✅
+
+**Organization**: Single small fix; phases collapse to setup → fix → polish.
+
+## Phase 1: Setup
+
+- [X] T001 Capture pre-fix maven SPDX 2.3 + SPDX 3 DEPENDS_ON counts to confirm starting state matches spec ("0 each")
+
+## Phase 2: Foundational (the fix)
+
+- [X] T002 Modify `mikebom-cli/src/scan_fs/mod.rs:373-379` `name_to_purl` insert loop to ALSO insert a `("maven", "groupId:artifactId")` key for entries whose ecosystem is `"maven"` (groupId from `e.purl.namespace()`, artifact-id from `e.purl.name()`). Both keys point at the same PURL. ~6 LOC.
+- [X] T003 Smoke-test: rebuild release binary, emit SPDX 2.3 against `tests/fixtures/maven/pom-three-deps`, assert 3 `DEPENDS_ON` relationships present.
+
+## Phase 3: US1 — SPDX 2.3 + SPDX 3 dep edges
+
+- [X] T004 [US1] Regenerate maven SPDX 2.3 golden: `MIKEBOM_UPDATE_SPDX_GOLDENS=1 cargo +stable test -p mikebom --test spdx_regression`. Verify ONLY `maven.spdx.json` changes; other 8 stay byte-identical.
+- [X] T005 [US1] Regenerate maven SPDX 3 golden: `MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test -p mikebom --test spdx3_regression`. Verify ONLY `maven.spdx3.json` changes.
+- [X] T006 [US1] Audit diff scope of regenerated maven SPDX goldens — only added `DEPENDS_ON` (SPDX 2.3) / `software_dependsOn` (SPDX 3); no other field changes.
+
+## Phase 4: US2 — clean parity gate
+
+- [X] T007 [US2] Remove the `("maven", "B1", _)` entry from `KNOWN_PARITY_GAPS` in `mikebom-cli/tests/holistic_parity.rs`. The const becomes an empty slice `&[]`.
+- [X] T008 [US2] Run `cargo +stable test -p mikebom --test holistic_parity` — confirm `parity_maven` passes without the allowlist.
+
+## Phase 5: US3 — CDX byte-identity
+
+- [X] T009 [US3] Run `cargo +stable test -p mikebom --test cdx_regression` without env var; confirm all 9 CDX goldens (including maven) pass byte-identical (no regen needed).
+- [X] T010 [US3] Run `cargo +stable test -p mikebom --test cdx_ref_closure_invariant` — confirm closure invariant + reverse-walk + compositions-anchor still pass for all 6 ecosystems including maven.
+
+## Phase 6: Polish
+
+- [X] T011 Pre-PR gate: `./scripts/pre-pr.sh` MUST exit 0 with zero clippy warnings + every test suite `0 failed`.
+- [X] T012 Update CLAUDE.md "Recent Changes" section if the speckit infrastructure didn't auto-update it.
+
+---
+
+## Dependencies
+
+- T001 → T002 → T003 (setup → fix → smoke)
+- T002 must complete before any of T004/T005/T007/T009/T010
+- T004/T005/T007 can run in parallel after T002 (different files, different test suites)
+- T011 last


### PR DESCRIPTION
## Summary

- Closes the maven SPDX 2.3 + SPDX 3 dep-edge gap surfaced by milestone 084 (PR #166). Pre-085 maven main-module's `entry.depends` (canonical `groupId:artifactId` form) silently failed to resolve in `name_to_purl` (keyed on artifact-id only). One extra HashMap insert per maven entry closes it.
- Cleans up several adjacent parity-test issues that surfaced once the dep edges were emitted: SPDX 3 lifecycle-scope used the wrong element type (plain `Relationship` instead of `LifecycleScopedRelationship`), and the parity extractors used stale source-side-only filters that mis-classified target-side test/dev edges.
- Removes the `KNOWN_PARITY_GAPS` allowlist entry milestone 084 added.

## Stacked on #166

This PR is **based on `084-cdx-mainmod-collapse`**, not `main`. Merge after #166. The PR's diff in GitHub will show only the milestone-085 changes; once #166 lands the base auto-rebases to main.

## Code changes

| File | Change |
|---|---|
| `mikebom-cli/src/scan_fs/mod.rs` | Insert `("maven", "groupId:artifactId")` key in `name_to_purl` for maven entries — main-module dep lookups now resolve |
| `mikebom-cli/src/generate/spdx/v3_relationships.rs` | Switch SPDX 3 emission of typed dep edges from plain `Relationship + scope` (invalid per SPDX 3.0.1 schema) to `LifecycleScopedRelationship + scope` (the proper subtype) |
| `mikebom-cli/src/parity/extractors/cdx.rs` | Per-edge runtime/dev classification on EITHER endpoint's scope (was source-side only) |
| `mikebom-cli/src/parity/extractors/spdx2.rs` | `spdx23_dev_deps` includes `TEST_DEPENDENCY_OF` + `BUILD_DEPENDENCY_OF` (was DEV-only) |
| `mikebom-cli/src/parity/extractors/spdx3.rs` | `spdx3_runtime_deps` excludes `LifecycleScopedRelationship` with non-runtime scope; `spdx3_dev_deps` rewritten to use the native scope encoding (replaces deprecated `mikebom:dev-dependency` annotation filter from milestone-052/part-2) |
| `mikebom-cli/tests/holistic_parity.rs` | Removed milestone-084's `KNOWN_PARITY_GAPS` allowlist entry; const becomes empty |
| `mikebom-cli/tests/fixtures/golden/spdx-2.3/maven.spdx.json` | +2 DEPENDS_ON + 1 TEST_DEPENDENCY_OF |
| `mikebom-cli/tests/fixtures/golden/spdx-3/maven.spdx3.json` | +3 dependsOn (1 with `type: LifecycleScopedRelationship + scope: test` for junit; 2 plain Relationships for guava + commons-lang3) |

## Side-discoveries documented in commit message

The investigation surfaced **three pre-existing bugs** that the milestone-085 fix exposes:

1. **SPDX 3 `LifecycleScopedRelationship` element-type mismatch** — milestone-052/part-2 emitted typed dep edges with `scope` field on plain `Relationship`, but SPDX 3.0.1 schema requires `LifecycleScopedRelationship` subtype. Pre-085 untested because cargo/gem/etc. fixtures only emit plain `DependsOn`.
2. **CDX parity extractor source-side-only scope filter** — only filtered source-side scope=excluded, missed target-side. Pre-085 untested because cargo's dev deps were source-side scoped.
3. **SPDX 3 dev-deps extractor used deprecated annotation** — milestone-052/part-2 removed `mikebom:dev-dependency` annotation in favor of native `scope` encoding, but the parity extractor wasn't updated.

All three would have remained latent bugs without milestone 084 + 085 surfacing them.

## Verification

- ✅ SPDX 2.3 maven: 2 `DEPENDS_ON` + 1 `TEST_DEPENDENCY_OF` (was 0+0 pre-fix)
- ✅ SPDX 3 maven: 3 dependsOn edges (1 LifecycleScopedRelationship for junit) — passes spdx3-validate JSON-Schema
- ✅ CDX maven: byte-identical to milestone-084 golden (the same 3 edges already came through the primary-dep fallback at `dependencies.rs:78-91`; post-085 they come through real `Relationship` entries)
- ✅ closure-invariant test (milestone-084): all 6 ecosystems pass
- ✅ holistic_parity: 12/12 pass without allowlist
- ✅ spdx3_conformance: 15/15 pass
- ✅ Other ecosystems' goldens (CDX, SPDX 2.3, SPDX 3): byte-identical
- ✅ `./scripts/pre-pr.sh` clean

## Test plan

- [ ] CI green after #166 lands
- [ ] Reviewer audits the parity-extractor changes (3 files) — these are shared infrastructure and worth scrutiny
- [ ] Reviewer confirms `LifecycleScopedRelationship` is the correct SPDX 3.0.1 subtype (per `spdx-json-schema.json` `LifecycleScopedRelationship_props` + `prop_LifecycleScopedRelationship_scope` enum)
- [ ] Optional: spot-check that fixture diffs are minimal (only maven SPDX 2.3 + SPDX 3 should regenerate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)