### PR TITLE
fix(090): build.rs fixture-cache OUT_DIR fallback for cross-compile

### DIFF
--- a/mikebom-cli/build.rs
+++ b/mikebom-cli/build.rs
@@ -54,17 +54,7 @@ fn fetch_fixtures() {
         panic!("\ntests/fixtures.rev MUST be a 40-char lowercase hex SHA; got {sha:?}\n");
     }
 
-    let cache_parent = std::env::var("MIKEBOM_FIXTURE_CACHE")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let home = std::env::var("HOME").unwrap_or_else(|_| {
-                std::env::var("USERPROFILE").expect("HOME or USERPROFILE must be set")
-            });
-            PathBuf::from(home)
-                .join(".cache")
-                .join("mikebom")
-                .join("fixtures")
-        });
+    let cache_parent = resolve_cache_parent();
     let cache_target = cache_parent.join(&sha);
 
     if cache_target.exists()
@@ -81,14 +71,8 @@ fn fetch_fixtures() {
         return;
     }
 
-    // Cache miss — clone + pin to exact SHA.
-    std::fs::create_dir_all(&cache_parent).unwrap_or_else(|e| {
-        panic!(
-            "\nfailed to create cache parent {}: {}\n",
-            cache_parent.display(),
-            e,
-        )
-    });
+    // Cache miss — clone + pin to exact SHA. `resolve_cache_parent`
+    // already guarantees the parent directory exists.
 
     println!("cargo:warning=fetching mikebom-test-fixtures @ {sha} (one-time per pin)");
 
@@ -127,4 +111,56 @@ fn fetch_fixtures() {
         "cargo:rustc-env=MIKEBOM_FIXTURES_DIR={}",
         cache_target.display()
     );
+}
+
+/// Resolve a writable directory to host the fixture-repo cache.
+///
+/// Resolution order:
+/// 1. `MIKEBOM_FIXTURE_CACHE` env var (explicit operator override).
+/// 2. `$HOME/.cache/mikebom/fixtures/` on Unix /
+///    `$USERPROFILE/.cache/mikebom/fixtures/` on Windows.
+/// 3. `$OUT_DIR/mikebom-fixtures/` as a defensive fallback when (2)
+///    isn't writable — cargo always sets `OUT_DIR` and guarantees it
+///    is writable. Triggered in `cross` Docker containers where
+///    `HOME=""` produces an unusable path like `/.cache/mikebom/...`
+///    that the container's root filesystem rejects.
+///
+/// Returns a path whose parent directory already exists and is
+/// writable, so callers can `clone`/`reset` into a subdirectory of it
+/// without panicking on permission errors.
+fn resolve_cache_parent() -> PathBuf {
+    let preferred = std::env::var("MIKEBOM_FIXTURE_CACHE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            let home = std::env::var("HOME")
+                .ok()
+                .or_else(|| std::env::var("USERPROFILE").ok())
+                .filter(|s| !s.is_empty())?;
+            Some(
+                PathBuf::from(home)
+                    .join(".cache")
+                    .join("mikebom")
+                    .join("fixtures"),
+            )
+        });
+
+    if let Some(path) = preferred {
+        if std::fs::create_dir_all(&path).is_ok() {
+            return path;
+        }
+        println!(
+            "cargo:warning=fixture cache parent {} not writable; falling back to $OUT_DIR/mikebom-fixtures/",
+            path.display()
+        );
+    }
+
+    // Fallback: $OUT_DIR is always set by cargo and is writable.
+    let out_dir = std::env::var("OUT_DIR")
+        .expect("cargo must set OUT_DIR in build.rs");
+    let fallback = PathBuf::from(out_dir).join("mikebom-fixtures");
+    std::fs::create_dir_all(&fallback)
+        .expect("OUT_DIR-based fixture cache fallback must be writable");
+    fallback
 }


### PR DESCRIPTION
## Summary

- Fixes the Linux x86_64 + linux-aarch64 release-build failures that landed on alpha.28 and alpha.29. Both release runs left macOS + eBPF artifacts published but skipped the GitHub pre-release step because the cross-compile binaries never built.
- Root cause: inside `cross`'s Docker container, `HOME` is empty (or `/`), so milestone-090's `build.rs` resolved the fixture cache parent to `/.cache/mikebom/fixtures/` and panicked at `Permission denied (os error 13)`.
- Fix: factor cache-parent resolution into a `resolve_cache_parent` helper with a three-tier chain — `MIKEBOM_FIXTURE_CACHE` env (existing) → `\$HOME/.cache/mikebom/fixtures/` (existing, now filters empty HOME) → `\$OUT_DIR/mikebom-fixtures/` (new defensive fallback). Cargo always sets `OUT_DIR` and guarantees it is writable, so the fallback works in any cross-compile environment.
- Constitution-friendly: zero new crates, std-only path resolution.

## Test plan

- [x] Pre-PR gate clean locally: `./scripts/pre-pr.sh` — zero clippy warnings, all test targets `0 failed`.
- [x] No regression for HOME-set environments: the HOME path is still tried first and used when writable (existing developer workflows + host-runs CI unaffected).
- [ ] **Real validation**: this PR will be reflected in the alpha.30 release's Linux cross-compile jobs (existing alpha.29 release won't be retroactively re-run since tag pushes can't be replayed).

## Followup

- The alpha.29 release published partial artifacts (macOS + eBPF only). Next milestone's release cycle bumps to alpha.30 and re-validates Linux cross-compile via this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)