### PR TITLE
chore: SHA-pin all actions in release.yml (close mutable-tag supply-chain risk)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build eBPF object
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install eBPF build deps
         run: |
@@ -29,12 +29,12 @@ jobs:
           sudo apt-get install -y clang llvm libelf-dev pkg-config
 
       - name: Install nightly Rust with rust-src
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly (2026-04-25)
         with:
           components: rust-src
 
       - name: Cache cargo + nightly build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           key: ebpf-nightly
           workspaces: |
@@ -48,7 +48,7 @@ jobs:
         run: cargo run --package xtask -- ebpf
 
       - name: Upload eBPF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mikebom-ebpf-object
           path: mikebom-ebpf/target/bpfel-unknown-none/release/mikebom-ebpf
@@ -62,15 +62,15 @@ jobs:
     env:
       TARGET: x86_64-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install stable Rust (x86_64 target)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-25)
         with:
           targets: x86_64-unknown-linux-gnu
 
       - name: Cache cargo + cross-compiled build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           key: ${{ env.TARGET }}
 
@@ -83,7 +83,7 @@ jobs:
         run: cargo install cross --locked
 
       - name: Download eBPF artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: mikebom-ebpf-object
           path: ebpf-download
@@ -133,7 +133,7 @@ jobs:
           ls -la "${stage}.tar.gz"
 
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mikebom-${{ github.ref_name }}-x86_64-unknown-linux-gnu
           path: mikebom-${{ github.ref_name }}-${{ env.TARGET }}.tar.gz
@@ -146,15 +146,15 @@ jobs:
     env:
       TARGET: aarch64-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install stable Rust (aarch64 target)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-25)
         with:
           targets: aarch64-unknown-linux-gnu
 
       - name: Cache cargo + cross-compiled build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           key: ${{ env.TARGET }}
 
@@ -162,7 +162,7 @@ jobs:
         run: cargo install cross --locked
 
       - name: Download eBPF artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: mikebom-ebpf-object
           path: ebpf-download
@@ -199,7 +199,7 @@ jobs:
           ls -la "${stage}.tar.gz"
 
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mikebom-${{ github.ref_name }}-aarch64-unknown-linux-gnu
           path: mikebom-${{ github.ref_name }}-${{ env.TARGET }}.tar.gz
@@ -211,15 +211,15 @@ jobs:
     env:
       TARGET: aarch64-apple-darwin
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install stable Rust (aarch64-apple-darwin)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-25)
         with:
           targets: aarch64-apple-darwin
 
       - name: Cache cargo + build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           key: ${{ env.TARGET }}
 
@@ -238,7 +238,7 @@ jobs:
           ls -la "${stage}.tar.gz"
 
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mikebom-${{ github.ref_name }}-aarch64-apple-darwin
           path: mikebom-${{ github.ref_name }}-${{ env.TARGET }}.tar.gz
@@ -252,7 +252,7 @@ jobs:
       contents: write
     steps:
       - name: Download all tarball artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: mikebom-${{ github.ref_name }}-*
           merge-multiple: true
@@ -264,7 +264,7 @@ jobs:
           cat SHA256SUMS
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           prerelease: true
           generate_release_notes: true


### PR DESCRIPTION
## Summary

Hardens the 7 tag-pinned action references in `release.yml` to immutable SHA pins with version comments. Brings `release.yml` in line with `ci.yml` + `realistic-projects.yml`, both of which were already SHA-pinned (e.g., `actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0`).

Closes the Kusari Inspector findings on PRs #195, #197, and #199, which all flagged dependabot's tag-form bumps in `release.yml` as a high-severity supply-chain risk:

> The release workflow operates with elevated permissions, including creating GitHub releases and uploading artifacts. Mutable tags can be silently reassigned by a compromised or malicious upstream repository, allowing arbitrary code execution within your release pipeline.

## Pins applied (functional no-op — same versions, immutable references)

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v6` | `@de0fac2e... # v6.0.2` |
| `dtolnay/rust-toolchain` (nightly) | `@nightly` | `@5b842231... # nightly (2026-04-25)` |
| `dtolnay/rust-toolchain` (stable) | `@stable` | `@29eef336... # stable (2026-04-25)` |
| `Swatinem/rust-cache` | `@v2` | `@e18b4977... # v2.9.1` |
| `actions/upload-artifact` | `@v4` | `@ea165f8d... # v4.6.2` |
| `actions/download-artifact` | `@v4` | `@d3f86a10... # v4.3.0` |
| `softprops/action-gh-release` | `@v2` | `@3bb12739... # v2.6.2` |

All SHAs are the latest tag for the channel currently in use. The `dtolnay/rust-toolchain` SHAs match what `ci.yml` already pins — `release.yml` was the only workflow file still tag-pinning them.

## What happens after merge

Dependabot's next pass will propose future version bumps **in SHA-pinned form** (preserving the existing pin shape), and Kusari Inspector will stop flagging the bumps as mutable-tag risks.

## Per-PR follow-up

- **#195** (`download-artifact@v4 → @v8`): will be superseded; close and let dependabot re-propose in SHA-pinned form.
- **#197** (`upload-artifact@v4 → @v7`): same.
- **#199** (`action-gh-release@v2 → @v3`): same.
- **#198** (`rust-toolchain` SHA): **nonsense bump** — replaced the **nightly** SHA with the **stable** SHA (which is why the eBPF build failed with `rust-src component missing`); close as rejected.
- **#196** (`cache@v4.3.0 → v5.0.5`): clean, ready to merge as-is.

## Test plan

- [x] Zero tag-pinned `uses:` lines remain: `grep -E "uses: [^@]+@(v[0-9]|nightly|stable|latest|main|master)$" .github/workflows/release.yml` returns empty.
- [x] 20 SHA-pinned lines confirmed (each of the 7 distinct actions × their per-job repetitions).
- [x] Functional no-op: every SHA is the head of the same tag currently in use; no version change in actual behavior.
- [ ] Post-merge: re-run dependabot to confirm future bumps land in SHA-pinned form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)