### PR TITLE
fix(089): bump sigstore 0.10 → 0.11 + drop tough feature, clear 11 of 15 transitive vulns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,47 @@ jobs:
       - name: Tests
         run: cargo +stable test --workspace
 
+      # Milestone 089 — production-deps vuln gate. Re-uses the trivy
+      # 0.69.3 install above. Excludes test fixtures (intentionally
+      # vulnerable) via path-skip. Fails the lane on any HIGH-severity
+      # advisory under target `Cargo.lock` not listed in milestone 089's
+      # known-acceptances.md. See specs/089-bump-sigstore-vulns/.
+      - name: Production-deps vuln gate
+        run: |
+          trivy --quiet fs \
+            --scanners vuln \
+            --skip-dirs tests/fixtures \
+            --skip-dirs mikebom-cli/tests/fixtures \
+            --skip-dirs target \
+            --severity HIGH \
+            --format json \
+            --output /tmp/prod-vulns.json \
+            .
+          # Extract accepted advisory IDs from milestone-089 known-acceptances.md.
+          # Empty file (no residual vulns) is OK.
+          ACC_FILE="specs/089-bump-sigstore-vulns/known-acceptances.md"
+          if [ -f "$ACC_FILE" ]; then
+            grep -oE 'GHSA-[a-z0-9-]+|CVE-[0-9]+-[0-9]+' "$ACC_FILE" | sort -u > /tmp/accepted-ids.txt
+          else
+            : > /tmp/accepted-ids.txt
+          fi
+          # Find HIGH advisories under Cargo.lock NOT on the acceptance list.
+          UNACCEPTED=$(jq -r '
+            [.Results[]?
+             | select(.Target == "Cargo.lock")
+             | .Vulnerabilities[]?
+             | select(.Severity == "HIGH")
+             | .VulnerabilityID
+            ] | unique | .[]
+          ' /tmp/prod-vulns.json | grep -vxF -f /tmp/accepted-ids.txt || true)
+          if [ -n "$UNACCEPTED" ]; then
+            echo "::error::Unaccepted HIGH advisories in production deps:"
+            echo "$UNACCEPTED"
+            echo "::error::Either fix the vulnerable dep, or add a justified entry to $ACC_FILE."
+            exit 1
+          fi
+          echo "✓ no unaccepted HIGH production-deps vulns"
+
   lint-and-test-macos:
     name: Lint + test (macos-latest)
     runs-on: macos-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-08
+Auto-generated from all feature plans. Last updated: 2026-05-09
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -76,6 +76,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-08
 - N/A — purely emission-time identifier resolution. (087-fix-cargo-workspace-version)
 - Rust stable (workspace toolchain inherited from milestones 001–087; no nightly required for this user-space-only test-pinning work). + existing only — no new crates. The regression test (`mikebom-cli/tests/transitive_parity_cargo.rs`) already uses `serde_json` (parsing emitted SBOM JSON), `tracing`, `anyhow`, and the milestone-083 `transitive_parity_common` helper. **No additions to the dependency tree.** (088-cargo-procmacro-edges)
 - N/A — purely test infrastructure. The regression test runs against the milestone-083 audit fixture (`mikebom-cli/tests/fixtures/transitive_parity/cargo/`), which is unchanged. (088-cargo-procmacro-edges)
+- Rust stable (workspace toolchain inherited from milestones 001–088; no nightly required). + bumping `sigstore = "0.10"` → `sigstore = "0.11"` in `mikebom-cli/Cargo.toml:141`. **Dropping** `sigstore-trust-root-rustls-tls` from the feature list (eliminates the `tough` transitive). Existing features kept: `bundle`, `cosign-rustls-tls`, `fulcio-rustls-tls`. No new direct Cargo deps. The transitively-promoted `pem = "3"` and `x509-parser = "0.16"` direct deps may need bumps if sigstore 0.11's openidconnect 4.0 forces newer versions; verified during smoke-test. (089-bump-sigstore-vulns)
+- N/A — pure dep-bump milestone. No state, no persistence. (089-bump-sigstore-vulns)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -138,9 +140,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 089-bump-sigstore-vulns: Added Rust stable (workspace toolchain inherited from milestones 001–088; no nightly required). + bumping `sigstore = "0.10"` → `sigstore = "0.11"` in `mikebom-cli/Cargo.toml:141`. **Dropping** `sigstore-trust-root-rustls-tls` from the feature list (eliminates the `tough` transitive). Existing features kept: `bundle`, `cosign-rustls-tls`, `fulcio-rustls-tls`. No new direct Cargo deps. The transitively-promoted `pem = "3"` and `x509-parser = "0.16"` direct deps may need bumps if sigstore 0.11's openidconnect 4.0 forces newer versions; verified during smoke-test.
 - 088-cargo-procmacro-edges: Added Rust stable (workspace toolchain inherited from milestones 001–087; no nightly required for this user-space-only test-pinning work). + existing only — no new crates. The regression test (`mikebom-cli/tests/transitive_parity_cargo.rs`) already uses `serde_json` (parsing emitted SBOM JSON), `tracing`, `anyhow`, and the milestone-083 `transitive_parity_common` helper. **No additions to the dependency tree.**
 - 087-fix-cargo-workspace-version: Added Rust stable (workspace toolchain inherited from milestones 001–086; no nightly). + existing only — no new crates. The cargo dep-string parsing uses `str::split_whitespace` which we already have. The dual-key insert in `scan_fs/mod.rs` mirrors milestone 085's existing maven pattern.
-- 083-transitive-correctness: Added Rust stable (workspace toolchain inherited from milestones 001–082; no nightly). + Existing only — `serde`/`serde_json` (parsing emitted SBOM JSON), `tracing`, `anyhow`. The audit harness shells out to `trivy` and `syft` as external CLI tools (similar to milestone 078's `spdx3-validate` shell-out pattern). Source-format direct readers use existing per-ecosystem parsers in `mikebom-cli/src/scan_fs/package_db/` for tiebreaker comparisons (we don't re-implement; we re-invoke). For OS package managers, native tools (`dpkg-query`, `rpm`, `apk`) are shelled out. **No new Cargo dependencies.**
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,17 +190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,7 +220,7 @@ checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
 dependencies = [
  "assert_matches",
  "aya-obj",
- "bitflags 2.11.1",
+ "bitflags",
  "bytes",
  "libc",
  "log",
@@ -325,12 +314,6 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -358,16 +341,6 @@ name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
-
-[[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "bumpalo"
@@ -539,16 +512,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efcdb2972eb64230b4c50646d8498ff73f5128d196a90c7236eec4cbe8619b8f"
 dependencies = [
  "version_check",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -939,15 +902,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "enum-display-derive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +922,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1263,19 +1223,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "globset"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,25 +1231,6 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1316,7 +1244,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -1398,26 +1326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,23 +1346,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -1465,8 +1362,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1484,30 +1381,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -1516,9 +1389,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1530,32 +1403,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.9.0",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.38",
+ "rustls",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1568,14 +1427,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.9.0",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1780,15 +1639,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2087,17 +1937,11 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2188,11 +2032,11 @@ dependencies = [
  "libc",
  "mikebom-common",
  "object",
- "oci-spec",
+ "oci-spec 0.9.0",
  "pem",
  "quick-xml",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "rpm",
  "serde",
  "serde_json",
@@ -2456,16 +2300,16 @@ dependencies = [
 
 [[package]]
 name = "oauth2"
-version = "4.4.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
- "http 0.2.12",
+ "http",
  "rand 0.8.6",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -2495,7 +2339,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "objc2",
 ]
 
@@ -2512,21 +2356,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "oci-distribution"
-version = "0.11.0"
+name = "oci-client"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95a2c51531af0cb93761f66094044ca6ea879320bccd35ab747ff3fcab3f422"
+checksum = "474675fdc023fbcc9dcf4782e938a3a1ae5fd469c728d8db40599bd25c77e1ba"
 dependencies = [
  "bytes",
  "chrono",
  "futures-util",
- "http 1.4.0",
+ "http",
  "http-auth",
  "jwt",
  "lazy_static",
+ "oci-spec 0.7.1",
  "olpc-cjson",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -2534,6 +2379,22 @@ dependencies = [
  "tokio",
  "tracing",
  "unicase",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da406e58efe2eb5986a6139626d611ce426e5324a824133d76367c765cf0b882"
+dependencies = [
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2548,8 +2409,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "thiserror 2.0.18",
 ]
 
@@ -2593,16 +2454,16 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openidconnect"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47e80a9cfae4462dd29c41e987edd228971d6565553fbc14b8a11e666d91590"
+checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.7",
  "chrono",
  "dyn-clone",
  "ed25519-dalek",
  "hmac",
- "http 0.2.12",
+ "http",
  "itertools 0.10.5",
  "log",
  "oauth2",
@@ -2612,7 +2473,6 @@ dependencies = [
  "rsa",
  "serde",
  "serde-value",
- "serde_derive",
  "serde_json",
  "serde_path_to_error",
  "serde_plain",
@@ -2749,26 +2609,6 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.14.0",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2932,9 +2772,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2942,13 +2782,12 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "bytes",
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -2963,12 +2802,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2976,34 +2815,56 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.12.0"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057237efdb71cf4b3f9396302a3d6599a92fa94063ba537b66130980ea9909f3"
+checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "once_cell",
  "prost",
- "prost-reflect-derive",
+ "prost-reflect-derive 0.14.0",
  "prost-types",
  "serde",
  "serde-value",
 ]
 
 [[package]]
-name = "prost-reflect-build"
-version = "0.12.0"
+name = "prost-reflect"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d0aa0c82e0fc36214c77b4dabe00750b3c41be45055baf2631cbbb7769b8ca"
+checksum = "37587d5a8a1b3dc9863403d084fc2254b91ab75a702207098837950767e2260b"
+dependencies = [
+ "prost",
+ "prost-reflect-derive 0.15.1",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-reflect-build"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8db7191445b1dbee19df4f6b6294e5123aef52620b344a630bb845d302622a"
 dependencies = [
  "prost-build",
- "prost-reflect",
+ "prost-reflect 0.15.3",
 ]
 
 [[package]]
 name = "prost-reflect-derive"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172da1212c02be2c94901440cb27183cd92bff00ebacca5c323bf7520b8f9c04"
+checksum = "f4fce6b22f15cc8d8d400a2b98ad29202b33bd56c7d9ddd815bc803a807ecb65"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-reflect-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab076798900edeaf1499ed1c30097db86e6697c5d02660a63d72fe4ebdcfefd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3012,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
@@ -3040,8 +2901,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.38",
- "socket2 0.6.3",
+ "rustls",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3060,7 +2921,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3078,7 +2939,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3169,7 +3030,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -3178,7 +3039,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -3249,49 +3110,6 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-rustls 0.24.1",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
@@ -3301,11 +3119,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -3313,14 +3131,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3330,7 +3148,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3364,7 +3182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15d9bae82f8f242aa4018be1df5186efdf365c2e9b8de23e460407aeb3cb7f1"
 dependencies = [
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags",
  "digest",
  "enum-display-derive",
  "enum-primitive-derive",
@@ -3429,40 +3247,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
 ]
 
 [[package]]
@@ -3474,18 +3267,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -3496,16 +3280,6 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -3521,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3606,16 +3380,6 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -3856,9 +3620,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d91d4a47a41b1bd378a6be69cbe32fc5473be6dfe900afed7a833b6c556142b"
+checksum = "9958ac57dea620d4059784dc0df9f997a873a168828d1028c5c7b9d7a089f5f2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3872,12 +3636,11 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "futures",
- "futures-util",
  "getrandom 0.2.17",
  "hex",
  "json-syntax",
  "lazy_static",
- "oci-distribution",
+ "oci-client",
  "olpc-cjson",
  "openidconnect",
  "p256",
@@ -3887,8 +3650,7 @@ dependencies = [
  "pkcs8",
  "rand 0.8.6",
  "regex",
- "reqwest 0.11.27",
- "reqwest 0.12.28",
+ "reqwest",
  "ring",
  "rsa",
  "rustls-webpki 0.102.8",
@@ -3900,11 +3662,10 @@ dependencies = [
  "sha2",
  "signature",
  "sigstore_protobuf_specs",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tls_codec",
  "tokio",
  "tokio-util",
- "tough",
  "tracing",
  "url",
  "webbrowser",
@@ -3924,15 +3685,15 @@ dependencies = [
 
 [[package]]
 name = "sigstore_protobuf_specs"
-version = "0.3.7"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d18b16bf8b6628bd34c2cd915476ff2a707b4e288995f3d675668c48c4a73d7"
+checksum = "799e5ed827a6d8d2be7fc598515d061b59d85f496d7066152822a80f3250af74"
 dependencies = [
  "anyhow",
  "glob",
  "prost",
  "prost-build",
- "prost-reflect",
+ "prost-reflect 0.14.7",
  "prost-reflect-build",
  "prost-types",
  "serde",
@@ -3986,39 +3747,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "snafu"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
-dependencies = [
- "futures-core",
- "pin-project",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4067,9 +3795,28 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "strum_macros"
@@ -4113,12 +3860,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -4135,27 +3876,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -4178,7 +3898,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -4320,7 +4040,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4338,21 +4058,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.38",
+ "rustls",
  "tokio",
 ]
 
@@ -4411,40 +4121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
-name = "tough"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a11e87698820a64152f36682e12017944619631d1a4881aaad532cbd843d5dc"
-dependencies = [
- "async-recursion",
- "async-trait",
- "bytes",
- "chrono",
- "dyn-clone",
- "futures",
- "futures-core",
- "globset",
- "hex",
- "log",
- "olpc-cjson",
- "pem",
- "percent-encoding",
- "reqwest 0.11.27",
- "ring",
- "serde",
- "serde_json",
- "serde_plain",
- "snafu",
- "tempfile",
- "tokio",
- "tokio-util",
- "typed-path",
- "untrusted",
- "url",
- "walkdir",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4453,7 +4129,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4465,11 +4141,11 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -4556,12 +4232,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "typed-path"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82205ffd44a9697e34fc145491aa47310f9871540bb7909eaa9365e0a9a46607"
 
 [[package]]
 name = "typenum"
@@ -4833,7 +4503,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -4865,7 +4535,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "jni",
  "log",
  "ndk-context",
@@ -4874,12 +4544,6 @@ dependencies = [
  "url",
  "web-sys",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
@@ -4892,13 +4556,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "6.0.3"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
- "home",
- "rustix 0.38.44",
+ "env_home",
+ "rustix",
  "winsafe",
 ]
 
@@ -4972,15 +4636,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5004,21 +4659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5056,12 +4696,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5074,12 +4708,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5089,12 +4717,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5122,12 +4744,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5137,12 +4753,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5158,12 +4768,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5173,12 +4777,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5202,16 +4800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5227,9 +4815,9 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http 1.4.0",
+ "http",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "log",
  "once_cell",
@@ -5298,7 +4886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -5372,7 +4960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]

--- a/mikebom-cli/Cargo.toml
+++ b/mikebom-cli/Cargo.toml
@@ -134,11 +134,14 @@ zip = { version = "0.6", default-features = false, features = ["deflate-miniz"] 
 rpm = { version = "0.22", default-features = false, features = [] }
 
 # Feature 006 — SBOMit compliance: DSSE envelope signing + Fulcio keyless +
-# Rekor transparency log. Pin to 0.10.x because 0.13+ forces aws-lc-rs via
+# Rekor transparency log. Pin to 0.11.x because 0.12+ forces aws-lc-rs via
 # the `cert` feature, violating Constitution Principle I (pure Rust, zero C).
-# rustls-tls variants chosen to match existing reqwest rustls posture. See
-# specs/006-sbomit-suite/research.md R1 for the audit.
-sigstore = { version = "0.10", default-features = false, features = ["sigstore-trust-root-rustls-tls", "cosign-rustls-tls", "fulcio-rustls-tls", "rekor-rustls-tls", "bundle"] }
+# rustls-tls variants chosen to match existing reqwest rustls posture.
+# `sigstore-trust-root-*` features dropped in milestone 089 — mikebom doesn't
+# use sigstore's TUF client, and the feature dragged in the vulnerable
+# `tough` transitive (see specs/089-bump-sigstore-vulns/research.md §2).
+# See specs/006-sbomit-suite/research.md R1 for the original audit.
+sigstore = { version = "0.11", default-features = false, features = ["cosign-rustls-tls", "fulcio-rustls-tls", "rekor-rustls-tls", "bundle"] }
 # Feature 006 — PEM + X.509 parsing for cert SAN + SPKI extraction in
 # `mikebom sbom verify`. Transitive deps of sigstore, promoted to direct
 # for re-use.

--- a/specs/006-sbomit-suite/research.md
+++ b/specs/006-sbomit-suite/research.md
@@ -48,6 +48,17 @@ sigstore = { version = "0.10", default-features = false, features =
 (Exact feature names TBD during implementation; the principle is
 "rustls, no native-tls, no openssl-sys".)
 
+**Update — milestone 089 (2026-05-09)**: the dep was bumped from `0.10`
+to `0.11`, and the `sigstore-trust-root-rustls-tls` feature was dropped
+because mikebom doesn't use sigstore's TUF client (the feature dragged
+in the vulnerable `tough` transitive). The aws-lc-rs version cliff is
+**0.12+**, not 0.13+ as previously documented at
+`mikebom-cli/Cargo.toml:137-138` — corrected in milestone 089. See
+`specs/089-bump-sigstore-vulns/research.md §1` for the corrected feature-
+flag audit, and `specs/089-bump-sigstore-vulns/known-acceptances.md`
+for residual rustls-webpki advisories that await an upstream sigstore
+bump from `rustls-webpki = "0.102"` to `0.103`.
+
 **Alternatives considered**:
 - **Hand-rolled DSSE + ed25519 via `ed25519-dalek`**: would avoid the
   larger `sigstore` dep, but loses Fulcio/Rekor for free. We'd have to

--- a/specs/088-cargo-procmacro-edges/tasks.md
+++ b/specs/088-cargo-procmacro-edges/tasks.md
@@ -44,8 +44,8 @@ Repository-relative paths from `/Users/mlieberman/Projects/mikebom/`:
 
 - [X] T005 [US2] Edit `specs/083-transitive-correctness/research.md §8 — Ecosystem: cargo` per quickstart Recipe 3, change 1: strikethrough gap #2's original observation, append the "Closed by milestone 087" annotation block (root-cause one-liner + reference to `transitive_parity_cargo.rs::EXPECTED_REPRESENTATIVE_EDGES` as the lock-down test). Mirrors gap #1's existing closure annotation. Verifies VR-088-005. **Also**: updated the "Tiebreaker resolution" + "Follow-up disposition" lines that referenced gap #2 as open.
 - [X] T006 [US2] Edit `specs/083-transitive-correctness/research.md` "Filed follow-up issues" footer per quickstart Recipe 3, change 2: append `. **Closed by milestone 087.**` to the `#173 — cargo: proc-macro crates emit zero outgoing edges (clap_derive case)` row. Mirrors how #172 is annotated. Verifies VR-088-006.
-- [ ] T007 [US2] Open the PR with `Closes #173` in the body so GitHub auto-closes issue #173 on merge. Verifies VR-088-007. **(deferred to commit step)**
-- [ ] T008 [US2] Post-merge: run `gh issue view 173` and confirm state is `closed`. Optional follow-up: post a closure comment on #173 linking PR #180 (milestone 087 root-cause fix) + this milestone's PR. Verifies VR-088-008. **(deferred to post-merge)**
+- [X] T007 [US2] Open the PR with `Closes #173` in the body so GitHub auto-closes issue #173 on merge. Verifies VR-088-007. **Result**: PR #182 opened with `Closes #173` in body.
+- [X] T008 [US2] Post-merge: run `gh issue view 173` and confirm state is `closed`. Verifies VR-088-008. **Result**: state=CLOSED, closedAt=2026-05-09T12:17:21Z, closedByPullRequestsReferences=#182, stateReason=COMPLETED.
 
 ## Phase 4: Polish
 

--- a/specs/089-bump-sigstore-vulns/checklists/requirements.md
+++ b/specs/089-bump-sigstore-vulns/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Clear sigstore-bundle transitive vulnerabilities
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs) — frames the goal as "operators see zero HIGH vulns" not "bump sigstore to X.Y.Z". Sigstore versions are referenced as Background context, not as a prescribed implementation.
+- [X] Focused on user value and business needs — operator-visible vuln count + maintainer-visible test green status are the primary success criteria.
+- [X] Written for non-technical stakeholders — intro explains TUF/CVE context plainly; the constitution-conflict constraint is described in business terms (security update vs. supply-chain integrity guarantee).
+- [X] All mandatory sections completed — User Scenarios & Testing, Requirements, Success Criteria, Assumptions, Dependencies, Out of Scope.
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain — the constitution-conflict edge case is captured as plan-level scope, not a spec-level clarification (multiple resolution paths are reasonable).
+- [X] Requirements are testable and unambiguous — each FR has a concrete pass/fail check.
+- [X] Success criteria are measurable — SC-001 through SC-005 are quantitative or pass/fail-binary.
+- [X] Success criteria are technology-agnostic — SC-001 frames as "operators see zero HIGH advisories"; SC-004 is technology-NEUTRAL on the scanner choice.
+- [X] All acceptance scenarios are defined — US1 has 2, US2 has 1, US3 has 3.
+- [X] Edge cases are identified — 4 edge cases listed (sigstore 0.11/0.12 aws-lc-rs status, oci-distribution co-attribution, sigstore API breakage, golden stability).
+- [X] Scope is clearly bounded — Out of Scope section explicit (test fixtures, new features, refactoring beyond migration, library replacement).
+- [X] Dependencies and assumptions identified — Assumptions + Dependencies sections both populated.
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria — FR-001/FR-002 ↔ US1/US2 acceptance scenarios; FR-003 ↔ SC-004; FR-005/FR-006 ↔ US3 acceptance scenarios; FR-004/FR-007/FR-008 each have a concrete pass/fail check.
+- [X] User scenarios cover primary flows — US1 (vuln-scanner clean run, P1) + US2 (MEDIUM/LOW noise, P2) + US3 (no functional regression, P1).
+- [X] Feature meets measurable outcomes defined in Success Criteria — yes.
+- [X] No implementation details leak into specification — sigstore version targets appear only in Background and Assumptions (as factual reference), never as prescribed FRs.
+
+## Notes
+
+All 16 checklist items pass. Spec is ready for `/speckit.clarify` (recommended given Constitution Principle I conflict surfaced) or `/speckit.plan`.

--- a/specs/089-bump-sigstore-vulns/contracts/sigstore-feature-set.md
+++ b/specs/089-bump-sigstore-vulns/contracts/sigstore-feature-set.md
@@ -1,0 +1,130 @@
+# Contract — milestone 089 sigstore feature set + CI vuln gate
+
+The milestone's two contracts: (1) the new sigstore version + feature set + the constitution-compatibility claim, and (2) the production-deps trivy CI gate behavior.
+
+## CLI surface
+
+**No new operator-facing CLI flags.** This is a transitive-dep cleanup milestone. `mikebom sbom verify`, `mikebom attestation sign|verify` keep their existing flag sets and behaviors.
+
+## Library surface (`mikebom-cli` crate)
+
+**No new public Rust API.** No internal API changes either. The byte-identical `sigstore::crypto::*` API surface between 0.10.0 and 0.11.0 (verified by file diff) means the existing imports at `attestation/{verifier,signer,serializer}.rs` resolve identically post-bump.
+
+## Sigstore version + feature set contract
+
+`mikebom-cli/Cargo.toml:141` MUST be:
+
+```toml
+sigstore = { version = "0.11", default-features = false, features = ["cosign-rustls-tls", "fulcio-rustls-tls", "rekor-rustls-tls", "bundle"] }
+```
+
+NOT:
+- `version = "0.12"` or higher (0.12+ forces aws-lc-rs).
+- Any feature list that includes `sigstore-trust-root-*`, `cert`, `*-native-tls`, or omits `default-features = false`.
+
+The pin comment at `mikebom-cli/Cargo.toml:137-138` MUST be updated per data-model.md VR-089-012 through VR-089-014.
+
+This contract is enforced by VR-089-001 + VR-089-002 + VR-089-003 + VR-089-006 + VR-089-012 + VR-089-013 + VR-089-014.
+
+## Production-deps trivy CI gate contract
+
+`.github/workflows/ci.yml` MUST contain a job step (or new job) that runs:
+
+```bash
+trivy --quiet fs \
+  --scanners vuln \
+  --skip-dirs tests/fixtures \
+  --skip-dirs mikebom-cli/tests/fixtures \
+  --skip-dirs target \
+  --severity HIGH \
+  --exit-code 1 \
+  --format json \
+  --output /tmp/prod-vulns.json \
+  .
+```
+
+And then post-process the JSON to:
+1. Filter to `target == "Cargo.lock"` entries only.
+2. Filter to `Severity == "HIGH"`.
+3. Cross-check each remaining entry against `specs/089-bump-sigstore-vulns/known-acceptances.md` IDs.
+4. Fail the lane (exit non-zero) if any HIGH entry is NOT on the acceptance list.
+
+This contract is enforced by FR-007 + VR-089-010 + VR-089-011.
+
+**Test fixtures stay excluded via path-skip**, NOT via allow-listing. Operators investigating fixture vulns can run trivy without `--skip-dirs` for visibility, but CI gates only on production deps.
+
+## CVE-acceptance list contract
+
+`specs/089-bump-sigstore-vulns/known-acceptances.md` (created if and only if residual vulns remain post-fix) MUST follow the schema documented in data-model.md "CVE-acceptance list" entity. Each accepted advisory:
+
+- Cites a CVE/GHSA ID.
+- Names the affected crate + version.
+- Records severity.
+- Explains why the vuln is unexploitable in mikebom's use case (REQUIRED — vague justifications like "low impact" don't count).
+- Links to an upstream issue or PR where the fix is being driven (REQUIRED — acceptances without a tracked path aren't allowed).
+- Sets a re-review date (typically 6 months out).
+
+This contract is enforced by VR-089-010 + VR-089-011.
+
+## Per-format scope contract
+
+| Format | Affected? | Verification |
+|---|---|---|
+| **CDX 1.6** (all 9 ecosystems) | NO — sigstore is verify-side, not emit-side | All 9 cdx goldens byte-identical |
+| **SPDX 2.3** (all 9 ecosystems) | NO — same | All 9 spdx goldens byte-identical |
+| **SPDX 3** (all 9 ecosystems) | NO — same | All 9 spdx3 goldens byte-identical |
+
+This is a transitive-dep cleanup milestone. ZERO golden regenerations. If goldens regenerate, scope has crept and the PR must be narrowed.
+
+## Test invocation contract
+
+```bash
+# Confirm sigstore bump compiles cleanly:
+cargo +stable build --workspace
+# Expected: success.
+
+# Confirm attestation tests pass with byte-identical assertions:
+cargo +stable test -p mikebom attestation
+# Expected: every existing attestation test passes; zero deletions; zero assertion weakenings.
+
+# Confirm goldens stay byte-identical:
+git status --short mikebom-cli/tests/fixtures/golden/
+# Expected: empty output.
+
+# Confirm tough is gone from the dep graph:
+! grep -q '^name = "tough"' Cargo.lock
+# Expected: exit 0 (tough absent).
+
+# Confirm no aws-lc:
+! grep -qE '^name = "aws-lc-(rs|sys)"' Cargo.lock
+# Expected: exit 0.
+
+# Confirm sigstore is at 0.11:
+grep -A1 '^name = "sigstore"' Cargo.lock | head -2
+# Expected: version = "0.11.x" (any patch).
+
+# Run production-deps trivy scan:
+trivy --quiet fs --scanners vuln \
+  --skip-dirs tests/fixtures \
+  --skip-dirs mikebom-cli/tests/fixtures \
+  --skip-dirs target \
+  --format json --output /tmp/post-089.json .
+# Expected: zero HIGH advisories under target=Cargo.lock NOT on known-acceptances.md.
+
+# Standard pre-PR gate:
+./scripts/pre-pr.sh
+# Expected: zero clippy warnings, every test suite reports `0 failed`.
+```
+
+## Performance contract
+
+- Build wall-time: within ±10% of pre-089 baseline. The dep graph SHRINKS post-089 (fewer transitive crates due to `tough` drop), so cold builds may speed up slightly.
+- Test wall-time: identical (no test changes).
+- Trivy production-deps scan: ≤30 s on standard developer hardware (matches pre-089 wall-time observed during the initial vuln audit).
+
+## Backward-compatibility contract
+
+- Operators of `mikebom sbom verify` against Cosign-signed bundles see zero behavior change. Pre-089 verify-pass bundles still verify post-089; pre-089 verify-fail bundles still fail post-089 with the same `FailureMode` exit codes.
+- Operators of `mikebom attestation sign|verify` see zero behavior change. The `SigStoreSigner`, `SigStoreKeyPair`, `SigningScheme` types are byte-identical between sigstore 0.10.0 and 0.11.0 — signing produces identical envelopes for identical inputs (modulo intentional non-determinism like nonces).
+- Operators using TUF-rooted Cosign trust-root verification flows are NOT supported pre-089 OR post-089 (mikebom never exercised that code path; the feature drop is removing dead transitive weight, not removing functionality).
+- The trivy CI gate is a NEW gate, not a modification of existing CI behavior. PRs that introduce HIGH vulns in production deps will fail CI; PRs that don't are unaffected.

--- a/specs/089-bump-sigstore-vulns/data-model.md
+++ b/specs/089-bump-sigstore-vulns/data-model.md
@@ -1,0 +1,98 @@
+# Data Model — milestone 089 sigstore vuln-bump
+
+This is a dep-bump milestone with no new domain types and no SBOM-emission impact. The "model" is the workspace dependency graph + the residual-vuln acceptance list.
+
+## Entities
+
+### Sigstore feature set (declared in `mikebom-cli/Cargo.toml:141`)
+
+The set of cargo features mikebom enables on its `sigstore` direct dep. Constrains which sigstore optional deps end up in `Cargo.lock`.
+
+**Pre-089 state** (5 features):
+- `sigstore-trust-root-rustls-tls`
+- `cosign-rustls-tls`
+- `fulcio-rustls-tls`
+- `rekor-rustls-tls`
+- `bundle`
+
+**Post-089 state** (4 features):
+- `cosign-rustls-tls`
+- `fulcio-rustls-tls`
+- `rekor-rustls-tls`
+- `bundle`
+
+**Validation rules**:
+- VR-089-001: post-089 `Cargo.toml` MUST drop `sigstore-trust-root-rustls-tls`.
+- VR-089-002: post-089 `Cargo.toml` MUST keep all 4 of `cosign-rustls-tls`, `fulcio-rustls-tls`, `rekor-rustls-tls`, `bundle` (removing any of these would break `mikebom sbom verify` / `mikebom attestation sign|verify`).
+- VR-089-003: post-089 `Cargo.toml` MUST NOT add any sigstore feature containing `cert` standalone, `*-native-tls`, or `default` — these would either (a) drag in C deps via aws-lc-rs in a future minor bump, or (b) reverse the rustls-only posture documented in milestone 006's R1 audit.
+
+### Workspace `Cargo.lock`
+
+Auto-regenerated when `Cargo.toml` changes. The post-089 graph MUST satisfy:
+
+**Validation rules**:
+- VR-089-004: post-089 `Cargo.lock` MUST NOT contain any entry for `tough` (any version). Verified by `! grep -q '^name = "tough"' Cargo.lock`.
+- VR-089-005: post-089 `Cargo.lock` MUST NOT contain any entry for `aws-lc-rs` or `aws-lc-sys`. Verified by `! grep -qE '^name = "aws-lc-(rs|sys)"' Cargo.lock`.
+- VR-089-006: post-089 `Cargo.lock` MUST contain `sigstore = "0.11.0"` (or any 0.11.x patch).
+- VR-089-007: post-089 `Cargo.lock` MAY contain `rustls-webpki = "0.102.x"` entries — these are residual vulns documented in `known-acceptances.md`. The trivy CI gate fails ONLY on NEW HIGH advisories, not existing accepted ones.
+
+### Sigstore API call sites (`mikebom-cli/src/attestation/`)
+
+The set of mikebom source files that import from `sigstore::*`.
+
+**Pre-089 inventory** (verified by grep):
+- `verifier.rs:18` — `use sigstore::crypto::{...};`
+- `verifier.rs:614, 615` — `use sigstore::crypto::signing_key::SigStoreSigner; use sigstore::crypto::SigningScheme;`
+- `serializer.rs:122` — `let scheme = sigstore::crypto::SigningScheme::ECDSA_P256_SHA256_ASN1;`
+- `signer.rs:17` — `use sigstore::crypto::signing_key::{SigStoreKeyPair, SigStoreSigner};`
+- `signer.rs:18` — `use sigstore::crypto::SigningScheme;`
+
+**Validation rules**:
+- VR-089-008: each pre-089 import path MUST resolve identically post-089 (`use sigstore::crypto::{...}` → same module + same exported symbol). Verified by successful `cargo build`.
+- VR-089-009: zero new `use sigstore::*` imports added by this milestone (Out-of-Scope: not refactoring).
+
+### CVE-acceptance list (`specs/089-bump-sigstore-vulns/known-acceptances.md`)
+
+Maintainer-curated list of advisories that remain flagged post-089 with documented justifications. Created if and only if residual vulns exist post-fix.
+
+**Schema** (per entry):
+- `id`: CVE ID or GHSA ID.
+- `crate`: name + version of affected dep.
+- `severity`: HIGH / MEDIUM / LOW.
+- `mikebom_exposure`: prose describing why the vuln is unexploitable in mikebom's use case (e.g., "does not process attacker-controlled CRLs").
+- `upstream_tracking`: link to the sigstore (or other upstream) issue/PR where the fix is being driven, with status.
+- `re_review_date`: target date for re-evaluating the acceptance (e.g., 6 months out).
+
+**Validation rules**:
+- VR-089-010: every advisory listed under `target == "Cargo.lock"` in the post-089 trivy output MUST have a corresponding entry in `known-acceptances.md`, OR be a NEW HIGH not yet seen pre-089 (which would fail CI per FR-007).
+- VR-089-011: each entry MUST cite a tracked-resolution path (upstream issue link). Acceptances with no resolution path are not allowed.
+
+### Pin comment (`mikebom-cli/Cargo.toml:137-138`)
+
+The maintainer-facing audit comment explaining why sigstore is pinned to a specific minor version.
+
+**Pre-089 text**:
+```text
+# Feature 006 — SBOMit compliance: DSSE envelope signing + Fulcio keyless +
+# Rekor transparency log. Pin to 0.10.x because 0.13+ forces aws-lc-rs via
+# the `cert` feature, violating Constitution Principle I (pure Rust, zero C).
+# rustls-tls variants chosen to match existing reqwest rustls posture. See
+# specs/006-sbomit-suite/research.md R1 for the audit.
+```
+
+**Post-089 text** (corrects the version threshold + reflects the feature drop):
+```text
+# Feature 006 — SBOMit compliance: DSSE envelope signing + Fulcio keyless +
+# Rekor transparency log. Pin to 0.11.x because 0.12+ forces aws-lc-rs via
+# the `cert` feature, violating Constitution Principle I (pure Rust, zero C).
+# rustls-tls variants chosen to match existing reqwest rustls posture.
+# `sigstore-trust-root-*` features dropped in milestone 089 — mikebom doesn't
+# use sigstore's TUF client, and the feature dragged in the vulnerable
+# `tough` transitive (see specs/089-bump-sigstore-vulns/research.md §2).
+# See specs/006-sbomit-suite/research.md R1 for the original audit.
+```
+
+**Validation rules**:
+- VR-089-012: post-089 comment MUST cite "0.12+ forces aws-lc-rs" (the corrected version cliff per research §1).
+- VR-089-013: post-089 comment MUST mention milestone 089 + the `tough` feature drop rationale.
+- VR-089-014: post-089 comment MUST preserve the "rustls-tls variants chosen" sentence + the milestone-006 R1 audit reference (continuity with prior maintainer decision-making).

--- a/specs/089-bump-sigstore-vulns/known-acceptances.md
+++ b/specs/089-bump-sigstore-vulns/known-acceptances.md
@@ -1,0 +1,66 @@
+# Known CVE Acceptances — milestone 089
+
+This file documents transitive vulnerabilities that remain in mikebom's production dep closure post-milestone-089 with maintainer-curated justifications. Per spec FR-001 / FR-002's OR clause, each entry represents a deliberately-unfixed advisory with a tracked-resolution path.
+
+The CI gate at `.github/workflows/ci.yml` (added in milestone 089) reads this file at lane time: any HIGH-severity advisory under target `Cargo.lock` not listed here fails CI.
+
+**Last reviewed**: 2026-05-09
+**Re-review cadence**: every 6 months OR when sigstore upstream cuts a new minor version.
+
+## Common context
+
+All four entries below have the same root cause: **sigstore 0.11.0's `Cargo.toml` declares `rustls-webpki = "0.102"` as a non-optional direct dep**. The semver-compatible `0.102.x` patch line has no security-fix release for any of these advisories — fixes are only available in `0.103.x` (a major-version bump for the rustls-webpki crate). Sigstore upstream needs to bump its own `rustls-webpki` requirement, which is tracked at:
+
+- **Upstream tracking**: file an issue at <https://github.com/sigstore/sigstore-rs/issues> requesting a bump to `rustls-webpki = "0.103"`. (Filed: TODO post-merge of milestone 089's PR.)
+
+mikebom cannot safely `[patch.crates-io]` rustls-webpki@0.102 → 0.103 because 0.103 is a major-version-incompatible API change for rustls-webpki, and sigstore's webpki call sites would need migration alongside.
+
+---
+
+## GHSA-82j2-j2ch-gfr8 — rustls-webpki: Denial of service via panic on malformed CRL BIT STRING
+
+- **id**: GHSA-82j2-j2ch-gfr8
+- **crate**: `rustls-webpki@0.102.8`
+- **severity**: HIGH
+- **mikebom_exposure**: mikebom does not consume attacker-controlled Certificate Revocation Lists (CRLs). The `mikebom sbom verify` flow uses Cosign keyless verification (Fulcio + Rekor), not CRL-based revocation. Sigstore's webpki usage is internal to TLS handshake validation against trusted public roots. The DoS panic requires a malformed CRL `BIT STRING` input, which mikebom does not parse from any external source. **Materially unexploitable** in mikebom's threat model.
+- **upstream_tracking**: <https://github.com/sigstore/sigstore-rs/issues> (sigstore-rs needs to bump `rustls-webpki` from 0.102 → 0.103, picking up the fix in 0.103.13).
+- **re_review_date**: 2026-11-09
+
+## GHSA-pwjx-qhcg-rvj4 — webpki: CRLs not considered authoritative by Distribution Point due to faulty matching logic
+
+- **id**: GHSA-pwjx-qhcg-rvj4
+- **crate**: `rustls-webpki@0.102.8`
+- **severity**: MEDIUM
+- **mikebom_exposure**: Same root cause as GHSA-82j2-j2ch-gfr8. mikebom does not configure or consume CRL Distribution Points; the `mikebom sbom verify` flow does not perform CRL-based revocation checks. The advisory describes a logic error in CRL Distribution Point matching that affects relying parties who DO use CRL-based revocation, which mikebom does not. **Materially unexploitable** in mikebom's threat model.
+- **upstream_tracking**: <https://github.com/sigstore/sigstore-rs/issues> (same bump path as GHSA-82j2-j2ch-gfr8).
+- **re_review_date**: 2026-11-09
+
+## GHSA-965h-392x-2mh5 — webpki: Name constraints for URI names were incorrectly accepted
+
+- **id**: GHSA-965h-392x-2mh5
+- **crate**: `rustls-webpki@0.102.8`
+- **severity**: LOW
+- **mikebom_exposure**: The advisory affects relying parties who validate X.509 cert chains containing `nameConstraints` extensions with URI-typed `GeneralName` constraints. mikebom's verify path uses Fulcio's standard cert chain (no URI-typed name constraints in the deployed Fulcio root) and operates against Sigstore's public good instance. The vulnerability requires a crafted certificate chain with URI name constraints to be presented during validation, which mikebom does not encounter in normal operation. **Theoretical attack only**; not exploitable in mikebom's threat model.
+- **upstream_tracking**: <https://github.com/sigstore/sigstore-rs/issues> (same bump path).
+- **re_review_date**: 2026-11-09
+
+## GHSA-xgp8-3hg3-c2mh — webpki: Name constraints were accepted for certificates asserting a wildcard name
+
+- **id**: GHSA-xgp8-3hg3-c2mh
+- **crate**: `rustls-webpki@0.102.8`
+- **severity**: LOW
+- **mikebom_exposure**: Same root cause as GHSA-965h-392x-2mh5 — affects relying parties validating X.509 cert chains with name constraints + wildcard SANs. mikebom's verify path operates against Fulcio's standard cert chain, not arbitrary cert chains with custom name-constraint configurations. **Theoretical attack only**; not exploitable in mikebom's threat model.
+- **upstream_tracking**: <https://github.com/sigstore/sigstore-rs/issues> (same bump path).
+- **re_review_date**: 2026-11-09
+
+---
+
+## Closed by milestone 089 (no longer in residual list)
+
+For audit-trail purposes, these advisories were eliminated by milestone 089's combined `sigstore 0.10 → 0.11` bump + `sigstore-trust-root-rustls-tls` feature drop + opportunistic `rustls-webpki@0.103.12 → 0.103.13` patch update:
+
+- ✅ `tough@0.18.0` — CVE-2026-6966 (HIGH), CVE-2026-6967 (HIGH), CVE-2025-2885 (MED), CVE-2025-2886 (MED), CVE-2025-2887 (MED), CVE-2025-2888 (MED), GHSA-j8x2-777p-23fc (LOW). Eliminated entirely by dropping the `sigstore-trust-root-rustls-tls` feature; mikebom never used sigstore's TUF client.
+- ✅ `rustls-webpki@0.101.7` — GHSA-82j2-j2ch-gfr8 (HIGH), GHSA-965h-392x-2mh5 (LOW), GHSA-xgp8-3hg3-c2mh (LOW). Eliminated by the openidconnect 3.5 → 4.0 modernization that came with the sigstore 0.11 bump (replaces the old reqwest 0.11 → rustls 0.21 → rustls-webpki 0.101.7 transitive stack with reqwest 0.12 → rustls 0.23 → rustls-webpki 0.103).
+- ✅ `rustls-webpki@0.103.12` — GHSA-82j2-j2ch-gfr8 (HIGH). Eliminated by `cargo update -p rustls-webpki@0.103.12 → 0.103.13` patch bump (no semver-incompat change required; just took the fix from the active 0.103 line).
+
+**Total**: 11 of the 15 pre-089 advisories eliminated. 4 residual (1 HIGH, 1 MED, 2 LOW) all rooted at sigstore's own `rustls-webpki = "0.102"` dep, awaiting the upstream bump.

--- a/specs/089-bump-sigstore-vulns/plan.md
+++ b/specs/089-bump-sigstore-vulns/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: Clear sigstore-bundle transitive vulnerabilities
+
+**Branch**: `089-bump-sigstore-vulns` | **Date**: 2026-05-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/089-bump-sigstore-vulns/spec.md`
+
+## Summary
+
+Phase 0 research turned up a much smaller scope than the spec's worst-case. Two findings drive the plan:
+
+1. **The aws-lc-rs requirement was introduced in sigstore 0.12, not 0.13** as the existing pin comment claims. Sigstore **0.11.0** keeps `cert = []` (empty feature, no aws-lc-rs). Bumping `sigstore@0.10 → 0.11` is constitution-compatible.
+2. **The `tough` dep is `optional = true` in both 0.10 and 0.11**, gated entirely behind the `sigstore-trust-root` feature. mikebom doesn't use sigstore's TUF client (the `TrustRootInvalid` enum at `attestation/verifier.rs:80` is mikebom's own, not sigstore's). **Dropping `sigstore-trust-root-rustls-tls` from mikebom's feature set eliminates `tough` entirely** — kills 6 of the 15 vulns (4 MED + 1 HIGH-pair + 1 LOW).
+
+The bump 0.10 → 0.11 also brings `openidconnect 3.5 → 4.0` which modernizes the reqwest/rustls/rustls-webpki transitive stack — likely clearing the `rustls-webpki@0.101.7` entries (3 LOWs + 1 HIGH co-attribution path).
+
+API surface impact: **zero**. Diff of `sigstore/src/crypto/signing_key/mod.rs` and `sigstore/src/crypto/mod.rs` between 0.10.0 and 0.11.0 is empty bytes. The `SigStoreSigner`, `SigStoreKeyPair`, `SigningScheme` types mikebom uses (verified by grep across `attestation/{verifier,signer,serializer}.rs`) are byte-identical between versions.
+
+Expected post-fix residual vulns: 1–4 entries in `rustls-webpki@0.102.x` from sigstore's own non-optional `rustls-webpki = "0.102"` direct dep. The fix is in `rustls-webpki@0.103.13`, which sigstore upstream has not yet bumped to. mikebom doesn't process attacker-controlled CRLs or unusual cert-chain name constraints, so these are materially unexploitable in mikebom's use case. They'll be documented in `known-acceptances.md` per FR-001's OR clause, with an upstream-tracking link to a sigstore GitHub issue.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–088; no nightly required).
+**Primary Dependencies**: bumping `sigstore = "0.10"` → `sigstore = "0.11"` in `mikebom-cli/Cargo.toml:141`. **Dropping** `sigstore-trust-root-rustls-tls` from the feature list (eliminates the `tough` transitive). Existing features kept: `bundle`, `cosign-rustls-tls`, `fulcio-rustls-tls`. No new direct Cargo deps. The transitively-promoted `pem = "3"` and `x509-parser = "0.16"` direct deps may need bumps if sigstore 0.11's openidconnect 4.0 forces newer versions; verified during smoke-test.
+**Storage**: N/A — pure dep-bump milestone. No state, no persistence.
+**Testing**: existing test suite. The `mikebom-cli/src/attestation/*` tests + `mikebom-cli/tests/*attestation*.rs` integration tests form the regression net for FR-005 + FR-006.
+**Target Platform**: All platforms supported by mikebom (Linux, macOS).
+**Project Type**: Single project — Rust workspace dep-bump + minor Cargo.toml feature-set edit.
+**Performance Goals**: Build wall-time stays within ±10% of pre-089 baseline (no new heavy crypto deps; just a minor sigstore version bump). Trivy production-deps scan stays ≤30 s (SC-005).
+**Constraints**: Constitution Principle I (Pure Rust, Zero C) — non-negotiable. Constitution Principle V (no `mikebom:*` properties without audit) — N/A for this milestone. The CVE-acceptance list (if any) is internal documentation, not SBOM-emitted metadata.
+**Scale/Scope**: ~5 LOC of `Cargo.toml` edits + ~0–10 LOC of attestation-module API migration (likely zero based on byte-identical mod files) + 1 new doc file (`known-acceptances.md`) + 1 CI-workflow addition for production-deps trivy gate (FR-007) + audit-comment update at `Cargo.toml:137-138` + spec-doc updates. ~50 LOC total diff target.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| I. Pure Rust, Zero C | ✅ PASS | sigstore 0.11.0 keeps `cert = []` (empty feature, no aws-lc-rs). Verified by inspecting `sigstore-0.11.0/Cargo.toml` `[features]` block. The 0.12+ aws-lc-rs requirement is the upper bound, NOT 0.13 as the existing pin comment incorrectly states (will be corrected per FR-004). |
+| II. eBPF-Only Observation | ✅ PASS | Not applicable — sigstore is a verify-side library, no discovery code path. |
+| III. Fail Closed | ✅ PASS | No change to scan-failure semantics. Existing `attestation/verifier.rs::FailureMode` enum (including `TrustRootInvalid`) preserved. |
+| IV. Type-Driven Correctness | ✅ PASS | The newtype-bounded crypto types (`SigStoreSigner`, `SigStoreKeyPair`, `SigningScheme`) are byte-identical between sigstore 0.10 and 0.11. No `String`-typed regressions. No new `.unwrap()` in production code. |
+| V. Specification Compliance | ✅ PASS | No SBOM-emission code path changes. CycloneDX/SPDX 2.3/SPDX 3 outputs unaffected. |
+| V — Standards-native precedence | ✅ PASS | No new `mikebom:*` properties / annotations / relationships introduced. The CVE-acceptance list is internal documentation, not SBOM-emitted. |
+| VI. Three-Crate Architecture | ✅ PASS | No new crates. mikebom-cli, mikebom-common, xtask remain the workspace members; mikebom-ebpf untouched. |
+| VII. Test Isolation | ✅ PASS | All attestation tests run unprivileged. No new eBPF dependencies. |
+| VIII. Completeness | ✅ PASS | Verify-side library bump; no impact on discovery completeness. |
+| IX. Accuracy | ✅ PASS | No phantom-component risk. |
+| X. Transparency | ✅ PASS | The CVE-acceptance list (if any) is documented per spec FR-001's OR clause, providing maintainer-facing transparency about residual risk. |
+| XI. Enrichment | ✅ PASS | No enrichment-source changes. |
+| XII. External Data Source Enrichment | ✅ PASS | No new external data sources. |
+
+**Strict Boundaries**:
+- ✅ No lockfile-based dependency discovery — unchanged.
+- ✅ No MITM proxy — unchanged.
+- ✅ No C code — REINFORCED. The original 0.10.x pin's intent (avoid aws-lc-rs) is preserved by stopping the bump at 0.11.0.
+- ✅ No `.unwrap()` in production — unchanged.
+
+**Pre-PR Verification (mandatory)**: standard `./scripts/pre-pr.sh` gate. Both `cargo +stable clippy --workspace --all-targets -- -D warnings` and `cargo +stable test --workspace` must report clean.
+
+**Gate verdict**: ✅ all gates pass. No constitution amendments required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/089-bump-sigstore-vulns/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (sigstore feature audit + tough optionality + API delta findings)
+├── data-model.md        # Phase 1 output (entities + validation rules)
+├── quickstart.md        # Phase 1 output (maintainer recipes: smoke-test, vuln-rescan, residual-acceptance flow)
+├── contracts/
+│   └── sigstore-feature-set.md  # The new sigstore version + feature set + the constitution-compatibility claim
+├── known-acceptances.md         # Created if any vulns remain post-bump (likely 1–4 rustls-webpki@0.102 entries)
+├── checklists/
+│   └── requirements.md  # Spec-quality checklist (already complete)
+└── tasks.md             # Phase 2 output (/speckit.tasks command — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/
+├── Cargo.toml                    # MODIFIED: line 137-141 — version bump + feature drop + comment correction
+├── src/
+│   └── attestation/
+│       ├── verifier.rs           # POSSIBLY MODIFIED: API migration if any (likely zero changes)
+│       ├── signer.rs             # POSSIBLY MODIFIED: same
+│       └── serializer.rs         # POSSIBLY MODIFIED: same
+└── tests/
+    └── (existing attestation tests — unchanged)
+
+Cargo.lock                        # MODIFIED: regenerated for new sigstore + dropped tough closure
+
+specs/006-sbomit-suite/
+└── research.md                    # MODIFIED: R1 audit row updated to reflect 0.11.0 + the new pin rationale
+
+.github/workflows/
+└── ci.yml                         # MODIFIED: add a production-deps trivy gate (FR-007) — runs on Linux lane only
+```
+
+**Structure Decision**: Existing single-project Rust workspace. This milestone touches:
+1. `mikebom-cli/Cargo.toml` (sigstore version + feature set + comment).
+2. `Cargo.lock` (auto-regenerated).
+3. `mikebom-cli/src/attestation/*` if API migration is needed (expected: zero changes given byte-identical sigstore mod files).
+4. `specs/006-sbomit-suite/research.md` R1 audit row (constitution-rationale doc update).
+5. `.github/workflows/ci.yml` for the production-deps trivy gate.
+6. `specs/089-bump-sigstore-vulns/known-acceptances.md` (if residual vulns remain).
+
+PR diff target: ~50 LOC across 4–6 files (one of which is `Cargo.lock` autoregenerated). Deliberately small.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No constitution violations. Complexity tracking N/A.

--- a/specs/089-bump-sigstore-vulns/quickstart.md
+++ b/specs/089-bump-sigstore-vulns/quickstart.md
@@ -1,0 +1,178 @@
+# Quickstart — milestone 089 maintainer recipes
+
+Five maintainer-facing recipes for the dep bump, validating the API delta, regenerating the lockfile, building the residual-vuln acceptance list, and verifying the post-fix vuln scan.
+
+## Recipe 1 — Reproduce the pre-fix vuln baseline
+
+```bash
+trivy --quiet fs \
+  --scanners vuln \
+  --skip-dirs tests/fixtures \
+  --skip-dirs mikebom-cli/tests/fixtures \
+  --skip-dirs target \
+  --format json \
+  --output /tmp/pre-089.json \
+  .
+
+# Severity histogram for the workspace Cargo.lock target only:
+jq -r '
+  [.Results[]? | select(.Target == "Cargo.lock") | .Vulnerabilities[]?.Severity]
+  | group_by(.) | map({severity: .[0], count: length})
+' /tmp/pre-089.json
+```
+
+Expected (alpha.26 baseline): 5 HIGH + 5 MEDIUM + 5 LOW = 15 vulns.
+
+## Recipe 2 — Apply the dep bump
+
+Edit `mikebom-cli/Cargo.toml:141`:
+
+```diff
+-sigstore = { version = "0.10", default-features = false, features = ["sigstore-trust-root-rustls-tls", "cosign-rustls-tls", "fulcio-rustls-tls", "rekor-rustls-tls", "bundle"] }
++sigstore = { version = "0.11", default-features = false, features = ["cosign-rustls-tls", "fulcio-rustls-tls", "rekor-rustls-tls", "bundle"] }
+```
+
+Edit the pin comment at lines 137-138 per `data-model.md` VR-089-012/013/014:
+
+```diff
+-# Feature 006 — SBOMit compliance: DSSE envelope signing + Fulcio keyless +
+-# Rekor transparency log. Pin to 0.10.x because 0.13+ forces aws-lc-rs via
+-# the `cert` feature, violating Constitution Principle I (pure Rust, zero C).
+-# rustls-tls variants chosen to match existing reqwest rustls posture. See
+-# specs/006-sbomit-suite/research.md R1 for the audit.
++# Feature 006 — SBOMit compliance: DSSE envelope signing + Fulcio keyless +
++# Rekor transparency log. Pin to 0.11.x because 0.12+ forces aws-lc-rs via
++# the `cert` feature, violating Constitution Principle I (pure Rust, zero C).
++# rustls-tls variants chosen to match existing reqwest rustls posture.
++# `sigstore-trust-root-*` features dropped in milestone 089 — mikebom doesn't
++# use sigstore's TUF client, and the feature dragged in the vulnerable
++# `tough` transitive (see specs/089-bump-sigstore-vulns/research.md §2).
++# See specs/006-sbomit-suite/research.md R1 for the original audit.
+```
+
+Then regenerate `Cargo.lock`:
+
+```bash
+cargo +stable update -p sigstore
+```
+
+Or trigger a full re-resolve:
+
+```bash
+rm Cargo.lock && cargo +stable build
+```
+
+## Recipe 3 — Smoke-test the build + tests
+
+```bash
+# 1. Compile cleanly:
+cargo +stable build --workspace
+# Expected: success. If it fails, the byte-identical-API assumption from research §3 was wrong; check the error message + plan an API migration patch.
+
+# 2. Run attestation tests:
+cargo +stable test -p mikebom attestation
+# Expected: every existing attestation test passes.
+
+# 3. Confirm tough is gone:
+! grep -q '^name = "tough"' Cargo.lock && echo "✓ tough eliminated" || echo "✗ tough still present"
+
+# 4. Confirm no aws-lc-rs:
+! grep -qE '^name = "aws-lc-(rs|sys)"' Cargo.lock && echo "✓ no aws-lc" || echo "✗ aws-lc detected"
+
+# 5. Confirm sigstore at 0.11:
+grep -A1 '^name = "sigstore"' Cargo.lock | head -2
+```
+
+## Recipe 4 — Re-scan + build the residual-vuln acceptance list
+
+```bash
+trivy --quiet fs \
+  --scanners vuln \
+  --skip-dirs tests/fixtures \
+  --skip-dirs mikebom-cli/tests/fixtures \
+  --skip-dirs target \
+  --format json \
+  --output /tmp/post-089.json \
+  .
+
+# Workspace Cargo.lock vulns post-fix:
+jq -r '
+  [.Results[]? | select(.Target == "Cargo.lock") | .Vulnerabilities[]?
+   | {pkg: .PkgName, ver: .InstalledVersion, sev: .Severity, id: .VulnerabilityID, fix: (.FixedVersion // "—"), title: .Title}]
+  | sort_by(.sev) | .[]
+  | "[\(.sev)] \(.pkg)@\(.ver) → fix=\(.fix)  \(.id)  \(.title)"
+'
+```
+
+Expected post-fix (rough): 1–4 entries in `rustls-webpki@0.102.x`, attributable to sigstore's own `rustls-webpki = "0.102"` direct dep that sigstore upstream hasn't yet bumped to 0.103.13.
+
+For each remaining entry, create / append to `specs/089-bump-sigstore-vulns/known-acceptances.md`:
+
+```markdown
+## GHSA-82j2-j2ch-gfr8 — rustls-webpki@0.102.x — HIGH
+
+- **Affected crate**: `rustls-webpki@0.102.x` (sigstore 0.11's direct dep).
+- **Vuln**: Denial of service via panic on malformed CRL BIT STRING.
+- **mikebom exposure**: mikebom does not process attacker-controlled CRLs. The `mikebom sbom verify` flow uses Cosign keyless verification (Fulcio + Rekor), not CRL-based revocation. Sigstore's webpki usage is internal to TLS handshake validation against trusted roots. The DoS panic requires a malformed CRL BIT STRING input which mikebom does not consume.
+- **Upstream tracking**: sigstore-rs/sigstore-rs#XXXX (file an issue if none exists; link here).
+- **Re-review date**: 2026-11-09 (6 months from acceptance).
+```
+
+Repeat for each residual entry. Save the file.
+
+## Recipe 5 — Add the production-deps trivy CI gate
+
+Edit `.github/workflows/ci.yml`. Add a step to the existing Linux lane (the lane that already has trivy installed for milestone-083's audit):
+
+```yaml
+- name: Production-deps vuln gate (milestone 089)
+  run: |
+    trivy --quiet fs \
+      --scanners vuln \
+      --skip-dirs tests/fixtures \
+      --skip-dirs mikebom-cli/tests/fixtures \
+      --skip-dirs target \
+      --severity HIGH \
+      --format json \
+      --output /tmp/prod-vulns.json \
+      .
+    # Filter to Cargo.lock + cross-check known-acceptances.md.
+    UNACCEPTED=$(jq -r --slurpfile acc <(grep -oE 'GHSA-[a-z0-9-]+|CVE-[0-9]+-[0-9]+' specs/089-bump-sigstore-vulns/known-acceptances.md 2>/dev/null | jq -R . | jq -s .) '
+      [.Results[]?
+       | select(.Target == "Cargo.lock")
+       | .Vulnerabilities[]?
+       | select(.Severity == "HIGH")
+       | select(.VulnerabilityID as $id | ($acc[0] // []) | index($id) | not)
+       | .VulnerabilityID
+      ] | join(",")
+    ' /tmp/prod-vulns.json)
+    if [ -n "$UNACCEPTED" ]; then
+      echo "::error::Unaccepted HIGH advisories in production deps: $UNACCEPTED"
+      exit 1
+    fi
+    echo "✓ no unaccepted HIGH production-deps vulns"
+```
+
+## Recipe 6 — Final pre-PR gate
+
+```bash
+./scripts/pre-pr.sh
+```
+
+Expected: zero clippy warnings, every test suite `0 failed`. Standard CLAUDE.md mandatory gate.
+
+Plus the new bonus check (run manually for visibility before pushing the PR):
+
+```bash
+git status --short mikebom-cli/tests/fixtures/golden/
+# Expected: empty output (no goldens regenerated).
+```
+
+## When in doubt
+
+- **`cargo build` fails post-bump**: the byte-identical-API assumption from research §3 was wrong. Check the error message:
+  - If a `use sigstore::*` import broke, look for the new module path in `sigstore-0.11.0/src/` and update.
+  - If a method signature changed, check the sigstore CHANGELOG between 0.10.0 and 0.11.0 (link from crates.io).
+- **`tough` still appears in `Cargo.lock`**: feature drop didn't take. Verify `mikebom-cli/Cargo.toml:141` has `default-features = false` AND lacks any `sigstore-trust-root*` feature. Run `cargo update -p sigstore` again.
+- **`rustls-webpki@0.103.12` HIGH still present**: it's the OCI-distribution co-attribution path. Verify with `cargo tree -i rustls-webpki@0.103.12` and decide whether to bump `oci-distribution` separately or add to `known-acceptances.md`.
+- **Goldens regenerate when running pre-PR gate**: scope creep. This is a transitive-dep milestone — if the cargo goldens regenerate, the dep-graph change has somehow leaked into SBOM output. Investigate (likely a `creator/tool` field that includes a bumped crate version).

--- a/specs/089-bump-sigstore-vulns/research.md
+++ b/specs/089-bump-sigstore-vulns/research.md
@@ -1,0 +1,111 @@
+# Research — milestone 089 sigstore vuln-bump scoping
+
+Phase 0 investigation against the spec's open questions. Six decision points; all resolved without further clarification.
+
+## §1 — Sigstore version target
+
+**Decision**: bump from `sigstore = "0.10"` → `sigstore = "0.11"` (NOT 0.13 as the original spec input suggested).
+
+**Rationale**: by inspecting `[features]` blocks in each version's published `Cargo.toml`:
+- **0.10.0**: `cert = []` — empty feature, no aws-lc-rs.
+- **0.11.0**: `cert = []` — empty feature, no aws-lc-rs. **Last constitution-compatible version.**
+- **0.12.1**: `cert = ["dep:aws-lc-rs", "rustls-webpki/aws-lc-rs"]` — **aws-lc-rs forced** (violates Constitution Principle I).
+- **0.13.0**: also forces aws-lc-rs (per the existing pin comment, which was correct about the direction but wrong about the version threshold).
+
+So the existing pin comment at `mikebom-cli/Cargo.toml:137-138` is **incorrect**: it claims "0.13+ forces aws-lc-rs", but the actual cliff is **0.12+**. The fix to the comment is part of this milestone (FR-004).
+
+**Alternatives considered**:
+- **Stay on 0.10 + `[patch.crates-io]` override on `tough` and `rustls-webpki`**: feasible but high-maintenance — a `[patch]` requires either a fork repo or a vendored copy. Rejected: bumping to 0.11 is simpler, byte-identical for our crypto API surface, and still pulls modern transitives.
+- **Bump to 0.12 with `default-features = false` to avoid `cert`**: rejected because `cosign-rustls-tls` (which mikebom needs) chains to `cert`, which in 0.12 forces aws-lc-rs. There's no way to use cosign-rustls-tls in 0.12 without aws-lc-rs.
+- **Wait for sigstore upstream to make `cert`'s aws-lc-rs requirement optional**: open-ended timeline; not viable for this milestone. Will track as upstream issue but not block.
+
+## §2 — Eliminate `tough` via feature toggle
+
+**Decision**: drop `sigstore-trust-root-rustls-tls` from mikebom's sigstore feature set. Final feature list becomes `["cosign-rustls-tls", "fulcio-rustls-tls", "rekor-rustls-tls", "bundle"]` (4 features, was 5).
+
+**Rationale**: `tough` is `optional = true` in sigstore 0.10.0 AND 0.11.0 (verified by inspecting `[dependencies.tough]` blocks). It's gated behind the `sigstore-trust-root` feature. The `sigstore-trust-root-rustls-tls` feature in mikebom's current setup chains to `sigstore-trust-root`, which pulls `tough = "0.18"` (0.10) or `tough = "0.19"` (0.11). Dropping the feature eliminates the entire `tough` transitive closure.
+
+**Verification that mikebom doesn't use sigstore's TUF client**: grep across `mikebom-cli/src/attestation/` shows zero references to `sigstore::tuf::`, `sigstore::trust_root::`, `TufClient`, or any TUF-related sigstore type. The `TrustRootInvalid` enum at `mikebom-cli/src/attestation/verifier.rs:80` is mikebom's own `FailureMode` variant, NOT a sigstore type — verified by the `enum FailureMode { ... TrustRootInvalid, ... }` definition.
+
+**Eliminated vulns** (all `tough@0.18.0`-rooted):
+- 2 HIGH: `CVE-2026-6966` (signature-threshold bypass), `CVE-2026-6967` (missing delegated-metadata validation).
+- 4 MEDIUM: `CVE-2025-2885` through `CVE-2025-2888` (root version sequence, terminating delegations, snapshot rollback, timestamp caching).
+- 1 LOW: `GHSA-j8x2-777p-23fc` (cyclic delegation graphs).
+
+**Total**: 7 of 15 vulns eliminated by this feature drop alone.
+
+**Alternatives considered**:
+- **Keep `sigstore-trust-root-rustls-tls` and accept the `tough` vulns**: rejected because mikebom doesn't actually use TUF, so accepting the vulns would document an unexploited risk forever. Dropping the feature flag is strictly better.
+
+## §3 — Sigstore API delta 0.10 → 0.11
+
+**Decision**: zero migration work. mikebom's `sigstore::*` API surface is byte-identical between versions.
+
+**Rationale**: the sigstore `crypto` module — the only one mikebom imports from (`sigstore::crypto::{SigStoreSigner, SigStoreKeyPair, SigningScheme}`, used at `attestation/{verifier,signer,serializer}.rs:{17, 18, 122, 614, 615}`) — has byte-identical files between 0.10.0 and 0.11.0:
+
+```text
+$ diff sigstore-0.10.0/src/crypto/signing_key/mod.rs sigstore-0.11.0/src/crypto/signing_key/mod.rs
+(empty diff)
+$ diff sigstore-0.10.0/src/crypto/mod.rs sigstore-0.11.0/src/crypto/mod.rs
+(empty diff)
+```
+
+**Verification path**: implementation will run `cargo +stable build -p mikebom` after the dep bump and confirm zero compilation errors in `attestation/` modules. If any errors surface (regression vs. byte-diff finding), they'd be in non-`crypto` re-exports that the byte-diff didn't catch — handled at implementation time.
+
+**Alternatives considered**:
+- **Pre-emptively refactor attestation/ to use raw `ring`/`p256`/`ed25519-dalek` types instead of sigstore wrappers**: rejected — out of scope (per spec Out of Scope), and unnecessary given byte-identical API.
+
+## §4 — Residual vulns post-fix
+
+**Expected residual** (post-feature-drop + post-bump):
+- `rustls-webpki@0.102.x`: the HIGH `GHSA-82j2-j2ch-gfr8` (CRL DoS panic), MED `GHSA-pwjx-qhcg-rvj4` (CRL distribution-point matching), and 2 LOW URI/wildcard name-constraint accepts. **Sigstore 0.11 still pins `rustls-webpki = "0.102"`** as a non-optional direct dep; the fix is only available in `rustls-webpki@0.103.13+`.
+- `rustls-webpki@0.103.12` HIGH (CRL DoS panic) — pulled via `oci-distribution@0.11.0` → `reqwest@0.12.28`. **Note**: with sigstore 0.11 the `oci-client` rename is in effect; need to verify whether the 0.103.12 path persists post-bump (it might become 0.103.13 if sigstore 0.11's deps moved forward).
+
+**Decision**: document residual vulns in `specs/089-bump-sigstore-vulns/known-acceptances.md` per spec FR-001's OR clause. For each entry:
+1. CVE / GHSA ID.
+2. Affected crate + version.
+3. Severity.
+4. Why it's not exploitable in mikebom's use case (e.g., "mikebom does not process attacker-controlled CRLs; the DoS panic requires a malformed CRL BIT STRING input which mikebom does not consume").
+5. Tracked next-step (e.g., "Upstream sigstore PR / issue link to bump rustls-webpki to 0.103.13").
+
+**Rationale**: rustls-webpki 0.102 → 0.103 is a major-version bump in a security-critical crate; sigstore upstream needs to do that bump deliberately. We can't safely `[patch]` it ourselves without potentially breaking sigstore's webpki API usage. Maintainer-curated acceptance + upstream tracking is the correct posture.
+
+**Alternatives considered**:
+- **Cargo `[patch.crates-io]` for rustls-webpki**: technically possible but risky — sigstore might call into webpki APIs that changed shape between 0.102 and 0.103. Requires deep-diving sigstore's webpki usage; out of scope.
+- **Fork sigstore at 0.11 and bump rustls-webpki**: maintenance burden too high for a single-version security carry.
+
+## §5 — `oci-distribution` co-attribution
+
+**Decision**: monitor; no separate bump needed in this milestone.
+
+**Rationale**: sigstore 0.10 uses `oci-distribution@0.11`; sigstore 0.11 uses `oci-client@0.14` (the rename). Bumping sigstore changes the OCI dep transitively. The 1 HIGH `rustls-webpki@0.103.12` co-attribution at the OCI path is bundled into the sigstore bump's effect on the dep graph. Verified post-bump via `cargo tree -i rustls-webpki@0.103.12`.
+
+If the post-bump trace still shows the OCI path attributing `rustls-webpki@0.103.12` and the fix isn't pulled in transitively, it'll go on the `known-acceptances.md` list with the same upstream-tracking pattern.
+
+## §6 — CI gate for production-deps trivy scan
+
+**Decision**: add a CI step to `.github/workflows/ci.yml` that runs trivy with the `--skip-dirs tests/fixtures --skip-dirs mikebom-cli/tests/fixtures --skip-dirs target` invocation and fails the lane if any HIGH-severity vuln appears under target `Cargo.lock`. Test-fixture vulns remain ignored via path-skip.
+
+**Rationale**: FR-007 requires a CI gate. Trivy 0.69.3 is already pinned in CI (per memory: "trivy 0.69.3 + syft 1.27.0 pinned versions"). The gate uses the existing trivy install + adds one job step. ~10 LOC of YAML.
+
+The gate's failure threshold is HIGH only (per FR-001). MEDIUM/LOW vulns appear in trivy output for visibility but don't fail CI; they're documented in `known-acceptances.md` if intentionally accepted.
+
+**Alternatives considered**:
+- **Use cargo-audit instead of trivy**: cargo-audit's CVSS-4.0 incompatibility (encountered during this milestone's investigation — fails on `RUSTSEC-2026-0073` libcrux-poly1305 entry) makes it unreliable for CI gating today. Trivy handles CVSS 4.0 fine.
+- **Use `cargo deny`**: not currently in CI; adds a new tool. Trivy is already there.
+- **Run the trivy gate on every push, not just CI**: out of scope for this milestone; CI integration is sufficient.
+
+## Coverage map
+
+| Spec section | Resolution |
+|--------------|------------|
+| FR-001 (zero HIGH) | §1 + §2 → ≥7 vulns eliminated; §4 documents residual HIGHs as accepted with upstream tracking. |
+| FR-002 (zero MED/LOW) | §2 → 5 of 5 MEDs eliminated. §4 documents residual MED/LOWs as accepted. |
+| FR-003 (no aws-lc-rs) | §1 → 0.11.0 chosen as ceiling because 0.12+ forces aws-lc-rs. |
+| FR-004 (pin comment update) | §1 → comment will be corrected from "0.13+ forces aws-lc-rs" to "0.12+ forces aws-lc-rs". |
+| FR-005 (no test regressions) | §3 → byte-identical API; expected zero migration work. Verified at impl time. |
+| FR-006 (`mikebom sbom verify` byte-identical CLI output) | §3 → no behavior change. Verified by running existing tests + manual smoke test against a Cosign bundle. |
+| FR-007 (CI gate) | §6 → trivy gate added to existing CI workflow. |
+| FR-008 (goldens stable) | Implicit — no SBOM-emission code path touched. Verified by `git status mikebom-cli/tests/fixtures/golden/` post-fix. |
+
+All open spec questions resolved. Ready for Phase 1 (data-model + contracts + quickstart).

--- a/specs/089-bump-sigstore-vulns/spec.md
+++ b/specs/089-bump-sigstore-vulns/spec.md
@@ -1,0 +1,126 @@
+# Feature Specification: Clear sigstore-bundle transitive vulnerabilities
+
+**Feature Branch**: `089-bump-sigstore-vulns`
+**Created**: 2026-05-09
+**Status**: Draft
+**Input**: User description: "Bump sigstore 0.10 → 0.13 to clear 15 transitive vulns (tough + rustls-webpki)"
+
+## Background
+
+A trivy scan against mikebom's workspace `Cargo.lock` (production deps only; test fixtures excluded) surfaced **15 transitive vulnerabilities** from a single root: the `sigstore = "0.10"` dependency.
+
+Severity breakdown:
+- **5 HIGH**: 2 in `tough@0.18.0` (TUF signature-threshold bypass `CVE-2026-6966`, missing delegated-metadata validation `CVE-2026-6967`); 3 in `rustls-webpki@{0.101.7, 0.102.8, 0.103.12}` (DoS panic on malformed CRL BIT STRING `GHSA-82j2-j2ch-gfr8`).
+- **5 MEDIUM**: 4 in `tough@0.18.0` (TUF root-version sequence check, terminating delegations, snapshot rollback, timestamp caching — `CVE-2025-2885` through `CVE-2025-2888`); 1 in `rustls-webpki@0.102.8` (CRL distribution-point matching `GHSA-pwjx-qhcg-rvj4`).
+- **5 LOW**: 1 in `tough@0.18.0` (cyclic delegation graphs); 4 in `rustls-webpki` (URI/wildcard name-constraint accepts).
+
+**14 of 15 vulns route through `sigstore@0.10.0`**. Only the modern `rustls-webpki@0.103.12` HIGH-severity entry has a co-attribution path through `oci-distribution@0.11.0`'s reqwest stack.
+
+**Constraint (already documented in code)**: `mikebom-cli/Cargo.toml:137-138` carries an explicit pin to sigstore 0.10 with the rationale: *"0.13+ forces aws-lc-rs via the `cert` feature, violating Constitution Principle I (pure Rust, zero C). rustls-tls variants chosen to match existing reqwest rustls posture. See specs/006-sbomit-suite/research.md R1 for the audit."* Constitution Principle I (Pure Rust, Zero C) is non-negotiable.
+
+This milestone reconciles the security-update goal with the constitution: drive the transitive vuln count to zero (or to a justified-and-tracked exception list) while keeping the user-space binary pure Rust.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Operators see zero HIGH transitive vulns from mikebom (Priority: P1)
+
+A security-conscious operator runs a vuln scanner (trivy / syft / cargo-audit / Snyk) against mikebom's release binary or against the workspace `Cargo.lock` and sees zero HIGH-severity vulnerabilities attributable to mikebom's production dependency closure.
+
+**Why this priority**: Two HIGH-severity TUF integrity bugs (`CVE-2026-6966`, `CVE-2026-6967`) are flagged in the very library mikebom uses to verify Cosign/Fulcio bundles — the integrity foundation of the `mikebom sbom verify` and `mikebom attestation verify` flows. An operator looking at mikebom for supply-chain integrity work sees its own deps flagging integrity-bypass CVEs in TUF; this is reputationally and substantively the most important class of finding to clear.
+
+**Independent Test**: `trivy --quiet fs --scanners vuln --skip-dirs tests/fixtures --skip-dirs target --skip-dirs mikebom-cli/tests/fixtures --format json --output /tmp/post-089.json . && jq '[.Results[]? | select(.Target == "Cargo.lock") | .Vulnerabilities[]? | select(.Severity == "HIGH")] | length' /tmp/post-089.json` returns `0`.
+
+**Acceptance Scenarios**:
+
+1. **Given** mikebom's workspace `Cargo.lock` post-089, **When** an operator runs trivy with the production-dep-only invocation above, **Then** zero HIGH-severity vulns are reported under target `Cargo.lock`.
+2. **Given** mikebom's workspace `Cargo.lock` post-089, **When** an operator runs `cargo audit` (with a CVSS-4.0-aware build), **Then** zero HIGH-severity advisories are reported.
+
+---
+
+### User Story 2 - Operators see zero MEDIUM/LOW transitive vulns from mikebom (Priority: P2)
+
+Same operator runs the same scanner; zero MEDIUM- and LOW-severity vulns are flagged from mikebom's production dep closure (or any remaining non-zero count is documented with a per-finding justification + tracked CVE-acceptance entry).
+
+**Why this priority**: MEDIUM/LOW findings are noise-level for most consumers but accumulate FUD. Closing them lets `mikebom audit` consumers see a clean run. Lower than P1 because the integrity-bypass HIGHs have material exploit potential while name-constraint LOWs are theoretical attacks against unusual cert chains.
+
+**Independent Test**: same trivy invocation as US1; `[.Results[]? | select(.Target == "Cargo.lock") | .Vulnerabilities[]? | select(.Severity == "MEDIUM" or .Severity == "LOW")] | length` returns either `0`, OR a value `N` matched by the same `N` entries documented in `specs/089-bump-sigstore-vulns/known-acceptances.md` (if the spec creates such a file).
+
+**Acceptance Scenarios**:
+
+1. **Given** the post-089 dep closure, **When** the operator filters for MEDIUM+LOW, **Then** the count is zero, OR every flagged advisory has a corresponding entry in a maintainer-curated acceptance list with a justification + tracked-bump-target CVE.
+
+---
+
+### User Story 3 - mikebom attestation features remain functional (Priority: P1)
+
+A maintainer running `mikebom sbom verify <bundle>` against a Cosign-signed in-toto attestation bundle sees identical pass/fail behavior pre-vs-post-089. `mikebom attestation sign` and `mikebom attestation verify` (used in the milestone-006 SBOMit suite) produce byte-identical outputs for identical inputs.
+
+**Why this priority**: Tied with US1 — a security update that breaks the security feature it's meant to protect is a net regression. The attestation flows are the most security-sensitive code paths in the project.
+
+**Independent Test**: every existing test in `mikebom-cli/src/attestation/` and every integration test under `mikebom-cli/tests/` that exercises the `attestation/` module passes post-089 with the same assertions. Specifically the milestone-006 SBOMit acceptance tests + the milestone-072 cross-tier-binding tests.
+
+**Acceptance Scenarios**:
+
+1. **Given** the existing `mikebom-cli/tests/sbom_user_metadata.rs` + `attestation_*.rs` test suite, **When** the maintainer runs `cargo +stable test -p mikebom`, **Then** every attestation-related test reports `0 failed`.
+2. **Given** a Cosign-signed bundle that verifies pre-089, **When** an operator runs `mikebom sbom verify <bundle>` post-089, **Then** the verification succeeds with the same exit code + same printed output.
+3. **Given** an operator signs an in-toto envelope via `mikebom attestation sign` pre-089 and verifies it via post-089 mikebom, **Then** the verification succeeds (cross-version compat).
+
+---
+
+### Edge Cases
+
+- **Sigstore 0.11 / 0.12 also pull aws-lc-rs**: if true, the simple bump path is closed across all 0.10+ versions and we'd need to either (a) accept the vulns + document the rationale, or (b) override the transitive deps via `[patch]` at the workspace level, or (c) fork sigstore to revert the aws-lc-rs change. Plan-level decision.
+- **`tough` and `rustls-webpki` are reachable independently of sigstore**: the modern `rustls-webpki@0.103.12` flag has a dual path through `oci-distribution@0.11.0` + `reqwest@0.12.28`. Bumping sigstore alone won't necessarily clear the `oci-distribution` co-attribution; that path may need its own dep bump.
+- **API breakage in sigstore 0.11+**: if a new sigstore version is viable, the `attestation/{verifier,signer,serializer}.rs` modules use `sigstore::crypto::{SigStoreSigner, SigStoreKeyPair, SigningScheme}` types that may be renamed/moved. Plan-level migration work.
+- **Goldens stability**: signing flows can produce non-deterministic outputs (random nonces). Existing tests should already use deterministic mocks; if any golden uses real signing output, the bump may regen unexpectedly. Need to verify scope is golden-stable.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Post-089 production dep closure (workspace `Cargo.lock`, excluding test fixtures) MUST emit zero HIGH-severity transitive vulnerabilities under a trivy + cargo-audit scan, OR every remaining HIGH MUST be documented in a maintainer-curated CVE-acceptance list with a justification and a tracked next-step (upstream PR, fork, or patch override).
+- **FR-002**: Post-089 production dep closure MUST emit zero MEDIUM+LOW vulnerabilities, OR each remaining vuln MUST be documented per FR-001's acceptance pattern.
+- **FR-003**: The user-space mikebom binary MUST remain pure Rust (Constitution Principle I). The fix MUST NOT introduce `aws-lc-rs`, `openssl-sys`, `libgit2-sys`, or any other crate that links a C library.
+- **FR-004**: The `mikebom-cli/Cargo.toml:137-138` pin comment MUST be updated to reflect the post-089 sigstore version + feature set. If the pin remains at 0.10.x with vuln acceptances, the comment MUST cite the acceptance list.
+- **FR-005**: All existing `mikebom-cli/src/attestation/*` tests MUST pass post-089 with zero behavioral changes (no test deletions, no assertion weakening). Migration to a new sigstore API MAY require code changes inside `attestation/{verifier,signer,serializer}.rs`, but the externally observable test outcomes stay identical.
+- **FR-006**: `mikebom sbom verify` MUST produce byte-identical CLI output (exit code + stdout + stderr) pre-vs-post-089 against a fixed Cosign-signed bundle test input.
+- **FR-007**: The fix MUST add OR maintain a CI gate that runs the production-deps trivy scan and fails CI on any new HIGH vuln in the production closure. Test fixtures (intentionally vulnerable lockfiles for ecosystem testing) MUST remain excluded from this gate via path-based skip, not by allow-listing.
+- **FR-008**: Existing 27 SBOM goldens (CDX, SPDX 2.3, SPDX 3 across 9 ecosystems) MUST stay byte-identical post-089 unless a sigstore-emitted field appears in the goldens (which would be unexpected — sigstore's role is verify-side, not emit-side). If goldens regenerate, scope has crept and the spec MUST document why.
+
+### Key Entities
+
+- **Workspace `Cargo.lock`**: the single resolved dep graph for the mikebom user-space binary. Test-fixture `Cargo.lock` files are NOT in scope and MUST stay separately scannable.
+- **Production-deps trivy scan**: the audit command run for FR-001/FR-002 (`trivy --quiet fs --skip-dirs tests/fixtures --skip-dirs mikebom-cli/tests/fixtures --skip-dirs target --format json .`).
+- **Attestation modules**: `mikebom-cli/src/attestation/{verifier,signer,serializer}.rs` — the only files that import from `sigstore::*`.
+- **CVE-acceptance list** (created if needed): `specs/089-bump-sigstore-vulns/known-acceptances.md` documenting any deliberately-unfixed advisories with justification + tracked-resolution.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Operators running a vuln scanner against a mikebom release binary or `Cargo.lock` see zero HIGH advisories from mikebom's production dependencies (or a documented per-finding justification list of length `N` matching exactly `N` flagged advisories).
+- **SC-002**: 100% of `mikebom-cli/src/attestation/*` tests + every milestone-006 SBOMit acceptance test + every milestone-072 cross-tier-binding test pass post-089. Zero test deletions; zero assertion weakenings.
+- **SC-003**: `cargo +stable test --workspace` post-089 reports `0 failed` for every test suite. `cargo +stable clippy --workspace --all-targets -- -D warnings` post-089 reports zero warnings.
+- **SC-004**: The mikebom binary remains pure Rust — `cargo tree -e features --no-default-features` against a fresh build shows zero `*-sys` crates that link C libraries (excluding `libc` which is a Rust shim, and `linux-raw-sys` which is also Rust).
+- **SC-005**: Production dep scan wall-time stays ≤30 s on standard developer hardware (matches the existing trivy invocation cost).
+
+## Assumptions
+
+- Sigstore 0.11.0 OR 0.12.x are available on crates.io (verified: yes — 0.11.0 released 2025-02-06, 0.12.0 released 2025-05-09, 0.12.1 released 2025-05-28, 0.13.0 released 2025-10-16). Whether 0.11 or 0.12 avoid the aws-lc-rs requirement is a plan-level investigation.
+- mikebom uses sigstore for crypto primitives only (`SigStoreSigner`, `SigStoreKeyPair`, `SigningScheme` — verified by grep). It does NOT use sigstore's TUF client (`tough` integration) directly. The `tough` vulns are dragged in by sigstore's optional features even though mikebom doesn't exercise the TUF code paths. Whether disabling those features in 0.10 clears the `tough` dep is a plan-level investigation.
+- The `oci-distribution@0.11.0`-rooted co-attribution to `rustls-webpki@0.103.12` (1 HIGH) may resolve as a side-effect of any reqwest/rustls bumps performed during sigstore migration, OR may need a separate `oci-distribution` bump.
+- No new external systems (no new MCP servers, no new GitHub Actions, no new release-pipeline steps).
+
+## Dependencies
+
+- Constitution Principle I (Pure Rust, Zero C) — non-negotiable; constrains the bump target.
+- `mikebom-cli/Cargo.toml:137-138` — pin comment must be updated post-fix.
+- `specs/006-sbomit-suite/research.md R1` — the original audit that established the 0.10.x pin. Must be referenced in the post-089 research.md.
+- Milestone 087's release (alpha.26) as the baseline. Post-089 may or may not warrant an alpha.27 release depending on user-observable behavior change scope.
+
+## Out of Scope
+
+- Fixing test-fixture vulnerabilities. The 38 vulns in `tests/fixtures/*` are intentional (the fixtures are real-world projects pinned at versions where vuln-detection differs across SBOM tools).
+- Adding new attestation features. This is a security maintenance milestone, not a feature addition.
+- Refactoring `attestation/{verifier,signer,serializer}.rs` beyond what's needed for sigstore API migration.
+- Switching off `sigstore` to a different crypto library entirely (e.g., `k256`, `ed25519-dalek`). That's a much larger scope change worth its own milestone if maintainability becomes an issue, but isn't required for this fix.

--- a/specs/089-bump-sigstore-vulns/tasks.md
+++ b/specs/089-bump-sigstore-vulns/tasks.md
@@ -1,0 +1,105 @@
+---
+description: "Tasks: Clear sigstore-bundle transitive vulnerabilities (sigstore 0.10 → 0.11 + drop sigstore-trust-root feature)"
+---
+
+# Tasks: Clear sigstore-bundle transitive vulnerabilities
+
+**Input**: Design documents from `/specs/089-bump-sigstore-vulns/`
+**Prerequisites**: spec.md ✅, plan.md ✅, research.md ✅, data-model.md ✅, contracts/sigstore-feature-set.md ✅, quickstart.md ✅
+
+**Organization**: Small dep-bump milestone with regression-net testing. Phase 1 captures pre-fix evidence. Phase 2 = the actual bump (single Cargo.toml edit). Phase 3 = US3 regression net (verify attestation tests pass post-bump — must run BEFORE US1/US2 because if tests break, the bump is wrong). Phase 4 = US1 (HIGH vuln verification). Phase 5 = US2 (MED/LOW + acceptance list). Phase 6 = Polish (CI gate, audit-doc, pin comment, pre-PR gate).
+
+## Path Conventions
+
+Repository-relative paths from `/Users/mlieberman/Projects/mikebom/`:
+- Cargo manifest (sigstore dep + pin comment): `mikebom-cli/Cargo.toml` (lines 137-141)
+- Resolved dep graph: `Cargo.lock`
+- Attestation modules (regression net): `mikebom-cli/src/attestation/{verifier,signer,serializer}.rs`
+- Milestone-006 audit doc (rationale update): `specs/006-sbomit-suite/research.md` R1 row
+- CI workflow (production-deps trivy gate): `.github/workflows/ci.yml`
+- CVE acceptance list: `specs/089-bump-sigstore-vulns/known-acceptances.md` (created if needed)
+
+---
+
+## Phase 1: Setup (pre-fix evidence)
+
+- [X] T001 [P] Capture the pre-fix vuln baseline per quickstart Recipe 1: run trivy with the production-dep-only invocation (`--skip-dirs tests/fixtures --skip-dirs mikebom-cli/tests/fixtures --skip-dirs target`), save to `/tmp/pre-089.json`. Confirm 5 HIGH + 5 MEDIUM + 5 LOW vulns in the workspace `Cargo.lock` target. Records the baseline for FR-001 / FR-002 verification.
+- [X] T002 [P] Verify the byte-identical-API claim from research §3 by re-confirming `diff sigstore-0.10.0/src/crypto/signing_key/mod.rs sigstore-0.11.0/src/crypto/signing_key/mod.rs` returns empty AND `diff sigstore-0.10.0/src/crypto/mod.rs sigstore-0.11.0/src/crypto/mod.rs` returns empty. (Cached crates from Phase 0 research already in `/tmp/sigstore-0.10.0/` and `/tmp/sigstore-0.11.0/`.)
+
+## Phase 2: Foundational (the bump)
+
+- [X] T003 Edit `mikebom-cli/Cargo.toml:141` per quickstart Recipe 2: change `sigstore = { version = "0.10", ... features = ["sigstore-trust-root-rustls-tls", "cosign-rustls-tls", "fulcio-rustls-tls", "rekor-rustls-tls", "bundle"] }` to `sigstore = { version = "0.11", ... features = ["cosign-rustls-tls", "fulcio-rustls-tls", "rekor-rustls-tls", "bundle"] }` (drop `sigstore-trust-root-rustls-tls`). Verifies VR-089-001, VR-089-002, VR-089-003.
+- [X] T004 Regenerate `Cargo.lock` via `cargo +stable update -p sigstore`. If sigstore 0.11 transitively bumps openidconnect 3.5 → 4.0 forces other dep churn beyond what `cargo update -p sigstore` resolves, run `rm Cargo.lock && cargo +stable build` for a full re-resolve.
+- [X] T005 Verify `cargo +stable build --workspace` compiles cleanly. If any `attestation/{verifier,signer,serializer}.rs` import or method call fails to resolve, investigate per quickstart "When in doubt" section — check sigstore CHANGELOG between 0.10 and 0.11 for the affected symbol. Expected: zero compilation errors based on the byte-identical-API finding from T002.
+- [X] T006 Verify `Cargo.lock` post-bump satisfies VR-089-004 (no `tough` entries), VR-089-005 (no `aws-lc-rs` / `aws-lc-sys`), VR-089-006 (sigstore at 0.11.x): run the assertions from quickstart Recipe 3 steps 3–5.
+
+## Phase 3: US3 — Attestation features remain functional (Priority: P1) — regression net
+
+**Goal**: Confirm `cargo +stable test -p mikebom` reports zero failures in attestation-related tests post-bump. Byte-identical CLI behavior for `mikebom sbom verify` against a Cosign-signed bundle.
+
+**Independent Test**: `cargo +stable test -p mikebom attestation` — every attestation-related test reports `0 failed` with the same assertions. Plus a manual `mikebom sbom verify <fixture-bundle>` smoke test producing identical exit code + stdout + stderr.
+
+**Why first**: if tests break, the bump is wrong and US1/US2 are moot. This phase gates Phases 4 + 5.
+
+### Implementation for User Story 3
+
+- [X] T007 [US3] Run `cargo +stable test -p mikebom attestation` and confirm every test passes. Verifies FR-005 (no test-deletion / assertion-weakening).
+- [X] T008 [US3] Run `cargo +stable test --workspace` (full test suite, not just attestation). Confirms no cross-module regression from the dep-graph change. Verifies SC-003.
+- [X] T009 [US3] Smoke-test `mikebom sbom verify` end-to-end against an existing Cosign-signed bundle test fixture (find one via `find mikebom-cli/tests -name "*cosign*" -o -name "*bundle*" 2>/dev/null`). Compare exit code + stdout + stderr against pre-fix output captured in T001's session. Verifies FR-006.
+
+## Phase 4: US1 — Zero HIGH transitive vulns (Priority: P1)
+
+**Goal**: trivy production-deps scan reports zero HIGH-severity vulns under target `Cargo.lock`, OR every remaining HIGH is documented in `known-acceptances.md` with a justification + upstream-tracking link.
+
+**Independent Test**: `jq '[.Results[]? | select(.Target == "Cargo.lock") | .Vulnerabilities[]? | select(.Severity == "HIGH")] | length' /tmp/post-089.json` returns 0, OR returns N matching exactly N entries in `known-acceptances.md`.
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Re-run trivy per quickstart Recipe 4 against the post-bump workspace. Save to `/tmp/post-089.json`. Compare HIGH-severity counts: pre-fix had 5 HIGH (2 tough + 3 rustls-webpki); post-fix expected ≤2 HIGH (the 2 tough HIGHs are eliminated by the feature drop; rustls-webpki HIGHs may remain).
+- [X] T011 [US1] If any HIGH remains in `/tmp/post-089.json` under target `Cargo.lock`, create `specs/089-bump-sigstore-vulns/known-acceptances.md` and add an entry per data-model.md "CVE-acceptance list" schema. Each entry MUST cite: id, crate@version, severity, mikebom_exposure prose, upstream_tracking link, re_review_date. Verifies VR-089-010 + VR-089-011.
+
+## Phase 5: US2 — Zero MED/LOW transitive vulns (Priority: P2)
+
+**Goal**: trivy production-deps scan reports zero MEDIUM- or LOW-severity vulns under target `Cargo.lock`, OR every remaining MED/LOW is documented in `known-acceptances.md`.
+
+**Independent Test**: same trivy invocation as US1; `[.Results[]? | select(.Target == "Cargo.lock") | .Vulnerabilities[]? | select(.Severity == "MEDIUM" or .Severity == "LOW")] | length` returns 0, OR returns N matching N entries in `known-acceptances.md`.
+
+### Implementation for User Story 2
+
+- [X] T012 [US2] Filter `/tmp/post-089.json` for MED + LOW under target `Cargo.lock`. Pre-fix had 5 MED + 5 LOW; post-fix expected: 4 MED tough entries eliminated (feature drop), 1 LOW tough entry eliminated, leaving residual rustls-webpki MED/LOWs (1 MED + 4 LOW pre-fix; some may persist via sigstore's `rustls-webpki = "0.102"` direct dep).
+- [X] T013 [US2] For each remaining MED/LOW entry not yet on the acceptance list, append to `specs/089-bump-sigstore-vulns/known-acceptances.md` with the same schema as T011. Verifies VR-089-010.
+
+## Phase 6: Polish
+
+- [X] T014 Update the pin comment at `mikebom-cli/Cargo.toml:137-138` per quickstart Recipe 2 / data-model.md VR-089-012/013/014: change "0.13+ forces aws-lc-rs" → "0.12+ forces aws-lc-rs"; add a sentence explaining the milestone-089 feature drop. Preserve the milestone-006 R1 audit reference + the "rustls-tls variants chosen" sentence.
+- [X] T015 Update `specs/006-sbomit-suite/research.md` R1 audit row to reflect sigstore 0.11.0 + the corrected aws-lc-rs cliff (0.12+, not 0.13+). Cross-link to milestone 089's research.md §1 for the corrected analysis.
+- [X] T016 Add the production-deps trivy CI gate to `.github/workflows/ci.yml` per quickstart Recipe 5. Use the existing Linux lane that already has trivy 0.69.3 installed for milestone-083's audit. The gate fails the lane on any HIGH vuln in `Cargo.lock` not on `known-acceptances.md`. Verifies FR-007.
+- [X] T017 Verify zero golden regenerations: `git status --short mikebom-cli/tests/fixtures/golden/` returns empty. Verifies FR-008. ANY golden regen indicates scope creep — narrow the diff.
+- [X] T018 Run `./scripts/pre-pr.sh`: zero clippy warnings + every test suite reports `0 failed`. Verifies SC-002 + SC-003 + the standard CLAUDE.md mandatory gate.
+- [X] T019 Update CLAUDE.md "Recent Changes" if the speckit infrastructure didn't auto-update it (verify with `grep "089-bump-sigstore-vulns" CLAUDE.md`). Speckit-plan typically auto-adds; this is a verify step.
+
+---
+
+## Dependencies & Execution Order
+
+- T001 + T002 (Phase 1 evidence) — both `[P]`, can run in parallel.
+- T003 → T004 → T005 → T006 (Phase 2 sequential, same files).
+- T007 → T008 → T009 (Phase 3 US3 sequential — fast tests first; T008 strictly supersedes T007 but explicit ordering helps debugging).
+- **Phase 3 MUST complete before Phase 4 + 5** — if tests fail, the bump is wrong and vuln-count work is wasted.
+- T010 → T011 (Phase 4 US1 sequential — scan then acceptance-list-update).
+- T012 → T013 (Phase 5 US2 sequential — same shape as Phase 4).
+- T014, T015, T016 (Polish doc/comment/CI work) — independent files, can run in parallel after Phases 3-5 complete.
+- T017 → T018 → T019 (Polish verification — sequential because pre-PR gate must run last).
+
+## Parallel Opportunities
+
+- T001 + T002 (Phase 1 evidence) — independent trivy scan vs. file diff.
+- T014 + T015 + T016 (Polish doc edits) — different files, no dependencies. Can parallelize.
+
+## Notes
+
+- **No new Cargo dependencies** at the lockfile level beyond the natural sigstore 0.10 → 0.11 closure (which SHRINKS by removing tough). Verifies FR-003 + SC-004.
+- **Zero golden regenerations** (verify-side library bump; no SBOM-emission code path touched). Verifies FR-008. T017 enforces this explicitly.
+- **PR diff target**: ~50 LOC across 4–6 files (`mikebom-cli/Cargo.toml`, `Cargo.lock`, `specs/006-sbomit-suite/research.md`, `.github/workflows/ci.yml`, optionally `attestation/*` if API migration is needed, plus this milestone's spec dir).
+- **Suggested MVP scope**: Phases 1 + 2 + 3 + 4 (the dep bump + regression net + HIGH-vuln clearance). US2 (MED/LOW) and Polish are the polish-pass tail; could ship as a follow-up if scope balloons.
+- **Tasks T007 + T008 ordering**: T008 strictly includes T007's test surface (running --workspace runs every test, including attestation). The split is for fast-feedback debugging — if T007 fails, the failure is contained to attestation and T008 isn't worth running yet.


### PR DESCRIPTION
## Summary

A pre-fix trivy scan against mikebom's workspace `Cargo.lock` (production deps; test fixtures excluded) flagged **15 transitive vulnerabilities** — 5 HIGH + 5 MEDIUM + 5 LOW — all routing through `sigstore@0.10.0`. This PR clears 11 of 15 (73%) via a targeted scope fix:

1. **Bump `sigstore = \"0.10\"` → `\"0.11\"`** — the last constitution-compatible minor (`0.12+` forces `aws-lc-rs`, violating Principle I; the existing pin comment incorrectly claimed `0.13+` was the cliff).
2. **Drop `sigstore-trust-root-rustls-tls` from feature set** — mikebom doesn't use sigstore's TUF client; the feature dragged in the 7 vulnerable `tough` advisories.
3. **Opportunistic `rustls-webpki@0.103.12 → 0.103.13`** patch bump — picks up `GHSA-82j2-j2ch-gfr8` fix on the active 0.103 line for the oci-client co-attribution.

API surface impact: **zero**. The `sigstore::crypto` module (the only sigstore namespace mikebom imports from) is byte-identical between 0.10.0 and 0.11.0. No changes to `attestation/{verifier,signer,serializer}.rs`.

## Vuln delta

| | Pre-089 | Post-089 |
|---|---|---|
| HIGH | 5 | 1 |
| MEDIUM | 5 | 1 |
| LOW | 5 | 2 |
| **Total** | **15** | **4** |

The 4 residuals (1 HIGH + 1 MED + 2 LOW) all root at `sigstore@0.11`'s own non-optional `rustls-webpki = \"0.102\"` direct dep, awaiting an upstream sigstore PR to bump to 0.103+. Documented in [`specs/089-bump-sigstore-vulns/known-acceptances.md`](https://github.com/kusari-sandbox/mikebom/blob/089-bump-sigstore-vulns/specs/089-bump-sigstore-vulns/known-acceptances.md) with materially-unexploitable justifications:

- **HIGH GHSA-82j2-j2ch-gfr8** (CRL DoS panic): mikebom does not process attacker-controlled CRLs. The verify path uses Fulcio keyless verification, not CRL-based revocation.
- **MED GHSA-pwjx-qhcg-rvj4** (CRL distribution-point matching): same root cause; mikebom does not configure CRL Distribution Points.
- **LOW GHSA-965h-392x-2mh5 + GHSA-xgp8-3hg3-c2mh** (URI/wildcard name constraints): theoretical attacks against unusual cert configs that mikebom never encounters against the public Fulcio root.

## What changed

- **`mikebom-cli/Cargo.toml:141`** — sigstore version bump + feature drop. Comment at lines 137-145 corrected (`0.13+` → `0.12+` aws-lc-rs cliff) and expanded to document the milestone-089 feature-drop rationale.
- **`Cargo.lock`** — regenerated; shrank by 355 lines net (`-585/+230` in deps) reflecting eliminated `tough` + old `reqwest 0.11 → rustls 0.21` transitive bundles.
- **`specs/006-sbomit-suite/research.md`** — R1 audit row updated with milestone-089 reference + corrected aws-lc-rs cliff.
- **`.github/workflows/ci.yml`** — added a production-deps trivy gate (Linux lane only, re-uses milestone-083's trivy 0.69.3 install). Fails CI on any HIGH `Cargo.lock` advisory not in `known-acceptances.md`.
- **`specs/089-bump-sigstore-vulns/`** — full spec/plan/tasks/research/contracts/quickstart + `known-acceptances.md`.
- **`specs/088-cargo-procmacro-edges/tasks.md`** — post-merge T007/T008 task-completion update from PR #182.

## Test plan

- [x] **Pre-fix vuln baseline** captured: 15 vulns matching the spec's described shape.
- [x] **Post-fix scan**: `trivy --skip-dirs tests/fixtures --skip-dirs mikebom-cli/tests/fixtures --skip-dirs target` against `Cargo.lock` returns 4 residual advisories, all matching `known-acceptances.md` entries.
- [x] **`cargo +stable build --workspace`** compiles cleanly with sigstore 0.11.
- [x] **`cargo +stable test -p mikebom attestation`** — 62/62 attestation tests pass.
- [x] **`cargo +stable test --workspace`** — every test suite reports `0 failed`.
- [x] **`verify_dsse` + `binding_verify` integration tests** — 9/9 pass (canonical FR-006 regression net for DSSE bundle verify path; no `*cosign*` named fixture exists so DSSE+binding tests are the proxy).
- [x] **`git status --short mikebom-cli/tests/fixtures/golden/`** — empty (zero golden regenerations; FR-008).
- [x] **`grep '^name = \"tough\"' Cargo.lock`** — empty (VR-089-004).
- [x] **`grep -E '^name = \"aws-lc-(rs|sys)\"' Cargo.lock`** — empty (VR-089-005, FR-003).
- [x] **`./scripts/pre-pr.sh`** — zero clippy warnings, every test suite `0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)