### PR TITLE
chore(093): repo polish — broken URL, SECURITY/CONTRIBUTING, templates, cargo binstall

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Report a bug or unexpected behavior in mikebom
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill
+        in the fields below so we can reproduce and triage quickly.
+
+        If you've found a **security vulnerability**, please STOP and
+        report it through GitHub Security Advisories instead — see
+        [SECURITY.md](https://github.com/kusari-sandbox/mikebom/blob/main/SECURITY.md).
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Operating system
+      description: Where did you see the bug?
+      options:
+        - linux-x86_64
+        - linux-aarch64
+        - macOS aarch64 (Apple Silicon)
+        - macOS x86_64 (Intel)
+        - Windows
+        - Other (specify in "Additional context")
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: mikebom version
+      description: Output of `mikebom --version`
+      placeholder: e.g., mikebom 0.1.0-alpha.30
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Command + output
+      description: Paste the exact command you ran and the full output (stdout + stderr).
+      placeholder: |
+        $ mikebom sbom scan --path ./my-project --format spdx-2.3-json
+        ...
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual
+      description: What did you expect to happen? What actually happened?
+      placeholder: |
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else? Screenshots, fixture pom.xml/Cargo.lock, related issues, environment details.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/kusari-sandbox/mikebom/security/advisories/new
+    about: Please report vulnerabilities privately via GitHub Security Advisories, NOT as public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Suggest a new feature or improvement for mikebom
+title: "[FEATURE] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! For non-trivial features please open
+        an issue here first so we can align on direction before code is
+        written. mikebom uses the speckit lifecycle for feature work —
+        see [CONTRIBUTING.md](https://github.com/kusari-sandbox/mikebom/blob/main/CONTRIBUTING.md).
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What are you trying to accomplish? Why is the current behavior insufficient?
+      placeholder: |
+        I want to scan ... so I can ...
+        Today mikebom does ... which doesn't ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like mikebom to handle this? A new flag, a new subcommand, a new ecosystem reader, a new output field?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else have you tried or considered? Existing workarounds, other SBOM tools' approaches.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to related issues, upstream spec references, prior art.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- 1-3 sentences explaining what this PR does and why. -->
+
+## Test plan
+
+<!-- Bulleted list of the verification steps you ran locally. -->
+
+- [ ]
+- [ ]
+
+## Pre-PR checklist
+
+- [ ] I ran `./scripts/pre-pr.sh` and it exited clean (zero clippy warnings, all test suites `0 failed`).
+- [ ] For non-trivial changes, I followed the speckit lifecycle (`specs/<NNN>-<short-name>/` exists with spec/plan/tasks); for drive-by fixes, this is a single-purpose change.
+- [ ] If I touched SBOM emission or output formats, I regenerated the affected byte-identity goldens (`MIKEBOM_UPDATE_{CDX,SPDX,SPDX3}_GOLDENS=1 cargo +stable test ...`).
+- [ ] If I added a new `mikebom:*` property / annotation / relationship type, I audited each target format for an existing native construct first (Constitution Principle V — see [`.specify/memory/constitution.md`](../.specify/memory/constitution.md)).
+- [ ] If this is a release-bump PR, I ran the SPDX-3 conformance gate locally: `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 ./scripts/pre-pr.sh`.
+
+🤖 If this PR was AI-assisted, include the Co-Authored-By trailer in the commit message.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1657,5 +1657,5 @@ per-release breakdown.
 
 ---
 
-[Unreleased]: https://github.com/mlieberman85/mikebom/compare/v0.1.0-alpha.3...HEAD
-[0.1.0-alpha.3]: https://github.com/mlieberman85/mikebom/releases/tag/v0.1.0-alpha.3
+[Unreleased]: https://github.com/kusari-sandbox/mikebom/compare/v0.1.0-alpha.3...HEAD
+[0.1.0-alpha.3]: https://github.com/kusari-sandbox/mikebom/releases/tag/v0.1.0-alpha.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ Auto-generated from all feature plans. Last updated: 2026-05-10
 - N/A — purely in-process per-scan resolution. Mirrors milestones 002–055. (091-go-sum-transitive-fallback)
 - Rust stable (workspace toolchain inherited from milestones 001–091; no nightly required for this user-space-only bug fix). + existing only — `quick-xml = "0.31"` (already used by `parse_pom_xml`), `serde`/`serde_json`, `tracing`, `anyhow`. **No new crates.** (092-fix-maven-version-extract)
 - N/A — pure metadata transform on the maven main-module emission code path; no caches, no persistence. (092-fix-maven-version-extract)
+- N/A — this milestone touches Markdown + (potentially) Cargo.toml metadata only. + None new. The existing `release.yml` artifact-naming convention is the only behavioral input that informs the cargo-binstall integration choice. (093-repo-polish-quickwins)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -146,9 +147,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 093-repo-polish-quickwins: Added N/A — this milestone touches Markdown + (potentially) Cargo.toml metadata only. + None new. The existing `release.yml` artifact-naming convention is the only behavioral input that informs the cargo-binstall integration choice.
 - 092-fix-maven-version-extract: Added Rust stable (workspace toolchain inherited from milestones 001–091; no nightly required for this user-space-only bug fix). + existing only — `quick-xml = "0.31"` (already used by `parse_pom_xml`), `serde`/`serde_json`, `tracing`, `anyhow`. **No new crates.**
 - 091-go-sum-transitive-fallback: Added Rust stable (workspace toolchain inherited from milestones 001–090; no nightly required for this user-space-only Go-reader extension). + existing only — `parse_go_sum` at `legacy.rs:353`, `WorkspaceContext.go_sum_modules` at `graph_resolver.rs`, `ResolutionStep` enum at `graph_resolver.rs:64`. **No new Cargo dependencies.**
-- 090-split-test-fixtures-repo: Added Rust stable (workspace toolchain inherited from milestones 001–089; no nightly required for this user-space-only test-infra refactor). + ONE new direct dep on `mikebom-cli` — `git2 = "0.19"` for pure-Rust Git clone in `build.rs`. Alternative: shell out to `git` via `std::process::Command` (mikebom already does this in golang reader + cargo reader). **Decision**: shell out to `git` — same pattern as existing readers (Constitution-friendly: zero new transitive crates, no `git2`'s `libgit2-sys` C dependency). The `git` binary is already a hard prereq for any mikebom dev setup.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+# Contributing to mikebom
+
+Thanks for your interest in contributing! mikebom is pre-1.0 alpha; we
+encourage a quick discussion on non-trivial changes before you open a
+PR so we can align on direction.
+
+## Workflow overview (the speckit lifecycle)
+
+For non-trivial changes (new features, behavior changes, large
+refactors, ecosystem additions), mikebom uses the spec-kit lifecycle:
+
+1. `/speckit.specify` — write the feature spec (what + why)
+2. `/speckit.clarify` (optional) — resolve open questions
+3. `/speckit.plan` — produce `research.md`, `data-model.md`, `contracts/`
+4. `/speckit.tasks` — break work into a checklist
+5. `/speckit.analyze` (optional) — cross-check spec ↔ plan ↔ tasks
+6. `/speckit.implement` — execute the task list
+
+Each milestone lives at `specs/<NNN>-<short-name>/`. See an existing one
+(e.g., [`specs/092-fix-maven-version-extract/`](specs/092-fix-maven-version-extract/))
+for a complete example.
+
+Per-skill references are under `.claude/skills/speckit-*/SKILL.md`.
+
+**Small drive-by fixes** (typo corrections, single-line bug fixes,
+doc tweaks) skip the lifecycle — just open a PR.
+
+## Local development setup
+
+```bash
+git clone https://github.com/kusari-sandbox/mikebom.git
+cd mikebom
+cargo +stable build --release
+```
+
+The `sbom`, `policy`, `attestation`, and related subcommands build
+under the **stable** toolchain. The eBPF-based `trace` subcommands
+additionally need nightly + bpf-linker — see
+[`docs/user-guide/installation.md`](docs/user-guide/installation.md)
+for the full setup, including the `mikebom-dev` container and Lima VM
+options for macOS.
+
+Test fixtures live in a sibling repo (`kusari-sandbox/mikebom-test-fixtures`)
+and are cloned automatically by `build.rs` on first build into a
+per-host cache at `~/.cache/mikebom/fixtures/<pinned-sha>/`. The
+pinned SHA lives in `tests/fixtures.rev`.
+
+## Pre-PR gate (MANDATORY)
+
+Before opening any PR, **both** of these MUST exit clean:
+
+```bash
+./scripts/pre-pr.sh
+```
+
+This single script runs, in order:
+
+1. `cargo +stable clippy --workspace --all-targets -- -D warnings` — zero
+   clippy warnings (warnings become errors).
+2. `cargo +stable test --workspace` — every test suite must report
+   `N passed; 0 failed`.
+
+Both gates are what CI enforces; running the script locally first saves
+a CI round-trip.
+
+For PRs that touch SBOM emission or output formats, also opt-in to the
+SPDX-3 conformance validator:
+
+```bash
+MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 ./scripts/pre-pr.sh
+```
+
+This requires the JPEWdev `spdx3-validate` Python package pinned in
+`.venv/spdx3-validate/`. If the validator isn't installed locally,
+the gate skips silently — but CI runs it strictly on release branches,
+so test locally before release-bump PRs.
+
+## Project principles + where to find them
+
+The canonical source-of-truth for project principles is
+[`.specify/memory/constitution.md`](.specify/memory/constitution.md).
+Twelve principles to be aware of:
+
+- **I. Pure Rust, Zero C** — no FFI, no `libbpf` bindings, no C
+  toolchains in the build pipeline. `aya` provides the eBPF stack.
+- **II. eBPF-Only Observation** — eBPF tracing is the trust-rooted
+  dependency-discovery path; external sources (lockfiles, registries)
+  only ENRICH what was observed.
+- **III. Fail Closed** — never gap-fill with heuristics when the
+  trace loses data; exit non-zero and surface the gap.
+- **IV. Type-Driven Correctness** — newtype wrappers for PURL,
+  hashes, license expressions; no `.unwrap()` in production code
+  (use `anyhow` / `thiserror`).
+- **V. Specification Compliance** — CycloneDX 1.6 + SPDX 2.3 +
+  SPDX 3.x conformance is non-negotiable. **Standards-native fields
+  take precedence over `mikebom:*` properties** — every new
+  `mikebom:*` field MUST first audit each target format for an
+  existing native construct.
+- **VI. Three-Crate Architecture** — `mikebom-ebpf/` (no_std kernel
+  programs), `mikebom-common/` (shared structs), `mikebom-cli/`
+  (user-space). Additional crates require a constitution amendment.
+- **VII. Test Isolation** — privilege-dependent tests (eBPF) gated
+  behind CAP_BPF; unprivileged unit tests run on every CI lane.
+- **VIII. Completeness** — minimize false negatives; every observed
+  fetch must appear in the SBOM.
+- **IX. Accuracy** — minimize false positives; flag low-confidence
+  matches via spec-native confidence/evidence fields.
+- **X. Transparency** — surface every limitation (overflow events,
+  inferred edges, heuristic matches) via spec-native mechanisms.
+- **XI. Enrichment** — license, VEX, supplier metadata when
+  available; never block SBOM emission on unavailable enrichment.
+- **XII. External Data Source Enrichment** — lockfiles / registries /
+  hash databases MAY enrich observed components but MUST NOT
+  introduce components the eBPF trace didn't observe.
+
+If your change touches any principle, link to it from your PR
+description and explain how the change preserves the principle. The
+mandatory pre-PR template (`.github/pull_request_template.md`) has
+a checkbox for this.
+
+## Pull request etiquette
+
+- Open one PR per logical change. The PR title should match the
+  format `<type>(<scope>): <subject>` (e.g., `fix(092): Maven pom.xml
+  version-extraction`).
+- Include a `## Test plan` section in the PR description with the
+  commands you ran locally.
+- Run `./scripts/pre-pr.sh` clean before requesting review.
+- For changes that regenerate byte-identity goldens, mention the
+  expected diff symmetry in the PR description (e.g., "+1521/-1521
+  tool-version churn only").
+
+## Reporting issues + security
+
+- Bugs / feature requests: use the structured templates at
+  https://github.com/kusari-sandbox/mikebom/issues/new/choose.
+- Vulnerabilities: see [`SECURITY.md`](SECURITY.md) — do **not**
+  open a public issue.
+
+## License
+
+By contributing, you agree your contributions are licensed under
+Apache-2.0 (the project's license — see [`LICENSE`](LICENSE)).

--- a/README.md
+++ b/README.md
@@ -232,10 +232,25 @@ sudo install -m 0755 mikebom /usr/local/bin/mikebom
 mikebom --version
 ```
 
-Or build from source:
+### Via cargo binstall (Rust toolchain users)
+
+If you already have [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall)
+installed, you can skip the `gh release download` dance:
 
 ```bash
-git clone https://github.com/mlieberman85/mikebom.git
+cargo binstall --git https://github.com/kusari-sandbox/mikebom mikebom
+```
+
+`mikebom-cli`'s [`[package.metadata.binstall]`](mikebom-cli/Cargo.toml)
+block pins the URL template to the existing release-tarball naming so
+discovery is deterministic. Once mikebom is published to crates.io
+(planned for a future milestone), bare `cargo binstall mikebom` will
+work without the `--git` flag.
+
+### Or build from source
+
+```bash
+git clone https://github.com/kusari-sandbox/mikebom.git
 cd mikebom
 cargo build --release
 # binary: ./target/release/mikebom
@@ -638,7 +653,7 @@ tests/fixtures/   Real + synthetic fixtures consumed by integration tests
 ## Reporting issues and contributing
 
 Open an issue or PR at
-[github.com/mlieberman85/mikebom](https://github.com/mlieberman85/mikebom).
+[github.com/kusari-sandbox/mikebom](https://github.com/kusari-sandbox/mikebom).
 CI enforces `cargo +stable clippy --workspace --all-targets` and
 `cargo +stable test --workspace` on every PR; run both locally before
 opening one.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please **do not open a public GitHub issue** for vulnerabilities. Report
+them privately through GitHub Security Advisories:
+
+  https://github.com/kusari-sandbox/mikebom/security/advisories/new
+
+This routes the report to the maintainers without exposing it publicly.
+
+## What to expect
+
+- **Acknowledgment** within 7 days of report.
+- **Triage decision** (accepted / declined / needs-more-info) within
+  14 days.
+- **Fix or detailed status update** within 30 days.
+
+Coordinated disclosure timelines can be negotiated case-by-case if a
+fix requires longer (e.g., a deep refactor or upstream dependency
+update).
+
+## Supported versions
+
+mikebom is pre-1.0 alpha. Only the **most recent alpha release** is
+supported for security fixes. SemVer guarantees do not apply until 1.0.
+
+| Version          | Supported          |
+|------------------|--------------------|
+| latest alpha     | ✅ yes              |
+| older alphas     | ❌ no               |
+| 1.0 and beyond   | (policy TBD at 1.0) |
+
+## Scope
+
+In scope:
+
+- Crashes, hangs, or memory-safety issues during `scan` / `verify` / `trace`.
+- SBOM emission that misrepresents the underlying observed evidence
+  (e.g., a component reported as present that wasn't observed in the
+  trace, or vice versa — this contradicts Constitution Principles VIII
+  + IX at `.specify/memory/constitution.md`).
+- Attestation verification failures that incorrectly accept malformed,
+  expired, or revoked signatures.
+- Privilege-escalation or container-escape via the eBPF tracer.
+- Path-traversal, command-injection, or arbitrary-file-write in scan
+  modes that consume operator-controlled paths.
+
+Out of scope:
+
+- Vulnerabilities in mikebom's upstream Rust crate dependencies — those
+  go through normal CVE channels and are tracked by the Kusari Inspector
+  CI gate that runs on every PR. If you've found a dependency CVE you
+  believe mikebom is exposed to, please mention it in an advisory anyway
+  — we'd rather have a duplicate than miss one.
+- Bugs that produce wrong SBOM output without a security implication
+  (those should be filed as regular GitHub issues).
+- Denial-of-service via legitimate-but-large inputs (e.g., a 10 GB
+  container layer that exhausts memory). Resource-exhaustion mitigations
+  are tracked as ordinary issues.

--- a/mikebom-cli/Cargo.toml
+++ b/mikebom-cli/Cargo.toml
@@ -202,3 +202,13 @@ wiremock = "0.6"
 aya = { version = "0.13", optional = true }
 aya-log = { version = "0.2", optional = true }
 libc = { version = "0.2", optional = true }
+
+# Milestone 093: cargo-binstall auto-discovery metadata. Locks the
+# pkg-url template to mikebom's existing release-tarball naming
+# (`mikebom-vX.Y.Z-<rust-triple>.tar.gz`) so `cargo binstall mikebom`
+# resolves the binary deterministically regardless of future
+# binstall-default changes. cargo treats unknown package.metadata.*
+# keys as opaque pass-through; this block cannot break the build.
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"
+pkg-fmt = "tgz"

--- a/specs/093-repo-polish-quickwins/checklists/requirements.md
+++ b/specs/093-repo-polish-quickwins/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Repo polish — quick-wins cleanup pass
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs) — describes file-level deliverables (SECURITY.md, CONTRIBUTING.md, templates) and their *content shape*, not how to format markdown internals or which clap APIs to call. The `Cargo.toml` mention is metadata-only, not a code change.
+- [X] Focused on user value and business needs — explicitly frames each gap as a new-visitor / contributor / researcher pain point.
+- [X] Written for non-technical stakeholders — Background section explains "git URL points at stale account" in plain English; FRs are testable in operator terms.
+- [X] All mandatory sections completed — User Scenarios & Testing (5 stories), Requirements (10 FRs), Success Criteria (7 SCs), Assumptions, Dependencies, Out of Scope.
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain — all five gaps have clear scope; the few open choices (e.g., supported-versions policy text, email-alias-vs-GHSA) are pinned in Assumptions with explicit reasonable-default rationale.
+- [X] Requirements are testable and unambiguous — FR-001 has a concrete grep check; FR-002–FR-005 enumerate file paths + required content sections; FR-006–FR-010 are diff-scope / metadata invariants.
+- [X] Success criteria are measurable — SC-001 (HTTP 200 on git clone), SC-002 (GitHub Security tab integration), SC-003 (4-question quiz), SC-004 (template count), SC-005 (60s install + SHA verification), SC-006 (pre-PR gate exit code), SC-007 (file-path diff allowlist).
+- [X] Success criteria are technology-agnostic — frame outcomes as visitor / contributor / researcher experiences, not "test X passes". The pre-PR gate reference is a project-level convention, not a tech detail.
+- [X] All acceptance scenarios are defined — 5 user stories, each with 2 Given/When/Then scenarios (10 total).
+- [X] Edge cases are identified — 5 edge cases covering repo transfer, channel rotation, GitHub auto-detection, template length, and `cargo binstall` discovery-vs-explicit-URL.
+- [X] Scope is clearly bounded — explicit Out of Scope section listing 9 deliberately-deferred items (Homebrew tap, install.sh, completions, man pages, crates.io, Docker, deb/rpm, CODE_OF_CONDUCT, repo rename).
+- [X] Dependencies and assumptions identified — both sections populated; dependency on existing `release.yml` artifact naming verified.
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria — FR-001 ↔ US1 AS#1 + SC-001; FR-002 ↔ US2 + SC-002; FR-003 ↔ US3 + SC-003; FR-004 ↔ US4 AS#1 + SC-004; FR-005 ↔ US4 AS#2; FR-006 ↔ US5 + SC-005; FR-007/FR-008/FR-009 ↔ SC-007 diff-scope audit; FR-010 ↔ SC-006 pre-PR gate.
+- [X] User scenarios cover primary flows — US1 (P1 install path works) + US2/US3 (P2 security disclosure + contributor onboarding) + US4/US5 (P3 issue templates + cargo-binstall).
+- [X] Feature meets measurable outcomes defined in Success Criteria — yes, every FR maps to ≥1 SC.
+- [X] No implementation details leak into specification — file paths are reference-only, not prescribing internal structure of any markdown file.
+
+## Notes
+
+All 16 checklist items pass. Spec is ready for `/speckit.plan` (small docs-only milestone; no clarification needed — the five gaps + their fix shapes are unambiguous and there are explicit Assumptions for the few minor open choices).

--- a/specs/093-repo-polish-quickwins/contracts/repo-surface-contracts.md
+++ b/specs/093-repo-polish-quickwins/contracts/repo-surface-contracts.md
@@ -1,0 +1,188 @@
+# Contract — Repo surface deliverables
+
+Behavioral / content contracts for every new or modified file. Each contract names: (a) what the file MUST contain, (b) how to verify (a) without executing code.
+
+## Contract 1 — README install commands resolve (FR-001 / SC-001)
+
+**File**: `README.md`
+
+**Pre-093 state**: line 238 contains `git clone https://github.com/mlieberman85/mikebom.git` — 404 against the canonical repo.
+
+**Post-093 state**: line 238 contains `git clone https://github.com/kusari-sandbox/mikebom.git`. Repo-wide grep for `mlieberman85` returns zero hits in committed content (`*.md`, `*.toml`, `*.yml`, etc. — excluding git log history).
+
+**Verification (no code execution required)**:
+```bash
+grep -rn "mlieberman85" --include='*.md' --include='*.toml' --include='*.yml' .
+# Expected: no output, exit 1.
+```
+
+## Contract 2 — README documents cargo binstall (FR-006 / SC-005)
+
+**File**: `README.md`'s `## Install` section.
+
+**Post-093 state**: a new subsection (heading approx `### Via cargo binstall (Rust toolchain users)`) appears AFTER the existing tarball-download path and BEFORE `## Supported ecosystems`. The subsection contains:
+
+- A one-line preamble explaining when this is useful.
+- A fenced bash block with the exact invocation: `cargo binstall --git https://github.com/kusari-sandbox/mikebom mikebom`
+- A note that bare `cargo binstall mikebom` works once mikebom publishes to crates.io.
+
+**Verification**: visual inspection of the rendered README. Open the PR's "Files changed" view and confirm the new section appears with all three elements.
+
+## Contract 3 — Cargo.toml binstall metadata block exists (FR-006)
+
+**File**: `mikebom-cli/Cargo.toml`
+
+**Post-093 state**: a `[package.metadata.binstall]` table appears, with at minimum:
+
+```toml
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"
+pkg-fmt = "tgz"
+```
+
+**Verification**:
+```bash
+grep -A2 "\[package.metadata.binstall\]" mikebom-cli/Cargo.toml
+# Expected: shows the table + pkg-url + pkg-fmt lines.
+cargo +stable build -p mikebom 2>&1 | tail -3
+# Expected: successful build (cargo treats unknown package.metadata.* as opaque; no parse error).
+```
+
+## Contract 4 — SECURITY.md presence + structure (FR-002 / SC-002)
+
+**File**: `SECURITY.md` at repo root.
+
+**Post-093 state**: file exists; renders cleanly on GitHub; contains four section headings:
+
+- `## Reporting a vulnerability`
+- `## What to expect`
+- `## Supported versions`
+- `## Scope`
+
+Required content per section per data-model.md §`SECURITY.md`.
+
+**Verification**:
+```bash
+test -f SECURITY.md && grep -E "^## (Reporting a vulnerability|What to expect|Supported versions|Scope)" SECURITY.md | wc -l
+# Expected: 4 matches.
+```
+
+GitHub Security-tab integration verification (post-merge): visit `https://github.com/kusari-sandbox/mikebom/security/policy` and confirm it renders the SECURITY.md file (not a "no security policy" empty state).
+
+## Contract 5 — CONTRIBUTING.md presence + structure (FR-003 / SC-003)
+
+**File**: `CONTRIBUTING.md` at repo root.
+
+**Post-093 state**: file exists; contains five section headings (per data-model.md §`CONTRIBUTING.md`):
+
+- `## Welcome`
+- `## Workflow overview (the speckit lifecycle)`
+- `## Local development setup`
+- `## Pre-PR gate (MANDATORY)`
+- `## Project principles + where to find them`
+
+Required content callouts:
+
+- The `## Pre-PR gate (MANDATORY)` section MUST name `./scripts/pre-pr.sh` and document the exact env-var opt-in for the SPDX-3 validator (`MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1`).
+- The `## Project principles` section MUST link to `.specify/memory/constitution.md` and enumerate the 12 principles by name.
+- The `## Workflow overview` section MUST link to the per-skill files under `.claude/skills/speckit-*/SKILL.md` (or equivalent).
+
+**Verification**:
+```bash
+test -f CONTRIBUTING.md \
+  && grep -c '^## ' CONTRIBUTING.md \
+  && grep -q "pre-pr.sh" CONTRIBUTING.md \
+  && grep -q "constitution.md" CONTRIBUTING.md \
+  && grep -q "MIKEBOM_REQUIRE_SPDX3_VALIDATOR" CONTRIBUTING.md
+# Expected: file exists; >= 5 H2 headings; all four greps succeed.
+```
+
+## Contract 6 — Issue templates as YAML forms (FR-004 / SC-004)
+
+**Files**: `.github/ISSUE_TEMPLATE/bug_report.yml` + `.github/ISSUE_TEMPLATE/feature_request.yml` (optional: `.github/ISSUE_TEMPLATE/config.yml`).
+
+**Post-093 state for `bug_report.yml`**: GitHub issue-form schema with required fields per data-model.md §`bug_report.yml`:
+
+- `name`, `description`, `title`, `labels` at the top level.
+- A `body:` array containing at least one `markdown` greeting, then required fields: OS dropdown, mikebom version input, command + output textarea, expected vs actual textarea, optional additional context textarea.
+
+**Post-093 state for `feature_request.yml`**: similar schema with required use-case + proposed-solution textareas, optional alternatives + additional context.
+
+**Verification**:
+```bash
+test -f .github/ISSUE_TEMPLATE/bug_report.yml \
+  && test -f .github/ISSUE_TEMPLATE/feature_request.yml
+# Expected: both files exist.
+
+# Validate YAML parses:
+python3 -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/bug_report.yml'))"
+python3 -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/feature_request.yml'))"
+# Expected: both succeed with no output.
+```
+
+GitHub UI verification (post-merge): visit `https://github.com/kusari-sandbox/mikebom/issues/new/choose` and confirm both templates appear in the chooser.
+
+## Contract 7 — PR template content (FR-005 / SC-004)
+
+**File**: `.github/pull_request_template.md`
+
+**Post-093 state**: file contains a Markdown body with a `## Pre-PR checklist` section containing at minimum these three checkbox items (additional items per data-model.md §`pull_request_template.md` allowed):
+
+- "I ran `./scripts/pre-pr.sh` and it exited clean"
+- "For non-trivial changes, I followed the speckit lifecycle"
+- "If I touched SBOM emission or output formats, I regenerated the affected byte-identity goldens"
+
+**Verification**:
+```bash
+test -f .github/pull_request_template.md \
+  && grep -c '^- \[ \]' .github/pull_request_template.md
+# Expected: file exists; >= 3 checklist items.
+
+grep -q "pre-pr.sh" .github/pull_request_template.md \
+  && grep -q "speckit" .github/pull_request_template.md \
+  && grep -q "goldens" .github/pull_request_template.md
+# Expected: all three succeed.
+```
+
+GitHub UI verification (post-merge): open a draft PR; confirm the template body appears pre-filled.
+
+## Contract 8 — Diff scope guard (FR-007 / FR-008 / FR-009 / SC-007)
+
+**Verification**:
+
+```bash
+# Allowed file paths only:
+git diff --name-only main \
+  | grep -vE '^(README\.md|SECURITY\.md|CONTRIBUTING\.md|\.github/.+\.(md|yml)|mikebom-cli/Cargo\.toml)$' \
+  | grep -v '^$' \
+  | wc -l
+# Expected: 0 (no unauthorized file paths).
+
+# No source-tree changes:
+git diff --name-only main \
+  | grep -E '^(mikebom-cli/src|mikebom-common/src|xtask/src)/' \
+  | wc -l
+# Expected: 0.
+
+# No golden regen:
+git diff --name-only main \
+  | grep -E '^mikebom-cli/tests/fixtures/golden/' \
+  | wc -l
+# Expected: 0.
+
+# No Cargo.lock churn:
+git diff --name-only main \
+  | grep -E '^Cargo\.lock$' \
+  | wc -l
+# Expected: 0.
+```
+
+## Contract 9 — Pre-PR gate clean (FR-010 / SC-006)
+
+**Verification**:
+```bash
+./scripts/pre-pr.sh
+# Expected: prints `>>> all pre-PR checks passed.`; exit code 0.
+```
+
+Both clippy (`--workspace --all-targets -- -D warnings`) and cargo test (`--workspace`) MUST report zero failures.

--- a/specs/093-repo-polish-quickwins/data-model.md
+++ b/specs/093-repo-polish-quickwins/data-model.md
@@ -1,0 +1,123 @@
+# Data Model — milestone 093
+
+Per-file structure for every deliverable. Zero schema-level changes (no JSON / no YAML data models). This is a documentation-only milestone; the "data model" here is just the section structure each Markdown file MUST adopt.
+
+## File inventory
+
+| File | State | Owner FRs |
+|------|-------|-----------|
+| `README.md` | MODIFIED (2 edits) | FR-001, FR-006 |
+| `SECURITY.md` | NEW (repo root) | FR-002 |
+| `CONTRIBUTING.md` | NEW (repo root) | FR-003 |
+| `.github/ISSUE_TEMPLATE/bug_report.yml` | NEW | FR-004 |
+| `.github/ISSUE_TEMPLATE/feature_request.yml` | NEW | FR-004 |
+| `.github/ISSUE_TEMPLATE/config.yml` | NEW (optional) | FR-004 |
+| `.github/pull_request_template.md` | NEW | FR-005 |
+| `mikebom-cli/Cargo.toml` | MODIFIED (metadata-only, ~5 lines added) | FR-006 |
+
+## `README.md` — modifications (NOT a full rewrite)
+
+### Edit 1 — FR-001 URL fix (line ~238)
+
+Search-replace `https://github.com/mlieberman85/mikebom.git` → `https://github.com/kusari-sandbox/mikebom.git`. Repo-wide grep for `mlieberman85` MUST return zero hits in committed content afterward.
+
+### Edit 2 — FR-006 cargo-binstall addition (Install section)
+
+Append a new subsection to `## Install` (after the existing tarball / source-build paths). Suggested heading: `### Via cargo binstall (Rust toolchain users)`. Body covers:
+
+- One-liner explaining when this is useful (already have `cargo binstall`; want to skip the `gh release download` dance).
+- The exact invocation: `cargo binstall --git https://github.com/kusari-sandbox/mikebom mikebom`.
+- A note that bare `cargo binstall mikebom` will start working once mikebom is published to crates.io (future milestone).
+- An acknowledgment that the install honors `--no-confirm` for CI use.
+
+## `SECURITY.md` — section structure
+
+Four sections, ~30-50 lines total:
+
+1. `## Reporting a vulnerability` — names the private disclosure channel (GitHub Security Advisories link: `https://github.com/kusari-sandbox/mikebom/security/advisories/new`) plus an optional email alias (TBD or omitted if no maintainer alias exists). Explicitly tells researchers NOT to open a public issue.
+2. `## What to expect` — response-time expectations. Per spec assumption: "acknowledge within 7 days, fix or status update within 30."
+3. `## Supported versions` — per spec assumption: "Only the most recent alpha release is supported. mikebom is pre-1.0; SemVer guarantees do not apply yet."
+4. `## Scope` — what counts as a vulnerability for this project (e.g., crashes during scan, SBOM emission that misrepresents the trace, etc.) vs what doesn't (e.g., upstream CVEs in dependencies — those go through normal advisories).
+
+## `CONTRIBUTING.md` — section structure
+
+Five sections, ~80-120 lines total:
+
+1. `## Welcome` — one-paragraph framing. Pre-1.0 alpha; coordination encouraged before non-trivial PRs.
+2. `## Workflow overview (the speckit lifecycle)` — explains specify → clarify → plan → tasks → analyze → implement. Links to `.claude/skills/speckit-*/SKILL.md` for full details. Notes that small drive-by fixes (typo corrections, doc tweaks) don't need the full lifecycle.
+3. `## Local development setup` — Rust stable toolchain, `cargo +stable build`, eBPF caveats deferred to `docs/user-guide/installation.md`.
+4. `## Pre-PR gate (MANDATORY)` — the exact commands from CLAUDE.md: `./scripts/pre-pr.sh` must exit clean (zero clippy warnings, all test suites `0 failed`). Includes the SPDX-3 validator opt-in (`MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1`) for spec-conformance-touching changes.
+5. `## Project principles + where to find them` — points at `.specify/memory/constitution.md` as the source-of-truth. Lists the 12 principles by name with one-line gloss each, so contributors can audit their PR against the right ones.
+
+## `.github/ISSUE_TEMPLATE/bug_report.yml` — form schema
+
+YAML issue form. Required fields:
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| Bug title | `title` (auto-populated to PR title field) | yes | Format hint: "[BUG] short description" |
+| Operating system | `dropdown` | yes | Options: `linux-x86_64`, `linux-aarch64`, `macOS aarch64`, `macOS x86_64 (Intel)`, `Windows`, `Other` |
+| mikebom version | `input` | yes | Hint: "Output of `mikebom --version`" |
+| Command + output | `textarea` | yes | Hint: "Paste the command you ran and the full output" |
+| Expected vs actual | `textarea` | yes | Hint: "What did you expect to happen? What actually happened?" |
+| Additional context | `textarea` | no | Hint: "Anything else? Screenshots, fixtures, related issues..." |
+
+## `.github/ISSUE_TEMPLATE/feature_request.yml` — form schema
+
+YAML issue form. Required fields:
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| Feature title | `title` | yes | Format hint: "[FEATURE] short description" |
+| Use case | `textarea` | yes | Hint: "What are you trying to accomplish? Why?" |
+| Proposed solution | `textarea` | yes | Hint: "How would you like mikebom to handle this?" |
+| Alternatives considered | `textarea` | no | Hint: "What else have you tried or considered?" |
+| Additional context | `textarea` | no | Hint: "Links, related work, anything else?" |
+
+## `.github/ISSUE_TEMPLATE/config.yml` (optional) — chooser config
+
+`blank_issues_enabled: false` so all reports go through one of the structured templates. Optional `contact_links` to point at `/discussions` or similar if those are enabled.
+
+## `.github/pull_request_template.md` — checklist
+
+Markdown body. Five checklist items per spec FR-005 + the spec's PR-template-length edge case:
+
+```markdown
+## Summary
+
+<!-- 1-3 sentences explaining what this PR does and why. -->
+
+## Test plan
+
+<!-- Bulleted list. -->
+
+## Pre-PR checklist
+
+- [ ] I ran `./scripts/pre-pr.sh` and it exited clean (zero clippy warnings, all test suites `0 failed`).
+- [ ] For non-trivial changes, I followed the speckit lifecycle (`specs/<NNN>-<short-name>/` exists with spec/plan/tasks).
+- [ ] If I touched SBOM emission or output formats, I regenerated the affected byte-identity goldens.
+- [ ] If I added a `mikebom:*` property, I audited each target format for an existing native construct first (Constitution Principle V).
+- [ ] If this is a release-bump PR, I ran the SPDX-3 conformance validator via `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 ./scripts/pre-pr.sh`.
+```
+
+## `mikebom-cli/Cargo.toml` — metadata-only addition
+
+Append a `[package.metadata.binstall]` table per research.md §1's resolution:
+
+```toml
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"
+pkg-fmt = "tgz"
+```
+
+This is metadata-only (no `dependencies` change, no version bump, no feature flags). Cargo treats unknown `package.metadata.*` keys as opaque pass-through; this change cannot break the build.
+
+## Compatibility
+
+- **Render targets**: every new Markdown file renders correctly in (a) GitHub web UI, (b) the rust-docs Markdown parser (relevant for any doc-comment cross-references), (c) standard `cat`-style viewing.
+- **Backward compatibility**: 100% additive. Anyone who previously installed mikebom by following the broken README:238 instruction was failing already; the fix is strict improvement.
+- **Cargo.lock**: the metadata-only Cargo.toml change does NOT modify `Cargo.lock`. Diff scope audit (FR-009) should show `Cargo.lock` unchanged.
+
+## No JSON / no YAML data model
+
+This milestone introduces no JSON shapes, no SBOM emission changes, no API contracts. The only YAML files added are GitHub issue-form schemas, whose structure is GitHub's responsibility, not ours.

--- a/specs/093-repo-polish-quickwins/plan.md
+++ b/specs/093-repo-polish-quickwins/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: Repo polish — quick-wins cleanup pass
+
+**Branch**: `093-repo-polish-quickwins` | **Date**: 2026-05-10 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Five small repo-polish gaps surfaced after alpha.30 shipped (broken README git URL, missing SECURITY.md, missing CONTRIBUTING.md, missing issue/PR templates, cargo-binstall undocumented). Bundle them as one docs-and-metadata-only PR (~1 hour). Zero production code, zero golden regen, zero new deps. The Homebrew tap + curl-pipe installer items remain deferred to a separate follow-up milestone per spec's Out of Scope.
+
+**Approach**: pure file additions / edits at the repo root and under `.github/`. The only `Cargo.toml` touch is an optional `[package.metadata.binstall.overrides]` table to make `cargo binstall mikebom` work against the existing release-tarball naming — verified at Phase 0 (research.md §1) to be a no-op if cargo-binstall's default autodiscovery already matches our naming, in which case the README documents the explicit invocation and the Cargo.toml stays untouched.
+
+## Technical Context
+
+**Language/Version**: N/A — this milestone touches Markdown + (potentially) Cargo.toml metadata only.
+**Primary Dependencies**: None new. The existing `release.yml` artifact-naming convention is the only behavioral input that informs the cargo-binstall integration choice.
+**Storage**: N/A — purely source-tree edits.
+**Testing**: `./scripts/pre-pr.sh` (mandatory pre-PR gate; clippy + workspace tests) — must continue to pass. No new automated test added; SECURITY.md / CONTRIBUTING.md / templates are content-quality artifacts validated by human review against the spec's acceptance scenarios.
+**Target Platform**: GitHub.com (renders `SECURITY.md`, the templates, the PR-checklist), plus any Markdown-rendering tooling (e.g., `cargo doc` doesn't touch these).
+**Project Type**: Documentation + repo-metadata cleanup. Not a software feature.
+**Performance Goals**: N/A. Spec's SC-005 (`cargo binstall mikebom` completes in 60 seconds) is bounded by network + the existing GitHub Releases CDN, not by anything this milestone adds.
+**Constraints**: FR-007 (no production code changes), FR-008 (no golden regen), FR-009 (no new Cargo deps), FR-010 (pre-PR gate clean). Hard guardrails for scope creep.
+**Scale/Scope**: ~5 new files at repo root + `.github/` (SECURITY.md, CONTRIBUTING.md, 2-3 issue templates, PR template), ~5 README edits, optionally one `Cargo.toml` table addition. Total diff target: <500 lines.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+- **I. Pure Rust, Zero C**: ✅ no code at all in this milestone; no FFI, no toolchain.
+- **II. eBPF-Only Observation**: N/A — no scan/discovery behavior changes.
+- **III. Fail Closed**: N/A — no runtime behavior changes.
+- **IV. Type-Driven Correctness / no `.unwrap()` in production**: N/A — no Rust source touched.
+- **V. Specification Compliance / standards-native precedence**: ✅ no `mikebom:*` properties involved; no SBOM emission affected.
+- **VI. Three-Crate Architecture**: ✅ untouched. The optional `Cargo.toml` metadata addition is at the workspace member level (`mikebom-cli`) and doesn't change crate boundaries.
+- **VII. Test Isolation**: N/A — no new tests.
+- **VIII. Completeness**, **IX. Accuracy**, **X. Transparency**, **XI. Enrichment**, **XII. External Data Source Enrichment**: N/A — no SBOM output touched.
+
+**No violations.** No Complexity Tracking entry needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/093-repo-polish-quickwins/
+├── plan.md                         # This file
+├── research.md                     # Phase 0: cargo-binstall behavior audit + GitHub auto-detection paths
+├── data-model.md                   # Phase 1: per-deliverable file shape (which sections each markdown file MUST contain)
+├── contracts/
+│   └── repo-surface-contracts.md   # Phase 1: section-level contracts for each new markdown file + the README edits
+├── quickstart.md                   # Phase 1: maintainer recipes (apply, verify, ship)
+├── checklists/
+│   └── requirements.md             # 16/16 pass — already complete
+└── spec.md                         # Feature spec
+```
+
+### Source Code (repository root)
+
+```text
+mikebom/                            # repo root
+├── README.md                       # MODIFIED (FR-001 URL fix + FR-006 cargo-binstall path)
+├── SECURITY.md                     # NEW (FR-002)
+├── CONTRIBUTING.md                 # NEW (FR-003)
+├── Cargo.toml                      # OPTIONALLY MODIFIED (FR-006 — only if cargo-binstall needs metadata overrides)
+└── .github/
+    ├── ISSUE_TEMPLATE/             # NEW directory
+    │   ├── bug_report.md           # NEW (FR-004)
+    │   └── feature_request.md      # NEW (FR-004)
+    └── pull_request_template.md    # NEW (FR-005)
+```
+
+**Structure Decision**: Pure additive at repo root + `.github/`. No source files in `mikebom-cli/`, `mikebom-common/`, or `xtask/` are touched. The optional `Cargo.toml` edit is the only Cargo-mediated file change.
+
+## Complexity Tracking
+
+> Not applicable — no Constitution gate violations.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|--------------------------------------|
+| (none)    | (none)     | (none)                               |
+
+## Phase Plan
+
+### Phase 0 — Research (`research.md`)
+
+Three decision points resolved at Phase 0:
+
+1. **Does `cargo binstall mikebom` work today without `Cargo.toml` metadata?** — audit `cargo binstall`'s default URL-template logic against mikebom's release-tarball naming (`mikebom-vX.Y.Z-<arch>-<os>.tar.gz`).
+2. **Where does GitHub auto-detect `SECURITY.md`?** — confirm repo-root vs `.github/` vs `docs/` precedence so the file lands in the right place for the Security-tab integration.
+3. **Issue template format: classic `.md` with front-matter vs YAML forms (`.yml`)?** — pick one for FR-004.
+
+### Phase 1 — Design (`data-model.md`, `contracts/`, `quickstart.md`)
+
+- **data-model.md** — per-file section structure (SECURITY.md has 4 sections, CONTRIBUTING.md has 5, templates have ~4 each).
+- **contracts/repo-surface-contracts.md** — what each section MUST contain.
+- **quickstart.md** — maintainer recipes for applying the edits and verifying SC-001 through SC-007.
+
+Re-evaluate Constitution Check post-design: still no violations expected (pure docs).
+
+### Phase 2 — Tasks
+
+Out-of-scope for `/speckit.plan`; will be generated by `/speckit.tasks`.
+
+## Agent Context Update
+
+The agent-context update script will be re-run after Phase 1; this milestone adds no new technology surface so the agent context delta should be empty or trivial.

--- a/specs/093-repo-polish-quickwins/quickstart.md
+++ b/specs/093-repo-polish-quickwins/quickstart.md
@@ -1,0 +1,299 @@
+# Quickstart — milestone 093 maintainer recipes
+
+Six maintainer-facing recipes to apply the polish edits and verify each contract.
+
+## Recipe 1 — Fix the broken README git URL (FR-001 / SC-001)
+
+```bash
+# Find the offending line:
+grep -n "mlieberman85/mikebom" README.md
+# Expected (pre-093): line ~238 prints the wrong URL.
+
+# Apply the fix (one-shot):
+sed -i.bak \
+  's|https://github.com/mlieberman85/mikebom.git|https://github.com/kusari-sandbox/mikebom.git|g' \
+  README.md
+rm README.md.bak
+
+# Verify:
+grep -rn "mlieberman85" --include='*.md' --include='*.toml' --include='*.yml' .
+# Expected: no output (exit code 1 from grep is OK — means no matches).
+```
+
+## Recipe 2 — Add cargo binstall to README + Cargo.toml (FR-006 / SC-005)
+
+Step 1 — append to `mikebom-cli/Cargo.toml`:
+
+```toml
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"
+pkg-fmt = "tgz"
+```
+
+Step 2 — add a new subsection to the README's `## Install` section (right after the existing tarball-download block, before "Or build from source"):
+
+```markdown
+### Via cargo binstall (Rust toolchain users)
+
+If you already have [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall)
+installed, you can skip the `gh release download` dance:
+
+```bash
+cargo binstall --git https://github.com/kusari-sandbox/mikebom mikebom
+```
+
+Bare `cargo binstall mikebom` will work once mikebom is published to crates.io
+(planned for a future milestone). Today the `--git` form pulls the release
+tarball from GitHub Releases per the same naming pattern the [Cargo.toml
+binstall metadata](mikebom-cli/Cargo.toml) pins.
+```
+
+Step 3 — verify the metadata table:
+
+```bash
+cargo +stable build -p mikebom 2>&1 | tail -3
+# Expected: clean build (cargo treats package.metadata.* as opaque).
+```
+
+## Recipe 3 — Create SECURITY.md (FR-002 / SC-002)
+
+```bash
+cat > SECURITY.md <<'EOF'
+# Security policy
+
+## Reporting a vulnerability
+
+Please **do not open a public GitHub issue** for vulnerabilities. Report
+them privately through GitHub Security Advisories:
+
+  https://github.com/kusari-sandbox/mikebom/security/advisories/new
+
+This routes the report to the maintainers without exposing it publicly.
+
+## What to expect
+
+- **Acknowledgment** within 7 days of report.
+- **Triage decision** (accepted / declined / needs-more-info) within
+  14 days.
+- **Fix or detailed status update** within 30 days.
+
+Coordinated disclosure timelines can be negotiated case-by-case if a
+fix requires longer (e.g., a deep refactor or upstream dependency
+update).
+
+## Supported versions
+
+mikebom is pre-1.0 alpha. Only the **most recent alpha release** is
+supported for security fixes. SemVer guarantees do not apply until 1.0.
+
+## Scope
+
+In scope:
+
+- Crashes, hangs, or memory-safety issues during scan / verify / trace.
+- SBOM emission that misrepresents the underlying observed evidence
+  (e.g., a component reported as present that wasn't observed in the
+  trace, or vice versa — this contradicts Constitution Principles VIII
+  + IX).
+- Attestation verification failures that incorrectly accept malformed
+  or revoked signatures.
+- Privilege-escalation or container-escape via the eBPF tracer.
+
+Out of scope:
+
+- Vulnerabilities in mikebom's upstream Rust crate dependencies — those
+  go through normal CVE channels and are tracked by `cargo audit` / the
+  release-blocking Kusari Inspector CI check.
+- Bugs that produce wrong SBOM output without a security implication
+  (those should be filed as regular GitHub issues).
+EOF
+```
+
+Verify:
+```bash
+grep -c '^## ' SECURITY.md
+# Expected: 4
+```
+
+## Recipe 4 — Create CONTRIBUTING.md (FR-003 / SC-003)
+
+See `data-model.md §CONTRIBUTING.md` for full content shape. Skeleton:
+
+```bash
+cat > CONTRIBUTING.md <<'EOF'
+# Contributing to mikebom
+
+Thanks for your interest in contributing! mikebom is pre-1.0 alpha; we
+encourage coordination on non-trivial changes before you open a PR.
+
+## Workflow overview (the speckit lifecycle)
+
+For non-trivial changes (new features, behavior changes, large
+refactors), mikebom uses the spec-kit lifecycle:
+
+1. `/speckit.specify` — write the feature spec
+2. `/speckit.clarify` (optional) — resolve open questions
+3. `/speckit.plan` — produce research.md, data-model.md, contracts/
+4. `/speckit.tasks` — break work into checklist tasks
+5. `/speckit.analyze` (optional) — cross-check spec ↔ plan ↔ tasks
+6. `/speckit.implement` — execute the task list
+
+Full skill references live under `.claude/skills/speckit-*/SKILL.md`.
+Small drive-by fixes (typos, doc tweaks, single-line bug fixes) skip
+the lifecycle — just open a PR.
+
+## Local development setup
+
+```bash
+git clone https://github.com/kusari-sandbox/mikebom.git
+cd mikebom
+cargo +stable build --release
+```
+
+The `sbom`, `policy`, `attestation`, and related subcommands build
+under the **stable** toolchain. The eBPF-based `trace` subcommands
+additionally need nightly — see
+[`docs/user-guide/installation.md`](docs/user-guide/installation.md).
+
+## Pre-PR gate (MANDATORY)
+
+Before opening any PR, **both** of these MUST exit clean:
+
+```bash
+./scripts/pre-pr.sh
+```
+
+This runs `cargo +stable clippy --workspace --all-targets -- -D warnings`
+(zero warnings) AND `cargo +stable test --workspace` (every suite
+`0 failed`). Both must pass before CI will accept the PR.
+
+For SBOM-spec-touching changes, also set the SPDX-3 conformance gate:
+
+```bash
+MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 ./scripts/pre-pr.sh
+```
+
+This requires the JPEWdev `spdx3-validate` package pinned in
+`.venv/spdx3-validate/`.
+
+## Project principles + where to find them
+
+The canonical source-of-truth is [`.specify/memory/constitution.md`](.specify/memory/constitution.md).
+Twelve principles to be aware of:
+
+- **I. Pure Rust, Zero C** — no FFI, no `libbpf` bindings.
+- **II. eBPF-Only Observation** — eBPF tracing is the trust-rooted
+  discovery path; external sources only enrich what was observed.
+- **III. Fail Closed** — never gap-fill with heuristics when the trace
+  loses data.
+- **IV. Type-Driven Correctness** — newtype wrappers for PURL, hashes,
+  license expressions; no `.unwrap()` in production code.
+- **V. Specification Compliance** — CycloneDX 1.6 + SPDX 2.3 +
+  SPDX 3.x conformance; **standards-native fields take precedence
+  over `mikebom:*` properties**.
+- **VI. Three-Crate Architecture** — `mikebom-ebpf` (no_std),
+  `mikebom-common` (shared structs), `mikebom-cli` (user-space).
+- **VII. Test Isolation** — privilege-dependent tests gated behind
+  CAP_BPF; unprivileged unit tests run on every CI.
+- **VIII. Completeness** — minimize false negatives.
+- **IX. Accuracy** — minimize false positives; flag low-confidence
+  matches.
+- **X. Transparency** — surface limitations via spec-native fields.
+- **XI. Enrichment** — license, VEX, supplier metadata when available.
+- **XII. External Data Source Enrichment** — lockfiles / registries
+  enrich; eBPF trace remains authoritative.
+
+If your change touches any principle, link to it from your PR description
+and explain how the change preserves the principle.
+
+## Per-spec planning artifacts
+
+Each milestone lives at `specs/<NNN>-<short-name>/`:
+
+```
+specs/092-fix-maven-version-extract/
+├── spec.md           # WHAT and WHY
+├── plan.md           # HOW (architecture, gates)
+├── research.md       # Phase 0 decisions
+├── data-model.md     # Phase 1 data shapes
+├── contracts/        # Phase 1 behavioral contracts
+├── quickstart.md     # Maintainer recipes
+├── tasks.md          # Phase 2 checklist
+└── checklists/
+    └── requirements.md
+```
+
+Open one for any non-trivial change before writing code.
+EOF
+```
+
+Verify:
+```bash
+grep -c '^## ' CONTRIBUTING.md       # >= 5
+grep -q 'pre-pr.sh' CONTRIBUTING.md
+grep -q 'constitution.md' CONTRIBUTING.md
+grep -q 'MIKEBOM_REQUIRE_SPDX3_VALIDATOR' CONTRIBUTING.md
+```
+
+## Recipe 5 — Create issue + PR templates (FR-004, FR-005 / SC-004)
+
+```bash
+mkdir -p .github/ISSUE_TEMPLATE
+```
+
+Then write the three template files (`.github/ISSUE_TEMPLATE/bug_report.yml`,
+`.github/ISSUE_TEMPLATE/feature_request.yml`, `.github/pull_request_template.md`)
+per the shape defined in `data-model.md` and Contracts 6 + 7. See those
+documents for exact YAML and Markdown bodies.
+
+Verify:
+
+```bash
+test -f .github/ISSUE_TEMPLATE/bug_report.yml \
+  && test -f .github/ISSUE_TEMPLATE/feature_request.yml \
+  && test -f .github/pull_request_template.md
+
+# YAML parses:
+python3 -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/bug_report.yml'))"
+python3 -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/feature_request.yml'))"
+
+# PR-template checklist count:
+grep -c '^- \[ \]' .github/pull_request_template.md
+# Expected: >= 3.
+```
+
+## Recipe 6 — Final pre-PR gate (FR-010 / SC-006)
+
+```bash
+./scripts/pre-pr.sh
+# Expected: prints `>>> all pre-PR checks passed.`
+# All test targets report `N passed; 0 failed`.
+# Zero clippy warnings.
+```
+
+## Recipe 7 — Diff scope audit (FR-007/FR-008/FR-009 / SC-007)
+
+```bash
+git diff --name-only main | sort
+
+# Expected output (exact set, only):
+# .github/ISSUE_TEMPLATE/bug_report.yml
+# .github/ISSUE_TEMPLATE/feature_request.yml
+# .github/pull_request_template.md
+# CONTRIBUTING.md
+# README.md
+# SECURITY.md
+# mikebom-cli/Cargo.toml
+
+# Confirm NO source-code, golden, or Cargo.lock files appear:
+git diff --name-only main | grep -E '^(mikebom-cli/src|mikebom-common/src|xtask/src|mikebom-cli/tests/fixtures/golden|Cargo\.lock)' \
+  && echo "SCOPE-CREEP DETECTED" || echo "Scope clean."
+```
+
+## When in doubt
+
+- **`SECURITY.md` doesn't surface on GitHub's Security tab post-merge**: confirm the file is at repo root (not `docs/`). GitHub picks it up automatically; no settings page interaction needed.
+- **Issue templates don't appear in the chooser**: the templates must be in `.github/ISSUE_TEMPLATE/` (uppercase `ISSUE_TEMPLATE`). YAML files must parse cleanly — a malformed YAML will silently fall through and not show.
+- **`cargo binstall --git ... mikebom` errors with "no matching binary found"**: the `[package.metadata.binstall]` block's `pkg-url` template doesn't match the actual release-tarball naming. Double-check the four template variables (`{ repo }`, `{ version }`, `{ name }`, `{ target }`, `{ archive-suffix }`) against an actual GitHub Releases URL.
+- **Pre-PR gate fails clippy**: shouldn't happen — no Rust source touched. If it does, audit `git diff` for accidental source-tree changes.
+- **PR-template checkbox renders as plain text not interactive**: ensure the Markdown uses `- [ ]` (with the space inside the brackets). `- []` won't render as a checkbox.

--- a/specs/093-repo-polish-quickwins/research.md
+++ b/specs/093-repo-polish-quickwins/research.md
@@ -1,0 +1,114 @@
+# Research — milestone 093 repo polish
+
+Phase 0 investigation. Three decision points; all resolved without further clarification.
+
+## §1 — cargo-binstall discovery + the crates.io gap
+
+**Findings**:
+
+`cargo binstall <name>` resolves `<name>` via the crates.io index. mikebom is NOT yet published to crates.io (per README's "Status: pre-1.0 alpha. ... no crates.io release yet"), so plain `cargo binstall mikebom` fails at lookup. The Git source workaround is supported via `--git`:
+
+```
+cargo binstall --git https://github.com/kusari-sandbox/mikebom mikebom
+```
+
+Default `pkg-url` autodiscovery joins:
+
+- Release-path prefix: `{repo}/releases/download/{version}/` then `{repo}/releases/download/v{version}/`
+- Filename patterns including `{name}-{target}-v{version}{archive-suffix}` and `{name}-v{version}-{target}{archive-suffix}` and others
+- `target` = **full Rust triple** (e.g. `aarch64-apple-darwin`, not short form)
+- `version` token = bare (`0.1.0-alpha.30`); the `v` prefix is literal in templates
+- Default `pkg-fmt` = `tgz`
+- Inside archive: searches `{name}-{target}-v{version}/`, …, down to root, expecting binary `{name}{binary-ext}`. No `bin/` subdir needed.
+
+mikebom's tarball naming `mikebom-v0.1.0-alpha.30-aarch64-apple-darwin.tar.gz` matches the `{name}-v{version}-{target}{archive-suffix}` fallback in binstall's default search list, so discovery WILL find it. But pinning it explicitly avoids any future drift if binstall's defaults change.
+
+**Decision**: ship both halves of the fix —
+
+(a) Add a deterministic `[package.metadata.binstall]` block to `mikebom-cli/Cargo.toml` so the URL template is locked to the existing release-tarball naming:
+
+```toml
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"
+pkg-fmt = "tgz"
+```
+
+(b) In the README's Install section, document the `--git` invocation (the crates.io workaround) until mikebom is published. Phrase it as "optional alternative, useful for Rust-toolchain users":
+
+```bash
+# alternative install path (skip the gh-release download dance):
+cargo binstall --git https://github.com/kusari-sandbox/mikebom mikebom
+```
+
+**Rationale**:
+- The Cargo.toml block is metadata-only (FR-007 compliant), zero new deps (FR-009), zero golden churn (FR-008).
+- Documenting `--git` instead of bare `cargo binstall mikebom` is honest about the current crates.io gap — silent failure ("not found in registry") is worse than no mention.
+- When mikebom is eventually published to crates.io (separate future milestone per Out of Scope), the documented invocation simplifies to `cargo binstall mikebom` with no other changes needed — the metadata block keeps working unchanged.
+
+**Alternatives considered**:
+- **Skip the metadata block, rely on default discovery**: works today but vulnerable to future binstall default-template changes. Rejected as fragile.
+- **Publish to crates.io as part of this milestone**: out of scope per spec (separate milestone). Crates.io publish is irreversible name-squat + ongoing release-cycle integration; needs its own constitution check and pre-PR ceremony.
+- **Skip cargo-binstall entirely, defer to Homebrew tap milestone**: leaves Rust-toolchain users with no one-command option until that lands. Rejected because the metadata block is ~5 lines and the README addition is ~3 lines — extremely low cost for non-zero adoption value.
+
+## §2 — SECURITY.md location
+
+**Findings**: GitHub auto-detects `SECURITY.md` at three paths: `.github/SECURITY.md`, repo-root `SECURITY.md`, `docs/SECURITY.md`. Precedence (observed): `.github/` > root > `docs/`. The same precedence chain falls back to the org-level `.github` repo's defaults if the project's own version is absent.
+
+**Decision**: place `SECURITY.md` at **repo root** (not `.github/SECURITY.md`).
+
+**Rationale**:
+- Maximum human discoverability — `SECURITY.md` at root is what visitors see when browsing the repo directly (alongside README, CONTRIBUTING, LICENSE).
+- GitHub's Security-tab integration works equally well from any of the three paths; the precedence only matters if multiple exist, which we don't have.
+- Mirrors the precedent of every other top-level community-health file in this milestone (CONTRIBUTING.md, README.md are already at root).
+
+**Alternatives considered**:
+- **`.github/SECURITY.md`**: technically takes precedence but obscures the file from anyone browsing without expanding `.github/`. Rejected for discoverability.
+- **`docs/SECURITY.md`**: lowest precedence; also less conventional. Rejected.
+
+## §3 — Issue template format
+
+**Findings**: GitHub supports two formats — classic Markdown templates (`.github/ISSUE_TEMPLATE/*.md` with YAML front-matter) and YAML issue forms (`.github/ISSUE_TEMPLATE/*.yml`). YAML forms render as structured UI with required-field enforcement, dropdowns, checkboxes; classic Markdown renders the body as-is and contributors can delete sections by accident.
+
+**Decision**: use **YAML issue forms** (`.github/ISSUE_TEMPLATE/bug_report.yml` + `.github/ISSUE_TEMPLATE/feature_request.yml`).
+
+**Rationale**:
+- Required-field enforcement guarantees the maintainer-needed inputs (OS, mikebom version, command + output, expected vs actual for bug reports) actually get filled in — Markdown templates contributors routinely strip section headings.
+- Dropdowns let us pre-enumerate the supported platforms (linux-x86_64, linux-aarch64, macOS aarch64) so we get clean data, not free-form OS strings.
+- No ongoing maintenance cost vs Markdown templates — write once, GitHub renders the form forever.
+- The YAML schema is well-documented; portability concerns are minimal because if the repo ever migrates off GitHub the templates would need rewriting either way.
+
+**Alternatives considered**:
+- **Classic Markdown templates**: portable across platforms (GitLab, Gitea also support them) but the spec is GitHub-specific and the small-OSS portability win is theoretical. Rejected.
+- **`config.yml` with external links only** (no templates, just a chooser pointing at e.g. discussions): doesn't capture bug-report structure. Rejected for FR-004 noncompliance.
+
+## §4 — PR template format
+
+**Findings**: GitHub supports a single `.github/pull_request_template.md` (no PR-form equivalent). Multiple templates are possible via query-string selection but require maintainer effort per category and offer marginal value for a small project.
+
+**Decision**: single `.github/pull_request_template.md` with a Markdown checklist body. ~5 checklist items per spec FR-005.
+
+**Rationale**:
+- Single template = zero choice-friction for the contributor. Click "New PR", template populates.
+- Checklist format (`- [ ]`) renders as interactive checkboxes in the GitHub UI — contributors can tick them as they verify each item.
+- ~5 items hits the spec's edge-case target ("too long and contributors skip it; too short and it doesn't help").
+
+**Alternatives considered**:
+- **Multiple PR templates via query-string**: maintenance cost > value for an alpha project. Rejected.
+
+## Coverage map
+
+| Spec section | Resolution |
+|--------------|------------|
+| FR-001 (README URL fix) | trivial; covered in quickstart Recipe 1. No research needed. |
+| FR-002 (SECURITY.md presence + content) | §2 → repo root; content shape covered in data-model + contracts. |
+| FR-003 (CONTRIBUTING.md presence + content) | content shape covered in data-model + contracts. No research needed. |
+| FR-004 (issue templates) | §3 → YAML forms; bug_report.yml + feature_request.yml. |
+| FR-005 (PR template) | §4 → single Markdown checklist. |
+| FR-006 (cargo binstall documented + auto-discoverable) | §1 → README mentions `--git` invocation; Cargo.toml metadata block locks discovery. |
+| FR-007 (no production code) | reinforced by §1's decision to keep Cargo.toml change to metadata-only. |
+| FR-008 (no golden regen) | implied — no source change emits goldens. |
+| FR-009 (no new deps) | implied — no `dependencies` table modified. |
+| FR-010 (pre-PR gate clean) | covered in quickstart Recipe 6. |
+| Constitution V audit | no `mikebom:*` properties; trivially satisfied. |
+
+All open spec questions resolved. Ready for Phase 1 (data-model + contracts + quickstart).

--- a/specs/093-repo-polish-quickwins/spec.md
+++ b/specs/093-repo-polish-quickwins/spec.md
@@ -1,0 +1,168 @@
+# Feature Specification: Repo polish — quick-wins cleanup pass
+
+**Feature Branch**: `093-repo-polish-quickwins`
+**Created**: 2026-05-10
+**Status**: Draft
+**Input**: User description: "let's do your suggestion" — bundle the small repo-polish items as a single PR before tackling Homebrew tap + curl-pipe installer in a follow-up.
+
+## Background
+
+The mikebom repo is now at alpha.30 with a working cross-platform release pipeline (closing the milestone-090 build.rs gap shipped today). A casual survey of the repo against typical OSS-project-polish expectations surfaced five small gaps that together degrade the new-visitor experience:
+
+1. **Broken git URL in README:238** — `git clone https://github.com/mlieberman85/mikebom.git` points at a stale personal-account location; the canonical repo is `kusari-sandbox/mikebom`. Anyone copy-pasting the install instructions hits a 404.
+2. **No `SECURITY.md`** — important signal for a security tool. GitHub surfaces this in the "Security" tab and links it from the vulnerability disclosure page.
+3. **No `CONTRIBUTING.md`** — onboarding new contributors. The CLAUDE.md mandatory pre-PR gate (`./scripts/pre-pr.sh`) and the speckit lifecycle (specify → plan → tasks → analyze → implement) aren't documented for external contributors.
+4. **No issue / PR templates** — `.github/ISSUE_TEMPLATE/` and `.github/pull_request_template.md` funnel reports into structured shapes (bug report vs feature request vs question) and remind PR authors to confirm pre-PR-gate compliance.
+5. **`cargo binstall` works but isn't documented** — the release artifact naming (`mikebom-vX.Y.Z-<arch>-<os>.tar.gz`) already matches `cargo binstall`'s auto-discovery convention. Adding one README line gives Rust-toolchain users a one-command install path without needing the multi-step `gh release download` dance.
+
+This is a low-risk, documentation-and-metadata-only milestone — zero production code changes, zero golden churn, no Constitution-V concerns. Designed as one immediate cleanup PR (~1 hour of work) ahead of a separate, larger Homebrew tap + curl-pipe installer milestone.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — New user follows the README install instructions and they actually work (Priority: P1)
+
+A new operator visits the mikebom GitHub page, scrolls to the Install section, and copy-pastes the recommended commands. Every URL and binary name resolves successfully; the install completes without manual fix-ups.
+
+**Why this priority**: First-touch friction kills alpha adoption. A broken `git clone` URL on the canonical install path is the highest-blast-radius polish gap — 100% of visitors who try the source-build path hit it.
+
+**Independent Test**: copy-paste each command block from README's Install section in a fresh shell. Confirm every URL resolves (no 404s) and every command completes successfully on at least one of: linux-x86_64, macOS aarch64.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor on the README at the Install section, **When** they run `git clone https://github.com/kusari-sandbox/mikebom.git`, **Then** the clone succeeds. The README MUST NOT reference `mlieberman85/mikebom`.
+2. **Given** a Rust-toolchain user, **When** they read the Install section, **Then** they see `cargo binstall mikebom` (or equivalent) documented as an alternative install path with a one-line callout.
+
+---
+
+### User Story 2 — Visitor reads SECURITY.md and knows how to report a vulnerability (Priority: P2)
+
+A security researcher discovers a vulnerability in mikebom and looks for the project's disclosure process. They find a `SECURITY.md` in the repo root that names a contact channel, the response-time expectation, and the supported-versions policy. GitHub's "Security" tab automatically surfaces this file.
+
+**Why this priority**: mikebom is itself a supply-chain security tool — operators expect it to demonstrate the security hygiene it advocates. Visible-and-credible vulnerability disclosure is table stakes for adoption by security-conscious teams.
+
+**Independent Test**: open the repo's GitHub Security tab. Confirm the "Security policy" entry now points at `SECURITY.md` instead of being absent. Read the file end-to-end and confirm it answers: where to report, what to expect, which versions are in scope.
+
+**Acceptance Scenarios**:
+
+1. **Given** a researcher who found a vulnerability, **When** they search the repo for "SECURITY.md", **Then** they find a populated file naming a private disclosure channel (GitHub Security Advisory and/or email alias), a response-time expectation, and the supported-versions policy.
+2. **Given** the GitHub Security tab, **When** the visitor lands on it, **Then** it shows a "Security policy" entry linking to the new `SECURITY.md` (GitHub auto-detects this file when present at repo root).
+
+---
+
+### User Story 3 — External contributor reads CONTRIBUTING.md and knows the workflow (Priority: P2)
+
+A new contributor wants to submit a bug fix or feature PR. They find a `CONTRIBUTING.md` at the repo root that explains the speckit-driven workflow, the mandatory pre-PR gate (`./scripts/pre-pr.sh`), the constitution location, and the local development setup. They don't have to reverse-engineer the project's expectations from commit messages or CI configuration.
+
+**Why this priority**: The project follows a non-obvious workflow (speckit specify → plan → tasks → analyze → implement) that external contributors won't know about. Without docs, the first PR-review cycle is spent explaining the pre-PR gate, the spec-first convention, the no-`.unwrap()`-in-production rule, etc.
+
+**Independent Test**: read `CONTRIBUTING.md` end-to-end as someone unfamiliar with the project. Confirm it answers: how do I run the tests? what do I need to do before opening a PR? where is the constitution? how does the speckit lifecycle work? does the project accept drive-by contributions or require coordination first?
+
+**Acceptance Scenarios**:
+
+1. **Given** a potential contributor reads `CONTRIBUTING.md`, **When** they finish, **Then** they know: (a) the speckit lifecycle is the expected workflow for non-trivial changes, (b) `./scripts/pre-pr.sh` is the mandatory local gate, (c) `.specify/memory/constitution.md` is the source-of-truth for project principles, and (d) where to find the per-spec planning artifacts under `specs/`.
+2. **Given** a contributor about to open a PR, **When** they re-read CONTRIBUTING.md's pre-PR section, **Then** the exact commands match what CI runs (clippy `--workspace --all-targets -D warnings` + `cargo test --workspace`).
+
+---
+
+### User Story 4 — Bug reporters and feature requesters file structured issues (Priority: P3)
+
+A user finds an unexpected scan result and clicks "New issue". GitHub offers them a choice between "Bug report", "Feature request", and "Question / discussion" templates, each with a pre-filled structure that prompts for the information maintainers need. PR authors see a checklist that reminds them to confirm the pre-PR gate ran clean.
+
+**Why this priority**: structured templates reduce the back-and-forth on every issue ("what OS?", "which version?", "what command did you run?"). Lower priority than US1–US3 because the project is alpha and issue volume is low.
+
+**Independent Test**: click "New issue" in the repo's GitHub UI. Confirm the template chooser appears with at least 2 distinct templates. Open a fake bug-report draft and confirm it prompts for OS / version / reproduction steps. Open a fake PR draft and confirm the template appears with a pre-PR-gate checkbox.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user on the "New issue" page, **When** they click the button, **Then** GitHub presents at least 2 templates: "Bug report" (prompts for: OS, mikebom version, command + output, expected vs actual) and "Feature request" (prompts for: use case, proposed solution, alternatives considered). Optional third template: "Question / discussion".
+2. **Given** a contributor opening a PR, **When** the PR form loads, **Then** the body is pre-filled with a checklist that includes "I ran `./scripts/pre-pr.sh` clean locally" and "I followed the speckit lifecycle for non-trivial changes (or this is a trivial change)".
+
+---
+
+### User Story 5 — Rust-toolchain user installs mikebom with one command via cargo binstall (Priority: P3)
+
+A user already running `cargo` runs `cargo binstall mikebom` and gets the latest pre-release tarball downloaded, verified against the SHA256SUMS, and installed to their cargo bin directory — no manual `gh release download` dance, no Homebrew dependency, no curl-pipe trust ceremony.
+
+**Why this priority**: `cargo binstall` already works today (mikebom's release artifact naming matches its auto-discovery convention as of alpha.30); the gap is purely documentation. Lowest priority because it requires the user to already have `cargo binstall` installed, which is itself an extra step. But it's effectively free to surface.
+
+**Independent Test**: on a host with `cargo binstall` installed, run `cargo binstall mikebom` (with any documented flags). Confirm the alpha.30 binary downloads, the SHA256 verifies, and `mikebom --version` reports `0.1.0-alpha.30`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the README Install section, **When** a Rust-toolchain reader scans it, **Then** they see `cargo binstall` mentioned as an option, with the exact command needed and any required flags (e.g., `--pkg-url`, `--pkg-fmt`) to make auto-discovery work against the existing release-tarball naming.
+2. **Given** a user runs the documented `cargo binstall mikebom` command, **When** it completes, **Then** the binary is installed in `~/.cargo/bin/mikebom` and runs successfully.
+
+---
+
+### Edge Cases
+
+- **Repo gets transferred or renamed in the future**: the README install command should not embed an account name in a non-templated way. Fix: use the actual canonical repo location at time of writing (`kusari-sandbox/mikebom`); if it ever moves, a single search-and-replace updates everywhere.
+- **`SECURITY.md` private-disclosure channel changes**: contact alias might rotate. Document the channel in `SECURITY.md` but keep the file short enough that updates are cheap.
+- **GitHub auto-detection of `SECURITY.md` location**: the file MUST be at the repo root (or `.github/SECURITY.md`, or `docs/SECURITY.md`) for GitHub's Security-tab integration to surface it. Stick to repo root for maximum discoverability.
+- **PR template length**: too long and contributors skip it; too short and it doesn't help. Target ~5 checklist items.
+- **`cargo binstall` auto-discovery vs explicit `--pkg-url`**: if the release-tarball naming requires explicit flags, the README example MUST include them — silent failure ("cargo binstall mikebom" with no flags producing "no matching binary found") is worse than no mention at all.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: README MUST replace the stale `mlieberman85/mikebom.git` URL at line 238 with the canonical `kusari-sandbox/mikebom.git`. A repo-wide grep for `mlieberman85` MUST return zero hits in committed content (excluding historical git log entries).
+- **FR-002**: A `SECURITY.md` MUST exist at the repo root. It MUST include: (a) a named private disclosure channel (GitHub Security Advisory link and/or email alias), (b) an explicit response-time expectation (e.g., "acknowledge within 7 days, fix or status update within 30"), (c) the supported-versions policy (e.g., "only the most recent alpha is supported"), (d) what NOT to do (e.g., "please don't open a public issue for vulnerabilities").
+- **FR-003**: A `CONTRIBUTING.md` MUST exist at the repo root. It MUST explain: (a) the speckit lifecycle for non-trivial changes (link to existing speckit docs), (b) the mandatory pre-PR gate (`./scripts/pre-pr.sh`) with the exact commands, (c) the project constitution location (`.specify/memory/constitution.md`), (d) the local development setup (`cargo +stable build`), (e) the per-spec planning artifacts location (`specs/<NNN>-<short-name>/`).
+- **FR-004**: A `.github/ISSUE_TEMPLATE/` directory MUST contain at least 2 issue templates: `bug_report.md` (or `.yml`) prompting for OS / mikebom version / reproduction steps / expected vs actual, and `feature_request.md` (or `.yml`) prompting for use case / proposed solution / alternatives. A third "Question / discussion" template is optional.
+- **FR-005**: A `.github/pull_request_template.md` MUST exist. It MUST include a checklist with at minimum: (a) "I ran `./scripts/pre-pr.sh` clean locally", (b) "I followed the speckit lifecycle for non-trivial changes (or this is a trivial change)", (c) "I updated any goldens that needed regen".
+- **FR-006**: The README's `## Install` section MUST add a `cargo binstall` install path with the exact command + any required flags so `cargo binstall mikebom` works against the existing release-tarball naming. If the naming requires updating release metadata in `Cargo.toml` to enable cargo-binstall's auto-discovery (a `[package.metadata.binstall]` block), that metadata MUST be added in this milestone.
+- **FR-007**: This milestone MUST NOT touch production Rust code paths (`mikebom-cli/src/`, `mikebom-common/src/`, `xtask/src/`). Allowed file types: `*.md` at repo root or under `.github/`, `Cargo.toml` metadata-only additions (e.g., `[package.metadata.binstall]`), README content.
+- **FR-008**: This milestone MUST NOT regenerate any byte-identity goldens. `git status mikebom-cli/tests/fixtures/golden/` MUST be empty after the polish PR's changes are applied.
+- **FR-009**: This milestone MUST NOT add new Cargo dependencies. `Cargo.lock` MUST be unchanged (except for non-version-changing field migrations the cargo tool emits on touch, if any).
+- **FR-010**: The mandatory pre-PR gate (`./scripts/pre-pr.sh`) MUST continue to pass post-changes — clippy zero warnings, all test suites `0 failed`.
+
+### Key Entities
+
+- **`README.md`**: the canonical landing-surface for new visitors. Touched in FR-001 (URL fix) and FR-006 (cargo-binstall path).
+- **`SECURITY.md`** (NEW): the vulnerability disclosure surface. Touched in FR-002.
+- **`CONTRIBUTING.md`** (NEW): the contributor onboarding surface. Touched in FR-003.
+- **`.github/ISSUE_TEMPLATE/*.md`** (NEW): bug-report + feature-request templates. Touched in FR-004.
+- **`.github/pull_request_template.md`** (NEW): PR checklist. Touched in FR-005.
+- **`Cargo.toml`** (potentially touched): optional metadata-only addition for `cargo binstall` auto-discovery (no version bump, no dependency change). Touched in FR-006 only if needed.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of README install commands resolve and complete successfully on a fresh checkout. Specifically, the `git clone` URL at the new README:238 location returns the cloned repo (HTTP 200 or successful clone exit code), not a 404.
+- **SC-002**: GitHub's Security tab surfaces a "Security policy" entry linking to `SECURITY.md` post-merge. (Validation: visit the rendered Security tab; confirm the entry appears without manual configuration — GitHub auto-detects files at the supported paths.)
+- **SC-003**: A first-time contributor reading `CONTRIBUTING.md` end-to-end (~10 minutes) can answer four questions correctly without consulting other docs: (a) "What command do I run before opening a PR?", (b) "Where is the project constitution?", (c) "Where do speckit planning artifacts live?", (d) "Do I need to coordinate before opening a non-trivial PR?".
+- **SC-004**: Clicking "New issue" in the GitHub UI presents a template chooser with at least 2 distinct templates (bug + feature). Each template's pre-filled body contains all the prompts named in FR-004.
+- **SC-005**: On a host with `cargo binstall` installed, running the documented `cargo binstall mikebom` command (with any required flags) installs the alpha.30 binary in `~/.cargo/bin/` within 60 seconds, with SHA256 verification passing.
+- **SC-006**: Pre-PR gate runs clean post-changes: `./scripts/pre-pr.sh` reports `>>> all pre-PR checks passed.` with zero clippy warnings and zero test failures across the workspace.
+- **SC-007**: Diff scope audit: 100% of changed files match one of {`README.md`, `SECURITY.md`, `CONTRIBUTING.md`, `.github/**.md`, `.github/**.yml`, `Cargo.toml` metadata-only}. Zero changes under `mikebom-cli/src/`, `mikebom-common/src/`, `xtask/src/`, `mikebom-cli/tests/fixtures/golden/`, `Cargo.lock` (except metadata-touch propagation).
+
+## Assumptions
+
+- The canonical repo location is `kusari-sandbox/mikebom` (verified from `gh pr create` outputs earlier in the session, e.g., `https://github.com/kusari-sandbox/mikebom/pull/190`). No imminent transfer plans known.
+- The private disclosure channel for `SECURITY.md` is GitHub Security Advisories (the most low-friction option for a small project; no email infrastructure required). A maintainer-named email alias can be added later if needed.
+- The supported-versions policy is "only the most recent alpha is supported" (matches current pre-1.0 reality; tightens to a real SemVer policy at 1.0).
+- `cargo binstall` auto-discovery works against mikebom's existing release-tarball naming (`mikebom-vX.Y.Z-<arch>-<os>.tar.gz`) with at most a `[package.metadata.binstall.overrides]` block in `Cargo.toml`. If discovery fails outright, the README documents the explicit `--pkg-url` + `--pkg-fmt` invocation as a workaround.
+- The speckit lifecycle docs already exist in `.claude/skills/` (verified earlier in the session) and `CONTRIBUTING.md` can link to them rather than re-explain end-to-end.
+- The constitution at `.specify/memory/constitution.md` is the canonical principles source (verified — used during milestone-092's Constitution Check). `CONTRIBUTING.md` links to it rather than excerpts.
+- The repo is OK without a `CODE_OF_CONDUCT.md` for this milestone (deliberately deferred — adds maintenance footprint without proportional alpha-stage value). Can be added in a follow-up if community grows.
+- This is a docs/metadata-only PR; no release version bump required. The next operator-facing change ships in a future milestone's release.
+
+## Dependencies
+
+- The repo's GitHub release-tarball naming MUST already match `cargo binstall` auto-discovery convention. Verified: alpha.30 artifacts use `mikebom-v0.1.0-alpha.30-aarch64-apple-darwin.tar.gz` etc. (per earlier `gh release view` output).
+- The mandatory pre-PR gate script (`./scripts/pre-pr.sh`) is in place and known to work on this branch (used throughout milestone 092).
+- `.github/workflows/` directory exists (CI runs `ci.yml`, `release.yml`, `realistic-projects.yml`); adding sibling `.github/ISSUE_TEMPLATE/` and `.github/pull_request_template.md` is purely additive.
+
+## Out of Scope
+
+- **Homebrew tap creation** (`kusari-sandbox/homebrew-tap` repo). Deferred to a separate follow-up milestone — requires a new repo, formula maintenance discipline, and an auto-bump step in `release.yml`. Out of scope here to keep the polish PR small.
+- **`install.sh` curl-pipe installer** + hosting at a stable URL. Same rationale as above — a small additional milestone of its own.
+- **Shell completions** (`mikebom completions <shell>` subcommand via `clap_complete`). Out of scope — adds a production code path which violates FR-007.
+- **Man pages** via `clap_mangen`. Same rationale as completions.
+- **crates.io publishing** of mikebom. Out of scope — requires Cargo.toml metadata polish, first-publish ceremony, and ongoing release-cycle integration; should be its own milestone.
+- **Docker image** in release.yml. Out of scope — requires Dockerfile maintenance + image-naming policy + an additional release-yml job. Separate milestone.
+- **deb / rpm packages** via cargo-deb / cargo-generate-rpm. Out of scope — same rationale as Docker.
+- **`CODE_OF_CONDUCT.md`**. Deferred per the Assumptions section — alpha-stage maintenance footprint cost > current value. Revisit when community grows.
+- **Renaming the canonical repo**, transferring ownership, or changing the GitHub org. Not happening in this milestone.

--- a/specs/093-repo-polish-quickwins/tasks.md
+++ b/specs/093-repo-polish-quickwins/tasks.md
@@ -1,0 +1,248 @@
+---
+description: "Task list for milestone 093 — repo polish quick-wins cleanup"
+---
+
+# Tasks: Repo polish — quick-wins cleanup pass
+
+**Input**: Design documents from `/Users/mlieberman/Projects/mikebom/specs/093-repo-polish-quickwins/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Not applicable — docs/metadata-only milestone. No new Rust tests added; verification is via the existing pre-PR gate + content-shape greps documented in `contracts/repo-surface-contracts.md`.
+
+**Organization**: Tasks grouped by user story. US1 (P1) is the MVP increment (fix the broken install URL). US2–US3 (P2) and US4–US5 (P3) follow in priority order. Because each user story touches a different file, US1–US5 are mutually independent and can be implemented in any order after Setup.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: User story this task belongs to (US1–US5)
+- File paths are workspace-relative.
+
+## Path Conventions
+
+Repo-root files (`README.md`, `SECURITY.md`, `CONTRIBUTING.md`), `.github/` files (`ISSUE_TEMPLATE/*.yml`, `pull_request_template.md`), and one workspace-member `Cargo.toml` metadata addition. Zero source-code changes.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Verify branch state before touching files.
+
+- [X] T001 Confirm working branch is `093-repo-polish-quickwins`. Run `git status` and `git log -1 --oneline`; verify the branch was created by `/speckit.specify` and main is at `426517d` (alpha.30 release commit) or later.
+- [X] T002 Confirm baseline pre-PR gate passes. Run `./scripts/pre-pr.sh` once on the unchanged tree; expect `>>> all pre-PR checks passed.` This isolates any post-edit failure as introduced by milestone 093 specifically.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No shared infrastructure required — each user story is file-level independent. This phase exists only to confirm the `.github/` parent directory layout (it already contains `workflows/`; we'll add `ISSUE_TEMPLATE/` as a sibling).
+
+- [X] T003 Confirm `.github/` exists and currently contains only `workflows/`. Run `ls .github/` and verify output is `workflows/`. The Phase 6 issue/PR-template tasks will add new files alongside it without modifying `workflows/`.
+
+**Checkpoint**: Foundation ready (trivial — no setup actually needed). US1–US5 can now begin in any order.
+
+---
+
+## Phase 3: User Story 1 — README install commands actually work (Priority: P1) 🎯 MVP
+
+**Goal**: Replace the broken `mlieberman85/mikebom.git` URL at README:238 with the canonical `kusari-sandbox/mikebom.git`. 100% of visitors who copy-paste the install instructions hit a working URL.
+
+**Independent Test**: `grep -rn "mlieberman85" --include='*.md' --include='*.toml' --include='*.yml' .` returns zero matches. Cloning the canonical URL succeeds in a fresh shell.
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] Fix the broken git URL in `README.md` (~line 238). Replace `https://github.com/mlieberman85/mikebom.git` with `https://github.com/kusari-sandbox/mikebom.git`. Use `sed -i.bak 's|mlieberman85/mikebom|kusari-sandbox/mikebom|g' README.md && rm README.md.bak` or an Edit tool invocation. Verify via `grep -rn "mlieberman85" --include='*.md' --include='*.toml' --include='*.yml' .` → expect zero matches (`exit 1` from grep is OK).
+- [X] T005 [US1] Verify the canonical URL resolves. Run `git ls-remote https://github.com/kusari-sandbox/mikebom.git HEAD 2>&1 | head -1` and confirm output starts with a 40-char hex SHA (means the repo exists at that URL).
+
+**Checkpoint**: US1 is complete. The MVP win lands here — fresh visitors can now copy-paste the install instructions without hitting a 404.
+
+---
+
+## Phase 4: User Story 2 — SECURITY.md exists and renders on GitHub Security tab (Priority: P2)
+
+**Goal**: Create a `SECURITY.md` at the repo root with the four mandatory sections (per Contract 4 + data-model §SECURITY.md) so the GitHub Security-tab integration surfaces it and researchers know how to disclose vulnerabilities.
+
+**Independent Test**: `test -f SECURITY.md && grep -cE '^## (Reporting a vulnerability|What to expect|Supported versions|Scope)' SECURITY.md` returns `4`. Post-merge: visiting `https://github.com/kusari-sandbox/mikebom/security/policy` renders the file.
+
+### Implementation for User Story 2
+
+- [X] T006 [P] [US2] Create `SECURITY.md` at the repo root with the four sections per `quickstart.md` Recipe 3 body (reporting channel via GHSA link, response-time expectation, supported-versions policy, in/out-of-scope classification). Use the exact body from quickstart Recipe 3 as the starting point; tweak prose for readability without dropping any of the four section headings.
+- [X] T007 [US2] Verify Contract 4. Run `grep -c '^## ' SECURITY.md` → expect exactly 4 H2 headings. Run `grep -c "https://github.com/kusari-sandbox/mikebom/security/advisories/new" SECURITY.md` → expect ≥ 1 (the GHSA private-disclosure link is present).
+
+**Checkpoint**: US2 complete. GitHub Security tab will auto-detect the file post-merge.
+
+---
+
+## Phase 5: User Story 3 — CONTRIBUTING.md onboards external contributors (Priority: P2)
+
+**Goal**: Create a `CONTRIBUTING.md` at the repo root with the five mandatory sections (per Contract 5 + data-model §CONTRIBUTING.md) so new contributors know the speckit lifecycle, pre-PR gate, project principles, and where the planning artifacts live.
+
+**Independent Test**: `grep -c '^## ' CONTRIBUTING.md` returns ≥ 5. The four critical-content greps from Contract 5 (`pre-pr.sh`, `constitution.md`, `MIKEBOM_REQUIRE_SPDX3_VALIDATOR`, speckit-lifecycle link) all succeed.
+
+### Implementation for User Story 3
+
+- [X] T008 [P] [US3] Create `CONTRIBUTING.md` at the repo root with the five mandatory sections per `quickstart.md` Recipe 4 body (Welcome, Workflow overview (speckit lifecycle), Local development setup, Pre-PR gate MANDATORY, Project principles + where to find them with all 12 constitution-principle one-liners). Use the exact body from quickstart Recipe 4 as the starting point.
+- [X] T009 [US3] Verify Contract 5. Run, in order: `grep -c '^## ' CONTRIBUTING.md` (≥ 5), `grep -q 'pre-pr.sh' CONTRIBUTING.md`, `grep -q 'constitution.md' CONTRIBUTING.md`, `grep -q 'MIKEBOM_REQUIRE_SPDX3_VALIDATOR' CONTRIBUTING.md`, `grep -q 'speckit' CONTRIBUTING.md`. All five MUST succeed.
+
+**Checkpoint**: US3 complete. New contributors have an explicit onboarding doc.
+
+---
+
+## Phase 6: User Story 4 — Bug reports + PRs use structured templates (Priority: P3)
+
+**Goal**: Create YAML issue forms (`bug_report.yml` + `feature_request.yml`) and a Markdown PR-template under `.github/`. GitHub's issue-chooser UI presents the templates; PR-form auto-fills with the checklist.
+
+**Independent Test**: All three files exist; YAML files parse cleanly (`python3 -c "import yaml; yaml.safe_load(open('...'))"`); PR template has ≥ 3 checkbox items; the three required-content greps from Contract 7 succeed.
+
+### Implementation for User Story 4
+
+- [X] T010 [P] [US4] Create `.github/ISSUE_TEMPLATE/bug_report.yml` per data-model §bug_report.yml (6-field YAML form: title, OS dropdown with the 6 platform options, mikebom-version input, command-output textarea, expected-vs-actual textarea, additional-context textarea). Top-level fields: `name: Bug report`, `description: Report a bug or unexpected behavior`, `title: "[BUG] "`, `labels: ['bug']`. Body field types: `markdown` (greeting), `dropdown`, `input`, `textarea` per the data-model spec.
+- [X] T011 [P] [US4] Create `.github/ISSUE_TEMPLATE/feature_request.yml` per data-model §feature_request.yml (5-field YAML form: title, use-case textarea, proposed-solution textarea, alternatives-considered textarea optional, additional-context textarea optional). Top-level fields: `name: Feature request`, `description: Suggest a new feature or improvement`, `title: "[FEATURE] "`, `labels: ['enhancement']`.
+- [X] T012 [P] [US4] Create `.github/ISSUE_TEMPLATE/config.yml` (optional but recommended). Body: `blank_issues_enabled: false` so all reports route through one of the structured templates. Skip `contact_links` (no discussions board active yet).
+- [X] T013 [P] [US4] Create `.github/pull_request_template.md` with the 5-checkbox body per data-model §pull_request_template.md. MUST include: `pre-pr.sh`, `speckit lifecycle`, `goldens`, `mikebom:* property audit`, `MIKEBOM_REQUIRE_SPDX3_VALIDATOR for release-bump PRs`.
+- [X] T014 [US4] Verify Contracts 6 + 7. Run: `test -f .github/ISSUE_TEMPLATE/bug_report.yml && test -f .github/ISSUE_TEMPLATE/feature_request.yml && test -f .github/pull_request_template.md`. Then validate YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/bug_report.yml'))"` and the same for `feature_request.yml`. Then PR template content: `grep -c '^- \[ \]' .github/pull_request_template.md` (≥ 3), and the three required-content greps (`pre-pr.sh`, `speckit`, `goldens`).
+
+**Checkpoint**: US4 complete. Post-merge, `https://github.com/kusari-sandbox/mikebom/issues/new/choose` will offer the template chooser.
+
+---
+
+## Phase 7: User Story 5 — cargo binstall works (Priority: P3)
+
+**Goal**: Add the `[package.metadata.binstall]` table to `mikebom-cli/Cargo.toml` (per research.md §1's resolution) AND document the `cargo binstall --git ... mikebom` invocation in the README's `## Install` section.
+
+**Independent Test**: `cargo +stable build -p mikebom` succeeds (metadata addition doesn't break parse). Contract 3 grep finds the `[package.metadata.binstall]` block with `pkg-url` + `pkg-fmt` lines. Contract 2 visual inspection confirms the new README subsection appears.
+
+### Implementation for User Story 5
+
+- [X] T015 [P] [US5] Append a `[package.metadata.binstall]` block to `mikebom-cli/Cargo.toml` per research.md §1's resolution. Exact content:
+    ```toml
+    [package.metadata.binstall]
+    pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"
+    pkg-fmt = "tgz"
+    ```
+    Place near the bottom of the file (after any existing `[package.metadata.*]` tables, or after `[dependencies]` if none).
+- [X] T016 [P] [US5] Add a new `### Via cargo binstall (Rust toolchain users)` subsection to `README.md`'s `## Install` section per data-model §`README.md` Edit 2 + quickstart Recipe 2 body. Place AFTER the existing tarball-download paragraph and BEFORE "Or build from source". Body MUST include: one-line preamble, the exact `cargo binstall --git https://github.com/kusari-sandbox/mikebom mikebom` command in a fenced bash block, and a note that bare `cargo binstall mikebom` works after crates.io publication.
+- [X] T017 [US5] Verify Contracts 2 + 3. Run `grep -A2 "\[package.metadata.binstall\]" mikebom-cli/Cargo.toml` → expect to see the table + pkg-url + pkg-fmt lines. Run `grep -A4 "cargo binstall" README.md` → expect to see the new subsection. Run `cargo +stable build -p mikebom 2>&1 | tail -3` → expect a successful build (cargo treats unknown metadata as opaque; no parse error).
+
+**Checkpoint**: US5 complete. Rust-toolchain users have a one-command install path.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Diff-scope audit + final pre-PR gate to confirm zero scope creep and CI-readiness.
+
+- [X] T018 Verify Contract 8 — diff scope guard. Run, in order:
+    ```bash
+    # Only allowed paths:
+    git diff --name-only main \
+      | grep -vE '^(README\.md|SECURITY\.md|CONTRIBUTING\.md|\.github/.+\.(md|yml)|mikebom-cli/Cargo\.toml)$' \
+      | grep -v '^$' \
+      | wc -l
+    # Expected: 0
+
+    # No source-tree changes:
+    git diff --name-only main | grep -E '^(mikebom-cli/src|mikebom-common/src|xtask/src)/' | wc -l
+    # Expected: 0
+
+    # No golden regen:
+    git diff --name-only main | grep -E '^mikebom-cli/tests/fixtures/golden/' | wc -l
+    # Expected: 0
+
+    # No Cargo.lock churn (FR-009):
+    git diff --name-only main | grep -E '^Cargo\.lock$' | wc -l
+    # Expected: 0
+    ```
+    If ANY check returns non-zero, STOP and investigate scope creep before proceeding to T019.
+- [X] T019 Run the mandatory pre-PR gate per Contract 9. Run `./scripts/pre-pr.sh`. Expect: `>>> all pre-PR checks passed.` with zero clippy warnings and every test suite reporting `0 failed`. This is the CLAUDE.md mandatory gate; failure here blocks PR.
+- [X] T020 Manual content-quality review pass. Re-read all five new files end-to-end (`SECURITY.md`, `CONTRIBUTING.md`, both YAML issue forms, the PR template) against the spec's User Stories acceptance scenarios. Specifically verify: a hypothetical visitor reading `SECURITY.md` knows where to report and what to expect; a hypothetical contributor reading `CONTRIBUTING.md` can answer the four SC-003 quiz questions. Fix any prose ambiguities.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Depends on Setup. Trivial — only confirms `.github/` layout.
+- **US1 / US2 / US3 / US4 / US5 (Phases 3–7)**: All depend on Foundational. **Mutually independent** because each touches a different file. Can ship in any order or in parallel.
+- **Polish (Phase 8)**: Depends on US1–US5 being complete (verifies aggregate diff scope + runs the gate).
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent. Touches `README.md` only.
+- **US2 (P2)**: Independent. Touches `SECURITY.md` only.
+- **US3 (P2)**: Independent. Touches `CONTRIBUTING.md` only.
+- **US4 (P3)**: Independent. Touches `.github/ISSUE_TEMPLATE/*.yml` + `.github/pull_request_template.md`.
+- **US5 (P3)**: Independent. Touches `mikebom-cli/Cargo.toml` + `README.md` (different section than US1's edit — appends a new subsection after the existing Install body).
+
+Note: US1 and US5 both touch `README.md` but at different sections. Sequential commits (US1 first, then US5) avoid any merge edge case.
+
+### Parallel Opportunities
+
+- US2, US3, US4 internal tasks (T006, T008, T010–T013) — all touch different files; ideal for parallel agent execution.
+- US5's two implementation tasks (T015 in `mikebom-cli/Cargo.toml`, T016 in `README.md`) — different files; parallel.
+- Phase-3 through Phase-7 tasks can interleave freely. Polish (Phase 8) is the only strict gate.
+
+---
+
+## Parallel Example: Phase 4–7 (Stories US2–US5)
+
+```bash
+# All four user stories touch different files; fan out:
+Task: "Create SECURITY.md at repo root (T006)"
+Task: "Create CONTRIBUTING.md at repo root (T008)"
+Task: "Create .github/ISSUE_TEMPLATE/bug_report.yml (T010)"
+Task: "Create .github/ISSUE_TEMPLATE/feature_request.yml (T011)"
+Task: "Create .github/ISSUE_TEMPLATE/config.yml (T012)"
+Task: "Create .github/pull_request_template.md (T013)"
+Task: "Add binstall metadata to mikebom-cli/Cargo.toml (T015)"
+Task: "Add cargo binstall README subsection (T016)"
+```
+
+The four `Verify` tasks (T007, T009, T014, T017) run after their corresponding implementation tasks complete.
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only)
+
+1. Phase 1: Setup (T001–T002)
+2. Phase 2: Foundational (T003 — trivial)
+3. Phase 3: US1 (T004–T005) — URL fix
+4. **STOP and VALIDATE**: confirm the README clone command resolves; this single change is shippable as its own one-line PR if needed.
+
+### Incremental Delivery
+
+1. Setup + Foundational → ready
+2. US1 → fixes the immediate broken link → could ship alone
+3. US2 + US3 → add SECURITY.md + CONTRIBUTING.md → community-health docs ready
+4. US4 → issue + PR templates → structured contributor flow
+5. US5 → cargo binstall → Rust-toolchain quick-install path
+6. Polish → diff-scope audit + pre-PR gate → ready for PR
+
+### Single-Developer Strategy (this milestone)
+
+This is a small docs-only milestone; one developer does it in a single pass:
+
+1. T001–T003 (setup, ~3 min)
+2. T004–T005 (US1, ~5 min — Edit + grep verification)
+3. T006–T007 (US2, ~10 min — write SECURITY.md using quickstart Recipe 3 body)
+4. T008–T009 (US3, ~15 min — write CONTRIBUTING.md using quickstart Recipe 4 body)
+5. T010–T014 (US4, ~20 min — write three template files; the YAML schema is the longest part)
+6. T015–T017 (US5, ~10 min — Cargo.toml table + README subsection)
+7. T018–T020 (Polish, ~5 min — diff audit + pre-PR gate + content review)
+
+Total: ~70 minutes including the pre-PR gate. Target ≤500 lines of diff across all changes.
+
+---
+
+## Notes
+
+- [P] markers = different files OR different sections within the same file with no implicit dependency.
+- [Story] label maps task to specific user story for traceability.
+- The five user stories are file-level independent — each story owns its file set and produces no cross-story merge edges (US1 + US5 both touch README.md but at different sections; sequential commits in that order keep history clean).
+- Verify tests fail pre-fix and pass post-fix per TDD discipline does NOT apply here — no code change, no Rust tests added; verification is content-shape greps + pre-PR gate.
+- The mandatory pre-PR gate (Contract 9 / SC-006) is the only automated CI signal. Pass = milestone is ready for PR.
+- Commit boundary suggestion: one commit per user-story phase (4–5 commits total) for clean atomic history, OR squash to a single commit at PR time.
+- Avoid: touching any path outside the Contract 8 allowlist (`README.md`, `SECURITY.md`, `CONTRIBUTING.md`, `.github/**.{md,yml}`, `mikebom-cli/Cargo.toml`). FR-007 / FR-008 / FR-009 are hard scope guardrails.


### PR DESCRIPTION
## Summary

Bundle five small repo-polish gaps as a single docs/metadata-only PR (~1 hour work). Zero production code, zero golden regen, zero new Cargo deps.

- **Fix broken git URL** (FR-001) — three stale `mlieberman85/mikebom` references (README install command, README "Reporting issues" section, CHANGELOG version-compare links) now point to the canonical `kusari-sandbox/mikebom`. Copy-paste install no longer hits a 404.
- **`SECURITY.md`** (FR-002) — at repo root; covers private disclosure via GitHub Security Advisories, response-time expectations, supported-versions policy, scope. GitHub Security tab will auto-detect.
- **`CONTRIBUTING.md`** (FR-003) — onboards new contributors: speckit lifecycle, local dev setup, mandatory pre-PR gate, one-line summaries of all 12 Constitution principles with links back to `.specify/memory/constitution.md`.
- **Issue + PR templates** (FR-004/005) — YAML issue forms with required OS dropdown / repro command / expected fields for bugs, use-case + proposal for features. PR template includes 5-checkbox pre-PR + speckit-lifecycle + Constitution-V audit list. `config.yml` disables blank issues and surfaces the security-advisory link.
- **`cargo binstall` integration** (FR-006) — `[package.metadata.binstall]` block in `mikebom-cli/Cargo.toml` pinning the URL template to the existing release-tarball naming. README's Install section gains a "Via cargo binstall" subsection with the `cargo binstall --git ... mikebom` invocation (bare invocation works once we publish to crates.io — future milestone).

Deferred to follow-up milestones per spec Out of Scope: Homebrew tap, curl-pipe `install.sh`, shell completions, man pages, crates.io publish, Docker image, deb/rpm packages, CODE_OF_CONDUCT.

## Test plan

- [x] Pre-PR gate clean locally: `./scripts/pre-pr.sh` — zero clippy warnings, every test target reports `0 failed`.
- [x] Diff scope audit (FR-007/008/009 / SC-007): zero changes under `mikebom-cli/src/`, `mikebom-common/src/`, `xtask/src/`, `mikebom-cli/tests/fixtures/golden/`, or `Cargo.lock`. All changed paths within the FR-007 allowlist.
- [x] FR-001 grep: `grep -rn mlieberman85 --include='*.md' --include='*.toml' --include='*.yml' .` returns zero non-spec hits (specs/093/ references describe the bug being fixed and are excluded by design).
- [x] FR-002 SECURITY.md: 4 H2 sections + GHSA advisory link present.
- [x] FR-003 CONTRIBUTING.md: 7 H2 sections; pre-pr.sh + constitution.md + MIKEBOM_REQUIRE_SPDX3_VALIDATOR + speckit + goldens all referenced.
- [x] FR-004 issue templates: 3 files exist; YAML parses cleanly via PyYAML.
- [x] FR-005 PR template: 7 checkbox items including pre-pr.sh + speckit + goldens + Constitution-V audit.
- [x] FR-006 cargo binstall: `[package.metadata.binstall]` block in `mikebom-cli/Cargo.toml`; README "Via cargo binstall" subsection; `cargo build -p mikebom` clean (metadata is opaque pass-through).
- [ ] Post-merge: GitHub Security tab surfaces SECURITY.md.
- [ ] Post-merge: `https://github.com/kusari-sandbox/mikebom/issues/new/choose` offers the template chooser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)