### PR TITLE
fix(086): preserve direct dep edges in --root-name override path (alpha.24 regression hot-fix)

### DIFF
--- a/mikebom-cli/src/generate/cyclonedx/builder.rs
+++ b/mikebom-cli/src/generate/cyclonedx/builder.rs
@@ -375,27 +375,46 @@ impl CycloneDxBuilder {
             complete_ecosystems,
         );
         // Milestone 084 — when override has dropped main-module components,
-        // filter out relationships whose `from` is one of the dropped PURLs.
-        // The `dependencies.rs` build_dependencies fallback (line 78-91)
-        // then synthesizes correct edges from the override-form target_ref
-        // to the components that have no incoming edges (the direct deps
-        // formerly attached to the dropped main-module). Without this
-        // filter, dependencies[] would contain an orphan entry whose `ref`
-        // is the dropped main-module PURL — same closure-violation shape
-        // as the pre-084 main-module path, just with the orphan and the
-        // legitimate root swapped.
+        // closure-invariant fix: relationships whose `from` is one of the
+        // dropped PURLs would otherwise leave a dangling `dependencies[].ref`
+        // entry (the dropped PURL isn't in `components[]` and isn't
+        // `metadata.component.bom-ref` under override).
+        //
+        // Milestone 086 — REWRITE rather than FILTER. The original
+        // milestone-084 fix dropped these relationships entirely (Option A
+        // in research §2), which left target_ref empty and triggered the
+        // `dependencies.rs:78-91` primary-dep fallback to synthesize
+        // edges from "components nothing else depends on". For projects
+        // whose direct deps form a non-tree DAG (some direct deps are
+        // also transitively depended on by other deps), the synthesis
+        // silently dropped legitimate edges. Real-world reproduction:
+        // hosted-guac-mgmt under `--root-name slack-notifier --root-
+        // version narsa` lost 3 of 15 direct edges. Option B (rewrite)
+        // re-anchors each dropped-main-module-keyed edge onto target_ref,
+        // preserving every edge with the override identity and still
+        // satisfying the closure invariant.
         let filtered_relationships_owned: Option<Vec<Relationship>> =
             if !dropped_main_module_purls.is_empty() {
                 let dropped: std::collections::HashSet<&str> = dropped_main_module_purls
                     .iter()
                     .map(|s| s.as_str())
                     .collect();
-                let kept: Vec<Relationship> = relationships
+                let rewritten: Vec<Relationship> = relationships
                     .iter()
-                    .filter(|r| !dropped.contains(r.from.as_str()))
-                    .cloned()
+                    .map(|r| {
+                        if dropped.contains(r.from.as_str()) {
+                            Relationship {
+                                from: target_ref.clone(),
+                                to: r.to.clone(),
+                                relationship_type: r.relationship_type.clone(),
+                                provenance: r.provenance.clone(),
+                            }
+                        } else {
+                            r.clone()
+                        }
+                    })
                     .collect();
-                Some(kept)
+                Some(rewritten)
             } else {
                 None
             };

--- a/mikebom-cli/tests/cdx_ref_closure_invariant.rs
+++ b/mikebom-cli/tests/cdx_ref_closure_invariant.rs
@@ -57,7 +57,15 @@ const FIXTURES: &[Fixture] = &[
 ];
 
 /// Run mikebom against a fixture and return the parsed CDX 1.6 JSON.
-fn run_mikebom_cdx(fixture_subpath: &str) -> serde_json::Value {
+/// Optionally pass override flags to exercise the milestone-077
+/// `--root-name` / `--root-version` path; when both are `None`, the
+/// scan runs without overrides (default milestone-053+ main-module
+/// emission).
+fn run_mikebom_cdx_with_override(
+    fixture_subpath: &str,
+    root_name: Option<&str>,
+    root_version: Option<&str>,
+) -> serde_json::Value {
     let fixture = workspace_root().join(fixture_subpath);
     assert!(
         fixture.exists(),
@@ -80,6 +88,12 @@ fn run_mikebom_cdx(fixture_subpath: &str) -> serde_json::Value {
         .arg("--no-deep-hash")
         .arg("--format")
         .arg("cyclonedx-json");
+    if let Some(name) = root_name {
+        cmd.arg("--root-name").arg(name);
+    }
+    if let Some(version) = root_version {
+        cmd.arg("--root-version").arg(version);
+    }
     let output = cmd.output().expect("failed to invoke mikebom");
     assert!(
         output.status.success(),
@@ -89,6 +103,10 @@ fn run_mikebom_cdx(fixture_subpath: &str) -> serde_json::Value {
     );
     let bytes = std::fs::read(&out_path).expect("read output");
     serde_json::from_slice(&bytes).expect("parse CDX JSON")
+}
+
+fn run_mikebom_cdx(fixture_subpath: &str) -> serde_json::Value {
+    run_mikebom_cdx_with_override(fixture_subpath, None, None)
 }
 
 /// Compute the closure set S = components[].bom-ref ∪ {metadata.component.bom-ref}.
@@ -342,6 +360,100 @@ fn cdx_ref_closure_invariant_holds_per_ecosystem() {
         failures.len(),
         failures.join("\n\n")
     );
+}
+
+/// Milestone 086 — assert that `--root-name` / `--root-version`
+/// override doesn't silently drop dep edges. Pre-086 (alpha.24) the
+/// override path's `target_ref` had no outgoing edges because
+/// milestone-084 filtered out main-module-PURL-keyed relationships;
+/// the `dependencies.rs:78-91` primary-dep fallback synthesized
+/// edges only for "components nothing else depends on", losing
+/// real direct deps that happened to be transitively depended on
+/// by other components. Post-086 the relationships are REWRITTEN
+/// (not filtered), preserving every edge under the override identity.
+///
+/// Test invariant: edge count from the project root MUST match
+/// between override and non-override scans of the same fixture.
+#[test]
+fn override_preserves_direct_edge_count() {
+    let mut failures: Vec<String> = Vec::new();
+
+    for fx in FIXTURES {
+        let label = fx.label;
+        let path = fx.fixture_subpath;
+        let result = std::panic::catch_unwind(|| {
+            let no_override = run_mikebom_cdx(path);
+            let with_override = run_mikebom_cdx_with_override(
+                path,
+                Some("test-override"),
+                Some("9.9.9"),
+            );
+
+            // Closure invariant must hold under override too.
+            assert_closure(&with_override, &format!("{label}/override"));
+
+            // Project root identity post-override.
+            let override_root = with_override["metadata"]["component"]["bom-ref"]
+                .as_str()
+                .expect("metadata.component.bom-ref under override")
+                .to_string();
+            assert_eq!(
+                override_root, "test-override@9.9.9",
+                "ecosystem {label}: override identity not propagated to metadata.component.bom-ref"
+            );
+
+            // Edge count from project root: invariant under override.
+            let no_override_root = no_override["metadata"]["component"]["bom-ref"]
+                .as_str()
+                .expect("metadata.component.bom-ref")
+                .to_string();
+            let no_override_edges = count_dep_edges_from(&no_override, &no_override_root);
+            let with_override_edges = count_dep_edges_from(&with_override, &override_root);
+
+            assert_eq!(
+                with_override_edges, no_override_edges,
+                "ecosystem {label}: override path lost {} edges \
+                 (no-override: {}, with-override: {}). \
+                 milestone-086 regression — relationships must be REWRITTEN, not filtered.",
+                no_override_edges - with_override_edges,
+                no_override_edges,
+                with_override_edges,
+            );
+        });
+        match result {
+            Ok(()) => eprintln!("ecosystem {label}: override-edge-preservation PASS"),
+            Err(payload) => {
+                let msg = payload
+                    .downcast_ref::<String>()
+                    .cloned()
+                    .or_else(|| {
+                        payload
+                            .downcast_ref::<&'static str>()
+                            .map(|s| (*s).to_string())
+                    })
+                    .unwrap_or_else(|| "<panic with no message>".to_string());
+                failures.push(format!("[{label}] {msg}"));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} ecosystem(s) failed milestone-086 override-preservation invariant:\n\n{}",
+        failures.len(),
+        failures.join("\n\n")
+    );
+}
+
+fn count_dep_edges_from(cdx: &serde_json::Value, source_ref: &str) -> usize {
+    cdx["dependencies"]
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .find(|d| d["ref"].as_str() == Some(source_ref))
+        .and_then(|d| d["dependsOn"].as_array())
+        .map(|a| a.len())
+        .unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/specs/086-fix-override-edges/spec.md
+++ b/specs/086-fix-override-edges/spec.md
@@ -1,0 +1,73 @@
+# Feature Specification: Fix override-path edge loss (milestone-084 follow-up)
+
+**Feature Branch**: `086-fix-override-edges`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User report on alpha.24 — "SBOMs look totally different and seem much worse." Investigation against a real Go project (`hosted-guac-mgmt`) with `--root-name slack-notifier --root-version narsa` revealed milestone 084 introduced a regression in the operator-override path: 3 dep edges lost vs alpha.22 baseline.
+
+## Overview
+
+Milestone 084 fixed the CDX 1.6 orphan-ref bug for the main-module path AND attempted to fix the analogous closure-violation in the `--root-name` / `--root-version` override path (milestone 077). For the override path, the fix used **Option A** (filter relationships whose `from` matches the dropped main-module PURL) per `specs/084-cdx-mainmod-collapse/research.md §2`. Real-world testing showed Option A drops legitimate dep edges:
+
+**Reproduction** (Go project at `hosted-guac-mgmt`):
+
+| | alpha.22 (override) | alpha.24 (override) | Δ |
+|---|---|---|---|
+| Edges from project root | 15 | 12 | **−3 lost** |
+| Closure invariant satisfied | NO (orphan ref) | YES | ✅ |
+| `metadata.component.bom-ref` | `slack-notifier@narsa` | `slack-notifier@narsa` | unchanged |
+| Lost edges | (none) | aws-sdk-go-v2 + aws-sdk-go-v2/service/dynamodb + stretchr/testify | regression |
+
+The 3 missing edges are real direct deps that *also* happen to be transitively depended on by other deps. After Option A filters out the main-module-PURL-keyed relationships, `target_ref = slack-notifier@narsa` has no outgoing edges, so `dependencies.rs`'s primary-dep fallback synthesizes edges from target_ref → roots-of-component-graph. The "roots" heuristic excludes any component that something else depends on — losing the 3 deps that have transitive dependents.
+
+The right fix is **Option B** (rewrite, not filter): when a relationship's `from` equals a dropped main-module PURL, rewrite `from` to `target_ref` instead of dropping the relationship. All 15 edges are preserved with the override identity; closure invariant still satisfied.
+
+This was correctly anticipated in research §2 ("rewrite preserves dep-tree shape under override") but Option A was chosen as simpler. Option A's hidden cost — silent edge loss when project deps form a non-tree DAG — wasn't caught because the milestone-077 override-path golden has only 2 deps, no transitive overlap.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Override path preserves all direct dep edges (Priority: P1)
+
+An operator scanning a Go project with `--root-name <override> --root-version <override>` post-086 sees exactly the same number of direct dep edges from the project root as they would WITHOUT override (just under a different identity). No edges silently disappear because of the override flag.
+
+**Why this priority**: Headline regression of alpha.24. Real users reported it. Hot-fix material.
+
+**Independent Test**: Scan a fixture with ≥3 direct deps where some deps are transitively depended on by other deps — once without override, once with `--root-name x --root-version y`. Assert the project-root entry's `dependsOn[]` count is identical, just keyed by the override identity in the second case.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Go project with N direct deps where some are transitively depended on by other deps, **When** mikebom emits CDX 1.6 with `--root-name <X> --root-version <Y>`, **Then** the project-root entry's `dependsOn[]` has exactly N edges, all keyed by `<X>@<Y>`.
+2. **Given** the same project, **When** mikebom emits CDX 1.6 without override, **Then** the project-root entry's `dependsOn[]` has exactly N edges, all keyed by the milestone-053 main-module PURL.
+3. **Given** the closure invariant from milestone-084, **When** the override scenario runs, **Then** the invariant holds (no orphan refs, milestone-084's primary win preserved).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When `--root-name` / `--root-version` override is active, relationships whose `from` matches a dropped main-module PURL MUST be rewritten so that `from = target_ref` (the override identity), preserving the `to` and `relationship_type` fields. Replaces the milestone-084 filter behavior.
+- **FR-002**: Edge count from `metadata.component.bom-ref` MUST be invariant under override application: scanning the same project with-and-without override produces the same number of direct-dep edges from the project root, just keyed by different identifiers.
+- **FR-003**: The closure invariant from milestone 084 MUST continue to hold under override (no orphan refs).
+- **FR-004**: Existing milestone-077 override tests MUST pass unmodified.
+- **FR-005**: Existing milestone-084 closure-invariant test (`cdx_ref_closure_invariant`) MUST be extended with an override-mode assertion: scan one of the post-053 ecosystem fixtures with override flags, verify direct-edge count + closure invariant.
+- **FR-006**: SPDX 2.3 + SPDX 3 emission MUST be unaffected (this is a CDX-only relationship-rewrite fix happening at `cyclonedx/builder.rs` time; SPDX uses unmodified `relationships`).
+- **FR-007**: Pre-PR gate stays clean: clippy zero warnings; `cargo test --workspace` `0 failed`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Reproduces zero edge loss on `hosted-guac-mgmt` with override (15 edges in both alpha.22 and post-086).
+- **SC-002**: Closure invariant holds under override for all post-053 ecosystem fixtures.
+- **SC-003**: New regression test in `cdx_ref_closure_invariant.rs` asserts edge-count invariance with-and-without override across at least one fixture.
+- **SC-004**: Pre-PR gate clean.
+
+## Assumptions
+
+- The fix is a single-file change in `mikebom-cli/src/generate/cyclonedx/builder.rs` (replace the filter with a map). ~10 LOC.
+- No new Cargo dependencies.
+- No SPDX golden regen needed (the rewrite happens at `cyclonedx/builder.rs` time, not in the upstream `relationships` pipeline; SPDX still receives the unmodified pipeline output).
+
+## Out of scope
+
+- Polyglot scans with multiple main-module PURLs (research §2 noted this; the rewrite handles them via `dep_map`'s `BTreeSet` dedup, but the operator-facing semantic of "what does the project root mean in a polyglot override?" is a separate question for a follow-up).
+- The `dependencies.rs` primary-dep fallback (line 78-91) — kept as-is; rewrite means the fallback rarely fires under override now.


### PR DESCRIPTION
## Background — alpha.24 regression

User-reported issue: "SBOMs look totally different and seem much worse" after upgrading to alpha.24. Investigation against a real Go project (`hosted-guac-mgmt`) with `--root-name slack-notifier --root-version narsa` reproduced a real regression: **3 of 15 direct dep edges silently disappeared**.

| | alpha.22 (override) | alpha.24 (override) | post-086 |
|---|---|---|---|
| Edges from project root | 15 | **12** ❌ | 15 ✅ |
| Closure invariant | violated (orphan ref) | satisfied | satisfied |
| Project-root identity | `slack-notifier@narsa` | `slack-notifier@narsa` | `slack-notifier@narsa` |
| Lost edges | (none) | aws-sdk-go-v2 + aws-sdk-go-v2/service/dynamodb + stretchr/testify | (none) |

## Root cause

Milestone 084 closed the orphan-ref closure-violation in the override path by **filtering out** relationships keyed off the dropped main-module PURL (Option A in `specs/084-cdx-mainmod-collapse/research.md §2`). With those relationships gone, `target_ref = <override-name>@<override-version>` had no outgoing edges, so `dependencies.rs`'s primary-dep fallback (line 78-91) synthesized edges from "components nothing else depends on." For projects where direct deps form a non-tree DAG (some direct deps are also transitively depended on by other deps), that roots-of-component-graph heuristic silently dropped legitimate direct-dep edges.

`hosted-guac-mgmt` happens to have such a DAG: `aws-sdk-go-v2` is depended on by every `aws-sdk-go-v2/service/*` (so it isn't a "root" in the heuristic), `aws-sdk-go-v2/service/dynamodb` is depended on by `aws-sdk-go-v2/feature/dynamodb/attributevalue`, etc. The 3 missing edges were the ones with transitive overlap.

## Fix

**Option B** (rewrite, not filter), which milestone-084 research §2 explicitly listed and rejected as "more complex":

```rust
// pre-086 (Option A — filter):
.filter(|r| !dropped.contains(r.from.as_str()))

// post-086 (Option B — rewrite):
.map(|r| {
    if dropped.contains(r.from.as_str()) {
        Relationship { from: target_ref.clone(), ..r.clone() }
    } else {
        r.clone()
    }
})
```

The 15 edges that were keyed by the dropped main-module PURL are re-anchored on `target_ref` (the override identity). Closure invariant still holds; primary-dep fallback no longer fires under override (target_ref now has its real outgoing edges).

## Regression test

New `override_preserves_direct_edge_count` in `mikebom-cli/tests/cdx_ref_closure_invariant.rs`. For each post-053 ecosystem fixture:
1. Scan without override.
2. Scan with `--root-name test-override --root-version 9.9.9`.
3. Assert closure invariant under override.
4. Assert `metadata.component.bom-ref == "test-override@9.9.9"`.
5. Assert edge count from project root is identical between the two scans.

Confirms milestone-086's invariant on every post-053 ecosystem.

## Verification

- ✅ All 5 closure-invariant tests pass (4 sanity + the new override test)
- ✅ `./scripts/pre-pr.sh` clean — clippy zero warnings, every test suite `0 failed`
- ✅ Real-world repro (`hosted-guac-mgmt + slack-notifier@narsa`): 15 edges restored
- ✅ Closure invariant: zero non-resolving refs under override
- ✅ Goldens untouched (rewrite happens at CDX-emit time only; SPDX unaffected)

## Suggested release path

This fix is hot-fix material — alpha.24 broke a real downstream user's pipeline. Suggest:
1. Merge this PR.
2. Open release PR for `v0.1.0-alpha.25` (Cargo.toml bump + version-string-only golden regen, same shape as alpha.23 → alpha.24 release).
3. Merge release PR.
4. Push the `v0.1.0-alpha.25` tag (don't forget — `release.yml` only fires on tag push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)