### PR TITLE
fix(092): Maven pom.xml project version-extraction (closes #175 partially)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-09
+Auto-generated from all feature plans. Last updated: 2026-05-10
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -82,6 +82,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-09
 - Per-host fixture cache directory at `$MIKEBOM_FIXTURE_CACHE` (default: `~/.cache/mikebom/fixtures/<pinned-rev>/`). Cache-key is the pinned Git SHA so multiple revisions can co-exist (useful during git-bisect through mikebom history). The cache layout mirrors the fixture repo's internal directory structure exactly so `fixture_path("transitive_parity/cargo")` resolves to `<cache>/transitive_parity/cargo`. (090-split-test-fixtures-repo)
 - Rust stable (workspace toolchain inherited from milestones 001–090; no nightly required for this user-space-only Go-reader extension). + existing only — `parse_go_sum` at `legacy.rs:353`, `WorkspaceContext.go_sum_modules` at `graph_resolver.rs`, `ResolutionStep` enum at `graph_resolver.rs:64`. **No new Cargo dependencies.** (091-go-sum-transitive-fallback)
 - N/A — purely in-process per-scan resolution. Mirrors milestones 002–055. (091-go-sum-transitive-fallback)
+- Rust stable (workspace toolchain inherited from milestones 001–091; no nightly required for this user-space-only bug fix). + existing only — `quick-xml = "0.31"` (already used by `parse_pom_xml`), `serde`/`serde_json`, `tracing`, `anyhow`. **No new crates.** (092-fix-maven-version-extract)
+- N/A — pure metadata transform on the maven main-module emission code path; no caches, no persistence. (092-fix-maven-version-extract)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -144,9 +146,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 092-fix-maven-version-extract: Added Rust stable (workspace toolchain inherited from milestones 001–091; no nightly required for this user-space-only bug fix). + existing only — `quick-xml = "0.31"` (already used by `parse_pom_xml`), `serde`/`serde_json`, `tracing`, `anyhow`. **No new crates.**
 - 091-go-sum-transitive-fallback: Added Rust stable (workspace toolchain inherited from milestones 001–090; no nightly required for this user-space-only Go-reader extension). + existing only — `parse_go_sum` at `legacy.rs:353`, `WorkspaceContext.go_sum_modules` at `graph_resolver.rs`, `ResolutionStep` enum at `graph_resolver.rs:64`. **No new Cargo dependencies.**
 - 090-split-test-fixtures-repo: Added Rust stable (workspace toolchain inherited from milestones 001–089; no nightly required for this user-space-only test-infra refactor). + ONE new direct dep on `mikebom-cli` — `git2 = "0.19"` for pure-Rust Git clone in `build.rs`. Alternative: shell out to `git` via `std::process::Command` (mikebom already does this in golang reader + cargo reader). **Decision**: shell out to `git` — same pattern as existing readers (Constitution-friendly: zero new transitive crates, no `git2`'s `libgit2-sys` C dependency). The `git` binary is already a hard prereq for any mikebom dev setup.
-- 089-bump-sigstore-vulns: Added Rust stable (workspace toolchain inherited from milestones 001–088; no nightly required). + bumping `sigstore = "0.10"` → `sigstore = "0.11"` in `mikebom-cli/Cargo.toml:141`. **Dropping** `sigstore-trust-root-rustls-tls` from the feature list (eliminates the `tough` transitive). Existing features kept: `bundle`, `cosign-rustls-tls`, `fulcio-rustls-tls`. No new direct Cargo deps. The transitively-promoted `pem = "3"` and `x509-parser = "0.16"` direct deps may need bumps if sigstore 0.11's openidconnect 4.0 forces newer versions; verified during smoke-test.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/generate/cyclonedx/metadata.rs
+++ b/mikebom-cli/src/generate/cyclonedx/metadata.rs
@@ -63,7 +63,25 @@ pub fn build_metadata(
     sbom_type_override: Option<crate::generate::lifecycle_phases::SbomType>,
 ) -> serde_json::Value {
     let version = env!("CARGO_PKG_VERSION");
-    let timestamp = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    // Determinism: honor `MIKEBOM_FIXED_TIMESTAMP` (same env-var
+    // contract as `scan_cmd::scan_created_timestamp`) so two
+    // back-to-back scans inside a test produce byte-identical
+    // metadata.timestamp + annotations[].timestamp values. Without
+    // this, two scans straddling a 1-second boundary produced
+    // differing `bom.annotations[].timestamp` strings (the normalizer
+    // masks `metadata.timestamp` but not per-annotation timestamps).
+    // Pre-existing latent bug from milestone 080 — surfaced as a
+    // Linux-CI flake on milestone 092's PR. An unparseable env value
+    // is treated as unset (defensive belt-and-braces, matching
+    // scan_created_timestamp).
+    let timestamp = {
+        let resolved = std::env::var("MIKEBOM_FIXED_TIMESTAMP")
+            .ok()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or_else(Utc::now);
+        resolved.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+    };
 
     // Serialize the enum via serde to reuse the existing kebab-case rename
     // attributes. Dropping quotes so the property value is a bare string.

--- a/mikebom-cli/src/scan_fs/package_db/maven.rs
+++ b/mikebom-cli/src/scan_fs/package_db/maven.rs
@@ -542,8 +542,20 @@ pub(crate) struct PomXmlDocument {
     /// inherited from `<parent>`). `self_coord` is only populated
     /// when groupId AND artifactId are both present; this field is
     /// populated whenever artifactId is present, so sidecar readers
-    /// can apply parent-inheritance themselves. Feature 007 US1.
+    /// can apply parent-inheritance themselves. Feature 007 US1. See
+    /// also `self_version` for the parallel `<version>` inheritance
+    /// gap (milestone 092).
     pub self_artifact_id: Option<String>,
+    /// Raw `<project>/<version>` element value, even when the POM
+    /// lacks a project-level `<groupId>` (which forces `self_coord =
+    /// None` because `self_coord` requires all three project-level
+    /// GAV components). Populated whenever the parser observed a
+    /// project-level `<version>` element, parallel to
+    /// `self_artifact_id`. Sidecar readers prefer this over
+    /// `parent_coord.2` when emitting main-module entries so the
+    /// project's own version takes precedence over the parent POM's
+    /// version. Milestone 092 / FR-001.
+    pub self_version: Option<String>,
     /// `<project>/<modules>/<module>` element values — relative
     /// subdirectories pointing at child POMs in a multi-module
     /// reactor build. Each `<module>` value is a directory path
@@ -709,6 +721,13 @@ pub(crate) fn parse_pom_xml(bytes: &[u8]) -> PomXmlDocument {
     // need it even when self_coord is None (child POM relying on
     // parent for groupId). Feature 007 US1.
     doc.self_artifact_id = self_a.clone();
+    // Always expose the raw project-level <version> when present, even
+    // when self_coord is None (child POM omitting <groupId> — inherited
+    // from <parent>). Without this, the project's own version is
+    // discarded for any pom with <parent> + omitted project-level
+    // <groupId>, and sidecar readers fall back to parent's version.
+    // Milestone 092 / FR-001.
+    doc.self_version = self_v.clone();
     if let (Some(g), Some(a), Some(v)) = (parent_g, parent_a, parent_v) {
         doc.parent_coord = Some((g, a, v));
     }
@@ -735,7 +754,21 @@ pub(crate) fn resolve_maven_property(
         let close_abs = open + close;
         let key = &result[open + 2..close_abs];
         let replacement = match key {
-            "project.version" => doc.self_coord.as_ref().map(|(_, _, v)| v.clone()),
+            // Milestone 092: fall back to `self_version` when
+            // `self_coord` is None (project-level <groupId> omitted,
+            // inherited from <parent>). Skip self_version if it's a
+            // placeholder (would be circular for a pom with
+            // `<version>${project.version}</version>`). See research.md §1.
+            "project.version" => doc
+                .self_coord
+                .as_ref()
+                .map(|(_, _, v)| v.clone())
+                .or_else(|| {
+                    doc.self_version
+                        .as_ref()
+                        .filter(|v| !v.contains("${"))
+                        .cloned()
+                }),
             "project.groupId" => doc.self_coord.as_ref().map(|(g, _, _)| g.clone()),
             "project.artifactId" => doc.self_coord.as_ref().map(|(_, a, _)| a.clone()),
             other => doc.properties.get(other).cloned(),
@@ -3348,10 +3381,24 @@ fn resolve_pom_property_value(
                 .as_ref()
                 .map(|c| c.1.clone())
                 .or_else(|| self_doc.self_artifact_id.clone()),
+            // Milestone 092: prefer self_version when it's a literal,
+            // skip it when it's a placeholder (e.g., child POM with
+            // `<version>${project.version}</version>` — using
+            // self_version would be circular). Fall through to
+            // parent_coord.2 (Maven's documented inheritance: a child
+            // that declares `<version>${project.version}</version>`
+            // resolves to the parent's version).
             "project.version" => self_doc
                 .self_coord
                 .as_ref()
                 .map(|c| c.2.clone())
+                .or_else(|| {
+                    self_doc
+                        .self_version
+                        .as_ref()
+                        .filter(|v| !v.contains("${"))
+                        .cloned()
+                })
                 .or_else(|| {
                     self_doc.parent_coord.as_ref().map(|c| c.2.clone())
                 }),
@@ -3409,10 +3456,18 @@ fn build_maven_main_module_entry(
         .as_ref()
         .map(|c| c.1.clone())
         .or_else(|| doc.self_artifact_id.clone())?;
+    // Milestone 092 / FR-001: prefer the project's own <version>
+    // (captured via `self_version` independent of self_coord) over
+    // the parent's version. Without this, a pom that omits
+    // project-level <groupId> but declares its own <version> would
+    // have `self_coord = None` and fall through to `parent_coord.2`
+    // — emitting the parent's version as the project's version.
+    // See specs/092-fix-maven-version-extract/research.md §1.
     let raw_version = doc
         .self_coord
         .as_ref()
         .map(|c| c.2.clone())
+        .or_else(|| doc.self_version.clone())
         .or_else(|| doc.parent_coord.as_ref().map(|c| c.2.clone()))?;
     let mut warned_unresolved = false;
     let mut resolve = |raw: &str| -> String {
@@ -3672,6 +3727,92 @@ mod tests {
                 "1.2.3".to_string(),
             ))
         );
+    }
+
+    /// Milestone 092 / FR-001: project's own `<version>` MUST be
+    /// captured even when project-level `<groupId>` is omitted (the
+    /// commons-lang3 / typical-Apache-project shape, where the child
+    /// inherits groupId from `<parent>`). Pre-092, `self_v` was
+    /// captured locally but discarded by the constructor at line 703
+    /// (which gates on BOTH self_g + self_a being present); the new
+    /// `self_version` field exposes it independently of `self_coord`.
+    #[test]
+    fn parse_pom_xml_extracts_self_version_when_groupid_inherited() {
+        // Commons-lang3 shape — exact bug-trigger fixture.
+        let pom = r#"<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <parent>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-parent</artifactId>
+    <version>64</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>commons-lang3</artifactId>
+  <version>3.14.0</version>
+</project>"#;
+        let doc = parse_pom_xml(pom.as_bytes());
+        // self_coord remains None because project-level <groupId> is
+        // absent (constructor at line 703 requires both g and a).
+        assert_eq!(doc.self_coord, None);
+        assert_eq!(
+            doc.self_artifact_id,
+            Some("commons-lang3".to_string())
+        );
+        // The new field — captures the project's own version even
+        // though self_coord is None. THIS is the milestone-092 fix.
+        assert_eq!(doc.self_version, Some("3.14.0".to_string()));
+        assert_eq!(
+            doc.parent_coord,
+            Some((
+                "org.apache.commons".to_string(),
+                "commons-parent".to_string(),
+                "64".to_string(),
+            ))
+        );
+    }
+
+    /// Milestone 092: when project-level `<version>` is absent (full
+    /// inheritance — child relies on parent's version), `self_version`
+    /// stays None so `build_maven_main_module_entry` falls through to
+    /// `parent_coord.2` per FR-002.
+    #[test]
+    fn parse_pom_xml_self_version_is_none_when_project_version_absent() {
+        let pom = r#"<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0</version>
+  </parent>
+  <artifactId>child</artifactId>
+</project>"#;
+        let doc = parse_pom_xml(pom.as_bytes());
+        assert_eq!(doc.self_coord, None);
+        assert_eq!(doc.self_version, None);
+        assert_eq!(doc.self_artifact_id, Some("child".to_string()));
+        assert_eq!(
+            doc.parent_coord,
+            Some(("com.example".to_string(), "parent".to_string(), "1.0".to_string()))
+        );
+    }
+
+    /// Milestone 092: fully-populated project-level GAV continues to
+    /// populate self_coord AND self_version (additive — no behavior
+    /// change for the pre-092 happy path).
+    #[test]
+    fn parse_pom_xml_self_version_populated_alongside_self_coord() {
+        let pom = r#"<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.example</groupId>
+  <artifactId>app</artifactId>
+  <version>1.2.3</version>
+</project>"#;
+        let doc = parse_pom_xml(pom.as_bytes());
+        assert_eq!(
+            doc.self_coord,
+            Some(("com.example".to_string(), "app".to_string(), "1.2.3".to_string()))
+        );
+        assert_eq!(doc.self_version, Some("1.2.3".to_string()));
     }
 
     #[test]

--- a/mikebom-cli/tests/maven_pom_version_extraction.rs
+++ b/mikebom-cli/tests/maven_pom_version_extraction.rs
@@ -1,0 +1,246 @@
+//! Integration tests for milestone 092 — Maven pom.xml version-extraction
+//! bug fix. Covers the FR-001 / FR-002 / FR-003 trio (project-version
+//! precedence, parent-version fallback, both-missing skip) plus the
+//! property-substitution preservation cases (US2 / Contracts 3 + 4).
+//!
+//! These tests build synthetic pom.xml fixtures in tempdirs so they
+//! exercise the parser + main-module emission paths without requiring
+//! the milestone-090 fixture-cache repo. The transitive_parity_maven
+//! test (mikebom-cli/tests/transitive_parity_maven.rs) provides the
+//! complementary audit-fixture coverage.
+
+use std::path::Path;
+use std::process::Command;
+
+fn scan_to_cdx(path: &Path) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("sbom.cdx.json");
+    let output = Command::new(bin)
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(path)
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(&out_path)
+        .arg("--no-deep-hash")
+        .output()
+        .expect("mikebom should run");
+    assert!(
+        output.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let raw = std::fs::read_to_string(&out_path).expect("read sbom");
+    serde_json::from_str(&raw).expect("valid JSON")
+}
+
+/// Milestone 092 / FR-001 / SC-001: when a pom.xml omits project-level
+/// `<groupId>` (inherits from `<parent>`) but declares its own
+/// project-level `<version>`, the emitted main-module PURL MUST use
+/// the project's own version, NOT the parent's. This is the exact bug
+/// triggered by the milestone-083 commons-lang3 audit fixture.
+///
+/// Pre-092 emits `pkg:maven/org.apache.commons/commons-lang3@64`
+/// (parent's version); post-092 emits
+/// `pkg:maven/org.apache.commons/commons-lang3@3.14.0`.
+#[test]
+fn main_module_emits_project_version_when_groupid_inherited_from_parent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("pom.xml"),
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-parent</artifactId>
+    <version>64</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>commons-lang3</artifactId>
+  <version>3.14.0</version>
+</project>"#,
+    )
+    .unwrap();
+    let cdx = scan_to_cdx(dir.path());
+    let purl = cdx["metadata"]["component"]["purl"]
+        .as_str()
+        .expect("metadata.component.purl");
+    assert_eq!(
+        purl, "pkg:maven/org.apache.commons/commons-lang3@3.14.0",
+        "main-module PURL must use project's own version (3.14.0), \
+         not parent's (64); got {purl}"
+    );
+}
+
+/// Milestone 092 / FR-002: when a pom.xml omits project-level
+/// `<version>` (intentional inheritance — child relies on parent's
+/// version), the emitted main-module PURL MUST fall back to the
+/// parent's version. This case worked correctly pre-092 by accident
+/// (the buggy "first-version-wins" path matched the parent slot);
+/// post-092 the fallback chain explicitly handles it.
+#[test]
+fn main_module_falls_back_to_parent_version_when_project_version_absent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("pom.xml"),
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>child</artifactId>
+</project>"#,
+    )
+    .unwrap();
+    let cdx = scan_to_cdx(dir.path());
+    let purl = cdx["metadata"]["component"]["purl"]
+        .as_str()
+        .expect("metadata.component.purl");
+    assert_eq!(
+        purl, "pkg:maven/com.example/child@1.0",
+        "main-module PURL must inherit parent's version when project-level \
+         <version> is absent; got {purl}"
+    );
+}
+
+/// Milestone 092 / FR-003: when BOTH project-level `<version>` and
+/// `<parent>/<version>` are absent, mikebom MUST NOT emit a main-module
+/// component (the existing `is_empty()` guard at maven.rs:3436 catches
+/// it). No malformed `pkg:maven/.../<artifact>@` PURL appears.
+#[test]
+fn main_module_emits_nothing_when_both_versions_absent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("pom.xml"),
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>orphan</artifactId>
+</project>"#,
+    )
+    .unwrap();
+    let cdx = scan_to_cdx(dir.path());
+    // Either no metadata.component.purl is emitted, or the emitted
+    // root is the synthetic workspace placeholder (NOT a maven PURL).
+    // Verify no maven PURL with the @-version-empty shape appears
+    // anywhere in the output.
+    let raw = serde_json::to_string(&cdx).expect("re-serialize");
+    assert!(
+        !raw.contains("pkg:maven/com.example/orphan@\""),
+        "must NOT emit maven PURL with empty version; raw contains: {raw}"
+    );
+    assert!(
+        !raw.contains("pkg:maven/com.example/orphan@,"),
+        "must NOT emit maven PURL with empty version (comma-terminated)"
+    );
+    // Also assert the metadata.component.purl, if present, is not a
+    // malformed maven PURL.
+    if let Some(purl) = cdx["metadata"]["component"]["purl"].as_str() {
+        assert!(
+            !purl.starts_with("pkg:maven/com.example/orphan"),
+            "metadata.component.purl must not be a malformed maven PURL; \
+             got {purl}"
+        );
+    }
+}
+
+/// Milestone 092 / US2 / Contract 3: existing property-substitution path
+/// continues to work post-fix when the pom uses `${revision}`-style
+/// version AND omits project-level `<groupId>`. Ensures the
+/// milestone-092 fix doesn't break the `<groupId>`-inherited +
+/// property-substituted-version combination.
+#[test]
+fn main_module_resolves_revision_property_when_groupid_inherited() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("pom.xml"),
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>10.0</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>app</artifactId>
+  <version>${revision}</version>
+  <properties>
+    <revision>1.2.3</revision>
+  </properties>
+</project>"#,
+    )
+    .unwrap();
+    let cdx = scan_to_cdx(dir.path());
+    let purl = cdx["metadata"]["component"]["purl"]
+        .as_str()
+        .expect("metadata.component.purl");
+    assert_eq!(
+        purl, "pkg:maven/com.example/app@1.2.3",
+        "property substitution must resolve ${{revision}} to 1.2.3 (not parent's 10.0); \
+         got {purl}"
+    );
+}
+
+/// Milestone 092 / US2 / Contracts 3 + 4: a dep with
+/// `<version>${{project.version}}</version>` inside a pom that omits
+/// project-level `<groupId>` MUST resolve to the project's own version,
+/// NOT the parent's. Exercises both `resolve_pom_property_value`'s
+/// "project.version" arm AND `resolve_maven_property`'s.
+#[test]
+fn dep_version_uses_project_version_property_when_groupid_inherited() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("pom.xml"),
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>10.0</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>app</artifactId>
+  <version>3.14.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>sibling</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>"#,
+    )
+    .unwrap();
+    let cdx = scan_to_cdx(dir.path());
+    // Main-module PURL is the project's own 3.14.0.
+    let main_purl = cdx["metadata"]["component"]["purl"]
+        .as_str()
+        .expect("metadata.component.purl");
+    assert_eq!(main_purl, "pkg:maven/com.example/app@3.14.0");
+    // The dep should resolve via property substitution to the
+    // project's version (3.14.0), NOT the parent's (10.0). We assert
+    // by serializing the whole document and checking the absence of
+    // the wrong version paired with sibling.
+    let raw = serde_json::to_string(&cdx).expect("re-serialize");
+    assert!(
+        !raw.contains("pkg:maven/com.example/sibling@10.0"),
+        "${{project.version}} on sibling dep must NOT resolve to parent's \
+         version (10.0); raw contains: {raw}"
+    );
+    // Note: we don't assert on the *presence* of `sibling@3.14.0`
+    // because the dep edge target is only emitted as a component if a
+    // matching cached jar exists — but the version *string* in any
+    // edge or dep entry must be 3.14.0 (not 10.0). The negative
+    // assertion above is sufficient to gate the regression.
+}

--- a/mikebom-cli/tests/transitive_parity_maven.rs
+++ b/mikebom-cli/tests/transitive_parity_maven.rs
@@ -1,18 +1,35 @@
 //! Maven transitive-parity regression test — milestone 083.
 //!
 //! Fixture: apache/commons-lang @ rel/commons-lang-3.14.0 (commit
-//! `c8774fa`). Manifest only — commons-lang has no parent POM
-//! resolution needed at this version (it's the top of its own
-//! release lineage).
+//! `c8774fa`). The fixture pom.xml declares a `<parent>` block
+//! (commons-parent@64) and inherits its `<groupId>` from the parent;
+//! the project's own `<version>` is `3.14.0`.
 //!
-//! Audit finding (mikebom-side gap): mikebom emits only 1 dep edge
-//! from this fixture, with a malformed version string
-//! (`commons-lang3@64`). This appears to be a pom.xml reader
-//! extracting the wrong version field — possibly a property
-//! reference that resolves to a build-system value rather than the
-//! library's GAV. Pinning current behavior pending a follow-up
-//! cycle to fix the Maven reader's version resolution. See
-//! research.md §8 for the full per-tool comparison.
+//! ## Closed by milestone 092 (populated-cache version-extraction)
+//!
+//! Pre-092, mikebom's pom.xml parser captured the project-level
+//! `<version>` only when project-level `<groupId>` was ALSO present.
+//! For commons-lang3 (which omits project-level `<groupId>` and
+//! inherits it from `<parent>`), `self_coord` was None and the
+//! project's own version was discarded — `build_maven_main_module_entry`
+//! fell back to the parent's version, emitting
+//! `pkg:maven/org.apache.commons/commons-lang3@64` (parent's
+//! `commons-parent@64`) instead of `@3.14.0`. Milestone 092 added a
+//! `self_version: Option<String>` field to `PomXmlDocument`,
+//! populated independently of `self_coord`, and threaded it through
+//! `build_maven_main_module_entry` + the property-substitution arms.
+//! See specs/092-fix-maven-version-extract/.
+//!
+//! ## Remaining gap (track 1 of #175 — out of scope for milestone 092)
+//!
+//! Even post-092, with `$M2_REPO` empty (the CI baseline), mikebom
+//! emits ZERO transitive dep edges from this fixture. Maven's parent
+//! POM inheritance + property substitution model means a single
+//! isolated `pom.xml` can't self-resolve transitive deps without
+//! cached or fetched parent POMs. trivy 0.69.3 also emits 0 in the
+//! same configuration; syft 1.27.0 emits 8 via DEPENDENCY_OF
+//! reverse-direction. A future milestone analogous to milestone-055's
+//! Go proxy fetch would close this gap.
 
 mod transitive_parity_common;
 
@@ -25,13 +42,12 @@ const FIXTURE_SUBPATH: &str = "maven";
 /// `$M2_REPO` is empty. Mikebom's maven reader needs cached parent
 /// POMs in `$M2_REPO` to resolve transitive dep declarations; with
 /// the cache empty, the reader extracts ZERO transitive edges.
-/// Real-world output on a developer's box with `~/.m2/` populated
-/// will be a small number of edges (1 was observed in the audit run
-/// from a populated cache; the actual count depends on which POMs
-/// happen to be cached). The 0-edge cache-empty count is what CI
-/// sees. Future Maven-reader work that adds parent-POM resolution
-/// without cache hits (or via deps.dev fallback per research §2) will
-/// bump this.
+/// Milestone 092 fixed the **version-extraction** bug for the
+/// populated-cache case (the main-module emission path now correctly
+/// reports `commons-lang3@3.14.0` instead of the parent's `@64`),
+/// but the cache-empty zero-edge gap (track 1 of #175) is unchanged
+/// here and will require a future milestone analogous to
+/// milestone-055's Go proxy fetch.
 const EXPECTED_MIKEBOM_EDGE_COUNT: usize = 0;
 
 fn fixture() -> PathBuf {

--- a/specs/083-transitive-correctness/research.md
+++ b/specs/083-transitive-correctness/research.md
@@ -265,13 +265,15 @@ mikebom 62 vs trivy 36 — mikebom emits ~2× more edges. syft emits 138 (after 
 
 **Diff classification**: **gap surfaced** — both mikebom + trivy emit zero edges from a real Maven project's pom.xml on cache-empty CI runs
 
-mikebom + trivy both fail to emit dep edges from `pom.xml` alone when `~/.m2/repository/` is empty — they need the cached parent + dependency POMs to resolve transitive declarations. syft emits 8 edges, possibly via a different parsing strategy. mikebom additionally has the milestone-085 + earlier-discovered Maven-reader bugs (commons-lang3 emits a malformed `version: "64"` when `~/.m2/` IS populated, surfaced in the local-cache-populated audit run earlier).
+mikebom + trivy both fail to emit dep edges from `pom.xml` alone when `~/.m2/repository/` is empty — they need the cached parent + dependency POMs to resolve transitive declarations. syft emits 8 edges, possibly via a different parsing strategy. mikebom additionally had the version-extraction bug (commons-lang3 emitted a malformed `version: "64"` — the parent's version — when `~/.m2/` IS populated, surfaced in the local-cache-populated audit run earlier).
 
 **Specific gap**: mikebom's Maven reader needs (a) inline parent-POM-less transitive resolution OR (b) a deps.dev / Maven Central fallback for cache-empty cases. Currently it emits zero in this fixture.
 
 **Indirect-vs-direct decision**: Maven `<scope>compile/test/provided/runtime</scope>` is mapped to lifecycle-scope work in milestone-052/part-2. No new decision.
 
-**Follow-up disposition**: **gap surfaced** — file follow-up for "Maven reader: cache-empty offline mode emits zero transitive edges (and version-extracted-incorrectly when cache populated)". Regression test pins the 0-edge cache-empty baseline.
+**Follow-up disposition**: **partially closed**.
+- **Closed by milestone 092**: the populated-cache version-extraction bug — pre-092 mikebom emitted `commons-lang3@64` (parent's version) because `parse_pom_xml` discarded the project's own `<version>` whenever project-level `<groupId>` was inherited from `<parent>`. milestone 092 added a `self_version: Option<String>` field that captures `<project>/<version>` independently of `self_coord`; populated-cache scans now correctly emit `commons-lang3@3.14.0`. See specs/092-fix-maven-version-extract/.
+- **Still open** (track 1 of #175): cache-empty zero-edge fallback. A future milestone analogous to milestone-055's Go proxy fetch (Maven Central `.pom` HTTP fetch with semaphore-bounded concurrency) would close it. Regression test at `mikebom-cli/tests/transitive_parity_maven.rs` continues to pin the 0-edge cache-empty baseline pending that work.
 
 ### Ecosystem: pip-plain
 

--- a/specs/092-fix-maven-version-extract/checklists/requirements.md
+++ b/specs/092-fix-maven-version-extract/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Fix Maven pom.xml version-extraction bug
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs) — describes the bug + the fix-shape (use project-level `<version>` not parent's) without prescribing parser internals.
+- [X] Focused on user value and business needs — operator-visible PURL correctness on Maven projects is the user payoff.
+- [X] Written for non-technical stakeholders — pom.xml's two-`<version>`-elements structure is explained with the concrete commons-lang example.
+- [X] All mandatory sections completed — User Scenarios & Testing, Requirements, Success Criteria, Assumptions, Dependencies, Out of Scope.
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain.
+- [X] Requirements are testable and unambiguous — each FR has a concrete pass/fail check.
+- [X] Success criteria are measurable — SC-001 through SC-005 are quantitative or pass/fail-binary.
+- [X] Success criteria are technology-agnostic — frame outcomes as PURL correctness + test-suite pass-rate, not internal parser details.
+- [X] All acceptance scenarios are defined — US1 has 3, US2 has 2.
+- [X] Edge cases are identified — 5 edge cases listed (parent without version, no project version, both property refs, multi-module, malformed pom).
+- [X] Scope is clearly bounded — explicit Out of Scope section listing 6 deliberately-deferred items including the larger cache-empty fallback work.
+- [X] Dependencies and assumptions identified — Assumptions + Dependencies sections both populated.
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria — FR-001 ↔ US1 scenario 1+2; FR-002/FR-003 ↔ edge cases; FR-004 ↔ US2; FR-005 ↔ SC-004; FR-006 ↔ regression test bump; FR-007/FR-008 are scope/no-deps invariants.
+- [X] User scenarios cover primary flows — US1 (P1 — fix the bug) + US2 (P2 — preserve property-substitution).
+- [X] Feature meets measurable outcomes defined in Success Criteria — yes, SC-001 through SC-005 each map to ≥1 FR.
+- [X] No implementation details leak into specification — file paths are reference-only, not prescribing internal structure.
+
+## Notes
+
+All 16 checklist items pass. Spec is ready for `/speckit.plan` (small surgical fix; no clarification needed — the bug + fix shape are unambiguous).

--- a/specs/092-fix-maven-version-extract/contracts/maven-version-extraction.md
+++ b/specs/092-fix-maven-version-extract/contracts/maven-version-extraction.md
@@ -1,0 +1,137 @@
+# Contract — Maven version-extraction
+
+Behavioral contract for the two production functions affected by milestone 092. Tests in `mikebom-cli/tests/maven_pom_version_extraction.rs` enforce these contracts.
+
+## Contract 1 — `parse_pom_xml` populates `self_version` independently of `self_coord`
+
+**Function**: `mikebom-cli/src/scan_fs/package_db/maven.rs:577 parse_pom_xml(bytes: &[u8]) -> PomXmlDocument`
+
+**Pre-092 behavior**:
+- `self_coord` populated iff project-level `<groupId>` AND `<artifactId>` both present.
+- Project-level `<version>` was only persisted when `self_coord` was populated.
+- A pom omitting `<groupId>` at project level would have its project-level `<version>` **silently discarded**.
+
+**Post-092 behavior**:
+- `self_coord` semantics **unchanged** (still requires all three).
+- New: `self_version: Option<String>` field populated whenever the parser observed `<project>/<version>` (regardless of project-level `<groupId>` state).
+
+**Test cases**:
+
+| Input pom shape | `self_coord` | `self_version` |
+|----------------|--------------|----------------|
+| `<groupId>g</groupId><artifactId>a</artifactId><version>v</version>` (all three) | `Some(("g", "a", "v"))` | `Some("v")` |
+| `<artifactId>a</artifactId><version>v</version>` (no groupId; inherits from parent) | `None` | `Some("v")` |
+| `<artifactId>a</artifactId>` (no groupId, no version; full inheritance) | `None` | `None` |
+| `<groupId>g</groupId><artifactId>a</artifactId>` (no version; intentional inheritance) | `None` (pre-092 path) — see note | `None` |
+| `<artifactId>a</artifactId><version>${revision}</version>` (raw placeholder) | `None` | `Some("${revision}")` |
+
+> **Note on row 4**: pre-092 the `if let (Some(g), Some(a)) = ...` block falls through to `unwrap_or_default() = ""`, producing `self_coord = Some(("g", "a", ""))`. Post-092 this is unchanged because `self_v = None`. The empty-string version case is already handled downstream by the `is_empty()` guard at line 3436. This row is not affected by the fix.
+
+## Contract 2 — `build_maven_main_module_entry` prefers `self_version` over parent's version
+
+**Function**: `mikebom-cli/src/scan_fs/package_db/maven.rs:3395 build_maven_main_module_entry(pom_path: &Path, doc: &PomXmlDocument, ctx: &MavenInheritanceContext) -> Option<PackageDbEntry>`
+
+**Pre-092 resolution chain for `raw_version`**:
+
+```rust
+let raw_version = doc
+    .self_coord
+    .as_ref()
+    .map(|c| c.2.clone())
+    .or_else(|| doc.parent_coord.as_ref().map(|c| c.2.clone()))?;
+```
+
+**Post-092 resolution chain for `raw_version`**:
+
+```rust
+let raw_version = doc
+    .self_coord
+    .as_ref()
+    .map(|c| c.2.clone())
+    .or_else(|| doc.self_version.clone())                          // NEW step
+    .or_else(|| doc.parent_coord.as_ref().map(|c| c.2.clone()))?;
+```
+
+**Behavioral guarantee**: for any pom where `<project>/<version>` is present, the emitted main-module PURL's version segment matches that value (after property substitution, per Contract 3).
+
+**Test cases**:
+
+| Input pom shape | Expected emitted PURL |
+|----------------|----------------------|
+| `<parent>/<groupId>org.apache.commons</groupId>/<version>64</version>` + `<artifactId>commons-lang3</artifactId><version>3.14.0</version>` | `pkg:maven/org.apache.commons/commons-lang3@3.14.0` |
+| Same parent, project omits `<version>` entirely | `pkg:maven/org.apache.commons/commons-lang3@64` (intentional inheritance per FR-002) |
+| Project has both `<groupId>` and `<version>` (no inheritance gap) | unchanged from pre-092 |
+
+## Contract 3 — `resolve_pom_property_value` resolves `${project.version}` correctly when `self_coord = None`
+
+**Function**: `mikebom-cli/src/scan_fs/package_db/maven.rs:3318 resolve_pom_property_value(raw: &str, self_doc: &PomXmlDocument, parent_doc: Option<&PomXmlDocument>) -> PropertyResolution`
+
+**Pre-092 `"project.version"` arm**:
+
+```rust
+"project.version" => self_doc
+    .self_coord
+    .as_ref()
+    .map(|c| c.2.clone())
+    .or_else(|| {
+        self_doc.parent_coord.as_ref().map(|c| c.2.clone())
+    }),
+```
+
+**Post-092 `"project.version"` arm**:
+
+```rust
+"project.version" => self_doc
+    .self_coord
+    .as_ref()
+    .map(|c| c.2.clone())
+    .or_else(|| self_doc.self_version.clone())                     // NEW step
+    .or_else(|| {
+        self_doc.parent_coord.as_ref().map(|c| c.2.clone())
+    }),
+```
+
+**Behavioral guarantee**: for a pom that omits project-level `<groupId>` but has project-level `<version>`, any dependency whose `<version>` is `${project.version}` resolves to the project's own version (not the parent's).
+
+**Test case**:
+
+| Input pom shape | Dep with `${project.version}` | Resolved dep version |
+|----------------|------------------------------|----------------------|
+| Project: omitted groupId, version=3.14.0; Parent: version=64; Dep: `<version>${project.version}</version>` | `pkg:maven/.../<dep>@3.14.0` | `3.14.0` |
+
+## Contract 4 — `resolve_maven_property` (sibling helper)
+
+**Function**: `mikebom-cli/src/scan_fs/package_db/maven.rs:723 resolve_maven_property(raw: &str, doc: &PomXmlDocument) -> MavenVersion`
+
+**Decision**: in scope to mirror Contract 3 — the function's `"project.version"` arm at line 738 reads `doc.self_coord.as_ref().map(|(_, _, v)| v.clone())` and would return `None` (then `Placeholder` per line 743) for the bug-trigger case. Update to fall back to `doc.self_version`.
+
+**Post-092 `"project.version"` arm**:
+
+```rust
+"project.version" => doc
+    .self_coord
+    .as_ref()
+    .map(|(_, _, v)| v.clone())
+    .or_else(|| doc.self_version.clone()),                         // NEW
+```
+
+**Test case**:
+
+| Input | Expected |
+|-------|----------|
+| pom with omitted project-level groupId, version=3.14.0; raw=`${project.version}` | `MavenVersion::Resolved("3.14.0")` |
+
+## Contract — non-regression
+
+| Test fixture | Pre-092 emission | Post-092 emission |
+|--------------|------------------|-------------------|
+| `mikebom-cli/tests/fixtures/maven/maven-source-project/pom.xml` (existing — has groupId) | unchanged | unchanged (golden byte-stable) |
+| `mikebom-cli/tests/fixtures/transitive_parity/maven/pom.xml` (commons-lang3 — omitted groupId) | `pkg:maven/org.apache.commons/commons-lang3@64` (BUG) | `pkg:maven/org.apache.commons/commons-lang3@3.14.0` (FIX) |
+| Any other Maven-using fixture in the workspace | unchanged | unchanged |
+
+## Out-of-scope (deferred to future milestones per spec.md "Out of Scope")
+
+- Maven cache-empty fallback (Track A of issue #175).
+- Variable-substitution from external property files (`${env.X}`, settings.xml).
+- Reactor parent-aggregation logic that walks `<modules>` with cross-module property inheritance beyond the existing Phase-1 implementation.
+- BOM-import resolution for `dependencyManagement/<dependency>/<scope>import</scope>`.

--- a/specs/092-fix-maven-version-extract/data-model.md
+++ b/specs/092-fix-maven-version-extract/data-model.md
@@ -1,0 +1,69 @@
+# Data Model — milestone 092
+
+Single struct delta. No schema-level changes. No JSON-output shape changes.
+
+## `PomXmlDocument` (existing struct)
+
+**Path**: `mikebom-cli/src/scan_fs/package_db/maven.rs:530`
+
+### Pre-092 shape
+
+```rust
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PomXmlDocument {
+    pub self_coord: Option<(String, String, String)>, // (groupId, artifactId, version)
+    pub parent_coord: Option<(String, String, String)>,
+    pub properties: HashMap<String, String>,
+    pub dependencies: Vec<PomDependency>,
+    pub dependency_management: Vec<PomDependency>,
+    /// Raw `<project>/<artifactId>` element value, even when the POM
+    /// lacks a `<groupId>` or `<version>` ...
+    pub self_artifact_id: Option<String>,
+    pub modules: Vec<String>,
+}
+```
+
+### Post-092 shape
+
+```rust
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PomXmlDocument {
+    pub self_coord: Option<(String, String, String)>, // (groupId, artifactId, version)
+    pub parent_coord: Option<(String, String, String)>,
+    pub properties: HashMap<String, String>,
+    pub dependencies: Vec<PomDependency>,
+    pub dependency_management: Vec<PomDependency>,
+    pub self_artifact_id: Option<String>,
+    /// Raw `<project>/<version>` element value, even when the POM
+    /// lacks a `<groupId>` (which forces `self_coord = None` because
+    /// `self_coord` requires all three project-level GAV components).
+    /// Populated whenever `<project>/<version>` is present, parallel
+    /// to `self_artifact_id`. Sidecar readers prefer this over
+    /// `parent_coord.2` when emitting main-module entries.
+    /// Milestone 092 / FR-001.
+    pub self_version: Option<String>,                 // NEW
+    pub modules: Vec<String>,
+}
+```
+
+### Field semantics
+
+| Field | When populated | Used by |
+|-------|---------------|---------|
+| `self_coord` | All three project-level GAV components present (g, a, v) | `MavenInheritanceContext::by_coord`, `resolve_pom_property_value`, `resolve_maven_property` |
+| `self_artifact_id` | `<project>/<artifactId>` present (regardless of g/v) | sidecar readers, milestone-007 child-POM identity |
+| `self_version` (NEW) | `<project>/<version>` present (regardless of g/a) | `build_maven_main_module_entry` raw_version resolution; `resolve_pom_property_value`'s `project.version` arm |
+| `parent_coord` | All three parent-block GAV components present | inheritance fallback, `MavenInheritanceContext::parent_doc` |
+
+### Compatibility
+
+- Strictly additive. No existing field removed or renamed.
+- Default value `None` matches pre-existing behavior for any consumer not yet aware of the field.
+- All existing call sites continue to work without modification; only `build_maven_main_module_entry` and `resolve_pom_property_value` are updated to read the new field.
+
+## No other model changes
+
+- `PomDependency`: unchanged.
+- `MavenVersion`: unchanged.
+- `MavenInheritanceContext`: unchanged (keys on `self_coord`, which is unaffected).
+- `PackageDbEntry`: unchanged (only the `version` string content differs in fixed cases).

--- a/specs/092-fix-maven-version-extract/plan.md
+++ b/specs/092-fix-maven-version-extract/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: Fix Maven pom.xml version-extraction bug
+
+**Branch**: `092-fix-maven-version-extract` | **Date**: 2026-05-08 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Maven main-module entries can emit the **parent** POM's version instead of the project's own — observed concretely in the milestone-083 transitive_parity fixture as `pkg:maven/org.apache.commons/commons-lang3@64` (commons-parent's version) instead of `@3.14.0` (commons-lang3's project-level version).
+
+**Root cause** (Phase 0 confirmed): `parse_pom_xml` at `mikebom-cli/src/scan_fs/package_db/maven.rs:703-707` only populates `PomXmlDocument.self_coord` when **both** project-level `<groupId>` AND project-level `<artifactId>` are present. Maven's POM inheritance routinely permits omitting `<groupId>` (inherited from `<parent>`); the commons-lang3 fixture exercises exactly this. With `self_g = None`, the entire `self_coord` block is skipped — the parsed `self_v = "3.14.0"` is **discarded**. Then `build_maven_main_module_entry` at line 3412 falls back to `parent_coord.2` (= "64").
+
+**Fix shape**: parallel to the existing `self_artifact_id: Option<String>` field (added in milestone 007 for the same inheritance pattern), add a `self_version: Option<String>` field that's populated from `self_v` regardless of `self_g`/`self_a` state. Update `build_maven_main_module_entry`'s `raw_version` resolution to prefer `doc.self_version` over `doc.parent_coord.2`. Surgical change; bug-fix-only milestone.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–091; no nightly required for this user-space-only bug fix).
+**Primary Dependencies**: existing only — `quick-xml = "0.31"` (already used by `parse_pom_xml`), `serde`/`serde_json`, `tracing`, `anyhow`. **No new crates.**
+**Storage**: N/A — pure metadata transform on the maven main-module emission code path; no caches, no persistence.
+**Testing**: `cargo +stable test --workspace` (existing). New unit test in `mikebom-cli/src/scan_fs/package_db/maven.rs` for the `<groupId>`-omitted parsing case; new integration test in `mikebom-cli/tests/maven_pom_version_extraction.rs` for the regression and a `${revision}` property-substitution case (FR-004 / SC-005).
+**Target Platform**: same as workspace — Linux x86_64, macOS aarch64, Linux aarch64.
+**Project Type**: Rust workspace, single binary (mikebom-cli).
+**Performance Goals**: zero per-component cost change. Adding one `Option<String>` field to `PomXmlDocument` is constant-overhead.
+**Constraints**: byte-stable golden output for non-Maven fixtures; the only allowed delta is the maven golden where the version corrects from a parent-version to the project-version. The milestone-083 `transitive_parity_maven` baseline becomes binding (it expected `@3.14.0`; this fix delivers it).
+**Scale/Scope**: ~10 lines of production code change + ~30 lines of tests. Single ecosystem (maven). Surgical fix.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+- **I. Pure Rust, Zero C**: ✅ no FFI, no C deps, no toolchain changes.
+- **II. eBPF-Only Observation**: N/A — this is a filesystem-mode parser; eBPF discovery path unchanged.
+- **III. Fail Closed**: ✅ no behavior change to error handling. The fix replaces wrong-version emission with correct-version emission; no new failure modes.
+- **IV. Strict Workspace Hygiene**: ✅ pre-PR gate (`./scripts/pre-pr.sh`) unchanged.
+- **V. Specification Compliance / standards-native precedence**: ✅ no new `mikebom:*` properties. Same emission shape pre/post fix; only the version string changes.
+- **X. Transparency**: ✅ surfacing the project's own version is *more* transparent, not less; no new opaque metadata.
+- **XII. External Data Source Enrichment**: N/A — pom.xml is filesystem-discovered manifest data, same source class as before.
+
+**No violations**. No Complexity Tracking entry needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/092-fix-maven-version-extract/
+├── plan.md                         # This file
+├── research.md                     # Phase 0: bug investigation + fix-shape decision
+├── data-model.md                   # Phase 1: PomXmlDocument struct delta
+├── contracts/
+│   └── maven-version-extraction.md # Phase 1: parser contract + main-module emission contract
+├── quickstart.md                   # Phase 1: maintainer recipes
+├── checklists/
+│   └── requirements.md             # 16/16 pass — already complete
+└── spec.md                         # Feature spec
+```
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/
+├── src/
+│   └── scan_fs/
+│       └── package_db/
+│           └── maven.rs            # PRODUCTION CHANGE: lines ~530-554 (struct field)
+│                                   #                    lines ~703-715 (parser wiring)
+│                                   #                    lines ~3395-3439 (build_maven_main_module_entry)
+└── tests/
+    └── maven_pom_version_extraction.rs  # NEW: integration tests for FR-001 / FR-004
+```
+
+**Structure Decision**: Single-crate fix in `mikebom-cli`. No new files in production code path; one new integration-test file. The maven sidecar reader at `maven.rs` is the sole production touchpoint.
+
+## Complexity Tracking
+
+> Not applicable — no Constitution gate violations.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|--------------------------------------|
+| (none)    | (none)     | (none)                               |
+
+## Phase Plan
+
+### Phase 0 — Research (this directory's `research.md`)
+
+Status: **complete**. The Phase 0 investigation traced the bug to the exact line numbers and resolved the fix-shape decision (add `self_version` field; do not relax the `self_coord` constructor — that would risk breaking dependent code paths in `MavenInheritanceContext::build_from_poms` that key on the full `(g, a, v)` tuple). See `research.md` for the three resolved decision points.
+
+### Phase 1 — Design (this directory's `data-model.md`, `contracts/`, `quickstart.md`)
+
+Output:
+
+- **data-model.md**: minimal — one new field on `PomXmlDocument`; no schema-level changes.
+- **contracts/maven-version-extraction.md**: precise behavioral contract for the two affected functions.
+- **quickstart.md**: maintainer recipes (reproduce, fix, verify, regenerate goldens).
+
+Re-evaluate Constitution Check post-design: still no violations expected (the fix is a pure-additive `Option<String>` field).
+
+### Phase 2 — Tasks
+
+Out-of-scope for `/speckit.plan`; will be generated by `/speckit.tasks`.
+
+## Agent Context Update
+
+The agent context file (`CLAUDE.md`) will be updated by the agent-context script to reflect milestone 092's stack (rust stable, no new deps, single ecosystem).

--- a/specs/092-fix-maven-version-extract/quickstart.md
+++ b/specs/092-fix-maven-version-extract/quickstart.md
@@ -1,0 +1,139 @@
+# Quickstart — milestone 092 maintainer recipes
+
+Five maintainer-facing recipes to reproduce the bug, apply the fix, regenerate the milestone-083 baseline, and confirm post-092 byte-stability for non-Maven fixtures.
+
+## Recipe 1 — Reproduce the pre-092 buggy emission
+
+```bash
+cargo +stable build --release -p mikebom
+
+target/release/mikebom --offline sbom scan \
+    --path "$MIKEBOM_FIXTURES_DIR/transitive_parity/maven" \
+    --format spdx-2.3-json \
+    --output /tmp/pre-092.spdx.json \
+    --no-deep-hash
+
+# Look up the main-module's PURL:
+jq -r '.packages[] | select(.name == "commons-lang3") | .externalRefs[] | select(.referenceType == "purl") | .referenceLocator' /tmp/pre-092.spdx.json
+# Expected (BUG): pkg:maven/org.apache.commons/commons-lang3@64
+```
+
+## Recipe 2 — Apply the fix
+
+Implementation lives in `mikebom-cli/src/scan_fs/package_db/maven.rs`. Three edits:
+
+```rust
+// Edit 1: PomXmlDocument struct (~line 546)
+//
+//     pub self_artifact_id: Option<String>,
+//     pub self_version: Option<String>,  // NEW — milestone 092
+//     pub modules: Vec<String>,
+
+// Edit 2: parse_pom_xml constructor (~line 711)
+//
+//     doc.self_artifact_id = self_a.clone();
+//     doc.self_version = self_v.clone();  // NEW — milestone 092
+
+// Edit 3: build_maven_main_module_entry's raw_version chain (~line 3412)
+//
+//     let raw_version = doc
+//         .self_coord
+//         .as_ref()
+//         .map(|c| c.2.clone())
+//         .or_else(|| doc.self_version.clone())  // NEW — milestone 092
+//         .or_else(|| doc.parent_coord.as_ref().map(|c| c.2.clone()))?;
+
+// Edit 4: resolve_pom_property_value's "project.version" arm (~line 3351)
+//
+//     "project.version" => self_doc
+//         .self_coord
+//         .as_ref()
+//         .map(|c| c.2.clone())
+//         .or_else(|| self_doc.self_version.clone())  // NEW — milestone 092
+//         .or_else(|| {
+//             self_doc.parent_coord.as_ref().map(|c| c.2.clone())
+//         }),
+
+// Edit 5: resolve_maven_property's "project.version" arm (~line 738)
+//
+//     "project.version" => doc
+//         .self_coord
+//         .as_ref()
+//         .map(|(_, _, v)| v.clone())
+//         .or_else(|| doc.self_version.clone()),  // NEW — milestone 092
+```
+
+Update doc-comment on `self_artifact_id` (line 540-546) to also reference `self_version` for the parallel inheritance gap.
+
+## Recipe 3 — Verify post-092 emission
+
+```bash
+cargo +stable build --release -p mikebom
+
+target/release/mikebom --offline sbom scan \
+    --path "$MIKEBOM_FIXTURES_DIR/transitive_parity/maven" \
+    --format spdx-2.3-json \
+    --output /tmp/post-092.spdx.json \
+    --no-deep-hash
+
+# Same query as Recipe 1:
+jq -r '.packages[] | select(.name == "commons-lang3") | .externalRefs[] | select(.referenceType == "purl") | .referenceLocator' /tmp/post-092.spdx.json
+# Expected (FIX): pkg:maven/org.apache.commons/commons-lang3@3.14.0
+```
+
+## Recipe 4 — Regenerate the milestone-083 transitive-parity baseline
+
+```bash
+# Step 1: run the existing transitive_parity_maven test post-fix.
+cargo +stable test -p mikebom --test transitive_parity_maven
+# If the milestone-083 expectation already pinned @3.14.0 (per FR-006),
+# this should now PASS (was failing pre-092). If the expectation pinned
+# @64 to "match the buggy emission", update it to @3.14.0.
+
+# Step 2: confirm the EXPECTED_REPRESENTATIVE_EDGES match.
+grep -n "commons-lang3" mikebom-cli/tests/transitive_parity_maven.rs
+# Expected: at least one edge entry with @3.14.0.
+
+# Step 3: re-run, confirm pass.
+cargo +stable test -p mikebom --test transitive_parity_maven
+# Expected: 4/4 tests pass.
+```
+
+## Recipe 5 — Confirm byte-stability for non-Maven goldens
+
+```bash
+cargo +stable test -p mikebom --test cdx_regression
+cargo +stable test -p mikebom --test spdx_regression
+cargo +stable test -p mikebom --test spdx3_regression
+# Expected: 0 failures across all three. Maven goldens MAY change
+# (correcting parent-version → project-version); non-Maven goldens
+# MUST NOT change.
+
+# Audit the diff scope:
+git status --short mikebom-cli/tests/fixtures/golden/
+# Expected: only maven golden files touched, if any.
+```
+
+If a Maven golden file shows a version flip (e.g., `@64` → `@3.14.0`), confirm:
+
+```bash
+git diff mikebom-cli/tests/fixtures/golden/ | grep -E "^[+-]" | head -20
+# Expected: ONLY version-string flips on commons-lang3-style entries.
+# NO PURL count changes, NO new components, NO new annotations.
+```
+
+## Recipe 6 — Final pre-PR gate
+
+```bash
+./scripts/pre-pr.sh
+```
+
+Expected: zero clippy warnings, every test suite reports `0 failed`. Standard CLAUDE.md mandatory gate.
+
+## When in doubt
+
+- **Post-092 emits correct version but a different fixture broke**: confirm the broken fixture has `<groupId>` AND `<version>` at project level. If yes, the issue is independent of milestone 092 (the `self_coord` path is unchanged).
+- **Property substitution still emits parent's version**: check that Contract 3 (the `resolve_pom_property_value` edit) was applied. The main-module fix alone doesn't cover `${project.version}`-resolved dep edges.
+- **Test failure in `transitive_parity_maven` pinning `@64`**: pre-092 the test may have been "XFAIL"-style, expecting the buggy value to lock in the regression. Update to the correct `@3.14.0`.
+- **`mikebom-test-fixtures` cache stale**: the fixture sibling repo's build.rs cache fetch should already have the right pom.xml. If you've recently re-pulled, run `cargo clean` once and rebuild.
+- **Edge count change in transitive_parity_maven**: not expected. The milestone-092 fix only changes the **version string** of the main-module emission; the dependency edges themselves are unaffected (their PURL targets are constructed independently via dep groupId/artifactId/version).

--- a/specs/092-fix-maven-version-extract/research.md
+++ b/specs/092-fix-maven-version-extract/research.md
@@ -1,0 +1,102 @@
+# Research — milestone 092 Maven version-extraction bug
+
+Phase 0 investigation. Three decision points; all resolved without further clarification.
+
+## §1 — Bug location: `PomXmlDocument` constructor in `parse_pom_xml`
+
+**Finding**: the bug is in **the constructor** at `mikebom-cli/src/scan_fs/package_db/maven.rs:703-707`, NOT in the per-element walker (lines 612-629) and NOT in the property substitution path (lines 3318-3387) and NOT in `build_maven_main_module_entry` (lines 3395-3439).
+
+The walker correctly distinguishes `<project>/<version>` (writes to local `self_v: Option<String>`) from `<project>/<parent>/<version>` (writes to local `parent_v: Option<String>`). When called against the commons-lang3 fixture pom.xml, by EOF the walker holds:
+
+| local | value           | source                         |
+|-------|-----------------|--------------------------------|
+| `self_g` | `None`        | omitted at project level       |
+| `self_a` | `Some("commons-lang3")` | `<project>/<artifactId>` |
+| `self_v` | `Some("3.14.0")`        | `<project>/<version>`    |
+| `parent_g` | `Some("org.apache.commons")` | `<parent>/<groupId>` |
+| `parent_a` | `Some("commons-parent")`     | `<parent>/<artifactId>` |
+| `parent_v` | `Some("64")`                  | `<parent>/<version>`   |
+
+The constructor at line 703 is:
+
+```rust
+if let (Some(g), Some(a)) = (self_g.clone(), self_a.clone()) {
+    let v = self_v.clone().or_else(|| parent_v.clone()).unwrap_or_default();
+    doc.self_coord = Some((g, a, v));
+}
+doc.self_artifact_id = self_a.clone();  // line 711
+if let (Some(g), Some(a), Some(v)) = (parent_g, parent_a, parent_v) {
+    doc.parent_coord = Some((g, a, v));
+}
+```
+
+Because `self_g = None`, the first `if let` fails. `self_v = Some("3.14.0")` is **discarded** — never written into `doc`. The doc-comment on `PomXmlDocument` at line 540-546 already acknowledged this gap for `<artifactId>` (resolved by adding `self_artifact_id` in milestone 007); the same gap exists for `<version>` and was never closed.
+
+Then in `build_maven_main_module_entry` at line 3412:
+
+```rust
+let raw_version = doc
+    .self_coord                                       // None
+    .as_ref()
+    .map(|c| c.2.clone())                             // None
+    .or_else(|| doc.parent_coord.as_ref().map(|c| c.2.clone()))?;  // Some("64")
+```
+
+`raw_version = "64"`. Bug.
+
+**Decision**: add a `self_version: Option<String>` field to `PomXmlDocument`, populated from local `self_v` regardless of `self_g`/`self_a` state — exactly parallel to `self_artifact_id`. Update `build_maven_main_module_entry`'s `raw_version` resolution to prefer `doc.self_version` over `parent_coord.2`.
+
+**Rationale**:
+- Strictly additive change to `PomXmlDocument`; cannot break any consumer keying on the existing fields.
+- Mirrors the milestone-007 precedent for `self_artifact_id`. Same pattern, same justification.
+- Keeps `self_coord` semantics intact: it remains "fully-resolved (g, a, v) tuple, all three project-level". Any consumer doing `doc.self_coord.as_ref()` (e.g., `MavenInheritanceContext::build_from_poms` keying `by_coord` on `self_coord`) sees no behavior change for the bug-trigger case (the fixture's child POM was already not in `by_coord` because `self_coord = None`; that's the parent inheritance lookup, which keys on the **child's** `parent_coord`, not on its own `self_coord`).
+- The fix preserves the milestone-053-onward FR-005 "no regressions on populated POMs" by leaving `self_coord` semantics untouched.
+
+**Alternatives considered**:
+- **Relax the `self_coord` constructor to fall back to parent groupId**: would change `self_coord`'s definition from "all three project-level" to "all three resolved-via-inheritance". Touches `MavenInheritanceContext::build_from_poms` (line 3293) which inserts into `by_coord` keyed on `self_coord`; relaxing the gate could let child POMs claim the same `(g, a, v)` as their parents in `by_coord`, breaking parent-doc lookup for siblings. Higher blast radius. Rejected.
+- **Inline `self_v` plumbing through `build_maven_main_module_entry`'s caller chain**: requires changing `parse_pom_xml`'s return type or threading an extra arg. Same effect as adding the field, but with broader API surface change. Rejected.
+- **Recompute version from `self_coord.or_else(re-parse pom)`**: re-parses the file; performance regression and semantics drift. Rejected.
+
+## §2 — Property substitution preserved
+
+**Finding**: the existing `resolve_pom_property_value` path at lines 3318-3387 routes `${project.version}` through `self_doc.self_coord.as_ref().map(|c| c.2.clone()).or_else(|| self_doc.parent_coord.as_ref().map(|c| c.2.clone()))` (lines 3351-3357). When `self_coord = None` post-fix (because `self_g` is still `None`), this falls through to `parent_coord.2` — which is **wrong** for the same reason as the main-module case.
+
+**Decision**: in `resolve_pom_property_value`'s `"project.version"` arm, prefer `self_doc.self_version` when present, falling back to `self_coord.2`, then `parent_coord.2`. Single-line change.
+
+**Rationale**:
+- US2 (preserve `${revision}` etc.) requires `${project.version}` to resolve correctly when used inside `<dependencies>/<dependency>/<version>`. Without this update, a child POM that omits project-level `<groupId>` and uses `${project.version}` for sibling-module deps would emit dependency edges with the parent's version — the same class of bug, one layer deeper.
+- The property-substitution call site is only reached during dep-edge construction; the additional `self_version` lookup adds zero new failure modes (both fields are already populated by the same parser pass).
+
+**Alternatives considered**:
+- **Leave property substitution as-is and only fix the main-module path**: would create a second-order inconsistency where main-module-version is correct but `${project.version}`-resolved dep versions are stale. Rejected.
+
+## §3 — Edge-case handling
+
+**Decision**: handle the four edge cases listed in `spec.md` as follows:
+
+| Edge case | Handling |
+|-----------|----------|
+| Project has no `<parent>` block at all | `parent_coord = None`; `self_version` populated; main-module emits with project version. No change vs. existing behavior. |
+| Project has `<parent>` but no project-level `<version>` | `self_version = None`; `build_maven_main_module_entry` falls back to `parent_coord.2` per existing line 3416 logic. **Intentional inheritance**, not the bug. |
+| Project has both `${revision}`-style version AND parent | `self_version = Some("${revision}")` (raw); `resolve_pom_property_value` resolves via `<properties>/<revision>` lookup; main-module emits the resolved value. |
+| Multi-module reactor with mixed inheritance | each child POM is parsed independently; `parse_pom_xml` is per-file, so `self_version` is per-child. No cross-child interference. |
+| Malformed pom.xml (parser fails mid-stream) | quick-xml's `Err(_)` arm at line 698 already breaks out; `self_version = None` if `</version>` was never reached. Existing behavior; main-module emission silently skipped per FR-001 step 4 (lines 3436-3438 `is_empty` guard). |
+
+**Rationale**: the fix is purely additive — every prior-working case stays working because `self_version` only takes precedence over `parent_coord.2` when `self_version.is_some()`. When the project's own `<version>` is absent (intentional inheritance), the fallback chain matches the pre-092 behavior exactly.
+
+## Coverage map
+
+| Spec section | Resolution |
+|--------------|------------|
+| FR-001 (use project's own `<version>` when present) | §1 → `self_version` field + `build_maven_main_module_entry` precedence change. |
+| FR-002 (fall back to parent's `<version>` when project-level missing) | §3 → existing `parent_coord.2` fallback chain unchanged. |
+| FR-003 (no `<parent>` block) | §3 → `parent_coord = None`; main-module emits with project version. |
+| FR-004 (`${revision}` property substitution) | §2 → `resolve_pom_property_value`'s `project.version` arm prefers `self_version`. |
+| FR-005 (no regressions on populated POMs) | §1 → `self_coord` semantics unchanged; consumers untouched. |
+| FR-006 (transitive_parity_maven baseline) | golden regen flips `@64` → `@3.14.0`; baseline already expected `@3.14.0` per milestone-083 spec. |
+| FR-007 (no scope creep beyond the bug fix) | §1 → ~10 lines production change; struct field add + 2 reads. |
+| FR-008 (no new dependencies) | §1+§2 → existing `quick-xml`, `serde`, `tracing` only. |
+| Constitution V audit | no `mikebom:*` properties added; standards-native PURL string change only. |
+| Constitution X transparency | improves transparency (correct version emitted); no opaque metadata. |
+
+All open spec questions resolved. Ready for Phase 1 (data-model + contracts + quickstart).

--- a/specs/092-fix-maven-version-extract/spec.md
+++ b/specs/092-fix-maven-version-extract/spec.md
@@ -1,0 +1,123 @@
+# Feature Specification: Fix Maven pom.xml version-extraction bug (closes #175 partially)
+
+**Feature Branch**: `092-fix-maven-version-extract`
+**Created**: 2026-05-10
+**Status**: Draft
+**Input**: User description: "175"
+
+## Background
+
+Issue #175 was filed during milestone 083's transitive-parity audit (`mikebom-cli/tests/transitive_parity_maven.rs`) against the `apache/commons-lang @ rel/commons-lang-3.14.0` fixture. It surfaces two parallel concerns in the Maven reader:
+
+1. **Cache-empty zero-edge gap**: When `~/.m2/repository/` is empty, mikebom emits 0 transitive dep edges from `pom.xml` alone. trivy 0.69.3 also emits 0 in the same configuration; syft 1.27.0 emits 8 via DEPENDENCY_OF reverse-direction. Maven's parent POM inheritance + property substitution model means a single isolated `pom.xml` cannot self-resolve transitive deps without cached or fetched parent POMs. This is **a structural Maven-ecosystem limitation that affects every SBOM tool** — mikebom's behavior matches trivy's. **Out of scope for this milestone.**
+2. **Version-extraction bug** (this milestone's scope): When `~/.m2/` IS populated, mikebom emits a single edge with a malformed version string — `pkg:maven/org.apache.commons/commons-lang3@64` instead of `@3.14.0`. **Root cause** (verified by inspecting the fixture's `pom.xml`): the project's pom.xml has two `<version>` elements at the top:
+
+```xml
+<project>
+  <parent>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-parent</artifactId>
+    <version>64</version>           <!-- parent POM's version -->
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>commons-lang3</artifactId>
+  <version>3.14.0</version>          <!-- project's own version -->
+  ...
+```
+
+mikebom's pom.xml parser at `mikebom-cli/src/scan_fs/package_db/maven.rs` extracts the FIRST `<version>` it encounters (the parent's `64`) rather than the project's own `<version>` element (`3.14.0`). The fix is to distinguish `/project/parent/version` from `/project/version` and use the latter as the project's component version.
+
+This is a small, surgical fix to the existing pom.xml parser. The cache-empty fallback work (track 1) is left as a deliberate follow-up because (a) it's a much larger architectural addition (Maven Central HTTP fetch infrastructure), (b) trivy doesn't solve it either so mikebom isn't behind, and (c) operators using mikebom for Maven projects who care about transitive coverage can populate `~/.m2/` once before scanning.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Operator gets correct version on the project's main-module component (Priority: P1)
+
+An operator scanning a Maven project with a `<parent>` element in `pom.xml` (the typical case for any project using a parent POM — Apache Commons projects, Spring Boot projects, anything using a corporate parent POM) sees the project's main-module component emitted with the **project's own version** (`pkg:maven/<group>/<artifact>@<project-version>`), NOT the parent POM's version.
+
+**Why this priority**: This is the entire reason for the milestone. Pre-092, every Maven project that declares a `<parent>` (which is the vast majority of real-world Maven projects) emits a wrong-version PURL. Downstream consumers using mikebom output for vuln-scanning, SLSA-attestation, or compliance get false-negatives on the project's own component because the version doesn't match any registry record.
+
+**Independent Test**: `target/release/mikebom sbom scan --path <commons-lang-fixture>` against the milestone-083 audit fixture. Confirm the emitted SBOM contains `pkg:maven/org.apache.commons/commons-lang3@3.14.0` (NOT `@64`).
+
+**Acceptance Scenarios**:
+
+1. **Given** the milestone-083 commons-lang fixture (a `pom.xml` with both `<parent><version>64</version></parent>` and a project-level `<version>3.14.0</version>`), **When** the operator runs `mikebom sbom scan --path <fixture>`, **Then** the emitted SBOM contains `pkg:maven/org.apache.commons/commons-lang3@3.14.0` as the project's main-module component PURL. The string `@64` does NOT appear in any commons-lang3-named PURL.
+2. **Given** any Maven project's `pom.xml` that declares a `<parent>` element with a `<version>`, **When** mikebom parses the pom, **Then** the project's main-module version is extracted from the project-level `<version>` element (a direct child of `<project>`), not from `<project><parent><version>`.
+3. **Given** a `pom.xml` that does NOT declare a `<parent>` element (uncommon but valid — top-level / corporate-root POMs), **When** mikebom parses it, **Then** the project's `<version>` element is the only `<version>` at the project level and gets extracted as today (no regression for parent-less POMs).
+
+---
+
+### User Story 2 - No regression for `<version>${property}` substitution (Priority: P2)
+
+A Maven `pom.xml` may declare its own version as a property reference (`<version>${revision}</version>` with `<properties><revision>3.14.0</revision></properties>` elsewhere). mikebom's existing property-substitution path continues to resolve these correctly post-092.
+
+**Why this priority**: Property substitution is the second-most-common pom.xml version pattern after literal versions. The fix in US1 must not weaken or break the existing property-resolution code path. P2 because property substitution isn't directly the bug being fixed; it's a regression boundary to honor.
+
+**Independent Test**: All milestone-085 + milestone-070 maven tests pass post-092 with zero behavioral change. Specifically `scan_maven.rs::scan_maven_property_substitution_resolves` (or similar — exact test name verified at impl time).
+
+**Acceptance Scenarios**:
+
+1. **Given** a `pom.xml` with `<version>${revision}</version>` + `<properties><revision>1.2.3</revision></properties>`, **When** mikebom parses it, **Then** the emitted main-module PURL is `pkg:maven/<group>/<artifact>@1.2.3` (property resolution works as today).
+2. **Given** the milestone-085 + milestone-070 test suites, **When** the maintainer runs `cargo +stable test -p mikebom`, **Then** every maven-related test reports `0 failed` with the same assertions.
+
+---
+
+### Edge Cases
+
+- **`<parent>` with no `<version>` (`relativePath`-only parent reference)**: rare but valid — child POM inherits parent version from a sibling `pom.xml`. mikebom should ignore the missing parent version cleanly and use the project's own `<version>` (or skip the project if the project also lacks a version, which would be a malformed pom.xml).
+- **Project lacks its own `<version>` and inherits from parent** (`<parent><version>1.0</version></parent>` + no project-level `<version>`): the inherited version semantically applies to the project. Pre-092, mikebom's "first version wins" heuristic accidentally returned the right answer for this case (parent's version IS the project's effective version when not overridden). Post-092, mikebom MUST handle this case explicitly: if no project-level `<version>` exists but a `<parent><version>` does, use the parent's version as the project's effective version. Documented behavior change: the heuristic is now "project version takes precedence; falls back to parent version when project version is absent."
+- **Both `<parent><version>` and project `<version>` are property references**: should resolve via the existing property-substitution path. Property scope is per-document so resolutions don't bleed between parent + project.
+- **Multi-module reactor builds** (parent POM with `<modules>`): per-module pom.xml files each get parsed independently; the version-extraction fix applies per-module without cross-module side effects. milestone 070's multi-module main-module emission stays unchanged.
+- **Malformed pom.xml with multiple project-level `<version>` elements** (invalid XML by Maven schema, but mikebom tolerates malformed input per the existing `quick-xml` parser's permissive mode): take the first one; document the choice.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When parsing a `pom.xml` for project main-module emission, mikebom MUST extract the version from the project-level `<version>` element (a direct child of `<project>`), NOT from `<project><parent><version>`. The parent's version is metadata about the parent POM and MUST NOT be used as the project's component version when a project-level `<version>` is present.
+- **FR-002**: When the project lacks a project-level `<version>` AND the `<parent>` declares a `<version>`, mikebom MUST use the parent's version as the project's effective version (Maven's documented inheritance semantics — the child inherits the parent's version when not overridden). This case is preserved-behavior post-092 (pre-092 already worked by accident; the new code path explicitly handles it).
+- **FR-003**: When the project lacks BOTH a project-level `<version>` AND a `<parent><version>`, mikebom MUST skip emitting that project as a main-module component. No malformed PURL emission.
+- **FR-004**: The fix MUST preserve all existing milestone-085 + milestone-070 test assertions. Zero test deletions; zero assertion weakenings.
+- **FR-005**: The fix MUST extend the existing per-format scope (CDX 1.6 / SPDX 2.3 / SPDX 3) — emitted main-module PURLs change from `<group>/<artifact>@<parent-version>` to `<group>/<artifact>@<project-version>` for any fixture whose pom.xml has both. The relevant fixture (milestone-070's `maven/pom-three-deps`) MAY regenerate its 3 maven goldens IF it declares a `<parent>` element with its own `<version>`; if it has no `<parent>`, the goldens stay byte-identical.
+- **FR-006**: The milestone-083 `transitive_parity_maven.rs` regression test MUST be updated post-092 to capture the corrected version. The pre-092 baseline pinned 1 emitted edge with the wrong version; post-092 the same 1 edge has the right version. Standard milestone-083 baseline-bump pattern.
+- **FR-007**: No new Cargo dependencies. The existing `quick-xml` parser at `mikebom-cli/src/scan_fs/package_db/maven.rs` already supports XPath-style child-element traversal; the fix is a parser-logic adjustment, not a new dep.
+- **FR-008**: This milestone does NOT address the cache-empty zero-edge gap (Track 1 of issue #175). That track requires a Maven Central HTTP fetch infrastructure analogous to milestone-055's Go proxy fetch — substantially larger scope, deferred to a future milestone. Issue #175 is closed PARTIALLY by this milestone; a follow-up issue MAY be filed for Track 1 if maintainers want it tracked separately.
+
+### Key Entities
+
+- **`pom.xml` document tree**: the XML data model the maven reader parses. The fix navigates to `/project/version` (project-level direct child) instead of any-`<version>`-anywhere.
+- **Project main-module entry**: the `PackageDbEntry` emitted for the project itself by milestone-070's main-module logic. Its `version` field is the target of the FR-001 extraction.
+- **Audit fixture**: `transitive_parity/maven/` from `mikebom-test-fixtures` repo (apache/commons-lang) — accessed via `MIKEBOM_FIXTURES_DIR` per milestone 090.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Operators scanning a Maven project with a `<parent>` element see the project's correct version in the emitted SBOM's main-module PURL. The commons-lang audit fixture emits `pkg:maven/org.apache.commons/commons-lang3@3.14.0` post-092 (vs `@64` pre-092).
+- **SC-002**: 100% of pre-092 milestone-070 + milestone-085 maven tests pass post-092 with no test deletions, no assertion weakenings.
+- **SC-003**: `cargo +stable test --workspace` post-092 reports `0 failed`. `./scripts/pre-pr.sh` clean.
+- **SC-004**: Per-format scope: at most 3 maven goldens regenerate (CDX 1.6 / SPDX 2.3 / SPDX 3) IF the milestone-013 maven fixture declares a `<parent>`. All 24 non-maven goldens stay byte-identical.
+- **SC-005**: Production-deps trivy CI gate (milestone 089) and milestone-090 fixture-cache CI step continue to pass.
+
+## Assumptions
+
+- The audit fixture (commons-lang) lives in the post-090 `mikebom-test-fixtures` repo at `transitive_parity/maven/`. Verified by inspection.
+- mikebom's existing pom.xml parser uses `quick-xml` (per memory of milestone 005) and supports per-element traversal. The version-extraction fix lives in `mikebom-cli/src/scan_fs/package_db/maven.rs`.
+- The milestone-083 `transitive_parity_maven.rs` regression test pins 1 emitted edge (pre-092 baseline). Post-092 the count stays 1; only the version string changes within that edge.
+- Maven's pom.xml inheritance semantics (project version overrides parent version when both present; parent version applies when project version is absent) are the documented Maven behavior. mikebom's fix matches Maven's reference behavior.
+
+## Dependencies
+
+- Milestone 070 (Maven main-module emission) — the existing infrastructure this milestone fixes.
+- Milestone 085 (Maven SPDX dep edges) — co-existing tests that must continue to pass.
+- Milestone 083 (transitive-parity audit) — the regression-test scaffolding (`transitive_parity_maven.rs`) that pins the post-092 baseline.
+- Milestone 090 (fixture-repo split) — the audit fixture lives in the new repo.
+
+## Out of Scope
+
+- **Cache-empty Maven transitive-edge fallback (Track 1 of #175)**: requires Maven Central HTTP fetch infrastructure analogous to milestone-055's Go proxy fetch. Substantially larger architectural scope; deferred to a future milestone.
+- **Adding a `--maven-fetch-parents` flag**: out of scope for the same reason.
+- **Refactoring the maven reader's parser engine**: minimal-scope edit to the existing version-extraction logic only.
+- **Bumping the commons-lang fixture version**: same fixture as milestone 083; reusing it directly.
+- **Per-component provenance annotation for the project version source**: not needed — the project version is now correct unambiguously, no fidelity downgrade signal required (unlike milestone 091's go-sum-fallback case).
+- **Improving Maven main-module emission beyond the version field**: groupId / artifactId / metadata extraction stays unchanged.

--- a/specs/092-fix-maven-version-extract/tasks.md
+++ b/specs/092-fix-maven-version-extract/tasks.md
@@ -1,0 +1,200 @@
+---
+description: "Task list for milestone 092 — fix Maven pom.xml version-extraction bug"
+---
+
+# Tasks: Fix Maven pom.xml version-extraction bug (closes #175 partially)
+
+**Input**: Design documents from `/Users/mlieberman/Projects/mikebom/specs/092-fix-maven-version-extract/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included. mikebom's pre-PR gate (CLAUDE.md mandatory) runs `cargo +stable test --workspace`; every milestone ships test coverage for its production change.
+
+**Organization**: Tasks are grouped by user story. US1 (P1, the main-module version fix) is the MVP increment; US2 (P2, property substitution) is layered on top of the same `self_version` field added in Foundational.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- File paths are absolute or workspace-relative.
+
+## Path Conventions
+
+Single-crate Rust workspace fix in `mikebom-cli`. All production changes land in one file: `mikebom-cli/src/scan_fs/package_db/maven.rs`. New integration test in `mikebom-cli/tests/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm branch + build state before touching production code.
+
+- [X] T001 Confirm working branch is `092-fix-maven-version-extract` and the working tree matches the spec's expected starting state. Run `git status` + `git log -1` and verify the branch was created by `/speckit.specify`.
+- [X] T002 Run baseline `./scripts/pre-pr.sh` once to confirm the pre-092 workspace passes clippy + tests cleanly (so any test failure post-edit is unambiguously caused by milestone 092, not pre-existing flakes).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the `self_version` field to `PomXmlDocument` and wire it up in `parse_pom_xml`. Both US1 (main-module fix) and US2 (property substitution) read from this field, so it MUST exist before either story's consumer-update tasks can land.
+
+**⚠️ CRITICAL**: No user story work can begin until T003 + T004 complete.
+
+- [X] T003 Add `pub self_version: Option<String>` field to `PomXmlDocument` struct in `mikebom-cli/src/scan_fs/package_db/maven.rs` (~line 546, immediately after `self_artifact_id`). Place the field with a doc-comment that mirrors the existing `self_artifact_id` rationale, per `data-model.md`'s post-092 shape. Update the surrounding doc-comment on `self_artifact_id` (lines 540-546) to also reference `self_version` for the parallel `<version>` inheritance gap.
+- [X] T004 Wire `self_version` in `parse_pom_xml` at `mikebom-cli/src/scan_fs/package_db/maven.rs` (~line 711). Add `doc.self_version = self_v.clone();` immediately after the existing `doc.self_artifact_id = self_a.clone();` line. Verify the constructor at line 703-707 (the `if let (Some(g), Some(a)) = ...` block) is **left unchanged** per research.md §1's rationale (preserves `self_coord` semantics for `MavenInheritanceContext::by_coord`).
+- [X] T005 [P] Run `cargo +stable build -p mikebom` to confirm the struct change compiles. No behavioral change yet (no consumer reads `self_version`); this is a compile-only checkpoint.
+
+**Checkpoint**: Foundation ready — `PomXmlDocument` carries the project's own version even when project-level `<groupId>` is absent. US1 and US2 implementations can now begin.
+
+---
+
+## Phase 3: User Story 1 - Operator gets correct version on main-module component (Priority: P1) 🎯 MVP
+
+**Goal**: Operator scanning a Maven project with a `<parent>` element sees the project's main-module emitted with the **project's own** version (`pkg:maven/<group>/<artifact>@<project-version>`), NOT the parent POM's version.
+
+**Independent Test**: `target/release/mikebom sbom scan --path $MIKEBOM_FIXTURES_DIR/transitive_parity/maven --format spdx-2.3-json --output /tmp/post-092.spdx.json`. Confirm the emitted SBOM contains `pkg:maven/org.apache.commons/commons-lang3@3.14.0` (NOT `@64`). Recipe 3 from `quickstart.md`.
+
+### Tests for User Story 1
+
+> **NOTE**: TDD-style — write the regression test FIRST, confirm it fails pre-fix, then apply T008 and confirm it passes.
+
+- [X] T006 [P] [US1] Add unit test `parse_pom_xml_extracts_self_version_when_groupId_inherited` to `mikebom-cli/src/scan_fs/package_db/maven.rs`'s test module. Construct a synthetic pom.xml byte string matching the commons-lang3 shape (parent block with `<groupId>`/`<artifactId>`/`<version>`, no project-level `<groupId>`, project-level `<artifactId>` + `<version>`). Assert: `doc.self_coord == None`, `doc.self_artifact_id == Some("commons-lang3")`, `doc.self_version == Some("3.14.0")`, `doc.parent_coord == Some(("org.apache.commons", "commons-parent", "64"))`. Cover the four `parse_pom_xml`-level rows from `contracts/maven-version-extraction.md` Contract 1's test-case table.
+- [X] T007 [P] [US1] Create new integration test file `mikebom-cli/tests/maven_pom_version_extraction.rs` and add three tests covering the FR-001 / FR-002 / FR-003 trio (so the post-fix fallback chain is fully exercised in one place). Mirror the temp-dir pattern from `scan_maven.rs`. Tests:
+    - **`main_module_emits_project_version_when_groupId_inherited_from_parent`** (FR-001 / SC-001): pom.xml with parent block (groupId+artifactId+version) and project-level `<artifactId>`/`<version>` only (no project-level `<groupId>`). Assert main-module PURL = `pkg:maven/org.apache.commons/commons-lang3@3.14.0`. MUST fail pre-fix (emits `@64`) and pass post-fix.
+    - **`main_module_falls_back_to_parent_version_when_project_version_absent`** (FR-002 / closes coverage gap C2): pom.xml with parent block (with `<version>1.0</version>`) and project-level `<artifactId>` only (NO project-level `<version>`, NO project-level `<groupId>`). Assert main-module PURL emission uses parent's `1.0`. Confirms the post-fix chain still falls through to `parent_coord.2` when both `self_coord` AND `self_version` are `None`.
+    - **`main_module_emits_nothing_when_both_versions_absent`** (FR-003 / closes coverage gap C1): pom.xml with parent block lacking `<version>` AND project lacking `<version>`. Assert NO main-module `PackageDbEntry` is emitted (or emitted with empty `version` and dropped by the existing `is_empty()` guard at maven.rs:3436). No malformed PURL appears in output.
+
+### Implementation for User Story 1
+
+- [X] T008 [US1] Update `build_maven_main_module_entry`'s `raw_version` resolution chain in `mikebom-cli/src/scan_fs/package_db/maven.rs` (~line 3412) to insert `.or_else(|| doc.self_version.clone())` between the existing `self_coord.2` lookup and the `parent_coord.2` fallback. Exact post-edit shape per `contracts/maven-version-extraction.md` Contract 2. Do not modify the `raw_group` or `raw_artifact` chains at lines 3402-3411.
+- [X] T009 [US1] Run `cargo +stable test -p mikebom --test maven_pom_version_extraction` and `cargo +stable test -p mikebom maven::tests::parse_pom_xml_extracts_self_version_when_groupId_inherited` (or whichever test-name pattern resolves). Confirm both pass. If either fails, debug — do NOT mark T008 complete until both pass.
+
+**Checkpoint**: US1 is fully functional and testable independently. The commons-lang3 fixture now emits the correct PURL. The milestone-083 transitive-parity baseline can be unfrozen (Phase 5 task).
+
+---
+
+## Phase 4: User Story 2 - No regression for `<version>${property}` substitution (Priority: P2)
+
+**Goal**: A `pom.xml` that uses `${revision}` or `${project.version}` for its own version OR for dep versions continues to resolve correctly post-092. Specifically, `${project.version}` resolved inside a child POM whose `<groupId>` is parent-inherited returns the project's own version (not the parent's).
+
+**Independent Test**: `cargo +stable test -p mikebom maven_property_substitution` (or the existing maven property-substitution tests, name verified at impl time). Plus the new `${project.version}`-with-inherited-groupId test from T011.
+
+### Tests for User Story 2
+
+- [X] T010 [P] [US2] Add regression test `existing_property_substitution_unchanged` to `mikebom-cli/tests/maven_pom_version_extraction.rs`. Build a temp pom.xml with `<version>${revision}</version>` + `<properties><revision>1.2.3</revision></properties>`, run the scanner, assert main-module PURL contains `@1.2.3`. Pre-existing milestone-085 / milestone-070 maven property substitution tests cover this case for `<groupId>`-present POMs; this new test specifically pairs property substitution with the `<groupId>`-inherited shape (the milestone 092 territory).
+- [X] T011 [P] [US2] Add test `dep_version_uses_project_version_property_when_groupId_inherited` to `mikebom-cli/tests/maven_pom_version_extraction.rs`. Build a temp pom.xml with: parent block (groupId=org.example, artifactId=parent, version=10.0); project-level `<artifactId>app` + `<version>3.14.0</version>` (no project-level groupId); a dep with `<version>${project.version}</version>`. Assert the emitted dep edge has version `3.14.0` (NOT `10.0`). This exercises Contract 3 + Contract 4.
+
+### Implementation for User Story 2
+
+- [X] T012 [P] [US2] Update `resolve_pom_property_value`'s `"project.version"` match arm in `mikebom-cli/src/scan_fs/package_db/maven.rs` (~line 3351) to insert `.or_else(|| self_doc.self_version.clone())` between the `self_coord.2` lookup and the `parent_coord.2` fallback. Exact post-edit shape per `contracts/maven-version-extraction.md` Contract 3.
+- [X] T013 [P] [US2] Update `resolve_maven_property`'s `"project.version"` match arm in `mikebom-cli/src/scan_fs/package_db/maven.rs` (~line 738) to add `.or_else(|| doc.self_version.clone())` after the existing `doc.self_coord.as_ref().map(|(_, _, v)| v.clone())`. Exact post-edit shape per `contracts/maven-version-extraction.md` Contract 4.
+- [X] T014 [US2] Run `cargo +stable test -p mikebom --test maven_pom_version_extraction` and confirm T010 + T011 pass. Run any pre-existing maven property-substitution tests (`cargo +stable test -p mikebom maven_property_substitution` and any milestone-070 / milestone-085 tests touching `${...}` resolution); confirm zero regressions.
+
+**Checkpoint**: US1 + US2 both pass. The fix is complete on the production-code side. Phase 5 covers downstream test/golden updates.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Update the milestone-083 transitive-parity baseline (FR-006), regenerate any maven goldens that flip from `@<parent-version>` to `@<project-version>` (FR-005), confirm byte-stability for non-maven goldens, and pass the mandatory pre-PR gate.
+
+- [X] T015 [P] Update `mikebom-cli/tests/transitive_parity_maven.rs` per FR-006: bump the pre-092 baseline from `pkg:maven/org.apache.commons/commons-lang3@64` to `@3.14.0` in `EXPECTED_REPRESENTATIVE_EDGES` (or whichever constant pins the version). The edge **count** does NOT change (still 1 emitted edge); only the version string within the pinned representative changes. Update the doc-comment to add a "Closed by milestone 092" subsection mirroring milestone-087/088 pattern.
+- [X] T016 [P] Update `specs/083-transitive-correctness/research.md` §8 — Ecosystem: Maven audit row to mark the version-extraction gap closed (mirror the milestone-087 / milestone-088 / milestone-091 pattern).
+- [X] T017 Regenerate maven goldens if any flip. Run, in sequence: `MIKEBOM_UPDATE_CDX_GOLDENS=1 cargo +stable test -p mikebom --test cdx_regression`; `MIKEBOM_UPDATE_SPDX_GOLDENS=1 cargo +stable test -p mikebom --test spdx_regression`; `MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test -p mikebom --test spdx3_regression`. Then `git status --short mikebom-cli/tests/fixtures/golden/` — expected: AT MOST 3 maven goldens modified (the milestone-070 maven main-module fixture, or any other maven golden whose source pom.xml declares a `<parent>` element with its own `<version>`), zero non-maven goldens. If any non-maven golden modifies, STOP and investigate scope creep.
+- [X] T018 Audit the golden diff scope. `git diff mikebom-cli/tests/fixtures/golden/` — confirm the only changes are version-string flips on commons-lang3-style entries (parent-version → project-version). NO new components, NO new annotations, NO PURL count changes. Per `quickstart.md` Recipe 5.
+- [X] T019 Run the mandatory pre-PR gate: `./scripts/pre-pr.sh`. Confirm zero clippy warnings AND every test suite reports `0 failed`. This is the CLAUDE.md mandatory gate; failure here blocks PR.
+- [X] T020 Run `cargo +stable test -p mikebom --test transitive_parity_maven` and confirm 4/4 tests pass post-T015 update.
+- [X] T021 Update `CLAUDE.md`'s "Recent Changes" section to add a milestone-092 line. The agent-context script already populated `## Active Technologies` with the milestone's stack; verify it reads correctly.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Depends on Setup. **BLOCKS** US1 + US2 (both consumers read `self_version`).
+- **US1 (Phase 3)**: Depends on Foundational. Independent of US2 — can ship as MVP.
+- **US2 (Phase 4)**: Depends on Foundational. Independent of US1.
+- **Polish (Phase 5)**: Depends on US1 + US2 production code being merged in.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Reads `doc.self_version` populated by T004. No dependency on US2.
+- **US2 (P2)**: Reads `doc.self_version` populated by T004. No dependency on US1.
+
+The two stories share the same Foundational field (`self_version`) but their consumer-update sites are in different functions (US1 → `build_maven_main_module_entry`; US2 → `resolve_pom_property_value` + `resolve_maven_property`). They CAN ship in either order or in parallel after Foundational completes.
+
+### Within Each User Story
+
+- Tests written before implementation (TDD-style).
+- Single production file (`maven.rs`) — implementation tasks within the same story affect different functions, so [P] applies between US2's T012 and T013 (different match-arm sites).
+- US1's T008 and US2's T012/T013 all touch the same file but DIFFERENT functions; they can happen in any order without merge-conflict risk.
+
+### Parallel Opportunities
+
+- T005 (build check) is independent of T003+T004 once those complete sequentially.
+- US1 tests T006 + T007 are in different files (test module in `maven.rs` vs new `maven_pom_version_extraction.rs`) — run in parallel.
+- US2 tests T010 + T011 are in the same new test file but different test functions — write together; no parallel-write conflict.
+- US2 implementation T012 + T013 touch different functions in `maven.rs` — can land in parallel commits if cleanly separated.
+- US1 + US2 implementation tasks (T008, T012, T013) all touch different functions in `maven.rs` — independent.
+- Phase 5 T015 (transitive_parity_maven.rs) + T016 (specs/083 doc update) are different files — parallel.
+
+---
+
+## Parallel Example: User Story 1 Tests
+
+```bash
+# Both tests touch different files; write them in parallel:
+Task: "Unit test parse_pom_xml_extracts_self_version_when_groupId_inherited in mikebom-cli/src/scan_fs/package_db/maven.rs's tests module"
+Task: "Integration test main_module_emits_project_version_when_groupId_inherited_from_parent in new file mikebom-cli/tests/maven_pom_version_extraction.rs"
+```
+
+## Parallel Example: User Story 2 Implementation
+
+```bash
+# Different functions in the same file — sequential commits, but logically independent:
+Task: "Update resolve_pom_property_value's project.version arm at maven.rs:~3351"
+Task: "Update resolve_maven_property's project.version arm at maven.rs:~738"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only)
+
+1. Phase 1: Setup (T001–T002)
+2. Phase 2: Foundational (T003–T005) — adds `self_version` field
+3. Phase 3: US1 (T006–T009) — main-module fix
+4. **STOP and VALIDATE**: run Recipe 3 from `quickstart.md` against the commons-lang3 fixture. Confirm `@3.14.0` emission. This is the milestone's headline win.
+
+### Incremental Delivery
+
+1. Setup + Foundational → field exists
+2. US1 → main-module emits correct version → MVP ready
+3. US2 → property substitution preserved → completes the milestone
+4. Polish → milestone-083 baseline + golden regen + pre-PR gate → ready for PR
+
+### Single-Developer Strategy (this milestone)
+
+This is a small surgical fix; one developer (you) does it sequentially:
+
+1. T001–T002 (setup, ~5 min)
+2. T003–T005 (foundational, ~10 min)
+3. T006–T009 (US1, ~30 min — bulk of the milestone)
+4. T010–T014 (US2, ~20 min)
+5. T015–T021 (polish + gate, ~20 min — golden regen is the longest single step)
+
+Total: ~90 min including pre-PR gate. The fix itself is ~10 lines of production code.
+
+---
+
+## Notes
+
+- [P] tasks = different files OR different functions in the same file with no implicit dependency.
+- [Story] label maps task to specific user story for traceability.
+- The fix is pure-additive: one new struct field, four `.or_else(|| ...)` insertions, no field removals or signature changes.
+- All edits land in a single production file (`mikebom-cli/src/scan_fs/package_db/maven.rs`) plus one new test file (`mikebom-cli/tests/maven_pom_version_extraction.rs`) plus one updated regression test (`mikebom-cli/tests/transitive_parity_maven.rs`).
+- The milestone-083 baseline pinning was either pinning the BUGGY value (`@64` — needs flipping) OR was already pinning `@3.14.0` and was failing pre-092 (needs verification at T015 time). Either way, T015's deliverable is a test that passes post-T008.
+- Verify tests fail pre-fix and pass post-fix per TDD discipline (US1 + US2 test tasks run before their corresponding implementation tasks).
+- Commit boundary suggestion: one commit per phase (Foundational, US1, US2, Polish). Optionally squash to a single commit at PR time.
+- Avoid: relaxing the `self_coord` constructor at line 703 (would break `MavenInheritanceContext::by_coord` keying — see research.md §1's rejected alternative).


### PR DESCRIPTION
## Summary

- Fixes the Maven version-extraction bug where `pkg:maven/org.apache.commons/commons-lang3@64` was emitted instead of `@3.14.0` for any pom.xml that declares `<parent>` AND inherits its `<groupId>` from the parent (the typical real-world Apache / Spring Boot / corporate-parent shape).
- Root cause: `parse_pom_xml` only populated `self_coord` when BOTH project-level `<groupId>` AND `<artifactId>` were present, so the project's own `<version>` was silently discarded for any POM omitting `<groupId>` — `build_maven_main_module_entry` then fell back to the parent POM's version.
- Fix: adds a `self_version: Option<String>` field to `PomXmlDocument` (parallel to milestone-007's `self_artifact_id`), populated from `<project>/<version>` independently of `self_coord`. Threads it through the main-module emission + property-substitution code paths. ~10 lines of production code; 8 new tests (3 unit + 5 integration).

Track 1 of #175 (cache-empty Maven Central HTTP fetch fallback) remains out of scope and is documented as a future milestone in `specs/083-transitive-correctness/research.md` §8.

## Test plan

- [x] New unit tests in `maven::tests` confirm `self_version` is captured for the commons-lang3 shape (groupId-inherited + version-present), absent shape (intentional inheritance), and fully-populated shape (no behavior change).
- [x] New integration test file `mikebom-cli/tests/maven_pom_version_extraction.rs` covers the FR-001 / FR-002 / FR-003 trio (project-version precedence, parent-version fallback, both-missing skip) plus 2 property-substitution preservation cases (US2).
- [x] All 13 pre-existing `scan_maven` integration tests continue to pass — including `scan_maven_multi_module_reactor_emits_per_submodule_main_modules` which exercises `<version>${project.version}</version>` in a child POM (the fix's `${`-placeholder skip in property-substitution arms preserves Maven's documented self-reference semantics).
- [x] All 88 `scan_fs::package_db::maven` unit tests pass.
- [x] `transitive_parity_maven.rs` passes (cache-empty edge count unchanged at 0).
- [x] Zero golden files regenerated — no fixture in the workspace exercises the bug-trigger shape, so byte-stability holds across all 27 goldens.
- [x] `./scripts/pre-pr.sh` clean: zero clippy warnings, all 78 test targets report `0 failed`.

## Constitution check

- **I (Pure Rust, Zero C)**: ✅ no FFI, no C deps, no toolchain change.
- **IV (Type-Driven Correctness, no `.unwrap()` in production)**: ✅ all production edits use `.or_else(|| ...)` + `.clone()`; `.unwrap()` only appears in test code.
- **V (Specification Compliance / standards-native precedence)**: ✅ no new `mikebom:*` properties; same emission shape pre/post fix.
- **X (Transparency)**: ✅ surfacing the project's own version is more transparent, not less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)