### PR TITLE
fix(ci): install trivy 0.69.3 from GitHub Releases .deb (unblock PR #178)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,15 +112,28 @@ jobs:
       # (matches the SPDX 3 conformance pattern + the dpkg/rpm/apk
       # OS-package fixtures are Linux-only per FR-009).
       - name: Install trivy
+        # Pinned at 0.69.3 per spec/083 research §1 — the audit
+        # comparison-baseline version. The apt repo at
+        # `aquasecurity.github.io/trivy-repo` carries only `latest`
+        # (no version-pinned packages), so `apt-get install
+        # trivy=0.69.3` fails with "Version '0.69.3' for 'trivy'
+        # was not found". Install the version-pinned .deb directly
+        # from GitHub Releases instead — also more reproducible
+        # (the release artifact bytes are immutable; the apt repo
+        # would silently roll forward across releases).
         run: |
           set -euo pipefail
-          sudo apt-get install -y wget gnupg
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key \
-            | sudo gpg --dearmor -o /usr/share/keyrings/trivy.gpg
-          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" \
-            | sudo tee /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update -qq
-          sudo apt-get install -y trivy=0.69.3
+          TRIVY_VERSION=0.69.3
+          ARCH=$(dpkg --print-architecture)
+          case "$ARCH" in
+            amd64) DEB_ARCH="64bit" ;;
+            arm64) DEB_ARCH="ARM64" ;;
+            *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
+          esac
+          curl -fsSL \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${DEB_ARCH}.deb" \
+            -o /tmp/trivy.deb
+          sudo dpkg -i /tmp/trivy.deb
           trivy --version
       - name: Install syft
         run: |


### PR DESCRIPTION
## Background

PR #178 (alpha.25 release) is failing CI on the trivy install step added in milestone 083 (commit 8f8517a):

\`\`\`
E: Version '0.69.3' for 'trivy' was not found
\`\`\`

## Root cause

The `aquasecurity/trivy` apt repo at `aquasecurity.github.io/trivy-repo` carries only the `latest` package — no version-pinned variants. So `apt-get install -y trivy=0.69.3` fails immediately. I missed this when writing the milestone-083 install step because I copied the pattern from trivy's published Debian install docs without testing that version pinning actually worked through the apt repo (it doesn't).

## Fix

Install from the GitHub Release .deb directly. Two reasons this is also better:
- **Reproducibility**: release-asset bytes are immutable, so `0.69.3` always means exactly the binary spec/083 research §1 audit-pinned against.
- **Reliability**: matches the pattern syft's install pipeline already uses (`install.sh -b /usr/local/bin v1.27.0`).

## Verification

\`\`\`bash
$ curl -sIL "https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_Linux-64bit.deb" | head -1
HTTP/2 302
\`\`\`

Both `Linux-64bit` (amd64 — what GitHub Actions runs) and `Linux-ARM64` URLs return the standard GitHub-asset 302 redirect. Asset names confirmed via the trivy v0.69.3 release page.

## Effect on PR #178

After this lands + #178 rebases on top, the alpha.25 CI lane should pass cleanly. No goldens regenerate from this fix; it's CI-config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)