### PR TITLE
feat(097): emit CPE candidates for binary-identified pkg:generic components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-12
 - N/A — test infrastructure only; no caches, no persistence. (094-deflake-perf-tests)
 - Rust stable (workspace toolchain inherited; no nightly required). + existing only — `object` crate (already in workspace, handles ELF/Mach-O/PE section iteration), `serde`/`serde_json`, `tracing`, `anyhow`. NO new crates. (096-binary-id-enrich)
 - N/A — pure read-only inference from the binary file itself. (096-binary-id-enrich)
+- Rust stable (workspace toolchain inherited from milestones 001–096; no nightly required). + Existing only — `serde`/`serde_json` (CDX/SPDX JSON output), `tracing`, `anyhow`. No new Cargo deps. (097-cpe-candidates)
+- N/A — pure metadata transform on SBOM emission code path; no caches, no persistence. (097-cpe-candidates)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -151,9 +153,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 097-cpe-candidates: Added Rust stable (workspace toolchain inherited from milestones 001–096; no nightly required). + Existing only — `serde`/`serde_json` (CDX/SPDX JSON output), `tracing`, `anyhow`. No new Cargo deps.
 - 096-binary-id-enrich: Added Rust stable (workspace toolchain inherited; no nightly required). + existing only — `object` crate (already in workspace, handles ELF/Mach-O/PE section iteration), `serde`/`serde_json`, `tracing`, `anyhow`. NO new crates.
 - 094-deflake-perf-tests: Added Rust stable (workspace toolchain inherited; no nightly required for this user-space test-infrastructure work). + existing only — `std::process::Command` for subprocess invocation, `tempfile`, `tar` (already used by current perf tests), `serde_json` (for byte-equivalence comparisons). The new GitHub Action `nick-fields/retry@v3` is permitted under FR-010 because it's a workflow YAML reference, not a Cargo dependency.
-- 093-repo-polish-quickwins: Added N/A — this milestone touches Markdown + (potentially) Cargo.toml metadata only. + None new. The existing `release.yml` artifact-naming convention is the only behavioral input that informs the cargo-binstall integration choice.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/generate/cpe.rs
+++ b/mikebom-cli/src/generate/cpe.rs
@@ -15,6 +15,52 @@
 
 use mikebom_common::resolution::ResolvedComponent;
 
+/// v1 mapping table for `pkg:generic/<library>@<version>` components per
+/// milestone-097 FR-001. Each row maps a library slug (the lowercase
+/// value emitted by `version_strings::CuratedLibrary::slug()` and
+/// `symbol_fingerprint::SymbolFingerprintMatch::library`) to one or more
+/// `(NVD vendor, NVD product)` pairs.
+///
+/// Sorted alphabetically by library_slug for diff-friendliness per FR-002.
+/// Adding a library is a one-line PR; new entries must keep the sort.
+///
+/// BoringSSL (the 11th library identified by the version-string scanner)
+/// is intentionally omitted — Google's BoringSSL has no NVD-tracked CPE
+/// namespace. BoringSSL-rooted vulnerabilities flow through
+/// `openssl:openssl` records when the issue exists upstream, but
+/// BoringSSL-specific issues lack a usable CPE. Components for the
+/// `boringssl` slug emit a PURL with no CPE field — an explicit
+/// "we don't know" per Constitution X transparency.
+const GENERIC_LIBRARY_CPES: &[(&str, &[(&str, &str)])] = &[
+    // libcurl: historical `haxx:curl` dominates pre-2023 NVD records;
+    // modern `curl:curl` also appears. Both emitted — primary goes to
+    // `component.cpe`, secondary to `mikebom:cpe-candidates` property.
+    ("curl", &[("haxx", "curl"), ("curl", "curl")]),
+    // GnuTLS — NVD canonical.
+    ("gnutls", &[("gnu", "gnutls")]),
+    // LibreSSL: most CVEs filed under `openbsd:libressl` (LibreSSL is an
+    // OpenBSD project). Secondary `libressl:libressl` for records that
+    // use the project namespace directly.
+    ("libressl", &[("openbsd", "libressl"), ("libressl", "libressl")]),
+    // LLVM umbrella project. Sub-projects (clang, lld) are out of scope
+    // for v1 — the version-string scanner doesn't distinguish them.
+    ("llvm", &[("llvm", "llvm")]),
+    // OpenJDK — `oracle:openjdk` dominates Java vuln records. Build
+    // suffix (e.g. `+12`) is stripped before CPE emission per NVD-shape
+    // inconsistency; the PURL preserves the full version verbatim.
+    ("openjdk", &[("oracle", "openjdk")]),
+    // OpenSSL — every CVE since 2014 uses `openssl:openssl`.
+    ("openssl", &[("openssl", "openssl")]),
+    // PCRE 8.x — `pcre:pcre`.
+    ("pcre", &[("pcre", "pcre")]),
+    // PCRE 10.x — same vendor, different product.
+    ("pcre2", &[("pcre", "pcre2")]),
+    // SQLite — NVD canonical.
+    ("sqlite", &[("sqlite", "sqlite")]),
+    // zlib — NVD canonical.
+    ("zlib", &[("zlib", "zlib")]),
+];
+
 /// Build the set of CPE 2.3 candidate strings for a resolved component.
 /// Returns empty when the component is in an ecosystem the synthesizer
 /// has no opinion on (generic/unknown PURLs).
@@ -97,6 +143,43 @@ pub fn synthesize_cpes(component: &ResolvedComponent) -> Vec<String> {
         }
         "nuget" => {
             push_unique(&mut vendors, name);
+        }
+        "generic" => {
+            // Milestone 097 — CPE candidates for binary-extracted
+            // `pkg:generic/<lib>@<version>` components from the
+            // milestone-096 version-string + symbol-fingerprint
+            // scanners. Lookup the lowercase library slug in the
+            // hand-curated mapping table; libraries with no row emit
+            // no CPE (FR-003 silent-skip) so non-tracked generic PURLs
+            // (e.g. `pkg:generic/weird@1.0.0`) continue to produce an
+            // empty Vec just as they did before milestone 097.
+            let mapping = GENERIC_LIBRARY_CPES
+                .iter()
+                .find(|(slug, _)| *slug == name.as_str())
+                .map(|(_, pairs)| *pairs);
+            let Some(pairs) = mapping else {
+                return Vec::new();
+            };
+            // OpenJDK build-suffix special-case: NVD records for Java
+            // vulns inconsistently encode the `+<build>` suffix —
+            // some use `update_<n>`, some omit it entirely. Stripping
+            // the suffix matches the most-common NVD shape and avoids
+            // false-negative CPE-matching against scanners that key
+            // on the canonical-version form. The full version stays
+            // verbatim on the component's PURL.
+            let cpe_version: String = if name == "openjdk" {
+                version
+                    .split(|c: char| !c.is_ascii_digit() && c != '.')
+                    .next()
+                    .unwrap_or(version)
+                    .to_string()
+            } else {
+                version.clone()
+            };
+            return pairs
+                .iter()
+                .map(|(vendor, product)| format_cpe(vendor, product, &cpe_version))
+                .collect();
         }
         _ => {
             // Unknown ecosystem — no opinion.
@@ -263,7 +346,13 @@ mod tests {
     }
 
     #[test]
-    fn unknown_ecosystem_returns_empty() {
+    fn generic_unknown_library_returns_empty() {
+        // Milestone 097 FR-003: a `pkg:generic/<slug>@<version>` PURL
+        // whose slug is NOT in `GENERIC_LIBRARY_CPES` (here, `weird`)
+        // emits an empty Vec — silent skip, no error. Same assertion
+        // as the pre-097 `unknown_ecosystem_returns_empty` test;
+        // renamed because the failure mode changed from "ecosystem
+        // not handled" to "library not in table".
         let c = make_component("pkg:generic/weird@1.0.0");
         let cpes = synthesize_cpes(&c);
         assert!(cpes.is_empty());
@@ -299,5 +388,203 @@ mod tests {
         assert_eq!(cpe_escape("1+2"), "1\\+2");
         assert_eq!(cpe_escape("a:b"), "a\\:b");
         assert_eq!(cpe_escape("a/b"), "a\\/b");
+    }
+
+    // ====================================================================
+    // Milestone 097 — CPE candidate emission for binary-identified
+    // `pkg:generic/<lib>@<version>` components.
+    // ====================================================================
+
+    /// T006 — Contract 1: canonical OpenSSL emission for the headline
+    /// US1 case. A binary-extracted `pkg:generic/openssl@3.0.13`
+    /// component receives the NVD-canonical `openssl:openssl` CPE
+    /// candidate as its primary (and only) CPE.
+    #[test]
+    fn generic_openssl_emits_canonical_cpe() {
+        let c = make_component("pkg:generic/openssl@3.0.13");
+        let cpes = synthesize_cpes(&c);
+        assert_eq!(cpes.len(), 1);
+        assert_eq!(cpes[0], "cpe:2.3:a:openssl:openssl:3.0.13:*:*:*:*:*:*:*");
+    }
+
+    /// T007 — Contract 1 (multi-vendor): libcurl gets two NVD-cited
+    /// vendor:product pairs. The first (`haxx:curl`) populates the
+    /// CDX `component.cpe`; the second (`curl:curl`) flows through
+    /// the existing `mikebom:cpe-candidates` overflow property.
+    #[test]
+    fn generic_curl_emits_dual_candidates() {
+        let c = make_component("pkg:generic/curl@8.4.0");
+        let cpes = synthesize_cpes(&c);
+        assert_eq!(cpes.len(), 2);
+        assert_eq!(cpes[0], "cpe:2.3:a:haxx:curl:8.4.0:*:*:*:*:*:*:*");
+        assert_eq!(cpes[1], "cpe:2.3:a:curl:curl:8.4.0:*:*:*:*:*:*:*");
+    }
+
+    /// T008 — Contract 4: OpenJDK build-suffix is stripped before CPE
+    /// emission (`21.0.1+12` → `21.0.1`). The PURL on the component
+    /// stays intact; only the CPE version segment is normalized to
+    /// the most-common NVD shape.
+    #[test]
+    fn generic_openjdk_strips_build_suffix() {
+        let c = make_component("pkg:generic/openjdk@21.0.1+12");
+        let cpes = synthesize_cpes(&c);
+        assert_eq!(cpes.len(), 1);
+        assert_eq!(cpes[0], "cpe:2.3:a:oracle:openjdk:21.0.1:*:*:*:*:*:*:*");
+    }
+
+    /// T009 — FR-005 / SC-004 / Contract from US1#4: composite-evidence
+    /// merge per milestone-096 Q1 produces ONE PackageDbEntry with a
+    /// version-string PURL; that single component receives ONE CPE
+    /// field — no duplicate emission for the symbol-fingerprint half
+    /// of the evidence trail. The CPE pipeline naturally satisfies
+    /// this because synthesize_cpes is per-component, not per-evidence.
+    #[test]
+    fn composite_evidence_emits_single_cpe() {
+        let c = make_component("pkg:generic/openssl@3.0.13");
+        let cpes = synthesize_cpes(&c);
+        assert_eq!(
+            cpes.len(),
+            1,
+            "milestone-096 Q1 composite-merge → ONE component → ONE CPE; got {cpes:?}"
+        );
+        assert_eq!(cpes[0], "cpe:2.3:a:openssl:openssl:3.0.13:*:*:*:*:*:*:*");
+    }
+
+    /// T011 — FR-002 maintainability: the v1 mapping table is sorted
+    /// alphabetically by library_slug for diff-friendliness. New rows
+    /// must keep the sort; this test fails the build when they don't.
+    #[test]
+    fn mappings_alphabetically_sorted() {
+        let unsorted: Vec<&str> = GENERIC_LIBRARY_CPES
+            .windows(2)
+            .filter(|w| w[0].0 >= w[1].0)
+            .map(|w| w[0].0)
+            .collect();
+        assert!(
+            unsorted.is_empty(),
+            "GENERIC_LIBRARY_CPES is not alphabetically sorted by library_slug. \
+             Offending row(s): {unsorted:?}. Reorder the table."
+        );
+    }
+
+    /// T012 — SC-002: every row in the mapping table emits a
+    /// syntactically valid CPE 2.3 string. Loop guard against a future
+    /// maintainer adding a row whose vendor or product slug breaks the
+    /// `format_cpe` template. CPE 2.3 has 13 colon-separated segments
+    /// (`cpe:2.3:a:vendor:product:version:update:edition:lang:sw_edition:target_sw:target_hw:other`).
+    #[test]
+    fn mappings_all_emit_valid_cpe23() {
+        for (slug, pairs) in GENERIC_LIBRARY_CPES {
+            let c = make_component(&format!("pkg:generic/{slug}@1.2.3"));
+            let cpes = synthesize_cpes(&c);
+            assert!(
+                !cpes.is_empty(),
+                "row {slug:?} produced no CPE candidates"
+            );
+            assert_eq!(
+                cpes.len(),
+                pairs.len(),
+                "row {slug:?}: expected {} candidates, got {}",
+                pairs.len(),
+                cpes.len(),
+            );
+            for cpe in &cpes {
+                assert!(
+                    cpe.starts_with("cpe:2.3:a:"),
+                    "row {slug:?} produced non-cpe23 string: {cpe}"
+                );
+                // CPE 2.3 formatted-string binding: 13 segments total,
+                // separated by 12 unescaped colons. Escaped colons
+                // (`\:`) inside an attribute don't count as separators.
+                let mut separator_count = 0usize;
+                let bytes = cpe.as_bytes();
+                let mut i = 0;
+                while i < bytes.len() {
+                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                        // Skip escaped char.
+                        i += 2;
+                        continue;
+                    }
+                    if bytes[i] == b':' {
+                        separator_count += 1;
+                    }
+                    i += 1;
+                }
+                assert_eq!(
+                    separator_count, 12,
+                    "row {slug:?}: CPE 2.3 must have 13 segments (12 unescaped colons), \
+                     got {separator_count} in {cpe}"
+                );
+            }
+        }
+    }
+
+    /// T013 — FR-002 / A1: the v1 mapping table must cover every
+    /// curated-library slug emitted by the milestone-096 / earlier
+    /// version-string scanner, EXCEPT for the documented-omission
+    /// allowlist (currently just `boringssl` — no NVD-tracked CPE
+    /// namespace). Future milestones extending the scanner must
+    /// either add a row here or extend the allowlist with a
+    /// documented rationale.
+    ///
+    /// The cross-module dependency on `version_strings::CuratedLibrary`
+    /// is permitted because the latter is `pub` and lives in the same
+    /// crate; the test reaches it via `crate::scan_fs::binary::version_strings`.
+    #[test]
+    fn mappings_cover_all_curated_libraries() {
+        use crate::scan_fs::binary::version_strings::CuratedLibrary;
+
+        // Documented-omission allowlist per spec Edge Cases.
+        const OMITTED: &[&str] = &["boringssl"];
+
+        // Walk every variant of CuratedLibrary and assert each slug
+        // is either in the mapping table OR on the omission allowlist.
+        // Update this list when adding library variants.
+        let all_curated: &[CuratedLibrary] = &[
+            CuratedLibrary::OpenSsl,
+            CuratedLibrary::BoringSsl,
+            CuratedLibrary::Zlib,
+            CuratedLibrary::Sqlite,
+            CuratedLibrary::Curl,
+            CuratedLibrary::Pcre,
+            CuratedLibrary::Pcre2,
+            CuratedLibrary::GnuTls,
+            CuratedLibrary::LibreSsl,
+            CuratedLibrary::Llvm,
+            CuratedLibrary::OpenJdk,
+        ];
+
+        for lib in all_curated {
+            let slug = lib.slug();
+            let in_table = GENERIC_LIBRARY_CPES.iter().any(|(s, _)| *s == slug);
+            let omitted = OMITTED.contains(&slug);
+            assert!(
+                in_table || omitted,
+                "curated library slug {slug:?} is missing from \
+                 GENERIC_LIBRARY_CPES AND not on the OMITTED allowlist. \
+                 Add a mapping row OR extend the allowlist with a documented rationale."
+            );
+        }
+    }
+
+    /// T015 — FR-004 / SC-003: a component with `pkg:generic/<lib>`
+    /// shape and empty version (the milestone-096 symbol-fingerprint-
+    /// only case + the SQLite source-id-only edge case) emits NO CPE.
+    /// Wildcard-version CPEs are explicitly out of scope — they would
+    /// match every CVE in the library's history and drown downstream
+    /// scanners in unactionable false positives.
+    ///
+    /// Implementation note: this is satisfied for free by the existing
+    /// `cpe.rs:25-28` empty-version fast-return, ahead of the
+    /// `match ecosystem` dispatch. The test guards against regression.
+    #[test]
+    fn generic_symbol_fingerprint_only_emits_no_cpe() {
+        let mut c = make_component("pkg:generic/openssl@dummy");
+        c.version = String::new();
+        let cpes = synthesize_cpes(&c);
+        assert!(
+            cpes.is_empty(),
+            "FR-004: versionless generic component must not emit a CPE; got {cpes:?}"
+        );
     }
 }

--- a/mikebom-cli/tests/cpe_binary_id.rs
+++ b/mikebom-cli/tests/cpe_binary_id.rs
@@ -1,0 +1,69 @@
+//! Milestone 097 integration test — CPE candidate emission for
+//! binary-extracted `pkg:generic/<lib>@<version>` components.
+//!
+//! Negative-control coverage for SC-007: mikebom's own binary uses
+//! rustls (not OpenSSL), so scanning the mikebom binary itself must
+//! NOT produce an OpenSSL CPE. If this test ever fires, either:
+//! (a) the milestone-096 version-string scanner now matches an
+//!     OpenSSL literal embedded in mikebom (a spurious match — fix
+//!     the scanner's anchor regex),
+//! (b) the milestone-097 CPE table has a row whose vendor/product
+//!     would produce an `openssl:openssl:` CPE for an unrelated PURL
+//!     (impossible by construction — the table maps slug → vendor),
+//! (c) mikebom genuinely started linking OpenSSL (which would be a
+//!     real dependency change worth reviewing).
+//!
+//! Positive end-to-end coverage is via the unit tests in
+//! `cpe.rs::tests` (8 new tests covering canonical OpenSSL,
+//! dual-candidate curl, OpenJDK suffix-strip, composite-evidence
+//! one-CPE, table well-formedness, all-row validity, slug coverage,
+//! and versionless-suppression). No toolchain-dependent fixture is
+//! required; build-OpenSSL fixtures are deliberately out of scope
+//! to keep CI hermetic.
+
+#![cfg(test)]
+#![allow(clippy::unwrap_used)]
+
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// SC-007 negative control: mikebom binary should not trip the
+/// milestone-097 CPE table OR the milestone-096 version-string
+/// scanner. Scanning mikebom-itself emits NO `openssl:openssl` CPE
+/// in the resulting CDX SBOM.
+#[test]
+fn mikebom_self_scan_emits_no_spurious_openssl_cpe() {
+    let dir = TempDir::new().unwrap();
+    let dest = dir.path().join("mikebom-under-test");
+    std::fs::copy(env!("CARGO_BIN_EXE_mikebom"), &dest).unwrap();
+
+    let out_file = dir.path().join("out.cdx.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_mikebom"))
+        .args(["sbom", "scan", "--path"])
+        .arg(dir.path())
+        .arg("--output")
+        .arg(&out_file)
+        .arg("--no-deep-hash")
+        .output()
+        .expect("failed to invoke mikebom");
+    assert!(
+        output.status.success(),
+        "mikebom sbom scan failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let bytes = std::fs::read(&out_file).expect("SBOM not written");
+    let sbom: Value = serde_json::from_slice(&bytes).expect("invalid SBOM JSON");
+    let json_str = serde_json::to_string(&sbom).expect("SBOM JSON re-serialize");
+
+    assert!(
+        !json_str.contains("cpe:2.3:a:openssl:openssl:"),
+        "milestone-097 SC-007 spurious-emission guard: mikebom binary \
+         should not emit an openssl:openssl CPE (mikebom uses rustls). \
+         If this fires, check (a) milestone-096 version-string scanner \
+         for a false-positive anchor match, OR (b) whether mikebom now \
+         genuinely links OpenSSL (a real dependency change)."
+    );
+}

--- a/specs/097-cpe-candidates/checklists/requirements.md
+++ b/specs/097-cpe-candidates/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: CPE candidate emission for binary-identified components
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-12
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- v1 scope deliberately narrow: 11 libraries already covered by milestone-096's embedded-version-string scanner. Edge cases enumerated for known NVD quirks (PCRE vs PCRE2, LibreSSL vendor conflict, OpenJDK build-suffix, SQLite source-id, BoringSSL omission).
+- Symbol-fingerprint-only components (no version) deliberately suppress CPE emission to avoid wildcard-version false-positive flood.
+- Composite-evidence (milestone-096 Q1) inheritance: the version-string side wins; symbol-fingerprint side contributes evidence but not a second CPE.

--- a/specs/097-cpe-candidates/contracts/cpe-emission-contracts.md
+++ b/specs/097-cpe-candidates/contracts/cpe-emission-contracts.md
@@ -1,0 +1,125 @@
+# Contract — milestone 097 CPE candidate emission
+
+Five behavioral contracts. Each specifies (a) the invariant and (b) a verification recipe — a unit test name, an integration test, or a `jq`-grep on emitted SBOM JSON.
+
+## Contract 1 — `pkg:generic/<v1-library>@<version>` emits canonical CPE (FR-001, SC-001)
+
+**Path**: `mikebom-cli/src/generate/cpe.rs::synthesize_cpes()` "generic" arm.
+
+**Invariant**: for every PURL of shape `pkg:generic/<slug>@<version>` where `<slug>` matches a row in `GENERIC_LIBRARY_CPES`, mikebom emits:
+- `component.cpes[0]` = `"cpe:2.3:a:<vendor>:<product>:<version>:*:*:*:*:*:*:*"` where `(vendor, product)` is the table's first mapping for that slug.
+- If the mapping has ≥2 vendor:product pairs, all are emitted into `component.cpes[]` in declaration order.
+
+**Verification**:
+```bash
+# Unit test (in cpe.rs::tests):
+cargo +stable test -p mikebom --bin mikebom \
+    --no-fail-fast cpe::tests::generic_openssl_emits_canonical_cpe \
+    cpe::tests::generic_curl_emits_dual_candidates 2>&1 | grep "test result:"
+# Expected: ok. 2 passed.
+
+# End-to-end via Trivy (toolchain-graceful-skip if absent):
+echo '{"purl": "pkg:generic/openssl@3.0.13"}' | ...synthesize SBOM with this component...
+trivy sbom /tmp/openssl.cdx.json
+# Expected: ≥1 CVE in OpenSSL 3.0.13 advisory list appears in output.
+```
+
+## Contract 2 — Missing table entry emits no CPE silently (FR-003)
+
+**Path**: same arm — the `let Some(vendors) = mapping else { return Vec::new(); };` branch.
+
+**Invariant**: when `<slug>` is not present in `GENERIC_LIBRARY_CPES`, `synthesize_cpes` returns an empty Vec. No log line, no error, no panic. The PURL still appears in the SBOM; only the CPE field/external-ref is absent.
+
+**Verification**:
+```bash
+cargo +stable test -p mikebom --bin mikebom \
+    cpe::tests::generic_unknown_library_returns_empty 2>&1 | grep "test result:"
+# Expected: ok. 1 passed.
+
+# Plus the existing `unknown_ecosystem_returns_empty` test continues to pass —
+# the test is renamed but the assertion is preserved.
+```
+
+## Contract 3 — Versionless components emit no CPE (FR-004, SC-003)
+
+**Path**: existing `cpe.rs:25-28` empty-version fast-return (no new code path).
+
+**Invariant**: when `ResolvedComponent.version` is the empty string — the symbol-fingerprint-only milestone-096 case + the SQLite source-id-only edge case — `synthesize_cpes` returns an empty Vec regardless of which ecosystem arm matches.
+
+**Verification**:
+```bash
+cargo +stable test -p mikebom --bin mikebom \
+    cpe::tests::generic_symbol_fingerprint_only_emits_no_cpe \
+    cpe::tests::empty_version_returns_empty 2>&1 | grep "test result:"
+# Expected: ok. 2 passed.
+```
+
+## Contract 4 — OpenJDK build-suffix stripping (Edge Cases, FR-001 nuance)
+
+**Path**: same "generic" arm — the `if name == "openjdk"` special-case.
+
+**Invariant**: `pkg:generic/openjdk@21.0.1+12` produces `cpe:2.3:a:oracle:openjdk:21.0.1:*:*:*:*:*:*:*` (build-suffix stripped). The PURL on the component is unchanged (`@21.0.1+12` stays); only the CPE field's version segment is normalized.
+
+**Verification**:
+```bash
+cargo +stable test -p mikebom --bin mikebom \
+    cpe::tests::generic_openjdk_strips_build_suffix 2>&1 | grep "test result:"
+# Expected: ok. 1 passed.
+```
+
+## Contract 5 — Mapping table well-formed at build time (FR-002 + FR-006)
+
+**Path**: `cpe.rs::tests::mappings_alphabetically_sorted()` + `cpe.rs::tests::mappings_cover_all_curated_libraries()`.
+
+**Invariant**:
+1. `GENERIC_LIBRARY_CPES` is sorted alphabetically by `library_slug` for diff-friendliness.
+2. Every `version_strings::CuratedLibrary::slug()` value either has a row in `GENERIC_LIBRARY_CPES` or is on the documented-omission list (currently `boringssl` only).
+3. Every emitted CPE 2.3 string round-trips through `cpe_escape()` and contains exactly 13 colon-separated segments per the spec.
+
+**Verification**:
+```bash
+cargo +stable test -p mikebom --bin mikebom \
+    cpe::tests::mappings_alphabetically_sorted \
+    cpe::tests::mappings_cover_all_curated_libraries 2>&1 | grep "test result:"
+# Expected: ok. 2 passed.
+```
+
+## Contract 6 — Diff scope guardrails (FR-007, FR-008, FR-009, SC-006, SC-007)
+
+**Verification**:
+```bash
+# No new Cargo deps (FR-007):
+git diff --name-only main | grep -E '^Cargo\.(lock|toml)$' | wc -l
+# Expected: 0
+
+# Production code outside generate/cpe.rs:
+git diff --name-only main | grep -E '^mikebom-cli/src/' \
+  | grep -vE '^mikebom-cli/src/generate/cpe\.rs$' \
+  | wc -l
+# Expected: 0
+
+# Golden regen scope (FR-009 / SC-006):
+git diff --stat mikebom-cli/tests/fixtures/golden/ | tail -1 | grep -oE '[0-9]+ files? changed'
+# Expected: zero (no existing fixture contains a binary-extracted
+# pkg:generic/<v1-library>@<version> component per milestone-096 SC-007).
+
+# Diff scope allowlist:
+git diff --name-only main | sort
+# Expected (allowlist):
+#   mikebom-cli/src/generate/cpe.rs
+#   mikebom-cli/tests/cpe_binary_id.rs           (NEW)
+#   specs/097-cpe-candidates/...
+#   CLAUDE.md                                    (auto-updated by /speckit-plan)
+```
+
+## Contract 7 — Pre-PR gate clean (SC-005)
+
+**Verification**:
+```bash
+MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 ./scripts/pre-pr.sh
+# Expected: prints `>>> all pre-PR checks passed.`; exit 0.
+# Clippy: zero warnings.
+# Test suite: every target `0 failed`.
+```
+
+The SPDX 3 validator (`spdx3-validate==0.0.5`) accepts standards-native CPE arrays; the new emissions don't break conformance.

--- a/specs/097-cpe-candidates/data-model.md
+++ b/specs/097-cpe-candidates/data-model.md
@@ -1,0 +1,200 @@
+# Data Model — milestone 097
+
+Single-file delta to `mikebom-cli/src/generate/cpe.rs`. The mapping table + the new `"generic"` ecosystem arm are the entire structural change.
+
+## File inventory
+
+| File | State | Owner FRs |
+|------|-------|-----------|
+| `mikebom-cli/src/generate/cpe.rs` | EXTEND existing | FR-001, FR-002, FR-003, FR-006 |
+| `mikebom-cli/tests/cpe_binary_id.rs` | NEW (or extend `binary_id_enrich.rs`) | SC-001 integration coverage |
+
+No changes outside these two files. SPDX 2.3 / SPDX 3 / CDX emission paths already iterate `component.cpes` and pick up new candidates automatically (audited at research §1).
+
+## `cpe.rs` — extension shape
+
+**New const table at top of module** (after the existing imports):
+
+```rust
+/// v1 library → (NVD vendor, NVD product) for `pkg:generic/<lib>@<version>`
+/// components per milestone-097 FR-001 + research §2. Sorted alphabetically
+/// by library_slug for diff-friendliness per FR-002.
+///
+/// Each row carries an in-source citation comment documenting the NVD-canonical
+/// vendor:product choice. Multi-candidate rows (curl, libressl) emit both pairs
+/// so downstream NVD matchers can take the union.
+const GENERIC_LIBRARY_CPES: &[(&str, &[(&str, &str)])] = &[
+    // OpenSSL — every CVE since 2014 uses openssl:openssl
+    ("openssl",  &[("openssl",  "openssl")]),
+    // zlib — NVD canonical
+    ("zlib",     &[("zlib",     "zlib")]),
+    // SQLite — NVD canonical
+    ("sqlite",   &[("sqlite",   "sqlite")]),
+    // libcurl — historical haxx:curl dominates; modern curl:curl also appears
+    ("curl",     &[("haxx",     "curl"), ("curl", "curl")]),
+    // PCRE 8.x
+    ("pcre",     &[("pcre",     "pcre")]),
+    // PCRE 10.x — same vendor, different product
+    ("pcre2",    &[("pcre",     "pcre2")]),
+    // GnuTLS
+    ("gnutls",   &[("gnu",      "gnutls")]),
+    // LibreSSL — most CVEs under openbsd:libressl; libressl:libressl secondary
+    ("libressl", &[("openbsd",  "libressl"), ("libressl", "libressl")]),
+    // LLVM umbrella (sub-projects clang/lld out of scope per spec)
+    ("llvm",     &[("llvm",     "llvm")]),
+    // OpenJDK — Java vuln records consistently file under oracle:openjdk
+    ("openjdk",  &[("oracle",   "openjdk")]),
+];
+```
+
+**New ecosystem arm** (inserted into the existing `match ecosystem` block in `synthesize_cpes`, immediately before the `_ => return Vec::new()` catch-all):
+
+```rust
+"generic" => {
+    // Lookup the library slug in the v1 mapping table. Missing slugs
+    // return empty (FR-003 — silent skip, no error).
+    let mapping = GENERIC_LIBRARY_CPES
+        .iter()
+        .find(|(slug, _)| *slug == name.as_str())
+        .map(|(_, vendors)| *vendors);
+    let Some(vendors) = mapping else {
+        return Vec::new();
+    };
+    // OpenJDK special-case: strip build-suffix (`21.0.1+12` → `21.0.1`)
+    // before CPE emission per research §3 NVD-shape rationale. Version
+    // stays verbatim on the PURL — only the CPE string is normalized.
+    let cpe_version = if name == "openjdk" {
+        version
+            .split(|c: char| !c.is_ascii_digit() && c != '.')
+            .next()
+            .unwrap_or(version)
+    } else {
+        version.as_str()
+    };
+    return vendors
+        .iter()
+        .map(|(vendor, product)| format_cpe(vendor, product, cpe_version))
+        .collect();
+},
+```
+
+**Updated test** (existing `unknown_ecosystem_returns_empty` renamed to clarify post-097 semantics — now matches by table-miss rather than ecosystem-miss):
+
+```rust
+#[test]
+fn generic_unknown_library_returns_empty() {
+    // `weird` is not in the v1 GENERIC_LIBRARY_CPES table → FR-003
+    // silent-skip → empty Vec emission.
+    let c = make_component("pkg:generic/weird@1.0.0");
+    let cpes = synthesize_cpes(&c);
+    assert!(cpes.is_empty());
+}
+```
+
+**New tests** (added to the existing `tests` module):
+
+```rust
+#[test]
+fn generic_openssl_emits_canonical_cpe() {
+    let c = make_component("pkg:generic/openssl@3.0.13");
+    let cpes = synthesize_cpes(&c);
+    assert_eq!(cpes.len(), 1);
+    assert_eq!(cpes[0], "cpe:2.3:a:openssl:openssl:3.0.13:*:*:*:*:*:*:*");
+}
+
+#[test]
+fn generic_curl_emits_dual_candidates() {
+    // Multi-vendor case — both haxx:curl and curl:curl emitted.
+    let c = make_component("pkg:generic/curl@8.4.0");
+    let cpes = synthesize_cpes(&c);
+    assert_eq!(cpes.len(), 2);
+    assert_eq!(cpes[0], "cpe:2.3:a:haxx:curl:8.4.0:*:*:*:*:*:*:*");
+    assert_eq!(cpes[1], "cpe:2.3:a:curl:curl:8.4.0:*:*:*:*:*:*:*");
+}
+
+#[test]
+fn generic_openjdk_strips_build_suffix() {
+    // NVD-shape normalization — `21.0.1+12` → `21.0.1` for the CPE only.
+    let c = make_component("pkg:generic/openjdk@21.0.1+12");
+    let cpes = synthesize_cpes(&c);
+    assert_eq!(cpes.len(), 1);
+    assert_eq!(cpes[0], "cpe:2.3:a:oracle:openjdk:21.0.1:*:*:*:*:*:*:*");
+}
+
+#[test]
+fn generic_symbol_fingerprint_only_emits_no_cpe() {
+    // FR-004 — `pkg:generic/openssl` (no version) → empty version → empty Vec.
+    let mut c = make_component("pkg:generic/openssl@dummy");
+    c.version = String::new();
+    let cpes = synthesize_cpes(&c);
+    assert!(cpes.is_empty());
+}
+```
+
+## `cpe_binary_id.rs` — NEW integration test
+
+Mirrors the milestone-096 negative-control test pattern. Scans the mikebom binary itself (or any unpacked system binary that doesn't statically link OpenSSL) and asserts the emitted SBOM contains no spurious `pkg:generic/openssl` AND no `openssl:openssl` CPE strings.
+
+```rust
+//! Milestone 097 integration test — CPE candidate emission for
+//! binary-extracted `pkg:generic/<lib>@<version>` components.
+//!
+//! Negative control: mikebom-itself scan should emit NO openssl CPE
+//! (mikebom uses rustls, not OpenSSL). Positive coverage is via the
+//! unit tests in `cpe.rs::tests` since toolchain-dependent OpenSSL
+//! fixtures aren't reliably present on CI.
+
+#![cfg(test)]
+#![allow(clippy::unwrap_used)]
+
+use std::process::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+#[test]
+fn mikebom_self_scan_emits_no_spurious_openssl_cpe() {
+    let dir = TempDir::new().unwrap();
+    let dest = dir.path().join("mikebom-under-test");
+    std::fs::copy(env!("CARGO_BIN_EXE_mikebom"), &dest).unwrap();
+
+    let out_file = dir.path().join("out.cdx.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_mikebom"))
+        .args(["sbom", "scan", "--path"])
+        .arg(dir.path())
+        .arg("--output")
+        .arg(&out_file)
+        .arg("--no-deep-hash")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let sbom: Value = serde_json::from_slice(&std::fs::read(&out_file).unwrap()).unwrap();
+    let json_str = serde_json::to_string(&sbom).unwrap();
+
+    // SC-007-style guard: no spurious openssl CPE on mikebom-itself.
+    assert!(
+        !json_str.contains("cpe:2.3:a:openssl:openssl:"),
+        "mikebom binary should not emit an openssl CPE — \
+         milestone-096 SC-007 spurious-match bound violated"
+    );
+}
+```
+
+(Optional addition: a positive-control test gated on a `MIKEBOM_TEST_OPENSSL_FIXTURE` env var pointing at a known-OpenSSL-static binary. Out of scope for v1 — defer until a fixture-management policy emerges.)
+
+## Validation rules
+
+- **Mapping table sort order**: alphabetical by `library_slug`. A unit test (`#[test] fn mappings_alphabetically_sorted()`) walks the table and asserts `.windows(2).all(|w| w[0].0 < w[1].0)` to keep diffs friendly.
+- **CPE syntax** (FR-006): by construction — the `format_cpe()` template + `cpe_escape()` produce valid CPE 2.3 formatted-string bindings. No external validator needed.
+- **Mapping table completeness** (FR-002): a unit test compares the table's library_slugs against the union of `version_strings::CuratedLibrary::slug()` values and asserts the table covers every supported slug except the explicitly-omitted ones (currently just `boringssl`). Catches the "scanner-team-added-a-library-but-forgot-the-CPE-row" regression.
+
+## Compatibility
+
+- **No `Cargo.lock` change** — pure-Rust, in-source const table.
+- **Goldens regen forecast** — zero. Existing ecosystem fixtures don't contain binary-extracted `pkg:generic/<v1-library>@<version>` components.
+- **Backward compatibility** — 100% additive. Components that previously had no CPE for `pkg:generic/<known-lib>@<version>` now get one. Components for non-table libraries continue to emit no CPE (FR-003 silent-skip).
+- **CDX `mikebom:cpe-candidates` property emission**: unchanged. When the mapping yields ≥2 candidates (curl, libressl), the existing emission path puts the full list in the property and `cpes[0]` in `component.cpe`.
+
+## No JSON / no YAML schema additions
+
+Zero new fields in any output schema. The new candidates flow through the existing `cpes` field on `ResolvedComponent`.

--- a/specs/097-cpe-candidates/plan.md
+++ b/specs/097-cpe-candidates/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: CPE candidate emission for binary-identified components
+
+**Branch**: `097-cpe-candidates` | **Date**: 2026-05-12 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/Users/mlieberman/Projects/mikebom/specs/097-cpe-candidates/spec.md`
+
+## Summary
+
+Add a `"generic"` ecosystem arm to the existing `mikebom-cli/src/generate/cpe.rs::synthesize_cpes()` synthesizer, backed by a small in-source `(library_slug, vendor, product)` mapping table for the 10 v1-supported libraries (the 11 milestone-096 / earlier version-string libraries minus BoringSSL — which has no NVD-tracked CPE namespace). For each binary-extracted `pkg:generic/<lib>@<version>` component whose `<lib>` matches a table row, emit ONE CPE 2.3 string at the component's CDX `component.cpe` field, SPDX 2.3 `externalRefs[].cpe23Type` ref, and SPDX 3 `Software:cpe` array. Symbol-fingerprint-only components (empty version) inherit the existing `synthesize_cpes` empty-version fast-return path (FR-004 satisfied for free). Composite-evidence merges inherit the version-string PURL's identity so the version-pinned CPE wins (FR-005 satisfied for free).
+
+The existing module already handles CPE 2.3 format-string emission, escape rules per spec §6.2, candidate-list ordering, and downstream wiring into CDX/SPDX 2.3 emission paths (CDX: `entry["cpe"] = json!(component.cpes[0])` at `cyclonedx/builder.rs:710`; SPDX 2.3: `cpe23Type` external ref at `spdx/packages.rs:406`). SPDX 3 audit at planning time (Phase 0) confirms the corresponding `Software:cpe` emission path. Net diff: ~50 lines of new mapping table + ecosystem-arm code + ~6 new unit tests + 1 integration test asserting CPE-present-on-binary-extracted-OpenSSL.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–096; no nightly required).
+**Primary Dependencies**: Existing only — `serde`/`serde_json` (CDX/SPDX JSON output), `tracing`, `anyhow`. No new Cargo deps.
+**Storage**: N/A — pure metadata transform on SBOM emission code path; no caches, no persistence.
+**Testing**: `cargo +stable test` workspace. Three new unit tests in `cpe.rs::tests`; one new integration test in `mikebom-cli/tests/cpe_binary_id.rs` (or extension of existing `binary_id_enrich.rs`).
+**Target Platform**: Same as host mikebom (linux/macos/win — the CPE synthesizer is host-platform-agnostic).
+**Project Type**: Rust CLI workspace (`mikebom-cli` binary + `mikebom-common` lib + `xtask`).
+**Performance Goals**: ≤1µs per component for CPE generation (a HashMap lookup + 12 `format!` calls). Sub-millisecond per full-SBOM emission delta.
+**Constraints**: Zero new Cargo deps (FR-007). Production code changes confined to `mikebom-cli/src/generate/cpe.rs` (FR-008). Goldens may regenerate for ≤1 fixture component per milestone-096 SC-007.
+**Scale/Scope**: 10 mapping-table rows in v1; pattern-set extension is one line per added library. SBOM emission already at workspace test-suite scale.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Rationale |
+|-----------|--------|-----------|
+| **I. Pure Rust, Zero C** | ✅ PASS | All new code is Rust. No new Cargo deps. |
+| **II. eBPF-Only Observation** | ✅ N/A | This milestone is enrichment, not discovery; no observation path touched. |
+| **IV. Test Discipline** | ✅ PASS | TDD + `cargo +stable clippy --workspace --all-targets -- -D warnings` clean. |
+| **V. Specification Compliance** | ✅ PASS | CDX 1.6 `component.cpe`, SPDX 2.3 `cpe23Type` external ref, SPDX 3 `Software:cpe` — all standards-native fields. NO `mikebom:*` annotation added. Existing `mikebom:cpe-candidates` property (carrying the 2nd-onward synthesized candidates) is unchanged. |
+| **X. Transparency** | ✅ PASS | The mapping table lives in-source with per-row NVD-citation rationale comments; no hidden lookups, no network calls. |
+| **XII. External Data Source Enrichment** | ✅ N/A | No external API calls; mapping table is in-source static data. |
+
+**No violations to track in Complexity Tracking.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/097-cpe-candidates/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+├── checklists/
+│   └── requirements.md  # Already exists (from /speckit-specify)
+├── spec.md              # Already exists
+└── tasks.md             # Phase 2 output (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/src/generate/
+├── cpe.rs               # EXTEND — add "generic" ecosystem arm + LIBRARY_CPE_MAPPINGS table
+└── (untouched)          # cyclonedx/builder.rs:710 + spdx/packages.rs:406 already
+                         # consume cpes[0]; no emission-side changes needed
+
+mikebom-cli/tests/
+└── cpe_binary_id.rs     # NEW — integration test asserting CPE on milestone-096
+                         # binary-extracted PackageDbEntry pipeline (or extend
+                         # binary_id_enrich.rs — implementer's call at task time)
+```
+
+**Structure Decision**: Single-file delta to `mikebom-cli/src/generate/cpe.rs`. The existing synthesizer is already wired into the post-dedup component-aggregation step at `scan_fs/mod.rs:641`, into CDX emission at `cyclonedx/builder.rs:710`, and into SPDX 2.3 emission at `spdx/packages.rs:406`. SPDX 3 emission path needs audit during Phase 0 — if it doesn't already plumb `cpes` through, add the same wire-up.
+
+## Complexity Tracking
+
+No constitution violations. Table empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| — | — | — |

--- a/specs/097-cpe-candidates/quickstart.md
+++ b/specs/097-cpe-candidates/quickstart.md
@@ -1,0 +1,118 @@
+# Quickstart — milestone 097 maintainer recipes
+
+Four recipes for landing CPE candidate emission for binary-identified components.
+
+## Recipe 1 — Add the mapping table + ecosystem arm (FR-001, FR-002)
+
+Open `mikebom-cli/src/generate/cpe.rs`. Above the `synthesize_cpes` function, add the const table from `data-model.md §cpe.rs — extension shape`:
+
+```rust
+const GENERIC_LIBRARY_CPES: &[(&str, &[(&str, &str)])] = &[
+    ("openssl",  &[("openssl",  "openssl")]),
+    ("zlib",     &[("zlib",     "zlib")]),
+    ("sqlite",   &[("sqlite",   "sqlite")]),
+    ("curl",     &[("haxx",     "curl"), ("curl", "curl")]),
+    ("pcre",     &[("pcre",     "pcre")]),
+    ("pcre2",    &[("pcre",     "pcre2")]),
+    ("gnutls",   &[("gnu",      "gnutls")]),
+    ("libressl", &[("openbsd",  "libressl"), ("libressl", "libressl")]),
+    ("llvm",     &[("llvm",     "llvm")]),
+    ("openjdk",  &[("oracle",   "openjdk")]),
+];
+```
+
+In the `match ecosystem` block (line ~30 of `synthesize_cpes`), add the `"generic"` arm **before** the existing `_ => { return Vec::new(); }` catch-all:
+
+```rust
+"generic" => {
+    let mapping = GENERIC_LIBRARY_CPES
+        .iter()
+        .find(|(slug, _)| *slug == name.as_str())
+        .map(|(_, vendors)| *vendors);
+    let Some(vendors) = mapping else {
+        return Vec::new();
+    };
+    let cpe_version = if name == "openjdk" {
+        version
+            .split(|c: char| !c.is_ascii_digit() && c != '.')
+            .next()
+            .unwrap_or(version)
+    } else {
+        version.as_str()
+    };
+    return vendors
+        .iter()
+        .map(|(vendor, product)| format_cpe(vendor, product, cpe_version))
+        .collect();
+},
+```
+
+Compile-check: `cargo +stable check -p mikebom`.
+
+## Recipe 2 — Add unit tests (Contract 1-5)
+
+Add the 5 new tests to the existing `tests` module per `data-model.md §cpe.rs`:
+- `generic_openssl_emits_canonical_cpe`
+- `generic_curl_emits_dual_candidates`
+- `generic_openjdk_strips_build_suffix`
+- `generic_symbol_fingerprint_only_emits_no_cpe`
+- Rename `unknown_ecosystem_returns_empty` → `generic_unknown_library_returns_empty`
+
+Plus the two well-formedness tests:
+- `mappings_alphabetically_sorted`
+- `mappings_cover_all_curated_libraries`
+
+Run via:
+
+```bash
+cargo +stable test -p mikebom --bin mikebom \
+    --no-fail-fast cpe:: 2>&1 | grep "test result:"
+# Expected: ok. <N>+5 passed (existing + 5 new).
+```
+
+## Recipe 3 — Add the integration test (SC-001 negative control)
+
+Create `mikebom-cli/tests/cpe_binary_id.rs` per `data-model.md §cpe_binary_id.rs`. The test:
+1. Copies the mikebom binary itself into a temp dir
+2. Runs `sbom scan --path <tempdir> --output <file> --no-deep-hash`
+3. Asserts the emitted CDX contains NO `cpe:2.3:a:openssl:openssl:` substring
+
+Mikebom uses `rustls` (not OpenSSL), so the assertion is a negative-control regression guard: if the milestone-096 binary scanner or the milestone-097 CPE table ever fires spuriously on mikebom's own bytes, this test catches it.
+
+Run via:
+
+```bash
+cargo +stable test -p mikebom --test cpe_binary_id 2>&1 | tail -5
+# Expected: ok. 1 passed.
+```
+
+## Recipe 4 — Run pre-PR gate + verify diff scope (Contract 6, Contract 7)
+
+```bash
+MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 ./scripts/pre-pr.sh
+# Expected: `>>> all pre-PR checks passed.`
+
+# Diff scope (Contract 6):
+git diff --name-only main | sort
+# Expected (allowlist):
+#   mikebom-cli/src/generate/cpe.rs
+#   mikebom-cli/tests/cpe_binary_id.rs
+#   specs/097-cpe-candidates/...
+#   CLAUDE.md (auto-updated by /speckit-plan)
+
+# No Cargo.* changes (FR-007):
+git diff --name-only main | grep -E '^Cargo\.(lock|toml)$' && echo "DEP CHURN" || echo "clean"
+# Expected: clean
+
+# Goldens regen scope (FR-009 / SC-006):
+git diff --stat mikebom-cli/tests/fixtures/golden/ | tail -1
+# Expected: empty output (no goldens regenerated).
+```
+
+## When in doubt
+
+- **A new library was added to milestone-098's version-string scanner but `mappings_cover_all_curated_libraries` test fails**: add a row to `GENERIC_LIBRARY_CPES` (1 line). If the library has no NVD-tracked CPE, add it to the documented-omission set in the test and document the omission rationale in a `//` comment above the table.
+- **A library's NVD vendor was renamed**: update the row's vendor string in-place. If the old vendor is still cited by older NVD records, demote it to a secondary candidate (add a second `(vendor, product)` pair after the primary).
+- **An OpenJDK-style version-suffix issue emerges for a new library**: extend the per-library special-case logic. Keep it inline in the `"generic"` arm rather than abstracting until a third such case appears.
+- **A binary triggers a spurious version-string match and the spurious component gets a CPE**: fix the milestone-096 version-string anchor (tighten the regex), not the CPE table. The CPE emission is downstream of identification; identification is the right layer to filter.
+- **An operator reports a missing CPE for an actual library that mikebom does identify**: add the row. v1 starter set is small by design; growth is one PR per library.

--- a/specs/097-cpe-candidates/research.md
+++ b/specs/097-cpe-candidates/research.md
@@ -1,0 +1,120 @@
+# Research — milestone 097 CPE candidate emission
+
+Phase 0 investigation. Four decision points, all resolved with audit-of-existing-code outcomes.
+
+## §1 — Existing CPE infrastructure audit (FR-008)
+
+**Decision**: extend `mikebom-cli/src/generate/cpe.rs::synthesize_cpes()` only. Zero changes to any emission file.
+
+**Evidence (from auditing main at `eca26f1`)**:
+
+| Concern | Where it already lives | Change needed |
+|---------|-----------------------|---------------|
+| CPE 2.3 format-string construction | `cpe.rs:129-136::format_cpe()` | None — reused |
+| Per-spec character escape | `cpe.rs:145-156::cpe_escape()` | None — reused |
+| Ecosystem-keyed candidate routing | `cpe.rs:21-111::synthesize_cpes()` match arm | **Add `"generic"` arm** |
+| Post-dedup invocation per ResolvedComponent | `scan_fs/mod.rs:641` | None — already runs |
+| CDX `component.cpe` emission | `cyclonedx/builder.rs:710` (first candidate) | None — auto-picks new candidate |
+| CDX `mikebom:cpe-candidates` property (overflow) | `cyclonedx/builder.rs:711-716` | None — applies when >1 candidate |
+| SPDX 2.3 `cpe23Type` external ref | `spdx/packages.rs:406-410` (first candidate) | None — auto-picks new candidate |
+| SPDX 3 `Software:cpe` external-id | `spdx/v3_external_ids.rs:51` iterates `cpes` | None — auto-picks new candidate |
+| Empty-version fast-return (FR-004) | `cpe.rs:25-28` | None — applies to symbol-fingerprint-only PURLs for free |
+
+**Net delta**: ~10 lines of mapping table + ~10 lines of new ecosystem arm + tests.
+
+**Rationale**: post-milestone-096, the binary-extracted `pkg:generic/openssl@3.0.13` PackageDbEntry flows through the same dedup → `synthesize_cpes(c)` pipeline as every other component. The synthesizer's "_ => empty Vec" catch-all at `cpe.rs:101-104` is the gap; adding a "generic" arm before the catch-all closes it.
+
+**Alternatives considered**:
+- **New module `cpe_candidates.rs`**: rejected — adds indirection without benefit. The "generic" mapping is naturally one more arm in the existing per-ecosystem `match`.
+- **Mapping table as `HashMap`**: rejected — 10 entries; linear-scan via `iter().find()` on a `const slice` is faster + diff-friendlier + compile-time-checked.
+- **Touch emission code**: not needed — all three format emitters already iterate `component.cpes`; adding a candidate to the Vec automatically surfaces.
+
+## §2 — v1 CPE mapping table (FR-001, FR-002)
+
+**Decision**: 10 entries covering the milestone-096 / earlier curated-library set (11 libs minus BoringSSL). Each row is `(library_slug, vendor, product)` with NVD-citation comments.
+
+| `library_slug` | NVD `vendor` | NVD `product` | Rationale |
+|---------------|--------------|--------------|-----------|
+| `openssl` | `openssl` | `openssl` | NVD canonical — every OpenSSL CVE since 2014 uses this pair |
+| `zlib` | `zlib` | `zlib` | NVD canonical |
+| `sqlite` | `sqlite` | `sqlite` | NVD canonical |
+| `curl` | `haxx` | `curl` | Historical NVD vendor for libcurl; modern records still file under `haxx:curl`. Some recent records use `curl:curl` — secondary candidate emitted via the existing multi-CPE property |
+| `pcre` | `pcre` | `pcre` | NVD canonical for PCRE 8.x |
+| `pcre2` | `pcre` | `pcre2` | NVD canonical for PCRE 10.x (same vendor, different product) |
+| `gnutls` | `gnu` | `gnutls` | NVD canonical |
+| `libressl` | `openbsd` | `libressl` | NVD canonical — most CVEs filed under OpenBSD's vendor namespace; `libressl:libressl` also appears for some records (secondary candidate) |
+| `llvm` | `llvm` | `llvm` | NVD canonical for the umbrella project (sub-projects clang/lld out of scope for v1) |
+| `openjdk` | `oracle` | `openjdk` | NVD canonical — `oracle:openjdk` dominates Java vuln records |
+
+**Omitted from v1**:
+- `boringssl` — no NVD-tracked CPE namespace; vulnerabilities flow through `openssl:openssl` records when the issue exists in upstream OpenSSL, but BoringSSL-specific issues lack their own CPE. Documented in spec Edge Cases. Skipping the row means BoringSSL components emit PURL without CPE — explicit "we don't know".
+
+**Multi-candidate emissions** (where two vendor:product pairs are plausible):
+- `curl` → `[haxx:curl, curl:curl]` — first goes to `component.cpe`, both go to `mikebom:cpe-candidates`
+- `libressl` → `[openbsd:libressl, libressl:libressl]` — same pattern
+- Other 8 libraries emit a single candidate.
+
+**Rationale**: the existing `synthesize_cpes` returns a `Vec<String>` to support exactly this multi-candidate case — the CDX emitter takes `[0]` as primary and dumps the full list into the `mikebom:cpe-candidates` property. Operators with fuzzy CVE matchers (Trivy, Grype) take the union; operators with strict matchers get the most-cited candidate. Matches the existing per-ecosystem pattern (dpkg emits `[debian:<pkg>, <pkg>:<pkg>]` per `cpe.rs:36-39`).
+
+## §3 — Version-handling decisions (FR-001 Edge Cases)
+
+**Decision**:
+
+| Case | Handling | Reason |
+|------|----------|--------|
+| OpenSSL letter-suffix (`1.1.1w`) | Emit as `cpe:...:openssl:openssl:1.1.1w:...` (verbatim) | CPE 2.3 §6.2 permits lowercase letters in version field; NVD records OpenSSL letters this way |
+| OpenJDK build-suffix (`21.0.1+12`) | Strip suffix before emission → `cpe:...:oracle:openjdk:21.0.1:...` | NVD inconsistency — sometimes `update_12`, sometimes `*`, sometimes omitted. Stripping matches the most-common shape |
+| SQLite source-id-only (no triplet captured) | Skip CPE emission (empty `version` → `synthesize_cpes` returns empty Vec) | Already handled by `cpe.rs:25-28` empty-version fast-return |
+| Symbol-fingerprint-only `pkg:generic/openssl` | Skip CPE emission (empty version) | Same path as SQLite-source-id-only; FR-004 satisfied for free |
+| Version with internal escape need (e.g. `+`, `/`) | `cpe_escape()` handles per CPE 2.3 §6.2 | Already in code at `cpe.rs:145-156` |
+
+**OpenJDK suffix strip — implementation**: at table-lookup time, special-case the `openjdk` slug to truncate the version at the first non-`[0-9.]` character. ~5 lines of code; doc-string explains the NVD inconsistency.
+
+## §4 — Test scope (SC-001, SC-002, SC-003, SC-004)
+
+**Decision**: extend the existing `cpe.rs::tests` module with 4 new test functions; add 1 integration test in `mikebom-cli/tests/cpe_binary_id.rs` that scans a synthetic fixture (or uses the milestone-096 control test pattern: mikebom-itself scan + assert NO openssl CPE because mikebom uses rustls).
+
+**Unit tests** (in `cpe.rs::tests`):
+1. `generic_openssl_emits_canonical_cpe` — `make_component("pkg:generic/openssl@3.0.13")` → asserts `cpes[0] == "cpe:2.3:a:openssl:openssl:3.0.13:*:..."`.
+2. `generic_curl_emits_dual_candidates` — `pkg:generic/curl@8.4.0` → asserts both `haxx:curl` and `curl:curl` candidates present.
+3. `generic_unknown_library_returns_empty` — RENAME existing `unknown_ecosystem_returns_empty` to clarify intent: `pkg:generic/weird@1.0.0` still returns empty because `weird` isn't in the mapping table.
+4. `generic_openjdk_strips_build_suffix` — `pkg:generic/openjdk@21.0.1+12` → asserts `cpes[0] == "cpe:2.3:a:oracle:openjdk:21.0.1:*:..."` (suffix stripped).
+
+**Integration test** (`mikebom-cli/tests/cpe_binary_id.rs`):
+- Scan a directory containing only the mikebom binary itself (which doesn't link OpenSSL) and assert the SBOM has zero `pkg:generic/openssl` components AND zero `cpe:2.3:a:openssl:openssl:*` strings anywhere in the JSON. Negative control for SC-007 spurious-emission bound.
+- (Optional positive control if a fixture binary is available: scan it, assert the emitted CDX has `components[*] | select(.purl=="pkg:generic/openssl@<ver>") | .cpe` matches the expected CPE 2.3 shape. Toolchain-graceful-skip if no fixture available — matches the milestone-096 pattern.)
+
+**SC-002 (CPE syntax validation)**: handled by `cpe_escape()` + the `format_cpe()` template — every emitted string is by construction a valid CPE 2.3 formatted-string binding. No external validator needed; mikebom emits, downstream tools parse.
+
+## §5 — Goldens regen forecast (FR-009, SC-006)
+
+**Decision**: regenerate the 3 format goldens once, accept the additive diff.
+
+**Forecast**: per milestone-096 SC-007 ≤1-spurious-bound, at most ONE existing fixture component newly gains a CPE field — likely zero. Realistically:
+- The 9 existing ecosystem fixtures (`apk/cargo/deb/gem/golang/maven/npm/pip/rpm`) do not contain `pkg:generic/<v1-library>@<version>` components (binary scanner doesn't fire on those fixtures; they're synthetic package-db fixtures).
+- The binary-id fixture set (milestone-096 controls in `binary_id_enrich.rs`) is integration-tested only, not gold-encoded.
+
+**Worst case**: zero golden regen. **Most-likely case**: zero. Diff scope guard via `git diff --stat mikebom-cli/tests/fixtures/golden/ | tail -1`.
+
+## Coverage map
+
+| Spec section | Resolution |
+|--------------|------------|
+| FR-001 (v1 CPE mapping for 10 libraries) | §2 → table locked |
+| FR-002 (in-source `const` table, alphabetical) | §2 + §1 → reuse existing `const`-pattern in `cpe.rs` |
+| FR-003 (silent skip on missing table entry) | §1 → existing match arm's catch-all returns empty Vec |
+| FR-004 (no CPE for versionless components) | §1 + §3 → existing empty-version fast-return |
+| FR-005 (composite-evidence inheritance) | §1 → milestone-096 merge produces single PackageDbEntry with `@version` PURL; CPE attaches to that |
+| FR-006 (syntax-valid CPE) | §3 + existing `cpe_escape()` |
+| FR-007 (no new Cargo deps) | §1-§4 — purely in-source |
+| FR-008 (production code scope) | §1 → single-file delta to `cpe.rs` |
+| FR-009 (≤ N golden regen) | §5 → forecast: zero |
+| FR-010 (parity catalog) | §1 → CPE fields are standards-native; no catalog row needed |
+| SC-001/SC-002/SC-003/SC-004 | §4 → unit + integration tests |
+| SC-005 (pre-PR gate clean) | inherits from CI |
+| SC-006 (golden regen scope) | §5 → expect zero |
+| SC-007 (zero Cargo deps) | inherits from FR-007 |
+| Constitution V audit | §1 → all 3 format fields are standards-native; no `mikebom:*` annotation added |
+| Constitution X transparency | §2 → mapping table in-source with NVD-citation comments per row |
+
+All open spec questions resolved. Ready for Phase 1 (data-model + contracts + quickstart).

--- a/specs/097-cpe-candidates/spec.md
+++ b/specs/097-cpe-candidates/spec.md
@@ -1,0 +1,147 @@
+# Feature Specification: CPE candidate emission for binary-identified components
+
+**Feature Branch**: `097-cpe-candidates`
+**Created**: 2026-05-12
+**Status**: Draft
+**Input**: User description: "milestone 097 — emit CPE candidates alongside the binary-extracted `pkg:generic/<lib>@<version>` components from milestone 096, so downstream vulnerability scanners can match without their own PURL-to-CPE mapping table"
+
+## Background
+
+Milestone 096 enriched mikebom's binary scanner to extract embedded version strings (11 libraries) and ELF symbol fingerprints (3 libraries) — both surface as `pkg:generic/<library>@<version>` components in the emitted SBOM. The PURL is sufficient identity for any tool that can map `pkg:generic/openssl@3.0.13` to its actual NVD records. **In practice, most CVE-driven scanners can't**.
+
+The dominant vulnerability matchers (Trivy, Grype, OWASP Dependency-Track, MSR-style enterprise scanners) drive their advisory lookup off **CPE 2.3 strings** — the NVD-defined platform-applicability identifier. A component with no CPE attached is effectively invisible to these scanners for advisories that key off the NVD CVE feed. For binaries with package-db-sourced components (dpkg/rpm/apk), the OS package metadata already carries enough information for downstream tools to construct a CPE. But for the *binary-extracted* `pkg:generic/openssl@3.0.13` from milestone 096 — the stripped third-party blob's static-link content — there is no package-db row, no maintainer-supplied CPE, and the operator's downstream scanner gets nothing.
+
+The fix: mikebom emits the CPE candidate **at SBOM-generation time**, using an in-source `(library → vendor, product)` mapping table indexed by the lowercase library slug that the milestone-096 scanners already produce. CDX 1.6 has a native `component.cpe` field; SPDX 2.3 has `externalRefs[].referenceType = "cpe23Type"`; SPDX 3 has `Software:cpe`. All three are first-class spec fields — no `mikebom:*` annotation needed, satisfying Constitution V (standards-native precedence).
+
+**Scope framing**: this milestone is deliberately narrow — *the v1 starter set is the same 11 libraries the embedded-version-string scanner already covers*. Operators who need broader coverage can extend the table in-source; new libraries land in follow-up milestones as the scanner backlog evolves. Composite-evidence components (where both version-string + symbol-fingerprint matched per milestone-096 Q1 clarification) inherit the version-string PURL's CPE candidate.
+
+**What this is NOT**: this is not CPE-name *matching* (looking up an unknown PURL against an external CPE database). This is candidate *generation* — converting an already-identified library's `pkg:generic/...` PURL into the CPE 2.3 string an NVD-driven scanner expects. The mapping is small (a handful of `vendor:product` pairs per library), maintainable in mikebom's source tree, and deterministic.
+
+Out of scope: external CPE-database lookups (NVD APIs, deps.dev), CPE-to-CPE alias resolution, package-db-sourced components (RPM/DEB/APK readers already produce CPEs via their distro metadata where applicable), version normalization beyond what the spec already requires.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Operator runs Trivy against a mikebom SBOM and CVEs land (Priority: P1)
+
+An operator scans a stripped binary with mikebom; the resulting CDX SBOM contains `pkg:generic/openssl@3.0.13` from the milestone-096 embedded-version-string scanner. They feed the SBOM to Trivy (or Grype, or Dependency-Track) for vulnerability matching. Today: zero CVE hits — the scanner has no CPE to drive its NVD lookup against. With this milestone: the same component carries `cpe:2.3:a:openssl:openssl:3.0.13:*:*:*:*:*:*:*` as a first-class CDX `component.cpe` field, and Trivy/Grype/DT match the OpenSSL 3.0.13 CVEs directly.
+
+**Why this priority**: this is the headline user-visible payoff of milestone 096. Without CPE emission, the static-link identification work from milestone 096 doesn't translate into downstream CVE visibility for the dominant scanner ecosystem. Operators see PURLs in the SBOM but no advisories on their dashboards.
+
+**Independent Test**: emit an SBOM containing a synthetic `pkg:generic/openssl@3.0.13` component (or run the milestone-096 openssl-static control test); inspect the CDX JSON; confirm `components[?(@.purl=='pkg:generic/openssl@3.0.13')].cpe == 'cpe:2.3:a:openssl:openssl:3.0.13:*:*:*:*:*:*:*'`. Feed the SBOM to a current Trivy/Grype binary and confirm the OpenSSL 3.0.13 CVE list appears in the scanner output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a CDX SBOM containing `pkg:generic/openssl@3.0.13` from the milestone-096 embedded-version-string scanner, **When** mikebom emits the SBOM, **Then** the same component carries `cpe = cpe:2.3:a:openssl:openssl:3.0.13:*:*:*:*:*:*:*` (CDX 1.6 native `component.cpe` field).
+2. **Given** the same component, **When** mikebom emits the SBOM as SPDX 2.3, **Then** the Package carries `externalRefs[]` containing `{ referenceCategory: "SECURITY", referenceType: "cpe23Type", referenceLocator: "cpe:2.3:a:openssl:openssl:3.0.13:*:*:*:*:*:*:*" }`.
+3. **Given** the same component, **When** mikebom emits the SBOM as SPDX 3, **Then** the `Software/Package` element carries `cpe = ["cpe:2.3:a:openssl:openssl:3.0.13:*:*:*:*:*:*:*"]` (or whatever SPDX 3's canonical `cpe` field name is per the milestone-079 vocab inventory).
+4. **Given** a binary triggering BOTH version-string AND symbol-fingerprint matches for OpenSSL on the same scan (composite-evidence per milestone-096 Q1), **When** mikebom emits the SBOM, **Then** the merged component still carries exactly ONE CPE candidate — the version-string-derived one. No double-emission, no second CPE for the symbol-fingerprint half of the evidence trail.
+
+---
+
+### User Story 2 — Maintainer extends the CPE vendor/product table when adding a new library (Priority: P2)
+
+A maintainer adds `libpng` to a future milestone's version-string scanner. They open the CPE mapping table in `mikebom-cli/src/generate/cpe_candidates.rs` (or equivalent), see a clean `const CPE_MAPPINGS: &[(library_slug, vendor, product)]` table mirroring the version-string `CuratedLibrary::slug()` enum, and add `("libpng", "libpng", "libpng")` in one line. Tests verify the emission shape for the new library.
+
+**Why this priority**: P2 because the v1 starter set covers the libraries the scanner can already identify; the maintainer-friendly extension story is what keeps this from becoming a write-once frozen artifact. Future milestones extend the version-string scanner OR the symbol-fingerprint scanner; the CPE table needs to track both surfaces.
+
+**Independent Test**: add a row to the CPE mapping table for a synthetic test library, build, run a unit test that calls the candidate-builder with a `pkg:generic/test-lib@1.2.3` PURL, confirm the produced CPE 2.3 string matches `cpe:2.3:a:test-lib:test-lib:1.2.3:*:*:*:*:*:*:*` (or whatever the table's vendor/product values were).
+
+**Acceptance Scenarios**:
+
+1. **Given** the CPE mapping table file, **When** a maintainer reads it, **Then** the table is a single in-source `const` with `(library_slug, vendor, product)` triples — no scattered per-library constants, no JSON config file, no DB. Sorted alphabetically by `library_slug` for diff-friendliness.
+2. **Given** a maintainer adds one row to the table, **When** they recompile + run the unit-test suite, **Then** the new library produces a valid CPE 2.3 string on a synthetic `pkg:generic/<slug>@<version>` PURL — no further wiring required.
+3. **Given** the table is missing a row for some library, **When** mikebom emits an SBOM containing that library's `pkg:generic/...` component, **Then** the component emits WITHOUT a CPE (silent skip), no SBOM-validation error, no crash. The operator sees the PURL but no CPE; this is an explicit "we don't know" rather than a guess.
+
+---
+
+### User Story 3 — Operator scans a symbol-fingerprint-only binary and the SBOM withholds the CPE (Priority: P2)
+
+An operator scans a binary that exports OpenSSL's symbol set but doesn't carry the embedded version string. The milestone-096 symbol-fingerprint scanner emits `pkg:generic/openssl` (no `@<version>` segment) with `mikebom:evidence-kind = symbol-fingerprint` and `confidence = heuristic`. Mikebom does NOT emit a CPE for this component — a wildcard-version CPE (`cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*`) would match *every* OpenSSL CVE ever filed, drowning downstream scanners in false positives that the operator can neither verify nor dismiss.
+
+**Why this priority**: P2 because it's a transparency-and-safety policy decision: emitting wildcard CPEs for symbol-only matches would degrade the operator's signal-to-noise ratio more than helping. Better to surface the PURL without CPE and let the operator make a manual call on whether to investigate further.
+
+**Independent Test**: build a test binary with OpenSSL symbols but no version string (or use the milestone-096 `openssl-symbols-only` fixture); scan; inspect the emitted SBOM; confirm the `pkg:generic/openssl` component has NO `cpe` field on its CDX entry, and NO `cpe23Type` `externalRefs` entry on its SPDX 2.3 Package.
+
+**Acceptance Scenarios**:
+
+1. **Given** a component with PURL shape `pkg:generic/<lib>` (no `@<version>` segment), **When** mikebom emits the SBOM, **Then** the component carries no `cpe` field (CDX), no `cpe23Type` external ref (SPDX 2.3), no `cpe` array entry (SPDX 3).
+2. **Given** the same operator inspects the SBOM, **When** they look for the OpenSSL component, **Then** they see the `pkg:generic/openssl` PURL, the `mikebom:evidence-kind = symbol-fingerprint` property, and the `mikebom:fingerprint-symbols-matched = 9/10` annotation — but no CPE. The transparency is: "we identified the library family, not the version; CVE matching requires a version pin".
+
+---
+
+### Edge Cases
+
+- **Library with no NVD-tracked CPE** (e.g., a niche library that NVD has never advisory'd): the mapping table simply omits that row. Component emits with PURL but no CPE. Same code path as US2 acceptance scenario 3.
+- **Version-letter suffix** (OpenSSL `1.1.1w`): CPE 2.3 accepts the version string verbatim — `cpe:2.3:a:openssl:openssl:1.1.1w:*:*:*:*:*:*:*` is valid. No special-case translation needed.
+- **Version with NVD-internal modification format** (e.g., NVD sometimes splits `1.1.1w` into `1.1.1:w` for update qualifier): out of scope for v1. Mikebom emits the raw version triplet; downstream scanners apply their own version-matching heuristics. Document the limitation in research.
+- **OpenJDK version with build suffix** (`21.0.1+12`): CPE 2.3 doesn't natively encode `+`; some NVD records use `update_12`, others put it in the `update` field. v1 emits the raw `21.0.1` (drops build suffix for CPE; full version stays on the PURL). Conservative: less false-negative risk than emitting a CPE that doesn't match any NVD record.
+- **BoringSSL fingerprint** (no NVD-tracked CPE — BoringSSL has CVE history but Google doesn't get standalone CPEs; vulnerabilities flow through `openssl:openssl`): omit BoringSSL from the v1 table. Document the gap.
+- **PCRE vs PCRE2**: two separate NVD records — `pcre:pcre` for PCRE 8.x, `pcre:pcre2` for PCRE 10.x. The version-string scanner already disambiguates; the CPE table picks the matching vendor/product pair for each.
+- **LibreSSL conflict** (`libressl:libressl` exists, but most CVEs are filed against `openbsd:libressl`): primary vendor is `openbsd:libressl` (the more-cited NVD shape — LibreSSL is an OpenBSD project and most advisory records use that namespace). Secondary candidate `libressl:libressl` is emitted via the existing `mikebom:cpe-candidates` property so fuzzy NVD matchers (Trivy, Grype) can take the union.
+- **LLVM** (compiler infrastructure, multiple sub-projects): NVD typically uses `llvm:llvm` for the umbrella project. Sub-component CVEs (`llvm:clang`, `llvm:lld`) are out of scope for v1 — the version-string scanner doesn't distinguish them anyway.
+- **SQLite encoding quirks**: NVD uses `sqlite:sqlite`. SQLITE_SOURCE_ID hashes (the milestone-096 fallback when version triplet isn't extractable) don't map to NVD records — omit CPE when only the source-id is captured.
+- **Composite evidence inheritance**: the milestone-096 Q1 merge produces one component with two evidence-identity entries. The CPE inherits from the version-string-side PURL (which has `@<version>`), not the symbol-fingerprint side (which doesn't). Verified by US1 acceptance scenario 4.
+- **Malformed CPE syntax fail-soft**: if the candidate-builder produces a syntactically-invalid CPE 2.3 string (e.g., a version containing whitespace or unescaped reserved character — should be impossible given the existing version-string scanner's anchors, but defensive), the component emits without a CPE rather than with a corrupt one.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: For each `pkg:generic/<library>@<version>` component in the emitted SBOM where `<library>` matches a row in the v1 CPE-mapping table, mikebom MUST emit `cpe:2.3:a:<vendor>:<product>:<version>:*:*:*:*:*:*:*` on the corresponding CDX `component.cpe` field, SPDX 2.3 `externalRefs[].referenceLocator` (with `referenceType = cpe23Type`, `referenceCategory = SECURITY`), and SPDX 3 `Software:cpe` (or the SPDX 3 IRI-vocab equivalent per milestone-079's IRI registry). v1 mapping table MUST cover **10 libraries** — OpenSSL, zlib, SQLite, curl, PCRE, PCRE2, GnuTLS, LibreSSL, LLVM, OpenJDK. The 11th library identified by the existing embedded-version-string scanner (BoringSSL) is omitted because it has no NVD-tracked CPE namespace; documented in Edge Cases. SQLite and OpenJDK are both in the table — only their version-handling edge cases (SQLite source-id-only suppression; OpenJDK build-suffix stripping) are covered separately per Edge Cases.
+- **FR-002**: The CPE-mapping table MUST live as a single in-source `const` array of `(library_slug, vendor, product)` triples, sorted alphabetically by `library_slug` for diff-friendliness. Adding a library MUST require touching only that one table — no scattered per-library wiring elsewhere.
+- **FR-003**: Components with no mapping-table entry (e.g., a maintainer adds version-string support for a library before adding its CPE row) MUST emit silently — the PURL appears, no CPE field, no error, no warning at INFO level. The "missing" state is explicit-by-omission; an operator who needs the CPE files a PR adding the row.
+- **FR-004**: Components without a captured version (`pkg:generic/<library>` shape — the symbol-fingerprint-only case from milestone-096 FR-004 per Clarification Q1 inheritance + the SQLite source-id-only edge case) MUST NOT emit a CPE. Wildcard-version CPEs are explicitly out of scope per Edge Case rationale.
+- **FR-005**: When a component carries BOTH milestone-096 evidence techniques (composite-evidence per Q1), the CPE is derived from the version-string PURL only — the version-pinned form. The symbol-fingerprint evidence does NOT add a second CPE. Composite components emit exactly ONE `cpe` field value.
+- **FR-006**: Generated CPE 2.3 strings MUST be syntactically valid per the [CPE 2.3 specification](https://csrc.nist.gov/projects/security-content-automation-protocol/specifications/cpe). Vendor/product slugs are lowercase ASCII; version is the verbatim captured triplet (with OpenSSL letter-suffix preserved; OpenJDK build-suffix stripped per Edge Cases). Pre-emission validation MUST reject any malformed candidate (e.g., one containing whitespace or unescaped reserved characters) and emit no CPE in that case rather than a corrupt one — fail-soft to "no CPE", never fail-loud.
+- **FR-007**: No new Cargo dependencies. CPE 2.3 emission is a pure-Rust string-formatting operation — no parser crate, no schema validator beyond a hand-rolled regex check. Constitution Principle I (zero new transitive crates per milestone unless justified) compliance.
+- **FR-008**: Production code changes confined to `mikebom-cli/src/generate/` (the existing `cpe.rs` module which already emits CPE candidates for package-db-sourced components is the natural home — extend it). No changes to `scan_fs/binary/`, no changes to `mikebom-common/`, no changes to the parity-catalog.
+- **FR-009**: Goldens may regenerate for the 11 v1 libraries if any existing fixture contains a binary that triggers a version-string match for those libraries. Per milestone-096 SC-007, the ≤1-spurious-match bound across the 9 existing ecosystem fixtures means the golden diff is bounded — likely zero or one component gaining a new `cpe` field.
+- **FR-010**: The parity-catalog row(s) currently covering `component.cpe` (CDX) / `cpe23Type` external refs (SPDX 2.3) / `Software:cpe` (SPDX 3) MUST already exist OR be added in this milestone IF the milestone introduces a new format-parity surface. Audit at planning time per Constitution V's standards-native-precedence rule; this is a documented native field across all 3 formats so no `mikebom:*` annotation is needed.
+
+### Key Entities
+
+- **CPE mapping entry**: a `(library_slug, vendor, product)` triple. `library_slug` is the lowercase string emitted by `version_strings::CuratedLibrary::slug()` (or `symbol_fingerprint::SymbolFingerprintMatch::library`). `vendor` and `product` are the NVD-canonical CPE 2.3 component-name strings (lowercase, no spaces, hyphens preserved). One entry per supported library.
+- **CPE candidate**: a CPE 2.3 string of the form `cpe:2.3:a:<vendor>:<product>:<version>:*:*:*:*:*:*:*`, produced at SBOM-generation time from a mapping entry plus a component's version field. Attached to the component via the format-native field (CDX `cpe`, SPDX 2.3 external ref, SPDX 3 `Software:cpe`).
+- **Mapping audit log entry**: an in-source `//` comment next to each table row documenting the NVD-citation rationale (e.g., `// libpng vuln history filed under libpng:libpng per NVD CVE-2024-XXXX`). Doesn't appear in emitted SBOMs; lives in the source tree for maintainer transparency.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator scans a fixture containing a `pkg:generic/openssl@3.0.13` component; the emitted CDX SBOM has `components[?(@.purl=='pkg:generic/openssl@3.0.13')].cpe == 'cpe:2.3:a:openssl:openssl:3.0.13:*:*:*:*:*:*:*'`. Verified end-to-end via Trivy invocation: feed the SBOM to `trivy sbom <file>`, confirm ≥1 OpenSSL 3.0.13 CVE appears in the output. (Toolchain-graceful-skip if `trivy` unavailable.)
+- **SC-002**: All 11 v1-supported library slugs (minus the documented exclusions) emit valid CPE 2.3 strings on a representative synthetic-PURL test set. Validation: each emitted string parses via a CPE 2.3 syntax check (URI-formatted CPE WFN canonical form) without error.
+- **SC-003**: Symbol-fingerprint-only components emit NO CPE — verified by integration test that scans a fixture that produces a `pkg:generic/openssl` (no version) component and asserts the absence of any CPE-related field across CDX, SPDX 2.3, and SPDX 3.
+- **SC-004**: Composite-evidence components (milestone-096 Q1) emit exactly ONE CPE — verified by integration test scanning a fixture that triggers both version-string + symbol-fingerprint matches for OpenSSL; the resulting merged component has exactly one CDX `cpe` field, one `cpe23Type` external ref in SPDX 2.3, one `cpe` array entry in SPDX 3.
+- **SC-005**: `./scripts/pre-pr.sh` clean — zero clippy warnings, every test target reports `0 failed`. `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1` opt-in also passes (CPE emission preserves SPDX 3 conformance — the validator accepts `Software:cpe` arrays).
+- **SC-006**: Golden regen scope bounded — at most 3 goldens regenerate (the 3 formats × 1 fixture if any existing fixture contains a binary-extracted CPE-eligible component). Per milestone-096 SC-007 the spurious-match bound was ≤1 across all 9 ecosystem fixtures, so this milestone inherits that constraint.
+- **SC-007**: Zero new Cargo dependencies (FR-007).
+
+## Assumptions
+
+- The 11 v1 libraries cover the bulk of statically-linked CVE-relevant cases that the milestone-096 scanner can identify. New library coverage lands in follow-up milestones (097.x or 098.x) as the version-string + symbol-fingerprint scanners expand.
+- NVD vendor/product names for the v1 libraries are stable enough that a once-set in-source table doesn't need monthly re-curation. Vendor renames in NVD do happen (rarely); when one is observed, a PR updates the table.
+- CPE 2.3 is the dominant format target. CPE 2.2 ("URI binding") is legacy; modern Trivy / Grype / Dependency-Track all consume 2.3. Skipping 2.2 emission keeps the table simple.
+- CDX 1.6's `component.cpe`, SPDX 2.3's `externalRefs[].referenceType = cpe23Type`, and SPDX 3's `Software:cpe` are stable native fields per the format specs (verified at planning time against the existing milestone-011 / -078 / -079 vocabulary inventory). No format-spec workarounds required.
+- Existing package-db-sourced components (RPM/DEB/APK readers) either already emit CPEs via their distro metadata or are out of scope for this milestone — milestone 097 narrowly targets the binary-extracted `pkg:generic/...@...` cases, not the broader CPE-everywhere ambition.
+- Existing `mikebom-cli/src/generate/cpe.rs` is the natural home for the new code (extend, not replace). At planning time the implementer audits its current shape to confirm — if it's RPM-specific, the new code lives in a sibling module under the same parent directory.
+
+## Dependencies
+
+- **Milestone 096** (binary-id enrichment) — provides the `pkg:generic/<lib>@<version>` components that this milestone enriches with CPE candidates. Direct dependency on milestone-096 PURL shape + library slug naming.
+- **Milestone 011** (SPDX 3 full support) — provides the SPDX 3 emission infrastructure; the new CPE field flows through the existing SPDX 3 builder.
+- **Milestone 079** (SPDX 3 ID vocab) — confirms the SPDX 3 `Software:cpe` field's exact IRI / canonical-name; this milestone defers to that registry for the field-name choice.
+- **Milestone 052/047** (lifecycle scope + standards-native precedence) — the existing pattern for emitting standards-native fields (no `mikebom:*` annotation) the new code follows.
+
+## Out of Scope
+
+- **External CPE database lookups** (NVD APIs, deps.dev CPE queries, ClearlyDefined). Network-fetch fallback; high-cost; deferred to a future milestone if signal emerges.
+- **CPE-to-CPE alias resolution** (e.g., `openssl:openssl` ↔ `openssl:openssl-foundation` ↔ `redhat:openssl`). The emitted CPE is the most-cited NVD vendor/product pair; downstream scanners do their own alias resolution.
+- **CPE 2.2 emission** (legacy URI binding). Modern scanners consume 2.3; the URI-form is documented as legacy in the CPE spec.
+- **Symbol-fingerprint-only CPE emission** (wildcard-version CPEs). Per FR-004 + Edge Cases — they generate too many false-positive CVE matches to be useful.
+- **CPE emission for package-db-sourced components** (RPM/DEB/APK readers). Those readers emit format-native PURLs (`pkg:rpm/...`, `pkg:deb/...`) and downstream tools have well-established PURL→CPE mapping for distro packages. Out of scope for this milestone; could be a separate milestone if signal emerges.
+- **Vendor-table runtime configuration** (CLI flag to add CPE rows from a YAML file at scan-time). Source-code edits suffice for v1; a runtime config path adds attack surface and dependency churn for marginal gain.
+- **Per-component CPE multiplicity at the top-level field**. CDX 1.6 `component.cpe` is single-valued by spec; mikebom emits ONE primary candidate there. The existing `mikebom:cpe-candidates` property (already populated by the deb/apk/rpm readers when their synthesizer produces multiple plausible vendor:product pairs) carries the secondary candidates for libraries where two vendors are both NVD-cited (curl: `haxx:curl` primary, `curl:curl` secondary; libressl: `openbsd:libressl` primary, `libressl:libressl` secondary). What's out of scope is *broader alias-explosion* — e.g., emitting `redhat:openssl` + `oracle:openssl` + every distro's namespace alongside the upstream `openssl:openssl`. Two well-cited NVD candidates per library is the ceiling for v1; alias resolution beyond that belongs in the downstream scanner, not the SBOM.
+- **OpenJDK build-suffix encoding** (`+12` in CPE update field). The CPE spec accommodates it, but NVD records are inconsistent — some use `update_12`, some `*`, some omit. v1 strips the suffix to match the most-common NVD shape; revisit if false-negatives emerge.
+- **CPE 2.3 "Update" field for security patches** (e.g., OpenSSL `1.0.2t` as `cpe:2.3:a:openssl:openssl:1.0.2:t:*:...`). Some NVD records split the letter into the update field; the milestone-096 version-string scanner emits the suffix as part of the version. v1 stays with the verbatim version; revisit if false-negatives emerge.
+- **CPE deprecation tracking** (some CPEs are deprecated in favor of newer ones per NVD's CPE dictionary). Beyond scope; the v1 table picks current canonical names per NVD's current state.
+- **SBOM-validate-time CPE-vs-PURL consistency check** (ensuring the emitted CPE matches the PURL's library identity). The mapping table is the source of truth; the components-emitting code unconditionally trusts it.

--- a/specs/097-cpe-candidates/tasks.md
+++ b/specs/097-cpe-candidates/tasks.md
@@ -1,0 +1,261 @@
+---
+description: "Task list for milestone 097 — CPE candidate emission for binary-identified pkg:generic/<lib>@<version> components"
+---
+
+# Tasks: CPE candidate emission for binary-identified components
+
+**Input**: Design documents from `/Users/mlieberman/Projects/mikebom/specs/097-cpe-candidates/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/cpe-emission-contracts.md, quickstart.md
+
+**Tests**: Included. Unit tests in `cpe.rs::tests` cover Contracts 1-5; one integration test covers the SC-007 negative-control bound.
+
+**Organization**: All three user stories converge on a single-file delta to `mikebom-cli/src/generate/cpe.rs`. US1 (P1) is the headline CPE-emission behavior. US2 (P2) is the *maintainability shape* of US1's mapping table — same code change, different framing. US3 (P2) is *automatic* via the existing `cpe.rs:25-28` empty-version fast-return; only a verification test is needed.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: User story this task belongs to (US1–US3)
+- File paths are workspace-relative.
+
+## Path Conventions
+
+Production code: `mikebom-cli/src/generate/cpe.rs` (single-file delta per plan.md). Integration test: `mikebom-cli/tests/cpe_binary_id.rs` (NEW). Zero changes to any other production file (FR-008).
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Verify environment + confirm preconditions before touching production code.
+
+- [X] T001 Confirm working branch is `097-cpe-candidates`. Run `git status` + `git log -1 --oneline`; verify branch was created by `/speckit-specify` and main is at post-PR-#203 (alpha.31 release) or later.
+- [X] T002 Confirm baseline pre-PR gate passes. Run `./scripts/pre-pr.sh` once on the unchanged tree; expect `>>> all pre-PR checks passed.` Isolates any post-edit failure as introduced by milestone 097.
+- [X] T003 Audit existing `cpe.rs` infrastructure per research §1. Run:
+    ```bash
+    grep -n 'fn synthesize_cpes\|match ecosystem\|return Vec::new()' mikebom-cli/src/generate/cpe.rs | head -5
+    grep -n 'component\.cpes\|c\.cpes' mikebom-cli/src/generate/cyclonedx/builder.rs mikebom-cli/src/generate/spdx/packages.rs mikebom-cli/src/generate/spdx/v3_external_ids.rs | head -5
+    ```
+    Expected: `synthesize_cpes` defined; `match ecosystem` block present with a `_ => return Vec::new();` catch-all that the new `"generic"` arm will go *before*; all three emission files already consume `component.cpes`. Confirms zero emission-side changes needed.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No shared infrastructure across all three user stories — the mapping table addition lives in US1's phase (T004) because the maintainability *shape* of that table IS US2's implementation. US3 is satisfied by the existing empty-version fast-return at `cpe.rs:25-28`; no new code path.
+
+(No tasks in this phase — file-level convergence between US1 / US2 / US3.)
+
+**Checkpoint**: US1, US2, US3 share the same edit to `cpe.rs`. Implementation order: T004 (table) → T005 (arm) → tests. US2 is satisfied as a side-effect of T004's maintainability requirements; US3 is satisfied as a side-effect of the existing empty-version fast-return (no new code path).
+
+---
+
+## Phase 3: User Story 1 — Operator runs Trivy against a mikebom SBOM and CVEs land (Priority: P1) 🎯 MVP
+
+**Goal**: For every binary-extracted `pkg:generic/<lib>@<version>` component whose `<lib>` is in the v1 mapping table, emit a canonical CPE 2.3 string on CDX `component.cpe`, SPDX 2.3 `cpe23Type` external ref, and SPDX 3 `Software:cpe` external-id. 10 libraries in v1: openssl / zlib / sqlite / curl / pcre / pcre2 / gnutls / libressl / llvm / openjdk.
+
+**Independent Test**: synthesize an SBOM containing `pkg:generic/openssl@3.0.13`; inspect the CDX JSON; confirm `components[?(@.purl=='pkg:generic/openssl@3.0.13')].cpe == 'cpe:2.3:a:openssl:openssl:3.0.13:*:*:*:*:*:*:*'`. (Toolchain-graceful end-to-end check: feed the SBOM to a current Trivy binary and confirm the OpenSSL 3.0.13 CVE list appears; skip if `trivy` unavailable.)
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] Add the `GENERIC_LIBRARY_CPES` const table to `mikebom-cli/src/generate/cpe.rs` per `data-model.md §cpe.rs — extension shape`. 10 rows, sorted alphabetically by library_slug for diff-friendliness per FR-002. Include the in-source NVD-citation `//` comment per row (research §2). The table goes above `synthesize_cpes` near the existing `use` statements.
+- [X] T005 [US1] Add the `"generic"` ecosystem arm to the `match ecosystem` block inside `synthesize_cpes` in `mikebom-cli/src/generate/cpe.rs`. Insert immediately BEFORE the existing `_ => { return Vec::new(); }` catch-all. Arm body per `data-model.md §cpe.rs — extension shape`: lookup by library_slug → `Option<&[(vendor, product)]>`; missing → empty Vec (FR-003 silent-skip); special-case `openjdk` to strip build-suffix before `format_cpe()`; emit one CPE per mapping pair.
+
+### Tests for User Story 1
+
+- [X] T006 [P] [US1] Add unit test `generic_openssl_emits_canonical_cpe` to `mikebom-cli/src/generate/cpe.rs::tests` per `data-model.md`. Asserts `synthesize_cpes(pkg:generic/openssl@3.0.13)` returns `["cpe:2.3:a:openssl:openssl:3.0.13:*:*:*:*:*:*:*"]`.
+- [X] T007 [P] [US1] Add unit test `generic_curl_emits_dual_candidates` to `mikebom-cli/src/generate/cpe.rs::tests`. Asserts multi-vendor emission: `pkg:generic/curl@8.4.0` → `[haxx:curl, curl:curl]` (both pairs present, declaration order preserved).
+- [X] T008 [P] [US1] Add unit test `generic_openjdk_strips_build_suffix` to `mikebom-cli/src/generate/cpe.rs::tests`. Asserts `pkg:generic/openjdk@21.0.1+12` → `["cpe:2.3:a:oracle:openjdk:21.0.1:*:*:*:*:*:*:*"]` (suffix stripped; PURL unchanged).
+- [X] T009 [P] [US1] Add unit test `composite_evidence_emits_single_cpe` to `mikebom-cli/src/generate/cpe.rs::tests` covering FR-005 / SC-004. Constructs a single `ResolvedComponent` with `purl = pkg:generic/openssl@3.0.13` (representing the milestone-096 Q1 composite-merge output where both version-string + symbol-fingerprint matched), calls `synthesize_cpes(c)`, asserts `len() == 1` and `cpes[0] == "cpe:2.3:a:openssl:openssl:3.0.13:*:*:*:*:*:*:*"`. Verifies that milestone-096's Q1 merge correctly produces ONE PackageDbEntry → ONE CPE field downstream — no duplicate emission for the symbol-fingerprint half of the evidence trail.
+- [X] T010 [US1] Verify Contract 1 from `contracts/cpe-emission-contracts.md`. Run:
+    ```bash
+    cargo +stable test -p mikebom --bin mikebom \
+        --no-fail-fast generic_openssl_emits_canonical_cpe \
+        generic_curl_emits_dual_candidates \
+        generic_openjdk_strips_build_suffix \
+        composite_evidence_emits_single_cpe 2>&1 | grep "test result:"
+    # Expected: ok. 4 passed.
+    ```
+
+**Checkpoint**: US1 complete. MVP win lands — Trivy/Grype/DT can now match advisories on binary-extracted OpenSSL components.
+
+---
+
+## Phase 4: User Story 2 — Maintainer extends the CPE vendor/product table (Priority: P2)
+
+**Goal**: The mapping table is structured so adding a new library is a one-line PR. Table is a single in-source `const`, alphabetically sorted, with per-row NVD-citation comments. Build-time test asserts the table covers every curated library slug from the milestone-096 + earlier version-string scanner.
+
+**Independent Test**: insert a new mapping row in `GENERIC_LIBRARY_CPES`; recompile; confirm a unit test calling `synthesize_cpes(pkg:generic/<new-slug>@1.2.3)` returns the expected CPE.
+
+**Note**: T004 (the table itself) is shared with US1 because the maintainability *shape* of US1's table IS the US2 implementation. Phase 4 only adds the well-formedness checks that lock the maintainability contract in.
+
+### Tests for User Story 2
+
+- [X] T011 [P] [US2] Add unit test `mappings_alphabetically_sorted` to `mikebom-cli/src/generate/cpe.rs::tests`. Walks `GENERIC_LIBRARY_CPES` and asserts `.windows(2).all(|w| w[0].0 < w[1].0)` to keep diffs friendly per FR-002. This is a build-time gate: if a new row breaks alphabetical order, the test fails and the maintainer reorders.
+- [X] T012 [P] [US2] Add unit test `mappings_all_emit_valid_cpe23` to `mikebom-cli/src/generate/cpe.rs::tests` covering SC-002. Iterates every row in `GENERIC_LIBRARY_CPES`; for each `(library_slug, vendors)` pair builds a synthetic `ResolvedComponent` with `purl = format!("pkg:generic/{slug}@1.2.3")`; calls `synthesize_cpes`; asserts the returned Vec has length ≥1 and every emitted CPE string starts with `"cpe:2.3:a:"` and contains exactly 12 unescaped colon separators (CPE 2.3 has 13 segments). Locks the FR-006 "syntactically valid CPE 2.3" invariant at build time across the entire table — protects against a future maintainer adding a row whose vendor/product string breaks `format_cpe()` shape.
+- [X] T013 [P] [US2] Add unit test `mappings_cover_all_curated_libraries` to `mikebom-cli/src/generate/cpe.rs::tests`. Walks `version_strings::CuratedLibrary` variants (via `slug()`), checks each against `GENERIC_LIBRARY_CPES` keys, and asserts every slug is either present in the table OR present in a documented-omission allowlist (`["boringssl"]` per spec). Catches the "scanner-team-added-a-library-but-forgot-the-CPE-row" regression at build time. **Implementation note (A1)**: `version_strings::CuratedLibrary` is `pub` and `slug()` is `pub fn` per audit; reach it via `crate::scan_fs::binary::version_strings::CuratedLibrary`. If module-visibility blocks the import at test time, fall back to a hardcoded local mirror of the slug list with a `//` comment pointing at `version_strings.rs` as the source of truth.
+- [X] T014 [US2] Verify Contract 5 from `contracts/cpe-emission-contracts.md`. Run:
+    ```bash
+    cargo +stable test -p mikebom --bin mikebom \
+        --no-fail-fast mappings_alphabetically_sorted \
+        mappings_all_emit_valid_cpe23 \
+        mappings_cover_all_curated_libraries 2>&1 | grep "test result:"
+    # Expected: ok. 3 passed.
+    ```
+
+**Checkpoint**: US2 complete. Maintainability contract locked in via build-time tests.
+
+---
+
+## Phase 5: User Story 3 — Symbol-fingerprint-only binary's SBOM withholds the CPE (Priority: P2)
+
+**Goal**: Components without a captured version (`pkg:generic/<library>` shape from milestone-096 symbol-fingerprint, or SQLite source-id-only edge case) emit NO CPE. Wildcard-version CPEs would over-match every NVD record for the vendor:product pair.
+
+**Independent Test**: synthesize a component with empty `version` field; call `synthesize_cpes`; expect empty Vec.
+
+**Note**: this US is *automatic* via the existing `cpe.rs:25-28` empty-version fast-return path (no new code). T015's test plus the regression of the existing `empty_version_returns_empty` test (already passing) cover the invariant.
+
+### Tests for User Story 3
+
+- [X] T015 [P] [US3] Add unit test `generic_symbol_fingerprint_only_emits_no_cpe` to `mikebom-cli/src/generate/cpe.rs::tests`. Constructs a component with `pkg:generic/openssl@dummy`, clears its `version` field, calls `synthesize_cpes`, asserts empty Vec returned. Documents in the test body the FR-004 + symbol-fingerprint-only / SQLite-source-id-only inheritance.
+- [X] T016 [P] [US3] Rename existing `unknown_ecosystem_returns_empty` → `generic_unknown_library_returns_empty` in `mikebom-cli/src/generate/cpe.rs::tests` to reflect post-097 semantics. Existing assertion (`pkg:generic/weird@1.0.0` → empty Vec) is preserved — `weird` is not in the new `GENERIC_LIBRARY_CPES` table, so the test still validates FR-003 silent-skip behavior.
+- [X] T017 [US3] Verify Contracts 2 and 3 from `contracts/cpe-emission-contracts.md`. Run:
+    ```bash
+    cargo +stable test -p mikebom --bin mikebom \
+        --no-fail-fast generic_symbol_fingerprint_only_emits_no_cpe \
+        generic_unknown_library_returns_empty \
+        empty_version_returns_empty 2>&1 | grep "test result:"
+    # Expected: ok. 3 passed.
+    ```
+
+**Checkpoint**: US3 complete. Symbol-fingerprint-only suppression verified; existing empty-version + missing-table-entry paths covered by tests.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Integration test for the SC-007 spurious-emission bound; final pre-PR gate; diff-scope guardrails.
+
+- [X] T018 [P] Create `mikebom-cli/tests/cpe_binary_id.rs` per `data-model.md §cpe_binary_id.rs — NEW integration test`. The test (`mikebom_self_scan_emits_no_spurious_openssl_cpe`):
+    1. Copies the mikebom binary itself into a temp dir
+    2. Runs `mikebom sbom scan --path <tempdir> --output <file> --no-deep-hash`
+    3. Asserts the emitted CDX JSON contains NO `cpe:2.3:a:openssl:openssl:` substring (mikebom uses rustls, not OpenSSL)
+    Negative control for SC-007 — guards against the milestone-096 binary scanner or the milestone-097 CPE table firing spuriously on mikebom's own bytes.
+- [X] T019 Verify Contract 6 — diff scope guardrails. Run:
+    ```bash
+    # No new Cargo deps (FR-007):
+    git diff --name-only main | grep -E '^Cargo\.(lock|toml)$' | wc -l
+    # Expected: 0
+
+    # Production code outside generate/cpe.rs:
+    git diff --name-only main | grep -E '^mikebom-cli/src/' \
+      | grep -vE '^mikebom-cli/src/generate/cpe\.rs$' \
+      | wc -l
+    # Expected: 0
+
+    # Golden regen scope (FR-009 / SC-006):
+    git diff --stat mikebom-cli/tests/fixtures/golden/ | tail -1
+    # Expected: empty (no goldens regenerated — research §5 forecast)
+
+    # Diff scope allowlist:
+    git diff --name-only main | sort
+    # Expected only:
+    #   mikebom-cli/src/generate/cpe.rs
+    #   mikebom-cli/tests/cpe_binary_id.rs
+    #   specs/097-cpe-candidates/...
+    #   CLAUDE.md
+    ```
+- [X] T020 Run the mandatory pre-PR gate per Contract 7. Run `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 ./scripts/pre-pr.sh`. Expect: `>>> all pre-PR checks passed.` with zero clippy warnings and zero test failures across the workspace. The new test file (`cpe_binary_id.rs`) reports its 1 test passing; the 8 new unit tests in `cpe.rs::tests` all pass; the SPDX 3 conformance validator passes against the unchanged goldens.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies. Start immediately.
+- **Foundational (Phase 2)**: No tasks (file-level convergence — the mapping table addition is part of US1's edit).
+- **US1 (Phase 3, P1, MVP)**: Independent. Touches `cpe.rs` only.
+- **US2 (Phase 4, P2)**: Requires T004 (the table) from US1 to exist. T011/T013 are test-only additions.
+- **US3 (Phase 5, P2)**: Independent at the code level — relies on the existing empty-version fast-return, not the new arm. T015/T016 are test-only additions.
+- **Polish (Phase 6)**: Requires US1+US2+US3 implementation tasks complete. T018 integration test + T019 diff audit + T020 pre-PR gate.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent at file level. Touches `cpe.rs` (T004 + T005).
+- **US2 (P2)**: Depends on US1's table existing (T004). Adds well-formedness tests only.
+- **US3 (P2)**: Independent — relies on existing code path, not the new arm.
+
+### Within Each User Story
+
+- US1: T004 + T005 are sequential (same file, T005 references T004's table). T006+T007+T008+T009 are parallel-safe (independent unit-test functions). T010 verifies after T006-T009.
+- US2: T011 + T012 + T013 are parallel-safe (independent unit-test functions). T014 verifies after T011-T013.
+- US3: T015 + T016 are parallel-safe. T017 verifies after T015-T016.
+
+### Parallel Opportunities
+
+- T006 / T007 / T008 / T009 / T011 / T012 / T013 / T015 / T016 — 9 parallel-safe unit tests across all three stories (different test functions, no in-file conflicts since all live in the same `cpe.rs::tests` module). Strong fan-out potential for an agent-parallelism path.
+- T018 (integration test file creation) is parallel-safe with any of the unit-test tasks.
+
+---
+
+## Parallel Example: Phase 3-5 (US1 + US2 + US3 tests)
+
+```bash
+# Implementation tasks (sequential — same file):
+Task: "Add GENERIC_LIBRARY_CPES table to cpe.rs (T004)"
+Task: "Add 'generic' ecosystem arm to synthesize_cpes (T005)"
+
+# Test tasks (parallel — independent test functions):
+Task: "Add unit test generic_openssl_emits_canonical_cpe (T006)"
+Task: "Add unit test generic_curl_emits_dual_candidates (T007)"
+Task: "Add unit test generic_openjdk_strips_build_suffix (T008)"
+Task: "Add unit test composite_evidence_emits_single_cpe (T009)"
+Task: "Add unit test mappings_alphabetically_sorted (T011)"
+Task: "Add unit test mappings_all_emit_valid_cpe23 (T012)"
+Task: "Add unit test mappings_cover_all_curated_libraries (T013)"
+Task: "Add unit test generic_symbol_fingerprint_only_emits_no_cpe (T015)"
+Task: "Rename unknown_ecosystem_returns_empty test (T016)"
+Task: "Create cpe_binary_id.rs integration test (T018)"
+```
+
+After T004 + T005 land, all test additions can land in any order.
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only)
+
+The user's stated payoff is "CVE matching for binary-extracted OpenSSL". MVP path:
+
+1. Phase 1: Setup (T001-T003)
+2. Phase 3: US1 (T004-T010) — table + arm + 4 unit tests + verification
+3. Phase 6 partial: T020 (pre-PR gate)
+4. **STOP and VALIDATE**: feed an SBOM containing `pkg:generic/openssl@3.0.13` to Trivy, confirm CVEs appear.
+
+US2 + US3 layer on after MVP-validation. The full milestone delivers all three stories in a single PR — small surface (~30 lines of new code, 8 new tests, 1 integration test).
+
+### Incremental Delivery (recommended)
+
+Single PR shipping all three stories — the single-file delta + parallel-safe tests make this the right size. Total estimated time: ~1 dev-hour.
+
+### Single-Developer Strategy
+
+1. T001-T003 (setup, ~5 min)
+2. T004-T010 (US1, ~25 min — table + arm + 4 tests + verification)
+3. T011-T014 (US2, ~15 min — well-formedness + all-valid + coverage tests + verification)
+4. T015-T017 (US3, ~10 min — empty-version tests + verification)
+5. T018-T020 (Polish, ~10 min — integration test + pre-PR gate + diff audit)
+
+Total: ~55 minutes single-developer focus. Heavily parallel across the 7 unit-test tasks with an agent or multiple developers.
+
+---
+
+## Notes
+
+- [P] markers = different test functions OR different files with no shared edit-dependency.
+- [Story] label maps task to the user story for traceability.
+- All three signal paths (US1 emit, US2 maintainability, US3 suppression) converge on the same `cpe.rs` file — but the *code surface* is fully captured by T004+T005. US2 and US3 are test-only stories layered on top of the same implementation.
+- The mapping-completeness test (T013) is a tripwire for milestone-098+ — when a future milestone adds a new library to `version_strings::CuratedLibrary`, the test fails and forces the maintainer to add the CPE row in the same PR.
+- Commit boundary suggestion: single commit (US1+US2+US3+Polish in one PR) per the incremental-delivery guidance. Surface is small enough that splitting adds noise.
+- Pre-PR gate (T020) MUST run with `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1` per CLAUDE.md SBOM-spec-touching-changes rule. CPE arrays on SPDX 3 are standards-native; conformance validator already accepts them.
+- Avoid: extending the v1 mapping table during this milestone (e.g., adding libpng, freetype). New libraries land in milestone-098+ as the version-string scanner expands. v1's purpose is the *mechanism*; the table grows on its own cadence.


### PR DESCRIPTION
## Summary

- New `"generic"` ecosystem arm in `mikebom-cli/src/generate/cpe.rs::synthesize_cpes()`, backed by a 10-row in-source `GENERIC_LIBRARY_CPES` const table.
- Translates milestone-096 binary-extracted `pkg:generic/<lib>@<version>` components into NVD-canonical CPE 2.3 strings on the standards-native CDX `component.cpe`, SPDX 2.3 `cpe23Type` external ref, and SPDX 3 `Software:cpe` fields.
- 8 new unit tests + 1 integration test (SC-007 negative-control).

## Why

Milestone 096 shipped binary-id enrichment producing `pkg:generic/openssl@3.0.13`-style components, but the dominant CVE scanners (Trivy, Grype, Dependency-Track) drive their advisory lookup off CPE strings, not PURLs. A component with no CPE attached is invisible to NVD-keyed scanners. This milestone closes the gap so binary-identified OpenSSL et al. immediately yield CVE matches downstream.

## Coverage

**v1 mapping table** (10 libraries):

| Library | NVD vendor:product (primary) | Secondary |
|---------|------------------------------|-----------|
| curl | `haxx:curl` | `curl:curl` |
| gnutls | `gnu:gnutls` | — |
| libressl | `openbsd:libressl` | `libressl:libressl` |
| llvm | `llvm:llvm` | — |
| openjdk | `oracle:openjdk` | — |
| openssl | `openssl:openssl` | — |
| pcre | `pcre:pcre` | — |
| pcre2 | `pcre:pcre2` | — |
| sqlite | `sqlite:sqlite` | — |
| zlib | `zlib:zlib` | — |

**Documented omission**: BoringSSL (no NVD-tracked CPE namespace).

**OpenJDK build-suffix normalization**: `21.0.1+12` → CPE `21.0.1` (most-common NVD shape); the PURL preserves the full version verbatim.

## Standards-native (Constitution V)

All three emission targets are first-class spec fields. No new `mikebom:*` annotation. The existing `mikebom:cpe-candidates` overflow property (already used by deb/apk/rpm readers) carries the secondary candidate when a library has two NVD-cited vendor:product pairs.

## Scope guardrails

- **Zero new Cargo deps** (FR-007 ✓)
- **Production code confined to `generate/cpe.rs`** (FR-008 ✓)
- **Zero golden regen** — research §5 forecast confirmed (FR-009 / SC-006 ✓)

## Test plan

- [x] `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 ./scripts/pre-pr.sh` → `>>> all pre-PR checks passed.`
- [x] `generate::cpe` test module: 19/19 pass (11 pre-existing + 8 new)
- [x] `tests/cpe_binary_id.rs::mikebom_self_scan_emits_no_spurious_openssl_cpe` passes (mikebom uses rustls, not OpenSSL)
- [x] Full workspace `cargo test`: every target `0 failed`
- [x] Clippy: zero warnings
- [x] Diff scope: only `mikebom-cli/src/generate/cpe.rs` + new `cpe_binary_id.rs` test + spec docs + `CLAUDE.md` (auto-updated)
- [x] No `Cargo.toml`/`Cargo.lock` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)