### PR TITLE
chore: add .project/ baseline-audit context (post /darnit-audit)

### DIFF
--- a/.project/darnit.yaml
+++ b/.project/darnit.yaml
@@ -1,0 +1,23 @@
+# .project/darnit.yaml - Darnit Extension
+# 
+# Extension fields for security tooling (OpenSSF Baseline, etc.)
+# Standard CNCF .project fields are in project.yaml
+
+slug: ''
+project_lead: ''
+cncf_slack_channel: ''
+package_managers: {}
+version: '1.0'
+controls: {}
+context:
+  has_subprojects: true
+  has_releases: true
+  is_library: false
+  has_compiled_assets: true
+  ci_provider: github
+  platform: github
+  primary_language: cargo
+  maintainers:
+  - '@mlieberman85'
+  security_contact: See SECURITY.md
+  governance_model: corporate

--- a/.project/project.yaml
+++ b/.project/project.yaml
@@ -1,0 +1,15 @@
+# .project/project.yaml - CNCF Project Configuration
+# https://github.com/cncf/automation/tree/main/utilities/dot-project
+# 
+# This file contains standard CNCF .project fields.
+# Extension fields are in separate files (darnit.yaml, etc.)
+
+name: mikebom
+description: ''
+schema_version: '1.0'
+type: software
+maturity_log: []
+repositories: []
+social: {}
+mailing_lists: []
+audits: []


### PR DESCRIPTION
## Summary

Persist the project context confirmed via the darnit OpenSSF Baseline MCP server (`confirm_project_data`). Two files added under `.project/` per the [CNCF dot-project schema](https://github.com/cncf/automation/tree/main/utilities/dot-project):

- `project.yaml` — standard CNCF fields (`name`, `type`, `description`, etc.)
- `darnit.yaml` — OpenSSF Baseline extension fields (maintainers, governance_model, security_contact, has_subprojects, has_releases, is_library, has_compiled_assets, ci_provider, primary_language).

Subsequent `darnit-audit` / `audit_openssf_baseline` runs use these values instead of re-prompting.

## Known accepted finding (not addressed in this PR)

`OSPS-QA-05.02` still flags 4 RPM SQLite databases at `tests/fixtures/rpm/*-image/var/lib/rpm/rpmdb.sqlite` as "looks like committed build artifacts". These are **legitimate stay-set test fixtures** per the milestone-090 split decision (see `mikebom-cli/tests/common/mod.rs:109-114`):

- mikebom's RPM scanner needs real `rpmdb.sqlite` files to validate against the actual RPM v6 database format.
- They don't trigger trivy/syft fs-scans (no source-language manifests), so they don't pollute repo-scan results the way manifest-bearing fixtures would.
- The 142-of-146 false-positive elimination in milestone 090 was specifically about *manifest-bearing* fixtures; these stay-set fixtures were deliberately retained.

This is a known accepted audit-finding, documented in agent memory + this PR description. The audit-tool's `confirm_project_data` schema doesn't support file-path exclusions, so the finding can't be silenced through the standard `.project/` context.

## Test plan

- [x] `audit_openssf_baseline(local_path=., output_format='summary')` reports `status: complete` for context (was 6 pending items pre-PR; 0 post-PR).
- [x] Audit numbers unchanged on the FAIL count (the OSPS-QA-05.02 false positive isn't suppressible via this mechanism); the value of this PR is making the context persistent so future audits don't re-prompt.
- [x] No production code touched. `git diff --name-only main` shows only `.project/project.yaml` + `.project/darnit.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)