### PR TITLE
test(094): deflake wall-clock perf tests — architectural fix, not threshold-bump

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,5 +16,6 @@
 - [ ] If I touched SBOM emission or output formats, I regenerated the affected byte-identity goldens (`MIKEBOM_UPDATE_{CDX,SPDX,SPDX3}_GOLDENS=1 cargo +stable test ...`).
 - [ ] If I added a new `mikebom:*` property / annotation / relationship type, I audited each target format for an existing native construct first (Constitution Principle V — see [`.specify/memory/constitution.md`](../.specify/memory/constitution.md)).
 - [ ] If this is a release-bump PR, I ran the SPDX-3 conformance gate locally: `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 ./scripts/pre-pr.sh`.
+- [ ] If this PR touches the scan pipeline, output dispatch, or per-format emission, I added the `perf` label to trigger the dedicated perf benchmarking lane ([`.github/workflows/perf.yml`](../.github/workflows/perf.yml)).
 
 🤖 If this PR was AI-assisted, include the Co-Authored-By trailer in the commit message.

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,62 @@
+name: Performance benchmarks
+
+# Wall-clock perf tests (triple_format_perf.rs, dual_format_perf.rs) are
+# marked #[ignore] in the default lane to avoid blocking PRs on
+# shared-CI-runner timing noise. This workflow runs them on demand
+# (perf label or workflow_dispatch) and on a daily schedule against
+# main. 3-attempt retry per test absorbs runner-noise spikes.
+#
+# NOT required for PR merge. Default-lane structural-correctness
+# coverage lives in mikebom-cli/tests/triple_format_structural.rs.
+#
+# See specs/094-deflake-perf-tests/ for the full rationale.
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'  # 06:00 UTC daily — off-peak for both NA and EU
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  perf:
+    name: Wall-clock perf benchmarks
+    # Gate the pull_request trigger to fire only on the `perf` label.
+    # workflow_dispatch + schedule always pass this check.
+    if: github.event_name != 'pull_request' || github.event.label.name == 'perf'
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-25)
+
+      - name: Cache cargo + build
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          key: perf-${{ matrix.runner }}
+
+      - name: Run triple_format_perf (with retry)
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          max_attempts: 3
+          timeout_minutes: 5
+          command: cargo +stable test --workspace -- --ignored --test-threads=1 triple_format_is_at_least_25_percent_faster_than_three_sequential_scans
+
+      - name: Run dual_format_perf (with retry)
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          max_attempts: 3
+          timeout_minutes: 5
+          command: cargo +stable test --workspace -- --ignored --test-threads=1 dual_format_is_at_least_30_percent_faster_than_two_sequential_scans

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-10
+Auto-generated from all feature plans. Last updated: 2026-05-11
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -85,6 +85,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-10
 - Rust stable (workspace toolchain inherited from milestones 001–091; no nightly required for this user-space-only bug fix). + existing only — `quick-xml = "0.31"` (already used by `parse_pom_xml`), `serde`/`serde_json`, `tracing`, `anyhow`. **No new crates.** (092-fix-maven-version-extract)
 - N/A — pure metadata transform on the maven main-module emission code path; no caches, no persistence. (092-fix-maven-version-extract)
 - N/A — this milestone touches Markdown + (potentially) Cargo.toml metadata only. + None new. The existing `release.yml` artifact-naming convention is the only behavioral input that informs the cargo-binstall integration choice. (093-repo-polish-quickwins)
+- Rust stable (workspace toolchain inherited; no nightly required for this user-space test-infrastructure work). + existing only — `std::process::Command` for subprocess invocation, `tempfile`, `tar` (already used by current perf tests), `serde_json` (for byte-equivalence comparisons). The new GitHub Action `nick-fields/retry@v3` is permitted under FR-010 because it's a workflow YAML reference, not a Cargo dependency. (094-deflake-perf-tests)
+- N/A — test infrastructure only; no caches, no persistence. (094-deflake-perf-tests)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -147,9 +149,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 094-deflake-perf-tests: Added Rust stable (workspace toolchain inherited; no nightly required for this user-space test-infrastructure work). + existing only — `std::process::Command` for subprocess invocation, `tempfile`, `tar` (already used by current perf tests), `serde_json` (for byte-equivalence comparisons). The new GitHub Action `nick-fields/retry@v3` is permitted under FR-010 because it's a workflow YAML reference, not a Cargo dependency.
 - 093-repo-polish-quickwins: Added N/A — this milestone touches Markdown + (potentially) Cargo.toml metadata only. + None new. The existing `release.yml` artifact-naming convention is the only behavioral input that informs the cargo-binstall integration choice.
 - 092-fix-maven-version-extract: Added Rust stable (workspace toolchain inherited from milestones 001–091; no nightly required for this user-space-only bug fix). + existing only — `quick-xml = "0.31"` (already used by `parse_pom_xml`), `serde`/`serde_json`, `tracing`, `anyhow`. **No new crates.**
-- 091-go-sum-transitive-fallback: Added Rust stable (workspace toolchain inherited from milestones 001–090; no nightly required for this user-space-only Go-reader extension). + existing only — `parse_go_sum` at `legacy.rs:353`, `WorkspaceContext.go_sum_modules` at `graph_resolver.rs`, `ResolutionStep` enum at `graph_resolver.rs:64`. **No new Cargo dependencies.**
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,46 @@ This requires the JPEWdev `spdx3-validate` Python package pinned in
 the gate skips silently — but CI runs it strictly on release branches,
 so test locally before release-bump PRs.
 
+### Performance benchmarks (opt-in)
+
+Wall-clock perf benchmarks (`triple_format_perf.rs`, `dual_format_perf.rs`)
+do NOT run in the default pre-PR gate or in the per-PR CI lanes — they
+inherit shared-CI-runner thermal/scheduler noise that false-fails
+intermittently on macOS-latest at ~14–22% measured-reduction vs the
+25% gate. Blocking PR merges on those flakes hurts more than the perf
+signal helps (see [`specs/094-deflake-perf-tests/`](specs/094-deflake-perf-tests/)
+for the architectural rationale).
+
+Instead, [`.github/workflows/perf.yml`](.github/workflows/perf.yml) runs
+them:
+
+- **Daily at 06:00 UTC on `main`** — catches background regressions
+  within ~24h.
+- **On manual `workflow_dispatch`** — `gh workflow run perf.yml`.
+- **On PRs labeled `perf`** — opt-in for PRs that touch the scan
+  pipeline, output dispatch, or per-format emission.
+
+The perf lane uses `nick-fields/retry@v3` with 3 attempts per test to
+absorb runner-noise spikes. It is NOT required for PR merge.
+
+To run perf benchmarks locally:
+
+```bash
+cargo +stable test --workspace -- --ignored --test-threads=1
+```
+
+`./scripts/pre-pr.sh` and the default `cargo +stable test --workspace`
+skip `#[ignore]`'d tests automatically, matching CI default-lane
+behavior.
+
+A deterministic structural-correctness sibling test
+([`mikebom-cli/tests/triple_format_structural.rs`](mikebom-cli/tests/triple_format_structural.rs))
+DOES run in the default lane. It catches single-pass dispatch
+regressions binary pass/fail via stderr log-line counting of the
+existing `"scan starting"` info-line, plus triple-vs-sequential output
+byte-equivalence — no wall-clock semantics, no thresholds, no
+flakiness.
+
 ## Project principles + where to find them
 
 The canonical source-of-truth for project principles is

--- a/mikebom-cli/tests/dual_format_perf.rs
+++ b/mikebom-cli/tests/dual_format_perf.rs
@@ -247,6 +247,7 @@ fn median_of_5(image: &std::path::Path, formats: &str) -> Duration {
 }
 
 #[test]
+#[ignore = "wall-clock perf test — opt in via `cargo test -- --ignored`, runs in dedicated .github/workflows/perf.yml lane"]
 fn dual_format_is_at_least_30_percent_faster_than_two_sequential_scans() {
     // Allow reviewers to point the benchmark at a real image
     // (`debian:12-slim.tar` is the spec's named fixture) by setting

--- a/mikebom-cli/tests/triple_format_perf.rs
+++ b/mikebom-cli/tests/triple_format_perf.rs
@@ -197,6 +197,7 @@ fn median_of_5(image: &std::path::Path, formats: &str) -> Duration {
 }
 
 #[test]
+#[ignore = "wall-clock perf test — opt in via `cargo test -- --ignored`, runs in dedicated .github/workflows/perf.yml lane"]
 fn triple_format_is_at_least_25_percent_faster_than_three_sequential_scans() {
     let (_fixture_guard, image) = if let Ok(p) = std::env::var("MIKEBOM_PERF_IMAGE") {
         let p = PathBuf::from(p);

--- a/mikebom-cli/tests/triple_format_structural.rs
+++ b/mikebom-cli/tests/triple_format_structural.rs
@@ -1,0 +1,366 @@
+//! Triple-format structural-correctness sibling test (milestone 094).
+//!
+//! Replaces `triple_format_perf.rs`'s wall-clock perf assertion as the
+//! per-PR signal — that test was repeatedly flaking on macOS-latest at
+//! 14-22% measured-reduction vs a 25% threshold. This file's tests
+//! catch the SAME class of regression (single-pass dispatch breakage
+//! that causes the scan pipeline to run N times instead of 1) using a
+//! deterministic side-channel signal instead of wall-clock timing:
+//!
+//!   - The production code at `mikebom-cli/src/cli/scan_cmd.rs:1413`
+//!     emits `tracing::info!(..., "scan starting")` exactly once per
+//!     scan-pipeline invocation.
+//!   - We capture stderr from `mikebom sbom scan` and count "scan
+//!     starting" occurrences. A correct triple-format invocation
+//!     produces count == 1; a broken-single-pass implementation would
+//!     produce count == 3.
+//!   - Plus a byte-equivalence sibling that confirms triple-format
+//!     output matches single-format output for each format (catches
+//!     dispatch-correctness regressions even if single-pass count is
+//!     wrong).
+//!
+//! Zero wall-clock semantics. Binary pass/fail. Deterministic — the 3
+//! assertions either hold or they don't, independent of CI runner
+//! thermal state, scheduler jitter, or page-cache contents.
+//!
+//! See `specs/094-deflake-perf-tests/` for the full rationale + the
+//! 100-iteration determinism check that gates this test's quality.
+//!
+//! The actual wall-clock perf test remains in `triple_format_perf.rs`
+//! but is now `#[ignore]`'d; the dedicated `.github/workflows/perf.yml`
+//! lane runs it on demand (PR `perf` label or scheduled nightly).
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+mod common;
+
+use common::normalize::{
+    apply_fake_home_env, normalize_cdx_for_golden, normalize_spdx23_for_golden,
+    normalize_spdx3_for_golden,
+};
+use common::{bin, workspace_root};
+
+/// Format-specific normalizer signature, shared by the three byte-equivalence
+/// comparison rows in `triple_format_outputs_byte_match_three_sequential`.
+/// Hoisted to a type alias because clippy's `clippy::type_complexity` lint
+/// flags an inline `fn(&str, &Path) -> String` in tuple position.
+type NormalizeFn = fn(&str, &std::path::Path) -> String;
+
+// ---------------------------------------------------------------------
+// Fixture-build helpers — duplicated from `triple_format_perf.rs`
+// because both files are standalone test targets and this test's
+// determinism requirement makes a shared `tests/common/mod.rs` helper
+// out-of-scope for milestone 094 (FR-008 forbids non-test changes).
+// ---------------------------------------------------------------------
+
+struct ImageFile {
+    path: &'static str,
+    content: Vec<u8>,
+}
+
+fn build_synthetic_image(files: &[ImageFile]) -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut layer_bytes = Vec::new();
+    {
+        let mut layer_tar = tar::Builder::new(&mut layer_bytes);
+        for f in files {
+            let mut header = tar::Header::new_ustar();
+            header.set_path(f.path).expect("set_path");
+            header.set_size(f.content.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            layer_tar
+                .append(&header, f.content.as_slice())
+                .expect("tar append");
+        }
+        layer_tar.finish().expect("layer finish");
+    }
+    let manifest = r#"[{"Config":"config.json","RepoTags":["mikebom-perf-triple-structural:latest"],"Layers":["layer0/layer.tar"]}]"#;
+    let tar_path = dir.path().join("image.tar");
+    let file = std::fs::File::create(&tar_path).expect("create image.tar");
+    {
+        let mut outer = tar::Builder::new(file);
+        let mut mh = tar::Header::new_ustar();
+        mh.set_path("manifest.json").unwrap();
+        mh.set_size(manifest.len() as u64);
+        mh.set_mode(0o644);
+        mh.set_cksum();
+        outer
+            .append(&mh, manifest.as_bytes())
+            .expect("outer append manifest");
+        let mut lh = tar::Header::new_ustar();
+        lh.set_path("layer0/layer.tar").unwrap();
+        lh.set_size(layer_bytes.len() as u64);
+        lh.set_mode(0o644);
+        lh.set_cksum();
+        outer
+            .append(&lh, layer_bytes.as_slice())
+            .expect("outer append layer");
+        outer.into_inner().expect("outer finish").flush().expect("flush");
+    }
+    (dir, tar_path)
+}
+
+/// Small synthetic image — enough to exercise the scan pipeline but
+/// fast (~1s per invocation). Smaller than the wall-clock perf
+/// fixture because we don't care about timing here.
+fn build_structural_fixture() -> (tempfile::TempDir, PathBuf) {
+    let mut files: Vec<ImageFile> = Vec::new();
+
+    files.push(ImageFile {
+        path: "etc/os-release",
+        content: b"ID=debian\nVERSION_ID=12\nVERSION_CODENAME=bookworm\n".to_vec(),
+    });
+
+    let mut dpkg = String::new();
+    for i in 0..20 {
+        use std::fmt::Write as _;
+        write!(
+            dpkg,
+            "Package: pkg-{i:04}\n\
+             Status: install ok installed\n\
+             Version: 1.{i}.0\n\
+             Architecture: amd64\n\
+             Maintainer: Debian <debian@example.org>\n\n",
+        )
+        .unwrap();
+    }
+    files.push(ImageFile {
+        path: "var/lib/dpkg/status",
+        content: dpkg.into_bytes(),
+    });
+
+    build_synthetic_image(&files)
+}
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+/// FR-005 / SC-003: a single `mikebom sbom scan --format A,B,C`
+/// invocation runs the scan pipeline exactly once. The structural
+/// signal is the `"scan starting"` log line emitted at
+/// `scan_cmd.rs:1413`; we count its occurrences in captured stderr.
+#[test]
+fn triple_format_invokes_scan_pipeline_exactly_once() {
+    let (_guard, image) = build_structural_fixture();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let fake_home = tempfile::tempdir().expect("fake-home");
+
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--image")
+        .arg(&image)
+        .arg("--format")
+        .arg("cyclonedx-json,spdx-2.3-json,spdx-3-json")
+        .arg("--output")
+        .arg(format!(
+            "cyclonedx-json={}",
+            tmp.path().join("out.cdx.json").display()
+        ))
+        .arg("--output")
+        .arg(format!(
+            "spdx-2.3-json={}",
+            tmp.path().join("out.spdx.json").display()
+        ))
+        .arg("--output")
+        .arg(format!(
+            "spdx-3-json={}",
+            tmp.path().join("out.spdx3.json").display()
+        ))
+        .arg("--no-deep-hash");
+    let out = cmd.output().expect("mikebom runs");
+    assert!(
+        out.status.success(),
+        "triple-format scan failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let count = stderr.matches("scan starting").count();
+    assert_eq!(
+        count, 1,
+        "triple-format MUST invoke the scan pipeline exactly once \
+         (single-pass dispatch). Saw {count} `scan starting` log lines. \
+         stderr (last 2k chars):\n{}",
+        &stderr[stderr.len().saturating_sub(2048)..]
+    );
+}
+
+/// FR-005 sanity check: three sequential single-format invocations
+/// produce three pipeline starts. Confirms the signal mechanism works
+/// in BOTH directions (i.e., the log line still fires when scanning;
+/// catches an upstream log-message rename regression that would
+/// silently make Test 1 fail-closed without surfacing why).
+#[test]
+fn three_sequential_invocations_emit_three_pipeline_starts() {
+    let (_guard, image) = build_structural_fixture();
+    let mut total = 0;
+    for fmt in &["cyclonedx-json", "spdx-2.3-json", "spdx-3-json"] {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fake_home = tempfile::tempdir().expect("fake-home");
+        let mut cmd = Command::new(bin());
+        apply_fake_home_env(&mut cmd, fake_home.path());
+        cmd.arg("--offline")
+            .arg("sbom")
+            .arg("scan")
+            .arg("--image")
+            .arg(&image)
+            .arg("--format")
+            .arg(fmt)
+            .arg("--output")
+            .arg(format!(
+                "{fmt}={}",
+                tmp.path().join("out").display()
+            ))
+            .arg("--no-deep-hash");
+        let out = cmd.output().expect("mikebom runs");
+        assert!(
+            out.status.success(),
+            "{fmt} scan failed: stderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        total += stderr.matches("scan starting").count();
+    }
+    assert_eq!(
+        total, 3,
+        "expected 3 `scan starting` log lines across 3 single-format \
+         invocations (one per subprocess); got {total}",
+    );
+}
+
+/// FR-005 dispatch-correctness check: each emitted format in a
+/// triple-format invocation byte-matches the output of a separate
+/// single-format invocation (after normalization). Catches dispatch
+/// regressions that produce wrong output even when single-pass count
+/// is correct.
+#[test]
+fn triple_format_outputs_byte_match_three_sequential() {
+    let (_guard, image) = build_structural_fixture();
+    let workspace = workspace_root();
+
+    // Triple-format invocation (single subprocess).
+    let triple_tmp = tempfile::tempdir().expect("tempdir");
+    let triple_home = tempfile::tempdir().expect("fake-home");
+    let mut triple_cmd = Command::new(bin());
+    apply_fake_home_env(&mut triple_cmd, triple_home.path());
+    triple_cmd
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--image")
+        .arg(&image)
+        .arg("--format")
+        .arg("cyclonedx-json,spdx-2.3-json,spdx-3-json")
+        .arg("--output")
+        .arg(format!(
+            "cyclonedx-json={}",
+            triple_tmp.path().join("out.cdx.json").display()
+        ))
+        .arg("--output")
+        .arg(format!(
+            "spdx-2.3-json={}",
+            triple_tmp.path().join("out.spdx.json").display()
+        ))
+        .arg("--output")
+        .arg(format!(
+            "spdx-3-json={}",
+            triple_tmp.path().join("out.spdx3.json").display()
+        ))
+        .arg("--no-deep-hash");
+    let triple_out = triple_cmd.output().expect("mikebom runs");
+    assert!(
+        triple_out.status.success(),
+        "triple-format scan failed: stderr={}",
+        String::from_utf8_lossy(&triple_out.stderr)
+    );
+
+    // Three sequential single-format invocations (each its own subprocess).
+    type FormatRow = (&'static str, &'static str, NormalizeFn);
+    let formats: [FormatRow; 3] = [
+        ("cyclonedx-json", "out.cdx.json", normalize_cdx_for_golden),
+        ("spdx-2.3-json", "out.spdx.json", normalize_spdx23_for_golden),
+        ("spdx-3-json", "out.spdx3.json", normalize_spdx3_for_golden),
+    ];
+
+    for (fmt, fname, normalize) in formats {
+        let single_tmp = tempfile::tempdir().expect("tempdir");
+        let single_home = tempfile::tempdir().expect("fake-home");
+        let mut single_cmd = Command::new(bin());
+        apply_fake_home_env(&mut single_cmd, single_home.path());
+        single_cmd
+            .arg("--offline")
+            .arg("sbom")
+            .arg("scan")
+            .arg("--image")
+            .arg(&image)
+            .arg("--format")
+            .arg(fmt)
+            .arg("--output")
+            .arg(format!(
+                "{fmt}={}",
+                single_tmp.path().join(fname).display()
+            ))
+            .arg("--no-deep-hash");
+        let single_out = single_cmd.output().expect("mikebom runs");
+        assert!(
+            single_out.status.success(),
+            "single-format {fmt} scan failed: stderr={}",
+            String::from_utf8_lossy(&single_out.stderr)
+        );
+
+        let triple_path = triple_tmp.path().join(fname);
+        let single_path = single_tmp.path().join(fname);
+        let triple_body =
+            std::fs::read_to_string(&triple_path).expect("read triple output");
+        let single_body =
+            std::fs::read_to_string(&single_path).expect("read single output");
+
+        let triple_norm = normalize(&strip_image_temp_dir(&triple_body), &workspace);
+        let single_norm = normalize(&strip_image_temp_dir(&single_body), &workspace);
+
+        assert_eq!(
+            triple_norm, single_norm,
+            "triple-format `{fmt}` output MUST byte-match the single-format \
+             `{fmt}` output after normalization. A divergence indicates a \
+             dispatch-correctness regression in single-pass emission.",
+        );
+    }
+}
+
+/// Strip the dynamic image-extraction temp-dir suffix from `mikebom:source-files`
+/// property values. Each `mikebom sbom scan --image <tar>` invocation extracts the
+/// image to a fresh `tempfile::tempdir()` named `mikebom-image-<random>`, so two
+/// independent subprocess invocations against the same image produce SBOMs whose
+/// `mikebom:source-files` properties differ only in that random segment. The
+/// per-format `normalize_*_for_golden` helpers don't mask this (they mask only
+/// `MIKEBOM_FIXTURES_DIR` and the workspace root) — so this helper does a
+/// pre-pass regex-replace to collapse `mikebom-image-<random>` to a stable
+/// placeholder before normalization. Preserves dispatch-correctness signal:
+/// component lists, dep edges, PURL bodies, and hashes still compared
+/// byte-for-byte; only the per-invocation extraction-path randomness is masked.
+fn strip_image_temp_dir(body: &str) -> String {
+    // Pattern: `mikebom-image-` followed by tempfile's random suffix
+    // (typically alphanumeric, up to ~30 chars on Unix). Greedy-match
+    // up to the next `/` since the rootfs subpath always follows.
+    let mut out = String::with_capacity(body.len());
+    let mut rest = body;
+    while let Some(idx) = rest.find("mikebom-image-") {
+        out.push_str(&rest[..idx]);
+        out.push_str("mikebom-image-PLACEHOLDER");
+        // Advance past the random suffix (everything up to the next `/`).
+        let after_prefix = &rest[idx + "mikebom-image-".len()..];
+        if let Some(slash_idx) = after_prefix.find('/') {
+            rest = &after_prefix[slash_idx..];
+        } else {
+            rest = "";
+        }
+    }
+    out.push_str(rest);
+    out
+}

--- a/specs/094-deflake-perf-tests/checklists/requirements.md
+++ b/specs/094-deflake-perf-tests/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Deflake wall-clock perf tests
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs) — describes WHAT (move perf tests out of default lane; add structural-correctness sibling) and WHY (CI-noise causes false fails; we still need regression catch). FR-005's "exact invariant assertion shape is an implementation choice deferred to planning" is the right level of indirection.
+- [X] Focused on user value and business needs — explicitly frames each gap by contributor / maintainer / CI-reviewer pain point.
+- [X] Written for non-technical stakeholders — Background explains the treadmill pattern in plain language with concrete history (median-3 → median-5 → still flaking at 22.9%); rationale references industry-standard patterns (rust-lang nightly perf tracker, criterion bench profile) without prescribing them.
+- [X] All mandatory sections completed — User Scenarios & Testing (3 stories), Requirements (10 FRs), Success Criteria (7 SCs), Assumptions, Dependencies, Out of Scope.
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain — all open choices (opt-in mechanism shape, retry implementation, structural-test assertion strategy) are explicitly captured in Assumptions with reasonable-default rationale.
+- [X] Requirements are testable and unambiguous — FR-001 has a concrete `#[ignore]` mechanism; FR-002–FR-004 have specific commands; FR-005 names the deterministic-pass/fail invariant; FR-006 names exact files to update; FR-007–FR-010 are diff-scope / metadata invariants with concrete checks.
+- [X] Success criteria are measurable — SC-001 (10-PR rolling window, zero failures), SC-002 (60s opt-in latency), SC-003 (regression caught in same CI run), SC-004 (24h scheduled-lane signal), SC-005 (pre-PR gate clean), SC-006 (100-iter local determinism check), SC-007 (file-path allowlist audit).
+- [X] Success criteria are technology-agnostic — outcomes framed as contributor / maintainer experiences; the few tool references (cargo test, gh run list) are project-conventional, not novel tech choices.
+- [X] All acceptance scenarios are defined — 3 user stories, each with 3 Given/When/Then scenarios (9 total).
+- [X] Edge cases are identified — 5 edge cases covering hardware-class limitations, scheduled-lane delay, structural-vs-wall-clock divergence, contributor opt-in / disable scenarios, and dual-vs-triple test divergence.
+- [X] Scope is clearly bounded — 7-item Out of Scope section explicitly defers threshold tuning, self-hosted runners, criterion bench infrastructure, wholesale removal of wall-clock tests, root-cause-of-noise investigation, threat-model gap, and branch-protection gap.
+- [X] Dependencies and assumptions identified — both sections populated; dependencies on existing files + workflow infrastructure named.
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria — FR-001 ↔ US1 AS#1; FR-002 ↔ US1 AS#2 + SC-005; FR-003 ↔ US2 AS#1 + SC-002; FR-004 ↔ US2 AS#3 + SC-004; FR-005 ↔ US3 AS#2 + SC-003 + SC-006; FR-006 ↔ US1/US2 (docs side); FR-007 (assertions preserved) ↔ US2 AS#2 + the existing test files; FR-008/FR-009/FR-010 ↔ SC-007 diff-scope audit.
+- [X] User scenarios cover primary flows — US1 (P1 — no false fails on default lane) + US2 (P1 — regression-catch preserved) + US3 (P2 — structural sibling test deterministically catches single-pass dispatch breakage).
+- [X] Feature meets measurable outcomes defined in Success Criteria — every FR maps to ≥1 SC; SC-006 specifically gates the structural-test determinism FR-005 implies.
+- [X] No implementation details leak into specification — exact opt-in UX, exact instrumentation hook for the structural test, exact retry mechanism, and exact CI-trigger condition are all explicitly deferred to planning per the Assumptions section.
+
+## Notes
+
+All 16 checklist items pass. Spec is ready for `/speckit.plan` (small architectural milestone touching 2 test files + 1 new test + 1 CI workflow + 2 docs; well-bounded; no production code changes).

--- a/specs/094-deflake-perf-tests/contracts/deflake-contracts.md
+++ b/specs/094-deflake-perf-tests/contracts/deflake-contracts.md
@@ -1,0 +1,192 @@
+# Contract — Deflake perf tests deliverables
+
+Behavioral contracts for every new or modified file. Each contract names: (a) what the file MUST contain, (b) how to verify (a) — typically a `grep`, `cargo test --list`, or local 100×-loop check.
+
+## Contract 1 — `triple_format_perf.rs` is skipped by default (FR-001 / FR-002 / SC-001)
+
+**File**: `mikebom-cli/tests/triple_format_perf.rs`
+
+**Post-094 state**: the test fn `triple_format_is_at_least_25_percent_faster_than_three_sequential_scans` carries a `#[ignore = "..."]` attribute. The body is unchanged (FR-007).
+
+**Verification**:
+
+```bash
+# Test is listed but flagged as ignored:
+cargo +stable test -p mikebom --test triple_format_perf -- --list \
+  | grep "triple_format_is_at_least_25_percent_faster" \
+  | grep -q "ignored"
+# Expected: exit 0 (grep finds the "ignored" annotation).
+
+# Default invocation skips it:
+cargo +stable test -p mikebom --test triple_format_perf 2>&1 \
+  | grep -E "test result: ok.*0 passed.*0 failed.*1 ignored"
+# Expected: 1 ignored, 0 passed, 0 failed.
+
+# Opt-in invocation runs it:
+cargo +stable test -p mikebom --test triple_format_perf -- --ignored \
+  | grep -E "test result: ok.*1 passed"
+# Expected: 1 passed (or, on macOS, possibly the original flake — which is OK,
+# the perf-lane retry handles that).
+```
+
+## Contract 2 — `dual_format_perf.rs` is skipped by default (FR-001)
+
+**File**: `mikebom-cli/tests/dual_format_perf.rs`
+
+**Post-094 state**: the dual_format perf test fn carries a `#[ignore = "..."]` attribute. Body unchanged.
+
+Same verification as Contract 1, applied to the dual-format test fn name and binary. ALSO verify the test stays skipped when included as a submodule of `holistic_parity`:
+
+```bash
+cargo +stable test -p mikebom --test holistic_parity 2>&1 \
+  | grep -E "test result: ok.*(N) passed.*(M) ignored" \
+  | grep -v "0 ignored"
+# Expected: at least 1 ignored test in the holistic_parity binary (from the
+# included dual_format_perf submodule).
+```
+
+## Contract 3 — `triple_format_structural.rs` deterministic + binary pass/fail (FR-005 / SC-006)
+
+**File**: `mikebom-cli/tests/triple_format_structural.rs`
+
+**Post-094 state**: 3 test fns, all without `#[ignore]`, all running in the default lane:
+
+- `triple_format_invokes_scan_pipeline_exactly_once` — captures stderr of a triple-format invocation; counts `"scan starting"`; asserts == 1.
+- `three_sequential_invocations_emit_three_pipeline_starts` — sanity-check that the signal works in both directions.
+- `triple_format_outputs_byte_match_three_sequential` — normalized byte-equivalence across the 3 emitted formats.
+
+**Verification (deterministic):**
+
+```bash
+# Sanity: tests are listed (not ignored):
+cargo +stable test -p mikebom --test triple_format_structural -- --list \
+  | grep -c "triple_format_invokes_scan_pipeline_exactly_once\|three_sequential_invocations_emit_three_pipeline_starts\|triple_format_outputs_byte_match_three_sequential"
+# Expected: 3
+
+# Default invocation runs them (no --ignored flag needed):
+cargo +stable test -p mikebom --test triple_format_structural 2>&1 \
+  | grep -E "test result: ok.*3 passed.*0 failed"
+
+# 100-iteration determinism check (SC-006):
+for i in $(seq 1 100); do
+  cargo +stable test -p mikebom --test triple_format_structural --quiet \
+    || { echo "FAIL on iteration $i"; exit 1; }
+done
+echo "100/100 passed — deterministic"
+```
+
+## Contract 4 — `.github/workflows/perf.yml` (FR-004 / SC-002 / SC-004)
+
+**File**: `.github/workflows/perf.yml`
+
+**Post-094 state**: workflow file exists; defines 3 triggers (`pull_request` labeled, `workflow_dispatch`, `schedule` daily); runs on `ubuntu-latest` + `macos-latest` matrix; wraps each perf test in a `nick-fields/retry@v3` step with `max_attempts: 3, timeout_minutes: 5`.
+
+**Verification**:
+
+```bash
+# File exists + parses as valid YAML:
+test -f .github/workflows/perf.yml && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/perf.yml'))"
+# Expected: exit 0.
+
+# Required triggers present:
+grep -E "pull_request:|workflow_dispatch:|schedule:" .github/workflows/perf.yml | wc -l
+# Expected: >= 3.
+
+# Retry action SHA-pinned (Kusari Inspector pass per milestone-094 conventions):
+grep -E "nick-fields/retry@[0-9a-f]{40}" .github/workflows/perf.yml
+# Expected: at least 2 matches (one per perf test).
+
+# `perf` label gate present:
+grep -q "github.event.label.name == 'perf'" .github/workflows/perf.yml
+# Expected: exit 0.
+```
+
+**Behavioral verification (post-merge, manual)**:
+
+- Add `perf` label to a test PR → expect `Performance benchmarks` workflow to start within ~1 minute.
+- `gh workflow run perf.yml` → expect a manual run to appear in `gh run list`.
+- Wait until 06:00 UTC the day after merge → expect a scheduled run to appear.
+- A deliberate single-pass-dispatch regression on a `perf`-labeled PR → expect at least one retry attempt to fail (the structural test in the default lane should ALSO fail and catch it earlier).
+
+## Contract 5 — `.github/pull_request_template.md` (FR-006)
+
+**File**: `.github/pull_request_template.md`
+
+**Post-094 state**: the existing Pre-PR checklist gains one new item referencing the `perf` label.
+
+**Verification**:
+
+```bash
+grep -c "perf.yml\|perf label\|perf benchmarking lane" .github/pull_request_template.md
+# Expected: >= 1.
+```
+
+## Contract 6 — `CONTRIBUTING.md` (FR-006)
+
+**File**: `CONTRIBUTING.md`
+
+**Post-094 state**: a new H3 subsection titled "Performance benchmarks (opt-in)" appears under "Pre-PR gate (MANDATORY)". Documents the default-skip behavior, the `-- --ignored` opt-in, and the perf.yml lane.
+
+**Verification**:
+
+```bash
+grep -c "^### Performance benchmarks" CONTRIBUTING.md
+# Expected: 1.
+
+grep -q "cargo +stable test --workspace -- --ignored" CONTRIBUTING.md
+# Expected: exit 0.
+```
+
+## Contract 7 — Diff scope guard (FR-008 / FR-009 / FR-010 / SC-007)
+
+**Verification**:
+
+```bash
+# Only allowed paths:
+git diff --name-only main | grep -vE '^(mikebom-cli/tests/(triple_format_perf|dual_format_perf|triple_format_structural)\.rs|\.github/(workflows/perf|pull_request_template)\.(yml|md)|CONTRIBUTING\.md|specs/094-deflake-perf-tests/.+)$' | grep -v '^$' | wc -l
+# Expected: 0.
+
+# No source-tree changes:
+git diff --name-only main | grep -E '^(mikebom-cli/src|mikebom-common/src|xtask/src)/' | wc -l
+# Expected: 0.
+
+# No golden regen:
+git diff --name-only main | grep -E '^mikebom-cli/tests/fixtures/golden/' | wc -l
+# Expected: 0.
+
+# No Cargo.lock churn:
+git diff --name-only main | grep -E '^Cargo\.(lock|toml)$' | wc -l
+# Expected: 0.
+```
+
+## Contract 8 — Pre-PR gate clean (FR-002 / SC-005)
+
+**Verification**:
+
+```bash
+./scripts/pre-pr.sh
+# Expected: prints `>>> all pre-PR checks passed.`; exit 0.
+```
+
+The pre-PR gate's `cargo +stable test --workspace` invocation:
+- ✅ skips both perf tests (they carry `#[ignore]`)
+- ✅ runs the 3 new structural tests in `triple_format_structural.rs`
+- ✅ runs every other existing test as today
+
+Net effect: pre-PR gate becomes faster (saves ~20s of perf-test runtime per local invocation) and more reliable (no perf-flake false fails).
+
+## Contract 9 — Default-lane CI reliability (SC-001)
+
+**Behavioral verification (post-merge, ambient observation)**:
+
+Over the 10 PRs following this milestone's merge, count failure events on the three default lanes (`Lint + test (linux-x86_64)`, `Lint + test (macos-latest)`, `Lint + test (linux-x86_64, --features ebpf-tracing)`) attributable to perf-test wall-clock flakes.
+
+```bash
+# Sample query for the 10 most recent PRs post-merge:
+gh pr list --state merged --base main --limit 10 --json number,statusCheckRollup --jq '.[] | "#\(.number) " + ((.statusCheckRollup // []) | map(select((.name // .context // "" | contains("Lint + test")) and (.conclusion == "FAILURE"))) | length | tostring)'
+# Expected: every line ends in "0" (zero default-lane failures). Allow ≤1
+# failure across all 10 PRs as a noise budget (covers genuinely-real
+# regressions, not perf flakes).
+```
+
+If ANY perf-flake failure surfaces on the default lane post-merge, the milestone's architectural change has NOT delivered FR-001. Root-cause that failure and patch in a follow-up.

--- a/specs/094-deflake-perf-tests/data-model.md
+++ b/specs/094-deflake-perf-tests/data-model.md
@@ -1,0 +1,263 @@
+# Data Model — milestone 094
+
+Per-file structure for every deliverable. No JSON / no YAML schema-level changes outside the new workflow file. This is a test-infrastructure milestone; the "data model" here is just the section structure each file MUST adopt.
+
+## File inventory
+
+| File | State | Owner FRs |
+|------|-------|-----------|
+| `mikebom-cli/tests/triple_format_perf.rs` | MODIFIED (1-line `#[ignore]` add) | FR-001 |
+| `mikebom-cli/tests/dual_format_perf.rs` | MODIFIED (1-line `#[ignore]` add) | FR-001 |
+| `mikebom-cli/tests/triple_format_structural.rs` | NEW | FR-005 |
+| `.github/workflows/perf.yml` | NEW | FR-004 |
+| `.github/pull_request_template.md` | MODIFIED (add 1 checklist line) | FR-006 |
+| `CONTRIBUTING.md` | MODIFIED (add ~10-line subsection on perf-test split) | FR-006 |
+
+## `triple_format_perf.rs` — modification
+
+Add `#[ignore]` attribute to the single test fn at line 199:
+
+```rust
+#[test]
+#[ignore = "wall-clock perf test — opt in via `cargo test -- --ignored`, runs in dedicated perf.yml lane"]
+fn triple_format_is_at_least_25_percent_faster_than_three_sequential_scans() {
+    // ... existing body unchanged ...
+}
+```
+
+The `ignore = "..."` form documents WHY the test is ignored; `cargo test --verbose` surfaces this reason. Existing body (fixture build, median-of-5, assertion) stays untouched (FR-007).
+
+## `dual_format_perf.rs` — modification
+
+Same pattern. The test fn name (and module-inclusion quirk via `mod dual_format_perf;` in `holistic_parity.rs`) doesn't affect the `#[ignore]` semantics — both inclusion contexts will skip the test in default `cargo test` runs.
+
+## `triple_format_structural.rs` — NEW
+
+Three test functions, all deterministic (no wall-clock measurement, no thresholds):
+
+### Test 1 — `triple_format_invokes_scan_pipeline_exactly_once`
+
+Asserts: a single `mikebom sbom scan --format cdx,spdx,spdx3` invocation emits exactly ONE `"scan starting"` log line on stderr.
+
+```rust
+#[test]
+fn triple_format_invokes_scan_pipeline_exactly_once() {
+    let (_guard, image) = build_synthetic_fixture();  // reuse helper from triple_format_perf
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let fake_home = tempfile::tempdir().expect("fake-home");
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    cmd.arg("--offline").arg("sbom").arg("scan")
+        .arg("--image").arg(&image)
+        .arg("--format").arg("cyclonedx-json,spdx-2.3-json,spdx-3-json")
+        .arg("--output").arg(format!("cyclonedx-json={}", tmp.path().join("out.cdx.json").display()))
+        .arg("--output").arg(format!("spdx-2.3-json={}", tmp.path().join("out.spdx.json").display()))
+        .arg("--output").arg(format!("spdx-3-json={}", tmp.path().join("out.spdx3.json").display()))
+        .arg("--no-deep-hash");
+    let out = cmd.output().expect("mikebom runs");
+    assert!(out.status.success(), "scan failed: stderr={}", String::from_utf8_lossy(&out.stderr));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let count = stderr.matches("scan starting").count();
+    assert_eq!(
+        count, 1,
+        "triple-format MUST invoke the scan pipeline exactly once (single-pass dispatch). \
+         Saw {count} `scan starting` log lines. stderr:\n{stderr}",
+    );
+}
+```
+
+### Test 2 — `three_sequential_invocations_emit_three_pipeline_starts`
+
+Asserts: three separate single-format invocations emit `"scan starting"` exactly 3 times total. (Sanity check that the signal mechanism works in both directions; catches log-message-rename regressions.)
+
+```rust
+#[test]
+fn three_sequential_invocations_emit_three_pipeline_starts() {
+    let (_guard, image) = build_synthetic_fixture();
+    let mut total = 0;
+    for fmt in &["cyclonedx-json", "spdx-2.3-json", "spdx-3-json"] {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fake_home = tempfile::tempdir().expect("fake-home");
+        let mut cmd = Command::new(bin());
+        apply_fake_home_env(&mut cmd, fake_home.path());
+        cmd.arg("--offline").arg("sbom").arg("scan")
+            .arg("--image").arg(&image)
+            .arg("--format").arg(fmt)
+            .arg("--output").arg(format!("{}={}", fmt, tmp.path().join("out").display()))
+            .arg("--no-deep-hash");
+        let out = cmd.output().expect("mikebom runs");
+        assert!(out.status.success(), "scan failed: stderr={}", String::from_utf8_lossy(&out.stderr));
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        total += stderr.matches("scan starting").count();
+    }
+    assert_eq!(total, 3, "expected 3 `scan starting` lines across 3 invocations; got {total}");
+}
+```
+
+### Test 3 — `triple_format_outputs_byte_match_three_sequential` (correctness sibling)
+
+Asserts: each of the 3 outputs from a triple-format invocation byte-matches (after normalization) the output from a single-format invocation. Catches dispatch-bug regressions that produce wrong output even when single-pass works.
+
+```rust
+#[test]
+fn triple_format_outputs_byte_match_three_sequential() {
+    let (_guard, image) = build_synthetic_fixture();
+    let workspace = workspace_root();
+    let formats = &[
+        ("cyclonedx-json",  "cdx.json",   normalize_cdx_for_golden  as fn(&str, &Path) -> String),
+        ("spdx-2.3-json",   "spdx.json",  normalize_spdx23_for_golden),
+        ("spdx-3-json",     "spdx3.json", normalize_spdx3_for_golden),
+    ];
+
+    // Single triple-format invocation.
+    let triple_tmp = tempfile::tempdir().expect("tempdir");
+    let triple_home = tempfile::tempdir().expect("fake-home");
+    let mut triple_cmd = Command::new(bin());
+    apply_fake_home_env(&mut triple_cmd, triple_home.path());
+    triple_cmd.arg("--offline").arg("sbom").arg("scan").arg("--image").arg(&image)
+        .arg("--format").arg("cyclonedx-json,spdx-2.3-json,spdx-3-json")
+        .arg("--no-deep-hash");
+    for (fmt, ext, _) in formats {
+        triple_cmd.arg("--output").arg(format!("{fmt}={}", triple_tmp.path().join(format!("out.{ext}")).display()));
+    }
+    assert!(triple_cmd.output().unwrap().status.success());
+
+    // Three single-format invocations.
+    for (fmt, ext, normalize) in formats {
+        let single_tmp = tempfile::tempdir().expect("tempdir");
+        let single_home = tempfile::tempdir().expect("fake-home");
+        let mut single_cmd = Command::new(bin());
+        apply_fake_home_env(&mut single_cmd, single_home.path());
+        single_cmd.arg("--offline").arg("sbom").arg("scan").arg("--image").arg(&image)
+            .arg("--format").arg(fmt)
+            .arg("--output").arg(format!("{fmt}={}", single_tmp.path().join(format!("out.{ext}")).display()))
+            .arg("--no-deep-hash");
+        assert!(single_cmd.output().unwrap().status.success());
+
+        let triple_out = std::fs::read_to_string(triple_tmp.path().join(format!("out.{ext}"))).unwrap();
+        let single_out = std::fs::read_to_string(single_tmp.path().join(format!("out.{ext}"))).unwrap();
+        assert_eq!(
+            normalize(&triple_out, &workspace),
+            normalize(&single_out, &workspace),
+            "triple-format `{fmt}` output MUST byte-match single-format `{fmt}` output after normalization",
+        );
+    }
+}
+```
+
+The new file imports `common::normalize::{apply_fake_home_env, normalize_cdx_for_golden, normalize_spdx23_for_golden, normalize_spdx3_for_golden}` and `common::workspace_root` per the existing `tests/common/mod.rs` shape. Fixture-build helper is duplicated locally from `triple_format_perf.rs` (only 2 functions, ~40 lines).
+
+## `.github/workflows/perf.yml` — NEW
+
+```yaml
+name: Performance benchmarks
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'  # 06:00 UTC daily
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  perf:
+    name: Wall-clock perf benchmarks
+    # Gate the pull_request trigger to only fire on the `perf` label.
+    if: github.event_name != 'pull_request' || github.event.label.name == 'perf'
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-25)
+
+      - name: Cache cargo + build
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          key: perf-${{ matrix.runner }}
+
+      - name: Run triple_format_perf (with retry)
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          max_attempts: 3
+          timeout_minutes: 5
+          command: cargo +stable test --workspace -- --ignored --test-threads=1 triple_format_is_at_least_25_percent_faster_than_three_sequential_scans
+
+      - name: Run dual_format_perf (with retry)
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          max_attempts: 3
+          timeout_minutes: 5
+          command: cargo +stable test --workspace -- --ignored --test-threads=1 dual_format_is_at_least_30_percent_faster_than_two_sequential_scans
+```
+
+(Test fn name for `dual_format_perf` is approximate; pinned at implementation time by reading `dual_format_perf.rs`.)
+
+## `.github/pull_request_template.md` — modification
+
+Add ONE checklist item to the existing Pre-PR checklist (after the SPDX-3-validator line):
+
+```markdown
+- [ ] If this PR touches the scan pipeline, output dispatch, or per-format emission, I added the `perf` label to trigger the dedicated perf benchmarking lane (`.github/workflows/perf.yml`).
+```
+
+## `CONTRIBUTING.md` — modification
+
+Add a new subsection under "Pre-PR gate (MANDATORY)" titled "Performance benchmarks (opt-in)":
+
+```markdown
+### Performance benchmarks (opt-in)
+
+Wall-clock perf benchmarks (`triple_format_perf.rs`, `dual_format_perf.rs`)
+do not run in the default pre-PR gate or in the per-PR CI lanes — they
+gate the per-PR merge button on a wall-clock measurement which inherits
+shared-CI-runner noise (thermal throttling, scheduler jitter) and false-fails
+intermittently.
+
+The dedicated `.github/workflows/perf.yml` lane runs them:
+
+- **On every nightly schedule** (06:00 UTC daily on `main`) — catches background
+  regressions within 24 hours.
+- **On manual workflow_dispatch** — `gh workflow run perf.yml`.
+- **On PRs labeled `perf`** — for PRs that touch the scan pipeline / output
+  dispatch / per-format emission.
+
+The perf lane uses retry-on-failure (3 attempts per test) to absorb runner
+noise. It is NOT required for PR merge.
+
+To run perf benchmarks locally:
+
+```bash
+cargo +stable test --workspace -- --ignored --test-threads=1
+```
+
+The default `cargo +stable test --workspace` and `./scripts/pre-pr.sh` skip
+ignored tests automatically, matching CI default-lane behavior.
+
+A deterministic structural-correctness sibling test
+(`triple_format_structural.rs`) DOES run in the default lane. It asserts
+single-pass dispatch via stderr log-line counting and triple-vs-sequential
+output byte-equivalence — no wall-clock semantics, binary pass/fail.
+```
+
+## Compatibility
+
+- **Render targets**: every new Markdown file renders correctly in GitHub UI; the new YAML file is GitHub-Actions-schema-valid.
+- **Backward compatibility**: 100% additive. The two perf tests still exist and still assert what they always did — just not in the default lane. Any maintainer running `cargo test ... -- --ignored` gets the same signal as today.
+- **Cargo.lock**: zero change. No new dep. (FR-010)
+- **Goldens**: zero regen. No source-tree change. (FR-009)
+
+## No SBOM-emission changes
+
+Zero `mikebom:*` properties involved. Zero output-shape changes. Zero spec-conformance impact.

--- a/specs/094-deflake-perf-tests/plan.md
+++ b/specs/094-deflake-perf-tests/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Deflake wall-clock perf tests (architectural fix, not threshold-bump)
+
+**Branch**: `094-deflake-perf-tests` | **Date**: 2026-05-11 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Two wall-clock perf tests (`triple_format_perf.rs`, `dual_format_perf.rs`) inherit-recur the same flakiness pattern: median-of-N filter doesn't absorb shared-CI-runner thermal/scheduler noise, so they keep false-failing on macOS-latest at ~14–22% measured-reduction vs a 25% gate. The "fix" treadmill (median-3 → median-5 → another fail at 22.9%) tightens parameters without fixing the structural problem.
+
+**Approach**: stop blocking PRs on wall-clock perf entirely. Three changes land together:
+
+1. **Mark both perf tests `#[ignore]`** so they skip in `cargo +stable test --workspace`. Existing assertions / sample-counts / threshold values stay (FR-007); only the default-lane execution is removed.
+2. **Add a NEW deterministic structural-correctness test** in the default lane that uses the existing `tracing::info!(... "scan starting")` log line at `scan_cmd.rs:1413` as a side-channel signal. Counts log occurrences in `mikebom sbom scan` stderr to assert "scan pipeline runs exactly ONCE for triple-format, exactly THREE TIMES for 3-sequential". Plus a byte-equivalence check between triple-format outputs and 3-single-format outputs (after normalization). Zero wall-clock semantics; pass/fail is binary.
+3. **Add a dedicated opt-in CI lane** at `.github/workflows/perf.yml` triggered by (a) `pull_request` with `perf` label, (b) `workflow_dispatch` (manual), (c) `schedule` cron nightly on main. Runs both perf tests with 3-attempt retry on each test (via `nick-fields/retry@v3`, SHA-pinned per milestone-094 conventions). NOT required for PR merge.
+
+**Constitution-friendly**: zero production code change (FR-008), zero golden regen (FR-009), zero new Cargo deps (FR-010), no new `mikebom:*` properties.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited; no nightly required for this user-space test-infrastructure work).
+**Primary Dependencies**: existing only — `std::process::Command` for subprocess invocation, `tempfile`, `tar` (already used by current perf tests), `serde_json` (for byte-equivalence comparisons). The new GitHub Action `nick-fields/retry@v3` is permitted under FR-010 because it's a workflow YAML reference, not a Cargo dependency.
+**Storage**: N/A — test infrastructure only; no caches, no persistence.
+**Testing**: `./scripts/pre-pr.sh` (mandatory pre-PR gate, must skip perf tests now) + the new opt-in `cargo +stable test --workspace -- --ignored --test-threads=1` (matches the perf.yml workflow invocation).
+**Target Platform**: same as workspace — Linux x86_64, macOS aarch64, Linux aarch64. The new perf CI lane runs on `ubuntu-latest` + `macos-latest` (matching existing default-lane platforms) so per-platform perf characteristics stay visible.
+**Project Type**: Rust workspace, test-infrastructure refactor. Not a software feature.
+**Performance Goals**: N/A from a user perspective. The structural test should run in <5s (one mikebom invocation per format-pair, plus 3 sequential = 4 invocations × ~1s synthetic-fixture = ~4s).
+**Constraints**: FR-007 (preserve existing assertion semantics — no median-N tuning, no threshold change in this milestone), FR-008 (no production code change), FR-009 (zero golden regen), FR-010 (zero new Cargo deps). The structural signal uses `tracing::info!` output already emitted by production code — no instrumentation hook added.
+**Scale/Scope**: 2 existing test files modified (add `#[ignore]`); 1 NEW test file (`triple_format_structural.rs` — structural-correctness check + 3-single-format byte-equivalence); 1 NEW workflow file (`.github/workflows/perf.yml`); 2 docs files updated (CONTRIBUTING.md + PR template). Total diff target: <600 lines.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+- **I. Pure Rust, Zero C**: ✅ no FFI, no C deps, no toolchain change.
+- **II. eBPF-Only Observation**: N/A — no scan-discovery behavior changes; eBPF lane continues unchanged.
+- **III. Fail Closed**: ✅ no runtime behavior changes; only test execution is moved between lanes.
+- **IV. Type-Driven Correctness / no `.unwrap()` in production**: ✅ no Rust production source touched. Test code may use `.unwrap()` per existing convention.
+- **V. Specification Compliance / standards-native precedence**: ✅ no `mikebom:*` properties involved; no SBOM emission affected.
+- **VI. Three-Crate Architecture**: ✅ no crate boundaries touched.
+- **VII. Test Isolation**: ✅ this milestone refines test-isolation discipline. The default lane gets MORE deterministic; wall-clock-dependent tests move to opt-in. Aligned with Principle VII's spirit.
+- **VIII. Completeness**, **IX. Accuracy**, **X. Transparency**, **XI. Enrichment**, **XII. External Data Source Enrichment**: N/A — no SBOM output touched.
+
+**No violations.** No Complexity Tracking entry needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/094-deflake-perf-tests/
+├── plan.md                          # This file
+├── research.md                      # Phase 0: log-signal verification, opt-in mechanism, retry pattern
+├── data-model.md                    # Phase 1: per-deliverable shape (test bodies, workflow shape)
+├── contracts/
+│   └── deflake-contracts.md         # Phase 1: assertion shapes + workflow trigger conditions
+├── quickstart.md                    # Phase 1: maintainer recipes (apply, verify, ship)
+├── checklists/
+│   └── requirements.md              # 16/16 pass — already complete
+└── spec.md                          # Feature spec
+```
+
+### Source Code (repository root)
+
+```text
+mikebom/
+├── mikebom-cli/tests/
+│   ├── triple_format_perf.rs                # MODIFIED: add #[ignore] to single test fn
+│   ├── dual_format_perf.rs                  # MODIFIED: add #[ignore] to single test fn
+│   │                                        # (Note: dual_format_perf is also included as
+│   │                                        # `mod dual_format_perf;` from holistic_parity.rs;
+│   │                                        # #[ignore] applies in both inclusion contexts.)
+│   └── triple_format_structural.rs          # NEW: deterministic structural-correctness test
+├── .github/workflows/
+│   └── perf.yml                             # NEW: opt-in/scheduled perf lane with retry
+├── .github/pull_request_template.md         # MODIFIED: add perf-touching-PR note (FR-006)
+└── CONTRIBUTING.md                          # MODIFIED: document the default-vs-opt-in split (FR-006)
+```
+
+**Structure Decision**: 5 file changes total (2 modified test files + 1 new test + 1 new workflow + 2 docs). All under repo root or `.github/`/`mikebom-cli/tests/`. Zero source-tree changes (`mikebom-cli/src/`, `mikebom-common/src/`, `xtask/src/` all untouched per FR-008).
+
+## Complexity Tracking
+
+> Not applicable — no Constitution gate violations.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|--------------------------------------|
+| (none)    | (none)     | (none)                               |
+
+## Phase Plan
+
+### Phase 0 — Research (`research.md`)
+
+Three decision points resolved:
+
+1. **Structural-signal mechanism** — confirmed via grep of `scan_cmd.rs:1413`: `tracing::info!(root = %..., "scan starting")` fires exactly once per scan-pipeline invocation. Stderr-grep `"scan starting"` count = number of pipeline invocations. Zero production code change needed.
+2. **Opt-in UX** — picked `#[ignore]` + `cargo test --workspace -- --ignored` as the opt-in mechanism. Standard Rust convention; works with `cargo test`'s built-in filtering; no env var dance needed. The pre-PR gate inherits the default-skip behavior because cargo's default test invocation skips ignored tests.
+3. **Retry mechanism** — picked `nick-fields/retry@v3` (SHA-pinned) for the perf.yml workflow. 3 attempts per perf test; the workflow_dispatch / scheduled trigger surfaces the final result.
+
+### Phase 1 — Design (`data-model.md`, `contracts/`, `quickstart.md`)
+
+- **data-model.md** — per-file shape: existing perf tests (1-line `#[ignore]` addition each), new structural test (3 test fns: triple-format-fires-once, sequential-fires-three-times, output-byte-equivalence), perf.yml workflow (3 trigger types × 2 jobs × retry-wrapped steps).
+- **contracts/deflake-contracts.md** — concrete invariants per test + workflow contract for the perf lane.
+- **quickstart.md** — maintainer recipes: apply the ignore attrs; verify the structural test passes 100× locally; verify the perf lane runs on `perf` label.
+
+Re-evaluate Constitution Check post-design: still no violations expected (pure test infrastructure).
+
+### Phase 2 — Tasks
+
+Out-of-scope for `/speckit.plan`; will be generated by `/speckit.tasks`.
+
+## Agent Context Update
+
+The agent-context update script will be re-run after Phase 1; this milestone adds no new technology surface (one new GitHub Action workflow dep, no Cargo changes), so the agent context delta should be empty or trivial.

--- a/specs/094-deflake-perf-tests/quickstart.md
+++ b/specs/094-deflake-perf-tests/quickstart.md
@@ -1,0 +1,152 @@
+# Quickstart — milestone 094 maintainer recipes
+
+Seven maintainer-facing recipes to apply the deflake architecture and verify each contract.
+
+## Recipe 1 — Add `#[ignore]` to `triple_format_perf.rs` (FR-001)
+
+```bash
+# Find the test fn (currently around line 199):
+grep -n "fn triple_format_is_at_least_25_percent_faster" mikebom-cli/tests/triple_format_perf.rs
+```
+
+Edit the function attribute block above the fn to:
+
+```rust
+#[test]
+#[ignore = "wall-clock perf test — opt in via `cargo test -- --ignored`, runs in dedicated perf.yml lane"]
+fn triple_format_is_at_least_25_percent_faster_than_three_sequential_scans() {
+    // ... existing body unchanged (FR-007) ...
+}
+```
+
+Verify:
+
+```bash
+cargo +stable test -p mikebom --test triple_format_perf -- --list \
+  | grep "triple_format_is_at_least_25_percent_faster"
+# Expected output contains "ignored".
+
+cargo +stable test -p mikebom --test triple_format_perf 2>&1 | tail -3
+# Expected: "test result: ok. 0 passed; 0 failed; 1 ignored; ..."
+```
+
+## Recipe 2 — Add `#[ignore]` to `dual_format_perf.rs` (FR-001)
+
+Same pattern. The exact fn name to locate:
+
+```bash
+grep -n "^fn dual_format_is_at_least\|^fn .*dual.*_faster" mikebom-cli/tests/dual_format_perf.rs
+```
+
+Apply the same `#[test] #[ignore = "..."]` pattern. Verify via the same commands, plus an additional check that the test stays skipped when included as a submodule of `holistic_parity`:
+
+```bash
+cargo +stable test -p mikebom --test holistic_parity -- --list 2>&1 \
+  | grep -E "dual_format.*ignored"
+# Expected: at least 1 ignored test surfaces from the included submodule.
+```
+
+## Recipe 3 — Add the structural-correctness sibling test (FR-005)
+
+Create `mikebom-cli/tests/triple_format_structural.rs` with the three test functions from `data-model.md §triple_format_structural.rs`:
+
+- `triple_format_invokes_scan_pipeline_exactly_once` — counts `"scan starting"` log lines == 1.
+- `three_sequential_invocations_emit_three_pipeline_starts` — counts == 3.
+- `triple_format_outputs_byte_match_three_sequential` — normalized byte-equivalence across the 3 formats.
+
+The fixture-build helper (`build_synthetic_fixture`) is copied from `triple_format_perf.rs` (~40 lines: `ImageFile` struct, `build_synthetic_image()` tar-builder, `build_benchmark_fixture()` deb + npm populator). The duplicated body is acceptable scope per FR-008 (test code only); a future refactor could move the helper into `tests/common/mod.rs`.
+
+Verify the deterministic 100-run loop (SC-006):
+
+```bash
+for i in $(seq 1 100); do
+  cargo +stable test -p mikebom --test triple_format_structural --quiet \
+    >/dev/null 2>&1 || { echo "FAIL on iteration $i"; exit 1; }
+done && echo "100/100 deterministic passes — SC-006 satisfied"
+```
+
+This takes ~10–20 minutes locally (each test invocation is ~4s). Run once during implementation; subsequent runs don't need this loop unless the test changes.
+
+## Recipe 4 — Create `.github/workflows/perf.yml` (FR-004)
+
+Copy the workflow body from `data-model.md §perf.yml`. Key elements:
+
+- Triggers: `pull_request: types: [labeled]` + `workflow_dispatch:` + `schedule: cron: '0 6 * * *'`.
+- Label gate: `if: github.event_name != 'pull_request' || github.event.label.name == 'perf'`.
+- Matrix: `runner: [ubuntu-latest, macos-latest]`.
+- Each perf-test step wrapped in `nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2` with `max_attempts: 3, timeout_minutes: 5`.
+- All other actions SHA-pinned per the milestone-094 / PR #200 convention.
+
+Verify the YAML parses + has the required triggers:
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/perf.yml'))" && echo "YAML OK"
+grep -E "pull_request:|workflow_dispatch:|schedule:" .github/workflows/perf.yml | wc -l
+# Expected: >= 3.
+grep -E "nick-fields/retry@[0-9a-f]{40}" .github/workflows/perf.yml | wc -l
+# Expected: >= 2.
+```
+
+## Recipe 5 — Update docs (FR-006)
+
+Edit `.github/pull_request_template.md` — add ONE checklist item to the Pre-PR checklist:
+
+```markdown
+- [ ] If this PR touches the scan pipeline, output dispatch, or per-format emission, I added the `perf` label to trigger the dedicated perf benchmarking lane (`.github/workflows/perf.yml`).
+```
+
+Edit `CONTRIBUTING.md` — add a new H3 subsection under "Pre-PR gate (MANDATORY)" titled "Performance benchmarks (opt-in)". Body per `data-model.md §CONTRIBUTING.md`.
+
+Verify:
+
+```bash
+grep -q "perf.yml\|perf label\|perf benchmarking lane" .github/pull_request_template.md && echo "PR template OK"
+grep -q "^### Performance benchmarks" CONTRIBUTING.md && grep -q -- "-- --ignored" CONTRIBUTING.md && echo "CONTRIBUTING OK"
+```
+
+## Recipe 6 — Pre-PR gate (FR-002 / FR-010 / SC-005)
+
+```bash
+./scripts/pre-pr.sh 2>&1 | grep -E "FAILED|warning:|error\[|^>>>" | tail -5
+# Expected: only the trailing ">>> ... passed." line; no failures.
+```
+
+The pre-PR gate now:
+- skips both wall-clock perf tests (they carry `#[ignore]`)
+- runs the 3 new structural tests in `triple_format_structural.rs`
+- runs every other existing test as today
+
+## Recipe 7 — Diff scope audit (FR-008 / FR-009 / FR-010 / SC-007)
+
+```bash
+git diff --name-only main | sort
+# Expected exact set (or close to it):
+#   .github/pull_request_template.md
+#   .github/workflows/perf.yml
+#   CONTRIBUTING.md
+#   mikebom-cli/tests/dual_format_perf.rs
+#   mikebom-cli/tests/triple_format_perf.rs
+#   mikebom-cli/tests/triple_format_structural.rs
+#   specs/094-deflake-perf-tests/...
+
+# Verify zero source-tree changes:
+git diff --name-only main | grep -E '^(mikebom-cli/src|mikebom-common/src|xtask/src)/' \
+  && echo "SCOPE CREEP" || echo "Source tree untouched — FR-008 satisfied."
+
+# Verify zero golden regen:
+git diff --name-only main | grep -E '^mikebom-cli/tests/fixtures/golden/' \
+  && echo "GOLDEN CHURN" || echo "No goldens regenerated — FR-009 satisfied."
+
+# Verify zero Cargo.lock/Cargo.toml change:
+git diff --name-only main | grep -E '^Cargo\.(lock|toml)$' \
+  && echo "DEP CHURN" || echo "Cargo.lock + Cargo.toml untouched — FR-010 satisfied."
+```
+
+## When in doubt
+
+- **Pre-PR gate fails**: shouldn't happen — no Rust production source touched. Audit `git diff` for accidental source-tree changes.
+- **The 100-iter determinism loop reports a flake**: the new structural test is NOT deterministic; investigate which assertion fired. Likely culprits: (a) the stderr-grep is timing-sensitive (race between subprocess buffer flush and parent read — solved by `cmd.output()` which waits for EOF), (b) the normalize helpers don't strip a volatile field. Fix before merging.
+- **perf.yml `pull_request` trigger doesn't fire on labeled PR**: confirm the `if:` gate references `github.event.label.name` correctly. GitHub Actions only delivers `labeled` events when the `pull_request` event type is enabled.
+- **`nick-fields/retry@<SHA>` flagged by Kusari Inspector**: confirm the SHA matches a known v3.x tag — check `gh api repos/nick-fields/retry/tags?per_page=20`. Kusari accepts SHA-pinned forms cleanly per the milestone-094 / PR #200 baseline.
+- **The structural test's `build_synthetic_fixture` duplicates triple_format_perf's helper**: that's intentional per FR-008 ("test code only"); both files are independent test binaries. A future refactor (out of scope here) could move it to `tests/common/mod.rs`.
+- **Default `cargo test` accidentally runs the perf tests**: confirm `#[ignore]` is on the test fn directly (not on a `mod` block). `cargo test -- --list` should show "ignored" annotation.

--- a/specs/094-deflake-perf-tests/research.md
+++ b/specs/094-deflake-perf-tests/research.md
@@ -1,0 +1,115 @@
+# Research — milestone 094 deflake perf tests
+
+Phase 0 investigation. Three decision points; all resolved without further clarification.
+
+## §1 — Structural-signal mechanism: existing log surface, no production code change
+
+**Finding**: `mikebom-cli/src/cli/scan_cmd.rs:1413` already emits:
+
+```rust
+tracing::info!(root = %root_path.display(), "scan starting");
+```
+
+This fires exactly once per `mikebom sbom scan` subprocess invocation, regardless of how many `--format` values are passed (the scan pipeline runs once and the format dispatch happens AFTER this log line; per `serialize_all` / format-dispatch code path). The default `tracing-subscriber` configuration in `mikebom-cli/src/main.rs` enables INFO-level emission to stderr.
+
+**Decision**: the structural-correctness test captures stderr from `mikebom sbom scan ...` invocations and counts occurrences of the substring `"scan starting"`. Asserts:
+
+- Triple-format invocation (`--format cdx,spdx,spdx3`): count = **1**.
+- Three single-format sequential invocations: count = **3**.
+- (Additionally: byte-equivalence between the triple-format outputs and the corresponding single-format outputs, after normalization, to catch dispatch-correctness regressions.)
+
+**Rationale**:
+- Zero production-code change (FR-008 compliant). The signal hook already exists.
+- Deterministic by construction. `tracing::info!` fires unconditionally; the stderr capture is byte-stable regardless of CI runner thermal/scheduler state.
+- The signal directly maps to the spec's user-facing intent: "single-invocation produces all 3 formats by running the scan pipeline once".
+
+**Alternatives considered**:
+- **New env-var-instrumented counter** (e.g., `MIKEBOM_SCAN_PIPELINE_COUNT=/tmp/foo`): would require new production code (the env-var-conditional emission), which violates FR-008. Rejected.
+- **Resource-usage comparison** (CPU time via `resource::getrusage` or `/usr/bin/time -v`): less wall-clock-sensitive than total wall-time but still has variance. Still needs a threshold. Not deterministic. Rejected.
+- **Output byte-equivalence alone**: if triple-format BREAKS single-pass internally (runs the scan pipeline 3 times but still emits 3 correct outputs), byte-equivalence would still pass. We'd lose the "single-pass" signal entirely. Rejected as sole signal — but kept as a complementary check alongside the log-count.
+- **Process count via `ps`-style inspection**: complex, platform-specific, fragile. Rejected.
+
+## §2 — Opt-in UX: `#[ignore]` + `cargo test -- --ignored`
+
+**Finding**: Rust's standard convention for "this test exists but is skipped by default" is the `#[ignore]` attribute. Cargo's default `cargo test ...` invocation skips `#[ignore]`'d tests; `cargo test ... -- --ignored` runs ONLY them. This matches the project's existing usage (e.g., `#[test] #[ignore] fn requires_privilege() { ... }` in `mikebom-cli/tests/scan_walker_loops.rs`).
+
+**Decision**: mark both perf tests with `#[ignore]`. The default lanes (and the pre-PR gate) skip them automatically. The dedicated perf lane invokes `cargo +stable test --workspace -- --ignored --test-threads=1` to run them.
+
+**Rationale**:
+- Standard Rust idiom; existing pattern in this project (`scan_walker_loops.rs`).
+- No env var dance. No conditional compilation. No feature-flag gymnastics.
+- `cargo test`'s built-in filtering handles the inclusion/exclusion split.
+- `--test-threads=1` reduces inter-test CPU contention during the perf measurement (the perf lane runs the 2 perf tests serially, not in parallel with other tests).
+
+**Alternatives considered**:
+- **`#[cfg(feature = "perf-tests")]`**: requires adding a `perf-tests` Cargo feature. Workable but more ceremonious than `#[ignore]`; also non-standard for this project. Rejected.
+- **Env-var conditional `return` at the top of each test**: skips at runtime instead of at filter time. Hides the test from `cargo test --list`'s output ambiguously. Worse UX than `#[ignore]`. Rejected.
+- **Move tests into a separate crate (e.g., `mikebom-perf-tests`)**: adds workspace member; requires lifecycle plumbing; out-of-proportion to the goal. Rejected.
+
+## §3 — Retry mechanism: `nick-fields/retry@v3` (SHA-pinned)
+
+**Finding**: GitHub Actions doesn't have built-in retry-on-failure for steps. The industry-standard third-party action is [`nick-fields/retry`](https://github.com/nick-fields/retry), pinned to v3.0.2. Mature, ~2k+ GitHub stars, used widely (kubernetes, rust-lang/rust, many others).
+
+**Decision**: use `nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2` in the new `perf.yml` workflow. SHA-pin per the milestone-094 / Kusari Inspector convention.
+
+Wrap each perf-test invocation in a retry step with:
+- `max_attempts: 3`
+- `timeout_minutes: 5` (each perf test typically completes in <60s; 5min buffer absorbs slow runner cold-start)
+- `command: cargo +stable test --workspace -- --ignored --test-threads=1 <test_name>` (one wrapped step per test, so failure attribution stays clean)
+
+**Rationale**:
+- 3 attempts × independent runner noise → P(all 3 flake on a 22% measured-reduction-vs-25%-threshold case) is ~negligible. Independent samples; the worst observed flake was a single CI run failure, not a sustained regression.
+- SHA-pinned per the just-established repo convention (PR #200). Kusari Inspector will pass cleanly on the new workflow file.
+
+**Alternatives considered**:
+- **Custom bash retry loop in the step**: works but reinvents what `nick-fields/retry` already does cleanly. Less readable in the workflow YAML. Rejected.
+- **GitHub Actions' built-in `continue-on-error: true`**: marks the step as soft-failed but doesn't retry. Wrong primitive. Rejected.
+- **No retry at all**: the user's stated goal is "stop flaky failures from blocking work". Even on the opt-in lane, a flake would surface as a failed run and re-trigger user frustration. Retry is necessary. Rejected.
+
+## §4 — Workflow trigger conditions
+
+**Finding**: GitHub Actions supports three trigger types relevant to this use case:
+- `pull_request: types: [labeled]` — fires when a maintainer adds a label to a PR.
+- `workflow_dispatch:` — manual trigger via the Actions UI or `gh workflow run`.
+- `schedule: - cron: '...'` — periodic execution.
+
+**Decision**: configure perf.yml with all three triggers:
+
+```yaml
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'  # 06:00 UTC daily (off-peak for both NA and EU)
+```
+
+For the `pull_request` trigger, the job's first step checks `if: github.event.label.name == 'perf'` so the workflow only runs on the `perf` label specifically, not on every label addition.
+
+**Rationale**:
+- `pull_request` + label gives maintainers an explicit opt-in for perf-touching PRs.
+- `workflow_dispatch` gives a manual-trigger escape hatch (e.g., re-run after a known-flaky moment).
+- `schedule` provides background regression-detection on main; daily cadence balances runner cost vs detection latency (24h max delay).
+
+**Alternatives considered**:
+- **`push: branches: [main]`**: runs on every commit to main. Too expensive given perf-test runtime + retry budget. Rejected in favor of daily schedule.
+- **No scheduled trigger; only manual + label**: loses background regression detection. Maintainers might forget to label perf-touching PRs. Rejected.
+
+## Coverage map
+
+| Spec section | Resolution |
+|--------------|------------|
+| FR-001 (skip perf tests in default lane) | §2 → `#[ignore]` attribute. |
+| FR-002 (pre-PR gate inherits default-skip) | §2 → `cargo test --workspace` skips ignored tests automatically. |
+| FR-003 (opt-in mechanism for maintainers) | §2 → `cargo +stable test --workspace -- --ignored --test-threads=1`. |
+| FR-004 (dedicated CI lane with retry, not required for merge) | §3 + §4 → new `perf.yml`; SHA-pinned `nick-fields/retry@v3`; 3 trigger types. |
+| FR-005 (structural-correctness test in default lane) | §1 → stderr-grep `"scan starting"` count + byte-equivalence. |
+| FR-006 (docs updates) | implementation detail; addressed in Phase 1's data-model / quickstart. |
+| FR-007 (preserve existing assertion semantics) | §2 → only `#[ignore]` added; no `median_of_5` → `median_of_7` tuning. |
+| FR-008 (no production code change) | §1 → log signal already exists; no instrumentation hook added. |
+| FR-009 (no golden regen) | implicit — no source change emits goldens. |
+| FR-010 (no new Cargo deps) | §3 → workflow YAML reference only, not a Cargo dep. |
+| Constitution V audit | no `mikebom:*` properties; trivially satisfied. |
+| Constitution VII (test isolation) | §1 + §2 → strengthened. |
+
+All open spec questions resolved. Ready for Phase 1 (data-model + contracts + quickstart).

--- a/specs/094-deflake-perf-tests/spec.md
+++ b/specs/094-deflake-perf-tests/spec.md
@@ -1,0 +1,151 @@
+# Feature Specification: Deflake wall-clock perf tests (architectural fix, not threshold-bump)
+
+**Feature Branch**: `094-deflake-perf-tests`
+**Created**: 2026-05-11
+**Status**: Draft
+**Input**: User description: "yes let's fix flaky perf-tests"
+
+## Background
+
+Two wall-clock perf tests in the workspace inherit-recur the same flakiness pattern:
+
+- `mikebom-cli/tests/triple_format_perf.rs::triple_format_is_at_least_25_percent_faster_than_three_sequential_scans` (milestone 011 SC-007)
+- `mikebom-cli/tests/dual_format_perf.rs` (milestone 010 SC-009, presumed similar)
+
+Both assert that an N-format combined scan completes in **≥25% less wall-clock time** than N sequential single-format scans, against a ~2-second synthetic fixture. They run on every PR in `cargo +stable test --workspace`, on macOS-latest + linux-x86_64 + (linux-x86_64 --features ebpf-tracing) lanes.
+
+**History of the treadmill**:
+- milestone 011 (origin): median-of-3, 30% spec target, 25% CI gate
+- milestone 045 (first deflake): bumped to median-of-5 after two macOS CI fails (14.4%, 19.9%). The fix's own doc-comment notes "local distribution sits around 50%"
+- 2026-05-10 (PR #194's CI): triple_format failed again at 22.9% on macOS-latest. The user merged despite the failure because the test gates the merge button on every PR and the failure isn't a real regression — just CI runner noise.
+
+Each "fix" cycle bumps a parameter (sample count up, threshold down) without addressing the architectural root cause: **wall-clock perf assertions don't belong in a per-PR CI lane that blocks merges**. Median-of-N is a noise filter; it doesn't reduce the underlying variance from CI-runner thermal throttling, concurrent-test CPU contention, page-cache jitter, or macOS-latest scheduler quirks. With ~2 seconds of total work per measurement and ~10s of total test runtime, a single 200ms outlier on one of the 5 triple-format samples can dominate the median.
+
+The user's frustration is explicit and the cause is structural. The fix is to **stop blocking PRs on wall-clock perf assertions** and instead:
+1. Run a deterministic structural-correctness check on every PR (asserts single-pass dispatch, not wall-clock — fast, byte-stable, catches real regressions in the single-invocation amortization logic).
+2. Move the wall-clock perf tests to a dedicated opt-in/scheduled CI lane that can retry, run on dedicated runners, and not gate per-PR merges.
+
+This is the standard pattern in mature Rust projects (rust-lang/rust's nightly perf tracker, cargo's `criterion`-based benchmarks gated behind `--release` + `bench` profile, tokio's perf-CI lane). It preserves the regression-catch surface while removing the merge-blocking flakiness.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Contributor opens a PR; CI does not fail on wall-clock noise (Priority: P1)
+
+A contributor (any contributor — maintainer or external) pushes a PR with a code change unrelated to performance. CI runs `cargo +stable clippy --workspace --all-targets -- -D warnings` and `cargo +stable test --workspace` across the 3 lanes. The two perf tests are skipped by default; no failure due to CI-runner timing noise occurs.
+
+**Why this priority**: The user-visible pain point is "I have to merge anyway despite perf-test failures". P1 because every other quality improvement in this milestone is downstream of CI no longer false-failing.
+
+**Independent Test**: open a no-op PR (e.g., README typo fix). All three CI lanes pass cleanly. `cargo +stable test --workspace` locally also passes cleanly without the perf tests running.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contributor pushes any PR, **When** the default CI lanes execute `cargo +stable test --workspace`, **Then** the triple_format_perf and dual_format_perf tests are NOT executed in the default test run (they are skipped or filtered out).
+2. **Given** the pre-PR gate (`./scripts/pre-pr.sh`), **When** a contributor runs it locally, **Then** the perf tests are also skipped by default (matches CI), and the gate completes with the same `0 failed` semantics.
+3. **Given** 5 consecutive PRs are opened over a single day, **When** all CI runs complete, **Then** zero merge-blocking failures occur from the two perf tests, even on macOS-latest (the noisiest lane).
+
+---
+
+### User Story 2 — Maintainer can still verify perf hasn't regressed (Priority: P1)
+
+A maintainer wants to confirm that a refactor or new feature hasn't regressed the single-pass amortization win that SC-007 / SC-009 originally promised. They have a way to run the wall-clock perf check on demand — locally, via a labeled CI run, or via a scheduled lane — and get the same signal as before (or better).
+
+**Why this priority**: Co-equal to US1. Removing the perf test from the default lane CAN'T mean losing the regression-catch surface. If we lose the signal, we'd accumulate silent regressions and the original SC-007 / SC-009 spec gets gutted. P1 because both US1 (no false failures) and US2 (still catch real regressions) are necessary for the architectural fix to land.
+
+**Independent Test**: a maintainer adds a deliberately-regressing change (e.g., disable the single-pass dispatch in `serialize_all`, forcing 3 full scans even in triple-format mode) on a test branch. They run the perf test on the dedicated lane / on-demand mechanism. The test fails with a clear message indicating ≥25% reduction is no longer met.
+
+**Acceptance Scenarios**:
+
+1. **Given** a maintainer wants to validate perf locally, **When** they invoke the documented opt-in command (e.g., `cargo test --workspace -- --ignored` or `MIKEBOM_RUN_PERF_TESTS=1 ./scripts/pre-pr.sh`), **Then** both perf tests run and produce the same wall-clock measurements with the same CI gate semantics as today.
+2. **Given** a deliberate regression that disables single-pass dispatch, **When** the perf test runs (on any platform), **Then** the test FAILS with a clear assertion message identifying the regression (reduction <25%).
+3. **Given** a maintainer wants periodic regression detection without per-PR overhead, **When** the scheduled / labeled CI lane runs, **Then** it executes both perf tests with built-in retry (e.g., up to 3 attempts) and reports overall pass/fail.
+
+---
+
+### User Story 3 — A structural-correctness test catches single-pass dispatch regressions deterministically (Priority: P2)
+
+The original spec intent of SC-007 / SC-009 is "a single invocation produces all N formats by amortizing the scan + deep-hash + layer-walk work". The wall-clock test is an *indirect proxy* for that intent — it's measuring "did the work happen once vs N times" by measuring how long it took. A structural-correctness test can measure the same intent **directly and deterministically**, without wall-clock semantics.
+
+**Why this priority**: This is the layered defense — it runs on every PR (replacing the wall-clock perf test in the default lane) and catches any change that breaks single-pass dispatch in a binary pass/fail way. P2 because US1 + US2 together would still work without US3 (perf tests opt-in lane catches regressions periodically), but US3 closes the per-PR window where a regression could ship.
+
+**Independent Test**: a maintainer adds a deliberate regression (same as US2's regression scenario). The new structural-correctness test (running in the default lane) fails immediately on the regression PR, with a clear message about the single-pass dispatch invariant being violated.
+
+**Acceptance Scenarios**:
+
+1. **Given** the default CI lane (`cargo +stable test --workspace`), **When** it runs against current main, **Then** a new structural-correctness test passes deterministically (no flakiness signal in the assertion — it's pass/fail on the structural invariant, not wall-clock).
+2. **Given** a change that breaks single-pass dispatch (e.g., the serializer is called 3 times instead of 1 for triple-format output), **When** the default CI lane runs, **Then** the structural-correctness test FAILS with an assertion message identifying which invariant broke (e.g., "expected 1 scan-pipeline invocation per triple-format request; observed 3").
+3. **Given** the new structural test runs back-to-back 100 times locally (`cargo test --workspace -- --test-threads=1 ${{ test_name }}`), **When** all runs complete, **Then** all 100 pass with no flakiness. The test is deterministic by construction.
+
+---
+
+### Edge Cases
+
+- **The opt-in lane needs perf-grade hardware**: macOS-latest GitHub Actions runners are noisy (shared with thousands of other repos). On the opt-in lane, retry-on-fail (≥3 attempts) absorbs most noise; running on a dedicated runner or self-hosted runner is a future option.
+- **A real perf regression sneaks in via a PR without the opt-in lane firing**: the scheduled nightly run on `main` catches it within ~24h. The opt-in label provides a synchronous gate for performance-touching PRs.
+- **The structural-correctness test passes but the wall-clock perf actually regresses by some small amount** (e.g., the per-invocation fixed overhead doubles): structural test doesn't catch this. The opt-in / scheduled wall-clock lane is the safety net for these cases. Documented tradeoff.
+- **A contributor disables an opt-in via env var locally and the PR breaks the perf gate**: the pre-PR gate (`./scripts/pre-pr.sh`) should NOT auto-enable the perf lane (matches CI default). Contributors opting in to the perf lane MUST be deliberate.
+- **dual_format_perf vs triple_format_perf divergence**: both tests have the same root cause; both should be moved together to the opt-in lane. No partial fix.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Both `triple_format_perf.rs` and `dual_format_perf.rs`'s wall-clock perf tests MUST be skipped by default in `cargo +stable test --workspace`. The standard mechanism is `#[ignore]` on the test functions.
+- **FR-002**: The pre-PR gate (`./scripts/pre-pr.sh`) MUST also skip these tests by default. No env var opt-in required to match CI behavior; the gate's `cargo test --workspace` invocation skips ignored tests automatically.
+- **FR-003**: A documented opt-in mechanism MUST exist for maintainers to run the wall-clock perf tests on demand. Specifically: `cargo +stable test --workspace -- --ignored` MUST run both perf tests with the same assertions as today (median-of-5, 25% CI gate).
+- **FR-004**: A dedicated CI lane MUST run both perf tests on a schedule (nightly on `main`) AND on PR opt-in (via a `perf` label OR via a manually-triggered workflow_dispatch). The dedicated lane MUST run `cargo +stable test --workspace -- --ignored --test-threads=1` with built-in 3-attempt retry on failure of each perf test. The lane MUST NOT be required for PR merge.
+- **FR-005**: A NEW structural-correctness test MUST be added to the default test suite that asserts the single-pass amortization invariant **without using wall-clock timing**. It MUST run on every PR via the default `cargo +stable test --workspace` invocation. The exact invariant assertion shape (e.g., counting the number of scan-pipeline invocations, checking for a single output-dispatch trace event, comparing emitted SBOM byte-equivalence between triple-format and concatenated-single-formats outputs) is an implementation choice deferred to the planning phase — but the test MUST fail deterministically when single-pass dispatch is broken.
+- **FR-006**: `CONTRIBUTING.md` MUST be updated to document the split: default gate is correctness + the new structural test; perf wall-clock tests are opt-in via `-- --ignored`. The PR template (`.github/pull_request_template.md`) MUST add a note that perf-touching PRs should opt in to the perf lane.
+- **FR-007**: The two perf tests' source files MUST retain their existing assertions, sample sizes, and threshold values. This milestone moves them out of the default lane; it does NOT weaken the assertions. Future tuning (e.g., sample-size bumps, threshold adjustments) is out of scope.
+- **FR-008**: No production code change. `mikebom-cli/src/` MUST NOT be modified. The only edits are to: the two perf-test source files (adding `#[ignore]`), CI workflow files (adding the dedicated lane), one new test file (the structural-correctness check), CONTRIBUTING.md, and `.github/pull_request_template.md`.
+- **FR-009**: Zero byte-identity golden regen. `git status mikebom-cli/tests/fixtures/golden/` MUST be empty after the change lands.
+- **FR-010**: No new Cargo dependencies. `Cargo.lock` MUST be unchanged.
+
+### Key Entities
+
+- **`triple_format_perf.rs` test function**: the existing milestone-011 perf test. State change: gains `#[ignore]` attribute. Behavior preserved when explicitly run.
+- **`dual_format_perf.rs` test function**: same pattern, milestone 010.
+- **Structural-correctness test** (NEW, file path TBD at planning): deterministic pass/fail test of the single-pass invariant.
+- **Dedicated perf CI lane** (NEW, in `.github/workflows/`): scheduled + label-gated workflow. Runs both perf tests with retry.
+- **`CONTRIBUTING.md`** + **`.github/pull_request_template.md`**: documentation updates.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Over the next 10 consecutive PRs (any author, any size), zero perf-test failures occur in the default CI lanes (`Lint + test (linux-x86_64)`, `Lint + test (macos-latest)`, `Lint + test (linux-x86_64, --features ebpf-tracing)`). Measured by querying `gh run list` for the workflow runs post-merge and confirming zero failures attributable to `triple_format_perf` or `dual_format_perf`.
+- **SC-002**: A maintainer can opt into the wall-clock perf test on demand and get a result within 60 seconds of invocation (matching today's test runtime for triple_format_perf — median-of-5 = ~10s per test × 2 tests = ~20s plus per-invocation overhead).
+- **SC-003**: A deliberate single-pass-dispatch regression (e.g., setting a hypothetical `force_per_format_scan: true` config) is caught BY the new structural-correctness test in the default lane on the PR that introduces it — within the same CI run, no scheduled-lane delay.
+- **SC-004**: The dedicated perf CI lane catches a deliberate amortization regression (e.g., adding a 500ms `sleep` to each scan invocation that wouldn't affect single-pass count but would affect per-invocation wall-clock) within 24 hours of the regression landing on `main`, via the scheduled nightly run.
+- **SC-005**: Pre-PR gate runs clean post-changes: `./scripts/pre-pr.sh` reports `>>> all pre-PR checks passed.` with zero clippy warnings and zero test failures across the workspace. The two perf tests are skipped (not failed, not unexpectedly run).
+- **SC-006**: The new structural-correctness test runs deterministically: 100 consecutive `cargo test ${{ structural_test_name }}` invocations locally produce 100 passes, zero flakes. Verified once during implementation as a `for i in $(seq 1 100); do ... done` loop.
+- **SC-007**: Diff scope audit: 100% of changed files match the allowlist {`mikebom-cli/tests/triple_format_perf.rs`, `mikebom-cli/tests/dual_format_perf.rs`, `mikebom-cli/tests/<new_structural_test>.rs`, `.github/workflows/*.yml`, `.github/pull_request_template.md`, `CONTRIBUTING.md`}. Zero changes under `mikebom-cli/src/`, `mikebom-common/src/`, `xtask/src/`, `mikebom-cli/tests/fixtures/golden/`, `Cargo.lock`.
+
+## Assumptions
+
+- Both perf tests have the same root-cause flakiness pattern (wall-clock variance on shared CI runners). dual_format_perf may not have had as many observed failures as triple_format_perf, but moving both together is the right call — splitting them would leave a known flakiness pattern in place for one of them.
+- The dedicated perf CI lane uses GitHub Actions (matches the existing CI infrastructure). A future improvement could be self-hosted runners with dedicated CPU pinning, but that's out of scope here.
+- Retry-on-failure logic in the dedicated lane is implemented via the standard GitHub Actions retry pattern (a step-level `continue-on-error` + a retry-action like `nick-fields/retry@v3`, OR via `cargo test`'s built-in retry mechanisms if available, OR via a small wrapper script). Implementation choice deferred to planning.
+- A `perf` label on a PR triggers the opt-in lane via a `pull_request: types: [labeled]` workflow trigger. Standard GitHub Actions pattern.
+- The "structural-correctness test" is implementable. Concrete approaches (any one suffices):
+   - Add a `MIKEBOM_PERF_INSTRUMENT=1` env var that causes the scan pipeline to emit a counter on stderr or a sidecar file (e.g., "scan_pipeline_invocations: 1"), then the test parses that.
+   - Use the existing `tracing` infrastructure to emit a span event per scan invocation, capture stderr, count spans.
+   - Compare emitted SBOMs across triple-format and 3-single-format invocations for byte-equivalence (after normalization) AND assert that triple-format's total subprocess CPU time is less than the sum of the 3 single-format invocations (proxy via `resource::getrusage` or similar; less wall-clock-sensitive).
+- The opt-in mechanism's exact UX (`-- --ignored` vs `--features perf-tests` vs env var) is a planning-phase choice. Any approach that satisfies FR-003 is acceptable.
+
+## Dependencies
+
+- The existing perf tests at `mikebom-cli/tests/{dual,triple}_format_perf.rs` (milestones 010 + 011) — this milestone moves them, doesn't replace them.
+- `./scripts/pre-pr.sh` — must continue to exit clean post-change (FR-002 + SC-005).
+- The existing CI workflows at `.github/workflows/ci.yml` — must continue to pass after the perf tests stop running in them.
+- The new dedicated perf workflow will be added at `.github/workflows/perf.yml` (or equivalent name).
+
+## Out of Scope
+
+- **Replacing GitHub Actions runners with self-hosted dedicated perf hardware**: longer-term improvement; can run on the same ubuntu-latest / macos-latest until perf-lane signal quality demands more.
+- **Tuning the assertion thresholds (25% gate, 30% spec target)**: FR-007 explicitly forbids weakening assertions in this milestone. Adjusting these is a separate decision, ideally driven by observed perf-lane signal over multiple weeks.
+- **Adding `criterion`-based microbenchmarks**: would shift mikebom toward bench-mark-as-test pattern. Scope creep; can be a future milestone if the team wants finer-grained perf signal.
+- **Removing the wall-clock perf tests entirely**: explicitly NOT proposed. The user wants the regression-catch surface preserved, just not blocking per-PR.
+- **Investigating WHY macOS-latest runners are noisier than linux**: documented downstream; out of scope here. Just need the opt-in lane to absorb the noise via retry.
+- **Threat-model documentation** (OSPS-SA-03.02 — left open from milestone-094 compliance work): tracked separately.
+- **Branch-protection settings** (OSPS-AC-03.01/.02, OSPS-QA-03.01, OSPS-QA-07.01): operator-side GitHub Settings; tracked separately.
+- **`generate_threat_model` MCP-tool retry**: separate effort.

--- a/specs/094-deflake-perf-tests/tasks.md
+++ b/specs/094-deflake-perf-tests/tasks.md
@@ -1,0 +1,255 @@
+---
+description: "Task list for milestone 094 — deflake wall-clock perf tests"
+---
+
+# Tasks: Deflake wall-clock perf tests (architectural fix, not threshold-bump)
+
+**Input**: Design documents from `/Users/mlieberman/Projects/mikebom/specs/094-deflake-perf-tests/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included. This milestone IS a test-infrastructure refactor — adding `#[ignore]` to two existing perf tests, creating a new deterministic structural-correctness test, and verifying determinism via a 100-iteration local loop. No production code is written; verification is via existing test machinery + content-shape greps.
+
+**Organization**: Tasks grouped by user story. US1 (P1) and US2 (P1) are co-equal in priority (eliminate false PR fails AND preserve regression-catch surface). US3 (P2) adds the deterministic sibling in the default lane. Stories are file-level independent (each owns a distinct file set) and can be implemented in any order or in parallel after Setup.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: User story this task belongs to (US1–US3)
+- File paths are workspace-relative.
+
+## Path Conventions
+
+Two existing test files modified (`mikebom-cli/tests/{triple,dual}_format_perf.rs`), one new test file (`triple_format_structural.rs`), one new workflow (`.github/workflows/perf.yml`), two docs files (`CONTRIBUTING.md`, `.github/pull_request_template.md`). Zero source-code changes (FR-008).
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Verify branch state + confirm the structural-signal hook still exists.
+
+- [X] T001 Confirm working branch is `094-deflake-perf-tests`. Run `git status` + `git log -1 --oneline`; verify the branch was created by `/speckit.specify` and main is at post-PR-#200 state or later.
+- [X] T002 Confirm baseline pre-PR gate passes. Run `./scripts/pre-pr.sh` once on the unchanged tree; expect `>>> all pre-PR checks passed.` Isolates any post-edit failure as introduced by milestone 094.
+- [X] T003 Confirm the structural-signal hook exists. Run `grep -n '"scan starting"' mikebom-cli/src/cli/scan_cmd.rs` → expect at least 1 match at approximately line 1413. If the line has been renamed/removed in main since the plan was written, STOP and update `research.md §1` + `data-model.md` to use the new signal hook.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No shared infrastructure required — each user story is file-level independent.
+
+(No tasks in this phase.)
+
+**Checkpoint**: US1, US2, US3 can begin in any order or in parallel.
+
+---
+
+## Phase 3: User Story 1 — Skip wall-clock perf tests in default lane (Priority: P1)
+
+**Goal**: Add `#[ignore]` to both perf tests so `cargo +stable test --workspace` and `./scripts/pre-pr.sh` no longer execute them by default. Existing assertions / sample counts / threshold values stay untouched (FR-007); only the default-lane execution is removed.
+
+**Independent Test**: `cargo +stable test -p mikebom --test triple_format_perf` reports `0 passed; 0 failed; 1 ignored`. Same for `--test dual_format_perf`. `cargo +stable test -p mikebom --test triple_format_perf -- --ignored` runs the test (succeeds when wall-clock allows, but doesn't gate PR merges).
+
+### Implementation for User Story 1
+
+- [X] T004 [P] [US1] Add `#[ignore = "wall-clock perf test — opt in via 'cargo test -- --ignored', runs in dedicated perf.yml lane"]` immediately above `#[test]` on `fn triple_format_is_at_least_25_percent_faster_than_three_sequential_scans` in `mikebom-cli/tests/triple_format_perf.rs` (the fn is at ~line 199). Body unchanged (FR-007).
+- [X] T005 [P] [US1] Add the same `#[ignore = "..."]` attribute to the dual_format_perf test fn in `mikebom-cli/tests/dual_format_perf.rs`. The exact fn name is one of `dual_format_is_at_least_30_percent_faster_than_two_sequential_scans` or similar — verify via `grep -n "^fn dual" mikebom-cli/tests/dual_format_perf.rs` before applying. Body unchanged.
+- [X] T006 [US1] Verify Contracts 1 + 2 from `contracts/deflake-contracts.md`, including the opt-in path that FR-003 requires. Run:
+    ```bash
+    # Default-skip behavior (Contracts 1 + 2):
+    cargo +stable test -p mikebom --test triple_format_perf -- --list | grep "triple_format_is_at_least" | grep -q ignored
+    cargo +stable test -p mikebom --test triple_format_perf 2>&1 | grep -E "test result: ok.*0 passed.*0 failed.*1 ignored"
+    cargo +stable test -p mikebom --test dual_format_perf -- --list | grep -i dual | grep -q ignored
+    cargo +stable test -p mikebom --test dual_format_perf 2>&1 | grep -E "test result: ok.*0 passed.*0 failed.*1 ignored"
+    cargo +stable test -p mikebom --test holistic_parity -- --list 2>&1 | grep -E "dual.*ignored"
+
+    # Local opt-in behavior (FR-003): the test actually runs when explicitly requested.
+    # Acceptance: 1 test runs (not "1 ignored"). Pass/fail of the assertion itself is
+    # NOT gated here — wall-clock noise is allowed; this only proves the opt-in
+    # mechanism executes the test body.
+    cargo +stable test -p mikebom --test triple_format_perf -- --ignored 2>&1 | grep -E "test result:.*1 (passed|failed); 0 (failed|passed); 0 ignored"
+    ```
+    The five `#[ignore]`-coverage greps MUST succeed. The opt-in verification MUST show the test was executed (status pass-or-fail, NOT "ignored"). Closes the FR-003 local-opt-in coverage gap surfaced by `/speckit.analyze` finding C1.
+
+**Checkpoint**: US1 complete. Default CI lanes + pre-PR gate no longer execute the wall-clock perf tests.
+
+---
+
+## Phase 4: User Story 2 — Add dedicated opt-in/scheduled perf CI lane (Priority: P1)
+
+**Goal**: Preserve the wall-clock regression-catch surface via a new `.github/workflows/perf.yml` workflow that runs both perf tests with 3-attempt retry. Triggered by `pull_request` (labeled `perf`), `workflow_dispatch`, and `schedule` (06:00 UTC daily). NOT required for PR merge.
+
+**Independent Test**: YAML parses cleanly via `python3 -c "import yaml; yaml.safe_load(...)"`. Required triggers + retry SHA + `perf`-label gate all present per Contract 4. Post-merge: adding the `perf` label to a test PR triggers the workflow within ~1 minute.
+
+### Implementation for User Story 2
+
+- [X] T007 [P] [US2] Create `.github/workflows/perf.yml` per the full body in `data-model.md §perf.yml`. **Before writing, resolve the actual `dual_format_perf` test fn name** via `grep -n "^fn dual" mikebom-cli/tests/dual_format_perf.rs` and substitute it into the retry-step `command:` field (data-model.md's body uses the assumed name `dual_format_is_at_least_30_percent_faster_than_two_sequential_scans`; correct it if the actual name differs). Key invariants: (a) three triggers (`pull_request: types: [labeled]`, `workflow_dispatch:`, `schedule: cron: '0 6 * * *'`); (b) job-level `if: github.event_name != 'pull_request' || github.event.label.name == 'perf'` so labeled-PR firings gate on the `perf` label specifically; (c) `runs-on: ${{ matrix.runner }}` with `matrix: runner: [ubuntu-latest, macos-latest]`; (d) every action SHA-pinned per the milestone-094 / PR #200 convention (use the exact SHAs from `data-model.md` — they match the same actions/SHAs already in `release.yml` for actions/checkout, dtolnay/rust-toolchain stable, Swatinem/rust-cache; plus `nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2`); (e) one retry-wrapped step per perf test (`triple_format` + `dual_format`) with `max_attempts: 3, timeout_minutes: 5`.
+- [X] T008 [US2] Verify Contract 4 from `contracts/deflake-contracts.md`. Run:
+    ```bash
+    test -f .github/workflows/perf.yml && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/perf.yml'))" && echo "YAML OK"
+    grep -E "pull_request:|workflow_dispatch:|schedule:" .github/workflows/perf.yml | wc -l   # expect >= 3
+    grep -E "nick-fields/retry@[0-9a-f]{40}" .github/workflows/perf.yml | wc -l               # expect >= 2
+    grep -q "github.event.label.name == 'perf'" .github/workflows/perf.yml                    # expect exit 0
+    ```
+    All four MUST succeed.
+- [X] T009 [US2] Verify the workflow's actions match the SHA-pinning convention from PR #200. Run `grep -E "uses: [^@]+@(v[0-9]|nightly|stable|latest|main|master)$" .github/workflows/perf.yml` → expect empty output. Kusari Inspector will fail the PR if any tag-pinned action lands.
+
+**Checkpoint**: US2 complete. Wall-clock regression-catch surface preserved on the opt-in/scheduled lane. PR merges no longer gated on wall-clock perf.
+
+---
+
+## Phase 5: User Story 3 — Deterministic structural-correctness sibling test in default lane (Priority: P2)
+
+**Goal**: Add `triple_format_structural.rs` with 3 deterministic test fns that catch single-pass-dispatch regressions binary pass/fail using the existing `"scan starting"` log signal — no wall-clock semantics, no thresholds, no flakiness.
+
+**Independent Test**: 100 consecutive `cargo test --test triple_format_structural` invocations all pass with no flakes (SC-006). Deliberately breaking single-pass dispatch (e.g., a hypothetical refactor that calls scan-pipeline 3 times for triple-format) causes the structural test to fail immediately.
+
+### Implementation for User Story 3
+
+- [X] T010 [P] [US3] Create `mikebom-cli/tests/triple_format_structural.rs` with the three test fns per `data-model.md §triple_format_structural.rs`:
+    - `triple_format_invokes_scan_pipeline_exactly_once` — single `mikebom sbom scan --format cdx,spdx,spdx3` invocation; capture stderr; assert `stderr.matches("scan starting").count() == 1`.
+    - `three_sequential_invocations_emit_three_pipeline_starts` — three separate single-format invocations; assert total `"scan starting"` count across all stderrs == 3.
+    - `triple_format_outputs_byte_match_three_sequential` — run triple-format once + three single-format runs; compare normalized output for each format using `common::normalize::{normalize_cdx_for_golden, normalize_spdx23_for_golden, normalize_spdx3_for_golden}`; assert byte-equality per format.
+    
+    Include `mod common;` + `use common::normalize::*;` (provides `apply_fake_home_env`, `normalize_cdx_for_golden`, `normalize_spdx23_for_golden`, `normalize_spdx3_for_golden`) + `use common::{bin, workspace_root};` at the top. Duplicate `build_synthetic_image` + `build_benchmark_fixture` + `ImageFile` from `triple_format_perf.rs` (~40 lines; acceptable per FR-008 as test-code duplication). **Do NOT** use local `bin()` / `apply_fake_home_env()` copies — the `dual_format_perf.rs` local-helper pattern exists only because that file is also included as a submodule of `holistic_parity.rs`; `triple_format_structural.rs` is a standalone test target with no such inclusion conflict, so the standard `common::` imports work cleanly.
+- [X] T011 [US3] Run the 3 new tests and verify they pass:
+    ```bash
+    cargo +stable test -p mikebom --test triple_format_structural 2>&1 | tail -5
+    # Expected: "test result: ok. 3 passed; 0 failed; 0 ignored"
+    ```
+- [X] T012 [US3] Run the 100-iteration determinism check per Contract 3 / SC-006:
+    ```bash
+    for i in $(seq 1 100); do
+      cargo +stable test -p mikebom --test triple_format_structural --quiet >/dev/null 2>&1 \
+        || { echo "FAIL on iteration $i"; exit 1; }
+    done && echo "100/100 deterministic passes — SC-006 satisfied"
+    ```
+    This takes ~10–20 min locally. If even ONE iteration fails, investigate the assertion that fired (likely culprits: stderr buffering race, normalize helper missing a volatile field). Do NOT mark T010 complete until 100/100 passes — a flaky structural test is worse than the wall-clock test it replaces.
+- [X] T013 [US3] Verify Contract 3 listing assertions. Run:
+    ```bash
+    cargo +stable test -p mikebom --test triple_format_structural -- --list | grep -cE "triple_format_invokes_scan_pipeline_exactly_once|three_sequential_invocations_emit_three_pipeline_starts|triple_format_outputs_byte_match_three_sequential"
+    # Expected: 3
+    ```
+
+**Checkpoint**: US3 complete. Default lane gains a deterministic, fast (~4s), binary-pass/fail signal for single-pass dispatch.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation updates (FR-006), diff-scope audit (FR-008/009/010 / SC-007), final pre-PR gate (FR-002 / SC-005).
+
+- [X] T014 [P] Update `.github/pull_request_template.md` per `data-model.md §pull_request_template.md`. Add ONE new checklist item to the existing "Pre-PR checklist" section (after the SPDX-3-validator line):
+    ```markdown
+    - [ ] If this PR touches the scan pipeline, output dispatch, or per-format emission, I added the `perf` label to trigger the dedicated perf benchmarking lane (`.github/workflows/perf.yml`).
+    ```
+- [X] T015 [P] Update `CONTRIBUTING.md` per `data-model.md §CONTRIBUTING.md`. Add a new `### Performance benchmarks (opt-in)` subsection under "Pre-PR gate (MANDATORY)". Body covers: rationale for the split, the three perf.yml triggers, the local opt-in command (`cargo +stable test --workspace -- --ignored --test-threads=1`), and a one-line pointer at the structural-correctness sibling test for what DOES run on every PR.
+- [X] T016 Verify Contract 7 — diff scope guard. Run, in order:
+    ```bash
+    git diff --name-only main | grep -vE '^(mikebom-cli/tests/(triple_format_perf|dual_format_perf|triple_format_structural)\.rs|\.github/(workflows/perf|pull_request_template)\.(yml|md)|CONTRIBUTING\.md|specs/094-deflake-perf-tests/.+)$' | grep -v '^$' | wc -l
+    # Expected: 0
+
+    git diff --name-only main | grep -E '^(mikebom-cli/src|mikebom-common/src|xtask/src)/' | wc -l
+    # Expected: 0 (FR-008)
+
+    git diff --name-only main | grep -E '^mikebom-cli/tests/fixtures/golden/' | wc -l
+    # Expected: 0 (FR-009)
+
+    git diff --name-only main | grep -E '^Cargo\.(lock|toml)$' | wc -l
+    # Expected: 0 (FR-010)
+    ```
+    If ANY check returns non-zero, STOP and investigate scope creep before T017.
+- [X] T017 Run the mandatory pre-PR gate per Contract 8. Run `./scripts/pre-pr.sh`. Expect: `>>> all pre-PR checks passed.` with zero clippy warnings; the test summary should show the 2 wall-clock perf tests as `ignored` and the 3 new structural tests as `passed`. This is the CLAUDE.md mandatory gate; failure here blocks PR.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies. Start immediately.
+- **Foundational (Phase 2)**: None — file-level independence between user stories.
+- **US1 (Phase 3)**: Independent. Touches `triple_format_perf.rs` + `dual_format_perf.rs`.
+- **US2 (Phase 4)**: Independent. Touches `.github/workflows/perf.yml` only.
+- **US3 (Phase 5)**: Independent. Touches new file `mikebom-cli/tests/triple_format_structural.rs` only.
+- **Polish (Phase 6)**: Depends on US1+US2+US3 being complete (verifies aggregate diff scope + runs the gate).
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent. Required for US2's opt-in mechanism to make sense (`-- --ignored` filters `#[ignore]`-marked tests).
+- **US2 (P1)**: Independent at FILE level (own workflow). At RUNTIME, perf.yml needs the perf tests to have `#[ignore]` so `-- --ignored` actually selects them. But the workflow can be MERGED before US1 is complete; it just won't run anything useful until US1 lands. In practice, ship them together.
+- **US3 (P2)**: Independent at FILE + RUNTIME level. The structural test only needs the existing `"scan starting"` log line.
+
+### Within Each User Story
+
+- US1: T004 + T005 can run in parallel (different files); T006 verifies both, runs after.
+- US2: T007 standalone; T008 + T009 verify after.
+- US3: T010 standalone; T011 verifies functional correctness; T012 verifies determinism (100-iter loop, the long-pole task); T013 verifies listing.
+
+### Parallel Opportunities
+
+- T004 + T005 + T007 + T010 (all on different files) — primary parallel batch.
+- T014 + T015 (different docs files) — parallel within Polish.
+- T011 + T013 (different verifications of the same file) — sequential but cheap.
+- T012 (100-iter loop) is the longest task; let it run in background while writing T014/T015.
+
+---
+
+## Parallel Example: Phase 3–5 (US1 + US2 + US3 implementation)
+
+```bash
+# All three stories touch different files; fan out:
+Task: "Add #[ignore] to triple_format_perf.rs (T004)"
+Task: "Add #[ignore] to dual_format_perf.rs (T005)"
+Task: "Create .github/workflows/perf.yml (T007)"
+Task: "Create mikebom-cli/tests/triple_format_structural.rs (T010)"
+```
+
+Verification tasks (T006, T008, T009, T011, T012, T013) run after their corresponding implementation tasks complete.
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2 — both P1)
+
+The user's core ask is "stop CI from false-failing". The MVP is US1 + US2:
+
+1. Phase 1: Setup (T001–T003)
+2. Phase 3: US1 (T004–T006) — `#[ignore]` applied
+3. Phase 4: US2 (T007–T009) — perf.yml created
+4. Phase 6 partial: T016 + T017 — diff scope + pre-PR gate
+5. **STOP and VALIDATE**: open a test PR; confirm no perf-test failures on the 3 default lanes.
+
+US3 + docs can land in the same PR or as a follow-up. US3 strengthens the regression-catch surface in the default lane; without it, US1+US2 still solve the immediate flaky-test pain but lose the per-PR regression signal for single-pass dispatch.
+
+### Incremental Delivery (recommended)
+
+1. Setup → US1 → US2 → US3 → Polish → ship as a single PR.
+2. The whole milestone is ~17 tasks, ~90 min including the 10–20 min 100-iter loop. Single PR is appropriate.
+
+### Single-Developer Strategy
+
+This is a small test-infrastructure milestone; one developer does it sequentially:
+
+1. T001–T003 (setup, ~5 min)
+2. T004–T006 (US1 ignore + verify, ~10 min)
+3. T007–T009 (US2 perf.yml + verify, ~15 min)
+4. T010 (US3 new structural test file write, ~20 min — the longest write)
+5. T011 + T013 (US3 quick verifications, ~3 min)
+6. T012 (US3 100-iter determinism loop, ~10–20 min wall-clock; can run in background)
+7. T014 + T015 (Polish docs, ~10 min)
+8. T016 + T017 (Polish audit + pre-PR gate, ~5 min)
+
+Total: ~80 min including the determinism loop's wall-clock.
+
+---
+
+## Notes
+
+- [P] markers = different files OR different verifications of independent files.
+- [Story] label maps task to specific user story for traceability.
+- US1 and US2 are co-equal P1 because the user's frustration is dual-rooted: (a) CI blocks merges on noise, (b) we don't want to lose the regression-catch surface that the wall-clock test ostensibly provides.
+- US3 is P2 because US1+US2 alone solve the immediate pain. US3 is the architectural completion: deterministic signal in the default lane that catches single-pass dispatch breakage immediately, complementing the periodic perf.yml lane.
+- The 100-iteration determinism check (T012) is non-negotiable. A flaky NEW structural test would defeat the milestone's purpose. If T012 fails, fix the test before merging.
+- Commit boundary suggestion: one commit per user-story phase (3 commits) + one polish commit, OR squash to a single PR-level commit at merge time.
+- Avoid: tuning median-N or threshold values in this milestone (FR-007). Those are separate decisions for future milestones once we have perf-lane signal over multiple weeks.


### PR DESCRIPTION
## Summary

Two wall-clock perf tests (`triple_format_perf.rs` milestone-011, `dual_format_perf.rs` milestone-010) repeatedly false-failed on macOS-latest CI runners at ~14–22% measured-reduction vs a 25% gate. Median-of-3 → median-of-5 (milestone-045) didn't fix the underlying issue: shared CI runner thermal/scheduler noise dominates a ~2s measurement window. The "fix" treadmill (sample-count bumps, threshold relaxations) is structurally wrong.

This PR ships the architectural fix:

1. **Mark both perf tests `#[ignore]`** — they skip in `cargo +stable test --workspace` and `./scripts/pre-pr.sh`. Existing assertions / sample counts / threshold values are unchanged (FR-007).
2. **Add a deterministic structural-correctness sibling test** at `mikebom-cli/tests/triple_format_structural.rs` that catches single-pass dispatch regressions via stderr log-line counting (existing `"scan starting"` info-line) + triple-vs-sequential output byte-equivalence. Zero wall-clock semantics, binary pass/fail.
3. **Add a dedicated opt-in/scheduled perf CI lane** at `.github/workflows/perf.yml` with `nick-fields/retry@v3` (3 attempts per test). Triggers: `perf`-labeled PR, manual `workflow_dispatch`, daily cron at 06:00 UTC on main. NOT required for PR merge.

Plus docs (`CONTRIBUTING.md` "Performance benchmarks (opt-in)" subsection, PR template checklist item).

## Determinism gate result

**100/100 deterministic passes in 192s** on the new structural test — locally verified (SC-006). The 3 sub-assertions are pass/fail on a structural invariant, not wall-clock measurement, so they're robust by construction.

## What landed (files)

| File | Change |
|------|--------|
| `mikebom-cli/tests/triple_format_perf.rs` | +1 line: `#[ignore = "wall-clock perf test — opt in via cargo test -- --ignored, runs in dedicated perf.yml lane"]` |
| `mikebom-cli/tests/dual_format_perf.rs` | same |
| `mikebom-cli/tests/triple_format_structural.rs` | NEW: 3 deterministic tests — pipeline-start-count == 1 for triple, == 3 for sequential, + byte-equivalence sibling with inline `strip_image_temp_dir` helper to mask per-invocation `mikebom-image-<random>` extraction paths |
| `.github/workflows/perf.yml` | NEW: 3 triggers, `ubuntu-latest`+`macos-latest` matrix, every action SHA-pinned per PR #200 convention, `nick-fields/retry@v3` wrapping each perf test |
| `.github/pull_request_template.md` | +1 checklist item for perf-touching PRs |
| `CONTRIBUTING.md` | +new H3 \"Performance benchmarks (opt-in)\" subsection |
| `specs/094-deflake-perf-tests/` | full speckit lifecycle artifacts (spec, plan, research, data-model, contracts, quickstart, tasks, checklists) |

## Remaining 6 OpenSSF Baseline FAILs (unchanged by this PR)

These remain known/accepted from milestone 094's audit work:
- 4 GitHub Settings branch-protection items
- 1 stay-set RPM SQLite fixture false-positive (per milestone-090)
- 1 threat-model generator (defer to follow-up)

Tracked separately; this PR is scoped to the deflake architecture.

## Test plan

- [x] `./scripts/pre-pr.sh` clean locally — zero clippy warnings, all test suites `0 failed`. The 2 wall-clock perf tests now `ignored` (not failed); the 3 new structural tests pass.
- [x] 100-iteration determinism loop: `for i in $(seq 1 100); do cargo +stable test -p mikebom --test triple_format_structural --quiet; done` → 100/100 passed in 192s.
- [x] Opt-in mechanism verified: `cargo +stable test -p mikebom --test triple_format_perf -- --ignored` runs the test (43.92s on local macOS).
- [x] Diff scope audit: zero source-tree changes (`mikebom-cli/src/`, `mikebom-common/src/`, `xtask/src/`), zero golden regen, zero Cargo.lock/Cargo.toml churn.
- [x] `perf.yml` actions all SHA-pinned: `grep -E \"uses: [^@]+@(v[0-9]|nightly|stable|latest|main|master)$\" .github/workflows/perf.yml` returns empty (Kusari Inspector will pass).
- [ ] Post-merge: add `perf` label to a synthetic test PR to verify the workflow fires within ~1 minute.
- [ ] Post-merge: observe 10 PRs over the next few days; confirm zero perf-test failures in the default CI lanes (SC-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)