### PR TITLE
feat(099): expand symbol-fingerprint table from 3 → 7 libraries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-12
+Auto-generated from all feature plans. Last updated: 2026-05-13
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -93,6 +93,7 @@ Auto-generated from all feature plans. Last updated: 2026-05-12
 - N/A — pure metadata transform on SBOM emission code path; no caches, no persistence. (097-cpe-candidates)
 - Rust stable (workspace toolchain inherited from milestones 001–097; no nightly required). + Existing only — `object` crate's `section_by_name_bytes` (ELF), the existing `for_each_load_command` helper at `macho.rs:178` (Mach-O), the existing `PeFile32`/`PeFile64::optional_header()` accessor exposed by `object` 0.36 (PE). `serde`/`serde_json` for `Value` construction in the `extra_annotations` bag. **No new Cargo deps.** (098-compiler-version-extract)
 - N/A — pure read-only inference per scan; no caches, no persistence. (098-compiler-version-extract)
+- Rust stable (workspace toolchain inherited from milestones 001–098; no nightly required). + Existing only — `std::collections::HashSet` (already imported in milestone-096's `symbol_fingerprint.rs`). **No new Cargo deps.** (099-symbol-fingerprint-expand)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -155,9 +156,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 099-symbol-fingerprint-expand: Added Rust stable (workspace toolchain inherited from milestones 001–098; no nightly required). + Existing only — `std::collections::HashSet` (already imported in milestone-096's `symbol_fingerprint.rs`). **No new Cargo deps.**
 - 098-compiler-version-extract: Added Rust stable (workspace toolchain inherited from milestones 001–097; no nightly required). + Existing only — `object` crate's `section_by_name_bytes` (ELF), the existing `for_each_load_command` helper at `macho.rs:178` (Mach-O), the existing `PeFile32`/`PeFile64::optional_header()` accessor exposed by `object` 0.36 (PE). `serde`/`serde_json` for `Value` construction in the `extra_annotations` bag. **No new Cargo deps.**
 - 097-cpe-candidates: Added Rust stable (workspace toolchain inherited from milestones 001–096; no nightly required). + Existing only — `serde`/`serde_json` (CDX/SPDX JSON output), `tracing`, `anyhow`. No new Cargo deps.
-- 096-binary-id-enrich: Added Rust stable (workspace toolchain inherited; no nightly required). + existing only — `object` crate (already in workspace, handles ELF/Mach-O/PE section iteration), `serde`/`serde_json`, `tracing`, `anyhow`. NO new crates.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs
+++ b/mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs
@@ -34,9 +34,30 @@ struct SymbolFingerprint {
     required: usize,
 }
 
-/// v1 starter set per research §3. Each library lists ≥10 public-API
+/// Symbol-fingerprint starter set. Milestone 096 shipped 3 libraries
+/// (openssl, zlib, libcurl); milestone 099 expanded to 7 by adding
+/// sqlite, pcre, pcre2, gnutls. Each library lists ≥10 public-API
 /// symbols; a match fires when ≥80% are present in the binary's
 /// `.dynsym` table.
+///
+/// Documented omissions per milestone-099 spec §1 + FR-004. These
+/// libraries are intentionally NOT in the fingerprint table; future
+/// maintainers should consult the per-library rationale before adding
+/// them:
+///
+///   - boringssl: drop-in OpenSSL ABI replacement; symbol overlap with
+///     openssl prevents reliable disambiguation at the symbol level.
+///     Operators wanting fork identification rely on the version-string
+///     scanner's `BoringSSL ` anchor (milestone 026).
+///   - libressl: same reasoning — OpenBSD's OpenSSL fork shares ABI.
+///     Version-string scanner's `LibreSSL ` anchor handles disambiguation.
+///   - llvm: API surface too broad (hundreds of public-API entry points
+///     across libLLVMCore / libLLVMAnalysis / ...); no stable 10-symbol
+///     slice. Different mikebom releases would pick different slices.
+///     Defer until a versioned compiler-libs strategy emerges.
+///   - openjdk: the launcher binary doesn't statically link JDK APIs
+///     (those live in libjvm.so loaded via JNI). Symbol fingerprinting
+///     at the launcher level yields no signal. Defer indefinitely.
 const FINGERPRINTS: &[SymbolFingerprint] = &[
     SymbolFingerprint {
         library: "openssl",
@@ -83,6 +104,82 @@ const FINGERPRINTS: &[SymbolFingerprint] = &[
             "curl_global_init",
             "curl_version",
             "curl_slist_append",
+        ],
+        required: 8,
+    },
+    // Milestone 099 — SQLite. `sqlite3_*` prefix → near-zero collision
+    // risk; most-statically-linked C library in CLI tooling. API stable
+    // since SQLite 3.0 (2004).
+    SymbolFingerprint {
+        library: "sqlite",
+        symbols: &[
+            "sqlite3_open",
+            "sqlite3_close",
+            "sqlite3_exec",
+            "sqlite3_prepare_v2",
+            "sqlite3_step",
+            "sqlite3_finalize",
+            "sqlite3_bind_int",
+            "sqlite3_column_text",
+            "sqlite3_errmsg",
+            "sqlite3_libversion",
+        ],
+        required: 8,
+    },
+    // Milestone 099 — PCRE 8.x. `pcre_*` prefix (distinct from `pcre2_*`).
+    // API frozen as of PCRE 8.45 (final 8.x release, 2021).
+    SymbolFingerprint {
+        library: "pcre",
+        symbols: &[
+            "pcre_compile",
+            "pcre_exec",
+            "pcre_free",
+            "pcre_study",
+            "pcre_get_substring",
+            "pcre_version",
+            "pcre_fullinfo",
+            "pcre_compile2",
+            "pcre_dfa_exec",
+            "pcre_jit_exec",
+        ],
+        required: 8,
+    },
+    // Milestone 099 — PCRE 10.x. 8-bit width variant only (`pcre2_*_8`
+    // — `libpcre2-8`); 16-bit / 32-bit variants deferred per
+    // research §3 (separate `libpcre2-{16,32}` artifacts; same NVD CPE
+    // `pcre:pcre2`).
+    SymbolFingerprint {
+        library: "pcre2",
+        symbols: &[
+            "pcre2_compile_8",
+            "pcre2_match_8",
+            "pcre2_match_data_create_8",
+            "pcre2_substring_get_byname_8",
+            "pcre2_substring_get_bynumber_8",
+            "pcre2_get_ovector_pointer_8",
+            "pcre2_code_free_8",
+            "pcre2_match_data_free_8",
+            "pcre2_compile_context_create_8",
+            "pcre2_set_compile_extra_options_8",
+        ],
+        required: 8,
+    },
+    // Milestone 099 — GnuTLS. `gnutls_*` prefix; Mozilla NSS / OpenSSL
+    // alternative common on Debian-derived distros. API stable since
+    // GnuTLS 3.0 (2011).
+    SymbolFingerprint {
+        library: "gnutls",
+        symbols: &[
+            "gnutls_init",
+            "gnutls_deinit",
+            "gnutls_handshake",
+            "gnutls_record_send",
+            "gnutls_record_recv",
+            "gnutls_global_init",
+            "gnutls_global_deinit",
+            "gnutls_set_default_priority",
+            "gnutls_credentials_set",
+            "gnutls_session_set_ptr",
         ],
         required: 8,
     },
@@ -294,5 +391,120 @@ mod tests {
         // 8 distinct zlib symbols → matches.
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].matched_count, 8);
+    }
+
+    // ====================================================================
+    // Milestone 099 — symbol-fingerprint expansion
+    // (sqlite, pcre, pcre2, gnutls)
+    // ====================================================================
+
+    /// T006 — SQLite full set matches (FR-001 / SC-001 / Contract 1).
+    /// Distinctive `sqlite3_*` prefix; all 10 symbols → one match.
+    #[test]
+    fn sqlite_full_set_matches() {
+        let s = syms(&[
+            "sqlite3_open",
+            "sqlite3_close",
+            "sqlite3_exec",
+            "sqlite3_prepare_v2",
+            "sqlite3_step",
+            "sqlite3_finalize",
+            "sqlite3_bind_int",
+            "sqlite3_column_text",
+            "sqlite3_errmsg",
+            "sqlite3_libversion",
+        ]);
+        let hits = scan(&s);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].library, "sqlite");
+        assert_eq!(hits[0].matched_count, 10);
+        assert_eq!(hits[0].total_count, 10);
+    }
+
+    /// T007 — SQLite under-threshold guard (FR-007 / Contract 2).
+    /// Only 7 of 10 symbols → under the 8/10 threshold → no match.
+    /// The threshold logic is shared across all libraries, so this one
+    /// test guards the threshold gate for all 7 fingerprints uniformly.
+    #[test]
+    fn sqlite_seven_of_ten_below_threshold() {
+        let s = syms(&[
+            "sqlite3_open",
+            "sqlite3_close",
+            "sqlite3_exec",
+            "sqlite3_prepare_v2",
+            "sqlite3_step",
+            "sqlite3_finalize",
+            "sqlite3_bind_int",
+        ]);
+        assert!(scan(&s).is_empty());
+    }
+
+    /// T010 — PCRE 8.x full set matches (FR-001 / SC-002 / Contract 3).
+    /// `pcre_*` prefix; the test asserts the matched library is `pcre`
+    /// (NOT `pcre2`) — the `hits.len() == 1` + library-name check
+    /// jointly verify the 8.x / 10.x disambiguation per Contract 3.
+    #[test]
+    fn pcre_full_set_matches() {
+        let s = syms(&[
+            "pcre_compile",
+            "pcre_exec",
+            "pcre_free",
+            "pcre_study",
+            "pcre_get_substring",
+            "pcre_version",
+            "pcre_fullinfo",
+            "pcre_compile2",
+            "pcre_dfa_exec",
+            "pcre_jit_exec",
+        ]);
+        let hits = scan(&s);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].library, "pcre");
+        assert_eq!(hits[0].matched_count, 10);
+    }
+
+    /// T011 — PCRE 10.x (8-bit width) full set matches.
+    /// `pcre2_*_8` prefix; asserts the matched library is `pcre2`
+    /// (NOT `pcre`) — same disambiguation guarantee as T010.
+    #[test]
+    fn pcre2_full_set_matches() {
+        let s = syms(&[
+            "pcre2_compile_8",
+            "pcre2_match_8",
+            "pcre2_match_data_create_8",
+            "pcre2_substring_get_byname_8",
+            "pcre2_substring_get_bynumber_8",
+            "pcre2_get_ovector_pointer_8",
+            "pcre2_code_free_8",
+            "pcre2_match_data_free_8",
+            "pcre2_compile_context_create_8",
+            "pcre2_set_compile_extra_options_8",
+        ]);
+        let hits = scan(&s);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].library, "pcre2");
+        assert_eq!(hits[0].matched_count, 10);
+    }
+
+    /// T014 — GnuTLS full set matches (FR-001 / SC-003).
+    /// `gnutls_*` prefix.
+    #[test]
+    fn gnutls_full_set_matches() {
+        let s = syms(&[
+            "gnutls_init",
+            "gnutls_deinit",
+            "gnutls_handshake",
+            "gnutls_record_send",
+            "gnutls_record_recv",
+            "gnutls_global_init",
+            "gnutls_global_deinit",
+            "gnutls_set_default_priority",
+            "gnutls_credentials_set",
+            "gnutls_session_set_ptr",
+        ]);
+        let hits = scan(&s);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].library, "gnutls");
+        assert_eq!(hits[0].matched_count, 10);
     }
 }

--- a/mikebom-cli/tests/binary_id_enrich.rs
+++ b/mikebom-cli/tests/binary_id_enrich.rs
@@ -176,7 +176,19 @@ fn mikebom_itself_does_not_emit_spurious_symbol_fingerprints() {
             // the version-string spurious-match test.
             matches!(
                 purl,
-                "pkg:generic/openssl" | "pkg:generic/zlib" | "pkg:generic/libcurl"
+                // Milestone-096 v1 fingerprints.
+                "pkg:generic/openssl"
+                    | "pkg:generic/zlib"
+                    | "pkg:generic/libcurl"
+                    // Milestone-099 v2 fingerprint expansion. Mikebom
+                    // uses rustls + Rust's own regex crate (NOT linking
+                    // any of these libraries) so the assertion still
+                    // holds — a regression here would mean mikebom
+                    // now actually depends on the matched library.
+                    | "pkg:generic/sqlite"
+                    | "pkg:generic/pcre"
+                    | "pkg:generic/pcre2"
+                    | "pkg:generic/gnutls"
             )
         })
         .collect();

--- a/specs/099-symbol-fingerprint-expand/checklists/requirements.md
+++ b/specs/099-symbol-fingerprint-expand/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Symbol-fingerprint table expansion
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-13
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- Scope deliberately narrow: 4 new fingerprint table rows (sqlite, pcre, pcre2, gnutls) — symmetry with milestone-026's version-string scanner coverage.
+- 4 documented-omission rationales (boringssl, libressl, llvm, openjdk) prevent future maintainers from re-asking the same questions.
+- Zero new Cargo deps; zero changes outside `symbol_fingerprint.rs`; no new properties; no new parity-catalog rows.
+- Composite-evidence merge with version-string matches per milestone-096 Q1 works automatically because slug-naming is consistent across both scanners.

--- a/specs/099-symbol-fingerprint-expand/contracts/fingerprint-expansion-contracts.md
+++ b/specs/099-symbol-fingerprint-expand/contracts/fingerprint-expansion-contracts.md
@@ -1,0 +1,122 @@
+# Contract — milestone 099 symbol-fingerprint expansion
+
+Six behavioral contracts. Each specifies (a) the invariant the const-table addition holds, (b) a verification recipe.
+
+## Contract 1 — Per-library full-set match (FR-001, FR-002, SC-001/SC-002/SC-003)
+
+**Path**: `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs::FINGERPRINTS`.
+
+**Invariant**: when a binary's `.dynsym` table contains all 10 symbols from any of the new library fingerprints (sqlite, pcre, pcre2, gnutls), `scan()` returns exactly one `SymbolFingerprintMatch { library: <slug>, matched_count: 10, total_count: 10 }` for that library — no spurious matches for other libraries.
+
+**Verification**:
+```bash
+cargo +stable test -p mikebom --bin mikebom \
+    --no-fail-fast sqlite_full_set_matches \
+    pcre_full_set_matches \
+    pcre2_full_set_matches \
+    gnutls_full_set_matches 2>&1 | grep "test result:"
+# Expected: ok. 4 passed.
+```
+
+## Contract 2 — Threshold enforcement (FR-007, SC-001 case 3)
+
+**Path**: same as Contract 1.
+
+**Invariant**: when a binary's `.dynsym` contains exactly 7 of a library's 10 fingerprint symbols (below the 8/10 threshold), `scan()` returns an empty Vec — no false claim of identification.
+
+**Verification**:
+```bash
+cargo +stable test -p mikebom --bin mikebom \
+    --no-fail-fast sqlite_seven_of_ten_below_threshold 2>&1 | grep "test result:"
+# Expected: ok. 1 passed.
+```
+
+(One under-threshold test is sufficient — the threshold logic in `scan()` is shared across all libraries; if it works for SQLite at 7/10, it works for all 4 new libraries.)
+
+## Contract 3 — PCRE 8.x vs PCRE 10.x disambiguation (US2)
+
+**Path**: same as Contract 1.
+
+**Invariant**: a binary exporting `pcre_*` symbols matches the `pcre` fingerprint (NOT `pcre2`); a binary exporting `pcre2_*_8` symbols matches the `pcre2` fingerprint (NOT `pcre`). The two prefix sets are disjoint at the symbol-name level, so disambiguation is automatic.
+
+**Verification**: the existing `pcre_full_set_matches` and `pcre2_full_set_matches` tests verify each library matches its own fingerprint. To verify they DON'T cross-match, the test suite implicitly relies on the deterministic table iteration order in `scan()` — each fingerprint is independently scored, and the threshold check fires once per fingerprint.
+
+```bash
+# Spot-check: a PCRE 8.x binary's symbol set should NOT trigger
+# `pcre2` because the threshold for pcre2 (8/10 of pcre2_*_8 symbols)
+# is unmet with 0/10 pcre2 symbols present.
+cargo +stable test -p mikebom --bin mikebom \
+    --no-fail-fast pcre_full_set_matches 2>&1 | grep "test result:"
+# Expected: ok. 1 passed.
+# The matched library MUST be "pcre" (assertion in the test body).
+```
+
+## Contract 4 — Composite-evidence merge correctness (FR-008, SC-004)
+
+**Path**: `mikebom-cli/src/scan_fs/binary/mod.rs::read()` — the milestone-096 Q1 merge loop. No code changes in this milestone — the existing merge keys on lowercase library name, and the v1 + v2 fingerprint slugs (sqlite, pcre, pcre2, gnutls) match the values from `CuratedLibrary::slug()`.
+
+**Verification** (existing-code behavior):
+```bash
+# Confirm the lowercase slug naming match:
+grep -nE '=> "(sqlite|pcre|pcre2|gnutls)"' \
+    mikebom-cli/src/scan_fs/binary/version_strings.rs
+# Expected: 4 matches (one per new library — already in CuratedLibrary::slug()).
+
+# Confirm the milestone-096 composite-merge code path is untouched:
+git diff --name-only main | grep -E 'binary/mod\.rs|binary/entry\.rs'
+# Expected: empty (no changes to those files in this milestone).
+```
+
+## Contract 5 — Documented-omission rationale present (FR-004)
+
+**Path**: `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs` (just above the `const FINGERPRINTS` declaration).
+
+**Invariant**: a `//`-comment block explicitly names the 4 deliberate omissions (boringssl, libressl, llvm, openjdk) with per-library rationale.
+
+**Verification**:
+```bash
+grep -nE '//\s+(- boringssl|- libressl|- llvm|- openjdk):' \
+    mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs
+# Expected: 4 matches.
+```
+
+## Contract 6 — Diff scope guardrails (FR-005, FR-006, FR-009)
+
+**Verification**:
+```bash
+# No new Cargo deps (FR-005 / SC-008):
+git diff --name-only main | grep -E '^Cargo\.(lock|toml)$' | wc -l
+# Expected: 0
+
+# Production code outside symbol_fingerprint.rs:
+git diff --name-only main | grep -E '^mikebom-cli/src/' \
+  | grep -vE '^mikebom-cli/src/scan_fs/binary/symbol_fingerprint\.rs$' \
+  | wc -l
+# Expected: 0
+
+# Golden regen scope (FR-009 / SC-007):
+git diff --stat mikebom-cli/tests/fixtures/golden/ | tail -1
+# Expected: empty (no goldens regenerated — milestone-096 SC-007 bound
+# inherits to milestone 099 because no existing fixtures statically link
+# sqlite / pcre / pcre2 / gnutls)
+
+# Diff scope allowlist:
+git diff --name-only main | sort
+# Expected only:
+#   CLAUDE.md                                              (auto-updated)
+#   mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs
+#   specs/099-symbol-fingerprint-expand/...
+```
+
+## Contract 7 — Pre-PR gate clean (SC-005)
+
+**Verification**:
+```bash
+MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 ./scripts/pre-pr.sh
+# Expected: prints `>>> all pre-PR checks passed.`; exit 0.
+# Clippy: zero warnings.
+# Test suite: every target `0 failed`.
+# Existing milestone-096 + binary_id_enrich tests continue to pass —
+# mikebom uses rustls so the new 4 fingerprints stay quiet on
+# mikebom-self (SC-006 mikebom-self regression guard).
+```

--- a/specs/099-symbol-fingerprint-expand/data-model.md
+++ b/specs/099-symbol-fingerprint-expand/data-model.md
@@ -1,0 +1,204 @@
+# Data Model — milestone 099
+
+Single-file delta to `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs`. The `FINGERPRINTS` const table grows from 3 → 7 entries; a new comment block documents 4 deliberate omissions; 5 new unit tests verify the additions.
+
+## File inventory
+
+| File | State | Owner FRs |
+|------|-------|-----------|
+| `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs` | EXTEND existing | FR-001, FR-002, FR-003, FR-004, FR-007, FR-010 |
+
+That's it. No other production code touched, no new files.
+
+## `symbol_fingerprint.rs` — extension shape
+
+**New const-table entries** (appended to the existing `FINGERPRINTS` array, per research §1 + §2):
+
+```rust
+const FINGERPRINTS: &[SymbolFingerprint] = &[
+    // ... existing milestone-096 entries: openssl, zlib, libcurl ...
+
+    SymbolFingerprint {
+        library_name: "sqlite",
+        symbols: &[
+            "sqlite3_open",
+            "sqlite3_close",
+            "sqlite3_exec",
+            "sqlite3_prepare_v2",
+            "sqlite3_step",
+            "sqlite3_finalize",
+            "sqlite3_bind_int",
+            "sqlite3_column_text",
+            "sqlite3_errmsg",
+            "sqlite3_libversion",
+        ],
+        required_symbol_count: 8,
+    },
+    SymbolFingerprint {
+        library_name: "pcre",
+        symbols: &[
+            "pcre_compile",
+            "pcre_exec",
+            "pcre_free",
+            "pcre_study",
+            "pcre_get_substring",
+            "pcre_version",
+            "pcre_fullinfo",
+            "pcre_compile2",
+            "pcre_dfa_exec",
+            "pcre_jit_exec",
+        ],
+        required_symbol_count: 8,
+    },
+    SymbolFingerprint {
+        library_name: "pcre2",
+        // 8-bit width variant (`libpcre2-8`) — dominant in practice.
+        // 16-bit / 32-bit variants are deferred per research §3.
+        symbols: &[
+            "pcre2_compile_8",
+            "pcre2_match_8",
+            "pcre2_match_data_create_8",
+            "pcre2_substring_get_byname_8",
+            "pcre2_substring_get_bynumber_8",
+            "pcre2_get_ovector_pointer_8",
+            "pcre2_code_free_8",
+            "pcre2_match_data_free_8",
+            "pcre2_compile_context_create_8",
+            "pcre2_set_compile_extra_options_8",
+        ],
+        required_symbol_count: 8,
+    },
+    SymbolFingerprint {
+        library_name: "gnutls",
+        symbols: &[
+            "gnutls_init",
+            "gnutls_deinit",
+            "gnutls_handshake",
+            "gnutls_record_send",
+            "gnutls_record_recv",
+            "gnutls_global_init",
+            "gnutls_global_deinit",
+            "gnutls_set_default_priority",
+            "gnutls_credentials_set",
+            "gnutls_session_set_ptr",
+        ],
+        required_symbol_count: 8,
+    },
+];
+```
+
+**New comment block** (immediately above the `const FINGERPRINTS` declaration, per research §6):
+
+```rust
+// Documented omissions per milestone-099 spec §1 + FR-004. These
+// libraries are intentionally NOT in the fingerprint table; future
+// maintainers should consult the per-library rationale before adding
+// them:
+//
+//   - boringssl: drop-in OpenSSL ABI replacement; symbol overlap with
+//     openssl prevents reliable disambiguation at the symbol level.
+//     Operators wanting fork identification rely on the version-string
+//     scanner's `BoringSSL ` anchor (milestone 026).
+//   - libressl: same reasoning — OpenBSD's OpenSSL fork shares ABI.
+//     Version-string scanner's `LibreSSL ` anchor handles disambiguation.
+//   - llvm: API surface too broad (hundreds of public-API entry points
+//     across libLLVMCore / libLLVMAnalysis / ...); no stable 10-symbol
+//     slice. Different mikebom releases would pick different slices.
+//     Defer until a versioned compiler-libs strategy emerges.
+//   - openjdk: the launcher binary doesn't statically link JDK APIs
+//     (those live in libjvm.so loaded via JNI). Symbol fingerprinting
+//     at the launcher level yields no signal. Defer indefinitely.
+```
+
+**New unit tests** (5 — appended to the existing `symbol_fingerprint::tests` module per research §5):
+
+```rust
+#[test]
+fn sqlite_full_set_matches() {
+    let s = syms(&[
+        "sqlite3_open", "sqlite3_close", "sqlite3_exec",
+        "sqlite3_prepare_v2", "sqlite3_step", "sqlite3_finalize",
+        "sqlite3_bind_int", "sqlite3_column_text", "sqlite3_errmsg",
+        "sqlite3_libversion",
+    ]);
+    let hits = scan(&s);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].library, "sqlite");
+    assert_eq!(hits[0].matched_count, 10);
+    assert_eq!(hits[0].total_count, 10);
+}
+
+#[test]
+fn pcre_full_set_matches() {
+    let s = syms(&[
+        "pcre_compile", "pcre_exec", "pcre_free", "pcre_study",
+        "pcre_get_substring", "pcre_version", "pcre_fullinfo",
+        "pcre_compile2", "pcre_dfa_exec", "pcre_jit_exec",
+    ]);
+    let hits = scan(&s);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].library, "pcre");
+    assert_eq!(hits[0].matched_count, 10);
+}
+
+#[test]
+fn pcre2_full_set_matches() {
+    let s = syms(&[
+        "pcre2_compile_8", "pcre2_match_8", "pcre2_match_data_create_8",
+        "pcre2_substring_get_byname_8", "pcre2_substring_get_bynumber_8",
+        "pcre2_get_ovector_pointer_8", "pcre2_code_free_8",
+        "pcre2_match_data_free_8", "pcre2_compile_context_create_8",
+        "pcre2_set_compile_extra_options_8",
+    ]);
+    let hits = scan(&s);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].library, "pcre2");
+    assert_eq!(hits[0].matched_count, 10);
+}
+
+#[test]
+fn gnutls_full_set_matches() {
+    let s = syms(&[
+        "gnutls_init", "gnutls_deinit", "gnutls_handshake",
+        "gnutls_record_send", "gnutls_record_recv", "gnutls_global_init",
+        "gnutls_global_deinit", "gnutls_set_default_priority",
+        "gnutls_credentials_set", "gnutls_session_set_ptr",
+    ]);
+    let hits = scan(&s);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].library, "gnutls");
+    assert_eq!(hits[0].matched_count, 10);
+}
+
+#[test]
+fn sqlite_seven_of_ten_below_threshold() {
+    // 7 of 10 < threshold 8 → no match.
+    let s = syms(&[
+        "sqlite3_open", "sqlite3_close", "sqlite3_exec",
+        "sqlite3_prepare_v2", "sqlite3_step", "sqlite3_finalize",
+        "sqlite3_bind_int",
+    ]);
+    assert!(scan(&s).is_empty());
+}
+```
+
+**No changes** to:
+- `SymbolFingerprint` struct definition (existing fields are sufficient).
+- `scan()` function signature or body (the existing loop iterates `FINGERPRINTS` and applies the threshold uniformly — growing the table doesn't change the loop).
+- `pub use` exports.
+- The `syms()` test helper (existing helper handles arbitrary string slices).
+
+## Compatibility
+
+- **No `Cargo.lock` change** — pure in-source const-table addition.
+- **Goldens regen forecast** — at most ≤1 spurious match across the 9 existing ecosystem fixtures (per milestone-096 SC-007 bound). Realistically zero: existing fixtures don't include real-world C-library-statically-linked binaries; the 4 new fingerprints are distinctive enough that even fortuitous symbol-name coincidence is improbable at 8/10 strength.
+- **Backward compatibility** — 100% additive. Existing 3-library fingerprint set continues to emit unchanged. The new 4 entries only fire on binaries that actually statically link the corresponding library.
+- **Mikebom-self regression**: the existing `binary_id_enrich.rs::mikebom_itself_does_not_emit_spurious_symbol_fingerprints` integration test currently checks for spurious openssl/zlib/libcurl matches. It should be extended to also check the 4 new libraries — addressed in tasks.md (Phase 2).
+
+## No JSON / no YAML schema additions
+
+Zero new fields in any output schema. The new fingerprints emit through the existing milestone-096 `mikebom:evidence-kind = symbol-fingerprint` + `mikebom:fingerprint-symbols-matched = N/10` annotation pipeline.
+
+## No new parity-catalog rows
+
+The 4 new libraries emit through the same existing parity-catalog rows that openssl/zlib/libcurl already use (the milestone-096 emission path). No Constitution V audit needed; no new `mikebom:*` properties introduced.

--- a/specs/099-symbol-fingerprint-expand/plan.md
+++ b/specs/099-symbol-fingerprint-expand/plan.md
@@ -1,0 +1,75 @@
+# Implementation Plan: Symbol-fingerprint table expansion to 7 libraries
+
+**Branch**: `099-symbol-fingerprint-expand` | **Date**: 2026-05-13 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/Users/mlieberman/Projects/mikebom/specs/099-symbol-fingerprint-expand/spec.md`
+
+## Summary
+
+Append 4 new entries to the existing `FINGERPRINTS` const table in `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs` — `sqlite`, `pcre`, `pcre2`, `gnutls` — each with 10 public-API symbols and the 8/10 match threshold inherited from milestone-096 FR-004. Add a documented-omission `//` comment block above the table explaining why BoringSSL, LibreSSL, LLVM, and OpenJDK are intentionally skipped. Add 4 new unit tests (one per new library) plus an under-threshold negative test. Zero new files, zero new Cargo dependencies, zero code changes outside the one module.
+
+The composite-evidence merge from milestone-096 Q1 works automatically because the library slugs (`sqlite`, `pcre`, `pcre2`, `gnutls`) match the values already produced by `version_strings::CuratedLibrary::slug()` — verified at planning time via `grep -nE '=> "sqlite"|=> "pcre"|=> "gnutls"' mikebom-cli/src/scan_fs/binary/version_strings.rs` which confirmed all 4 slugs exist in the milestone-026 starter set.
+
+Net delta: ~40 lines of new const-table entries + ~10 lines of comment-block omissions + ~60 lines of new unit tests. Estimated implementation time: ~30 min single-developer.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–098; no nightly required).
+**Primary Dependencies**: Existing only — `std::collections::HashSet` (already imported in milestone-096's `symbol_fingerprint.rs`). **No new Cargo deps.**
+**Storage**: N/A — pure read-only inference per scan; no caches, no persistence.
+**Testing**: `cargo +stable test` workspace. 4 new unit tests in `symbol_fingerprint::tests` + 1 under-threshold negative test (per FR-010). The milestone-096 `binary_id_enrich.rs::mikebom_itself_does_not_emit_spurious_symbol_fingerprints` integration test continues to pass (mikebom uses rustls, not sqlite/pcre/gnutls — so all 4 new fingerprints stay quiet on mikebom-self).
+**Target Platform**: Host-agnostic. ELF parsing via the `object` crate is platform-independent — Mach-O and Windows hosts can still scan ELF binaries via mikebom.
+**Project Type**: Rust CLI workspace (`mikebom-cli` binary + `mikebom-common` lib + `xtask`).
+**Performance Goals**: ≤1µs additional per-binary scan time. The fingerprint loop is a HashSet membership check on each fingerprint's symbol list; growing the table from 3 → 7 rows is linear in the table size + O(10) per row. Sub-microsecond per binary.
+**Constraints**: Zero new Cargo deps (FR-005). Production code confined to `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs` (FR-006). 8/10 match threshold uniformly across all 7 libraries (FR-007).
+**Scale/Scope**: Library coverage 3 → 7. Documented-omission list 1 → 5 entries. Codebase delta: ~110 lines (table + comments + tests). Single-file diff.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Rationale |
+|-----------|--------|-----------|
+| **I. Pure Rust, Zero C** | ✅ PASS | All new code is Rust. No new Cargo deps. |
+| **II. eBPF-Only Observation** | ✅ N/A | Enrichment milestone, not discovery; no observation path touched. |
+| **IV. Test Discipline** | ✅ PASS | 4 new unit tests + 1 under-threshold guard + existing mikebom-self spurious-match regression test. Pre-PR gate per SC-005. |
+| **V. Specification Compliance** | ✅ N/A | No new emission paths. Existing `mikebom:evidence-kind = symbol-fingerprint` annotation unchanged. No new parity-catalog rows. The new fingerprints flow through the existing milestone-096 emission infrastructure. |
+| **X. Transparency** | ✅ PASS | The `mikebom:fingerprint-symbols-matched = N/10` annotation (milestone 096) continues to surface match-strength; under-threshold matches silently skip emission (no false-positive claims). Documented-omission rationale in-source for future maintainer visibility. |
+| **XII. External Data Source Enrichment** | ✅ N/A | No external API calls; all parsing is in-source against the binary bytes. |
+
+**No CRITICAL violations.** No new properties; no new parity-catalog rows; no new emission paths.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/099-symbol-fingerprint-expand/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+├── checklists/
+│   └── requirements.md  # Already exists
+├── spec.md              # Already exists
+└── tasks.md             # Phase 2 output (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/src/scan_fs/binary/
+└── symbol_fingerprint.rs   # EXTEND — append 4 rows to FINGERPRINTS table,
+                             #         add OMITTED-rationale comment block,
+                             #         add 4 + 1 unit tests in tests module
+```
+
+**Structure Decision**: single-file delta. No new files, no new modules, no changes to `binary/mod.rs`, no changes to `entry.rs`, no changes to `generate/*`, no changes to parity catalog or docs.
+
+## Complexity Tracking
+
+No constitution violations. Table empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| — | — | — |

--- a/specs/099-symbol-fingerprint-expand/quickstart.md
+++ b/specs/099-symbol-fingerprint-expand/quickstart.md
@@ -1,0 +1,85 @@
+# Quickstart — milestone 099 maintainer recipes
+
+Three recipes for landing the symbol-fingerprint table expansion. Total estimated implementation time: ~30 min single-developer.
+
+## Recipe 1 — Add the documented-omission comment block + 4 new fingerprint rows (FR-001, FR-002, FR-004)
+
+Open `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs`. Above the existing `const FINGERPRINTS: &[SymbolFingerprint] = &[` line (around line 39 per current code), insert the comment block from `data-model.md §symbol_fingerprint.rs — extension shape` documenting the 4 omissions.
+
+Then append the 4 new rows (sqlite, pcre, pcre2, gnutls) to the `FINGERPRINTS` array — full symbol lists per `data-model.md`.
+
+Compile-check: `cargo +stable check -p mikebom`.
+
+## Recipe 2 — Add 5 new unit tests (FR-010)
+
+Append to the existing `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs::tests` module. 5 tests per `data-model.md §symbol_fingerprint.rs — extension`:
+- `sqlite_full_set_matches`
+- `pcre_full_set_matches`
+- `pcre2_full_set_matches`
+- `gnutls_full_set_matches`
+- `sqlite_seven_of_ten_below_threshold`
+
+Run:
+
+```bash
+cargo +stable test -p mikebom --bin mikebom \
+    --no-fail-fast sqlite_ pcre_ pcre2_ gnutls_ 2>&1 | grep "test result:"
+# Expected: ok. 5 passed (+ any matching existing test names; verify the 5 new ones report ok).
+```
+
+## Recipe 3 — Extend mikebom-self regression test for the 4 new libraries (SC-006)
+
+The existing `mikebom-cli/tests/binary_id_enrich.rs::mikebom_itself_does_not_emit_spurious_symbol_fingerprints` test currently checks for `pkg:generic/openssl`, `pkg:generic/zlib`, `pkg:generic/libcurl`. Extend the assertion to also forbid `pkg:generic/sqlite`, `pkg:generic/pcre`, `pkg:generic/pcre2`, `pkg:generic/gnutls`.
+
+Specifically, the existing test's `matches!` arm:
+```rust
+matches!(purl, "pkg:generic/openssl" | "pkg:generic/zlib" | "pkg:generic/libcurl")
+```
+becomes:
+```rust
+matches!(purl,
+    "pkg:generic/openssl" | "pkg:generic/zlib" | "pkg:generic/libcurl"
+        | "pkg:generic/sqlite" | "pkg:generic/pcre" | "pkg:generic/pcre2"
+        | "pkg:generic/gnutls"
+)
+```
+
+Run:
+
+```bash
+cargo +stable test -p mikebom --test binary_id_enrich \
+    mikebom_itself_does_not_emit_spurious_symbol_fingerprints 2>&1 | tail -5
+# Expected: ok. 1 passed (mikebom uses rustls → no sqlite/pcre/gnutls
+# symbols exported → the assertion still passes).
+```
+
+## Recipe 4 — Run pre-PR gate + verify diff scope (Contract 6, Contract 7)
+
+```bash
+MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 ./scripts/pre-pr.sh
+# Expected: `>>> all pre-PR checks passed.`
+
+# Diff scope (Contract 6):
+git diff --name-only main | sort
+# Expected:
+#   CLAUDE.md                                              (auto-updated)
+#   mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs
+#   mikebom-cli/tests/binary_id_enrich.rs                  (mikebom-self guard)
+#   specs/099-symbol-fingerprint-expand/...
+
+# No Cargo.* changes (FR-005):
+git diff --name-only main | grep -E '^Cargo\.(lock|toml)$' && echo "DEP CHURN" || echo "clean"
+# Expected: clean
+
+# Goldens regen scope (FR-009 / SC-007):
+git diff --stat mikebom-cli/tests/fixtures/golden/ | tail -1
+# Expected: empty
+```
+
+## When in doubt
+
+- **A new library is added to the milestone-026 version-string scanner without a fingerprint here**: the binary-id-enrich pipeline continues to work — version-string emission handles that library. The fingerprint scanner stays quiet. Add a fingerprint row in a follow-up milestone when both signals are valuable.
+- **A library's public-API prefix evolves** (e.g., a hypothetical SQLite 4.x that switches from `sqlite3_*` to `sqlite4_*`): the existing fingerprint stops matching. Detection of the new major version is a separate milestone's concern — the v1 fingerprint targets long-stable APIs (SQLite 3.x has shipped since 2004 with stable symbol names).
+- **A 16-bit / 32-bit PCRE2 fingerprint becomes interesting**: per research §3, extend the `pcre2` row's symbol list OR add separate `pcre2-16` / `pcre2-32` rows. The existing slug naming convention can accommodate either approach.
+- **The mikebom-self regression test starts failing on a future toolchain that statically links one of these libraries**: that's a real signal — mikebom now depends on the matched library. Update the assertion list AND document the dependency change.
+- **A binary trips two fingerprints because a custom library happens to share 8+ symbol names with a tracked library**: vanishingly unlikely at the chosen prefix-distinctiveness levels. If it ever happens, narrow the offending fingerprint by replacing its lowest-distinctiveness symbol with a more-distinctive alternative.

--- a/specs/099-symbol-fingerprint-expand/research.md
+++ b/specs/099-symbol-fingerprint-expand/research.md
@@ -1,0 +1,137 @@
+# Research — milestone 099 symbol-fingerprint table expansion
+
+Phase 0 investigation. Six decision points, all resolved with reference-doc citations + audit-of-existing-code outcomes.
+
+## §1 — Library coverage selection (FR-001 / FR-004)
+
+**Decision**: add 4 libraries — sqlite, pcre, pcre2, gnutls. Document 4 deliberate omissions — boringssl, libressl, llvm, openjdk.
+
+**Selection criteria**: a library is a good symbol-fingerprint target when (a) the version-string scanner already covers it (so composite-evidence merge per milestone-096 Q1 has somewhere to land), (b) its public-API symbol set is distinctive (high-uniqueness prefix avoids collision), (c) its API has been stable across major versions (no per-version fingerprint divergence), (d) it is genuinely statically linked in the wild (not just a system-wide shared library).
+
+| Library | Add? | Rationale |
+|---------|------|-----------|
+| openssl | ✓ existing | milestone-096 v1 set |
+| zlib | ✓ existing | milestone-096 v1 set |
+| libcurl | ✓ existing | milestone-096 v1 set |
+| sqlite | **+ ADD** | `sqlite3_*` prefix → near-zero collision risk. Most-statically-linked C library in CLI tooling. API stable since SQLite 3.0 (2004). |
+| pcre | **+ ADD** | PCRE 8.x; `pcre_*` prefix distinctive. Common statically-linked dependency in regex-heavy CLIs (`grep -P`, perl-derived tools). API frozen as of PCRE 8.45 (final 8.x release, 2021). |
+| pcre2 | **+ ADD** | PCRE 10.x; `pcre2_*_8` prefix (8-bit width — dominant variant). Successor to PCRE 8.x; separate NVD vendor:product (`pcre:pcre2`). 16-bit/32-bit width variants deferred to a future milestone (see §3). |
+| gnutls | **+ ADD** | `gnutls_*` prefix. Mozilla NSS / OpenSSL alternative; common on Debian-derived distros. API stable since GnuTLS 3.0 (2011). |
+| boringssl | ✗ OMIT | Drop-in OpenSSL ABI replacement; symbols overlap with OpenSSL almost completely. Operators wanting fork-specific identification rely on the version-string scanner where the anchor `"BoringSSL "` is distinctive. Symbol fingerprinting cannot reliably distinguish forks. |
+| libressl | ✗ OMIT | Same reasoning as BoringSSL — LibreSSL is OpenBSD's OpenSSL fork with overlapping symbol set. Version-string scanner's `"LibreSSL "` anchor handles disambiguation. |
+| llvm | ✗ OMIT | API surface has hundreds of public-API entry points spread across `LLVM*`-prefixed libraries (`libLLVMCore`, `libLLVMAnalysis`, ...). Picking any stable 10-symbol slice is arbitrary; different mikebom releases would pick different slices. Skip. |
+| openjdk | ✗ OMIT | OpenJDK's binary is the `java` launcher, a small wrapper that loads `libjvm.so` via JNI. The launcher's `.dynsym` doesn't carry JDK API symbols (those live in the JVM shared lib loaded at runtime). Symbol fingerprinting at the launcher level doesn't yield OpenJDK identification. Defer indefinitely. |
+
+**Result**: 7-library coverage at v1 (3 existing + 4 added). 4 documented omissions with in-source rationale.
+
+## §2 — Symbol list curation per library (FR-002)
+
+**Decision**: 10 high-distinctiveness public-API symbols per new library, all matching the library's canonical prefix.
+
+| Library | Prefix | Symbols (10 each) | Source-of-truth header |
+|---------|--------|-------------------|------------------------|
+| sqlite | `sqlite3_*` | `sqlite3_open`, `sqlite3_close`, `sqlite3_exec`, `sqlite3_prepare_v2`, `sqlite3_step`, `sqlite3_finalize`, `sqlite3_bind_int`, `sqlite3_column_text`, `sqlite3_errmsg`, `sqlite3_libversion` | `sqlite3.h` |
+| pcre | `pcre_*` | `pcre_compile`, `pcre_exec`, `pcre_free`, `pcre_study`, `pcre_get_substring`, `pcre_version`, `pcre_fullinfo`, `pcre_compile2`, `pcre_dfa_exec`, `pcre_jit_exec` | `pcre.h` (PCRE 8.45) |
+| pcre2 | `pcre2_*_8` | `pcre2_compile_8`, `pcre2_match_8`, `pcre2_match_data_create_8`, `pcre2_substring_get_byname_8`, `pcre2_substring_get_bynumber_8`, `pcre2_get_ovector_pointer_8`, `pcre2_code_free_8`, `pcre2_match_data_free_8`, `pcre2_compile_context_create_8`, `pcre2_set_compile_extra_options_8` | `pcre2.h` (PCRE2 10.42) |
+| gnutls | `gnutls_*` | `gnutls_init`, `gnutls_deinit`, `gnutls_handshake`, `gnutls_record_send`, `gnutls_record_recv`, `gnutls_global_init`, `gnutls_global_deinit`, `gnutls_set_default_priority`, `gnutls_credentials_set`, `gnutls_session_set_ptr` | `gnutls/gnutls.h` (GnuTLS 3.8) |
+
+**Rationale**:
+- All symbols are public-API functions documented in each library's primary header (not internal/private symbols).
+- Prefix distinctiveness: `sqlite3_*`, `pcre_*` vs `pcre2_*_8`, `gnutls_*` — collision probability with unrelated libraries is vanishingly small at the 8-of-10 threshold.
+- Symbol stability: each set is dominated by functions that have shipped in every major version of the library for the past 10+ years.
+
+**Alternatives considered**:
+- **Fewer symbols per library** (e.g., 5): rejected — would lower the 8/10 → 4/5 threshold and increase false-positive risk on small custom libraries that happen to define one or two name-collision symbols. The 10-symbol corpus matches milestone-096's existing pattern for consistency.
+- **Larger symbol corpus per library** (e.g., 20): rejected — diminishing returns. The 10 chosen per library are the most-public-API of each library; adding more risks pulling in less-stable functions (deprecated, internal-leaked-public, etc.).
+
+## §3 — PCRE2 width variant scope (Edge Case)
+
+**Decision**: cover the 8-bit width (`pcre2_*_8`) only in v1. The 16-bit (`pcre2_*_16`) and 32-bit (`pcre2_*_32`) variants are deferred to a future milestone if signal emerges.
+
+**Rationale**:
+- PCRE2 ships in 3 width variants for `char` (8-bit), `wchar_t`/UTF-16 (16-bit), and UTF-32 (32-bit) string types. Each is a separate `libpcre2-{8,16,32}.{a,so}` artifact.
+- The 8-bit width is dominant in practice — `grep`, `php`'s preg, Apache `mod_rewrite`, and the vast majority of regex consumers use `char *` strings.
+- 16/32-bit variants are common in some specific contexts (Qt's QRegularExpression, ICU-aware applications) but a small minority of binaries.
+- All three variants are the SAME NVD CPE (`pcre:pcre2`); operators with vulnerability matching don't need width-disambiguation. The version-string scanner already covers all 3 widths uniformly under the `pcre2` slug.
+- Future extension: a 16/32-bit binary would currently produce no fingerprint match (the symbols don't match the 8-bit set). That's an honest "we don't know" — fixable by adding `pcre2_compile_16` / `pcre2_compile_32` variant tables in a follow-up milestone if signal emerges.
+
+**Implementation note**: the library_name for all PCRE2 width variants stays `pcre2` (single slug). A future milestone adding 16/32-bit variants would add separate fingerprint table rows (e.g., `pcre2-16`, `pcre2-32`) or extend the existing `pcre2` row's `symbols` list to include all 30 symbols across widths — implementation-time choice.
+
+## §4 — Composite-evidence merge correctness (FR-008)
+
+**Decision**: no code changes required. The milestone-096 `binary/mod.rs::read()` composite-evidence merge keys on lowercase library name; the v1 starter set's slug naming convention is preserved by FR-003.
+
+**Verified at planning time**:
+```
+$ grep -nE '=> "sqlite"|=> "pcre"|=> "gnutls"' mikebom-cli/src/scan_fs/binary/version_strings.rs
+66:            CuratedLibrary::Sqlite => "sqlite",
+68:            CuratedLibrary::Pcre => "pcre",
+69:            CuratedLibrary::Pcre2 => "pcre2",
+70:            CuratedLibrary::GnuTls => "gnutls",
+```
+
+All 4 new fingerprint slugs (`sqlite`, `pcre`, `pcre2`, `gnutls`) already exist in `CuratedLibrary::slug()` from milestone 026. The milestone-096 Q1 merge uses these exact strings as the HashMap key. Composite-evidence behavior:
+- Binary statically links SQLite, version string retained: version-string scanner emits `pkg:generic/sqlite@3.45.1` first; fingerprint scanner emits a `SymbolFingerprintMatch { library: "sqlite", ... }`. The merge in `binary/mod.rs::read()` collapses to ONE `PackageDbEntry` with the version-pinned PURL + the fingerprint annotation.
+- Binary statically links SQLite, version string stripped: fingerprint scanner alone emits `pkg:generic/sqlite` (no version). ONE component, symbol-fingerprint-only.
+
+## §5 — Test approach (FR-010)
+
+**Decision**: unit tests with synthetic symbol lists, following milestone-096's pattern in `symbol_fingerprint::tests`. No toolchain-dependent fixture binaries.
+
+**Rationale**: milestone 096 established the unit-test-with-synthetic-symbol-set pattern for `symbol_fingerprint::tests::openssl_full_set_matches` etc. — synthesizing the exact symbol set the fingerprint expects, calling `scan()`, asserting the match. This avoids the build-an-sqlite-static-binary-in-CI complexity that the milestone-096 spec explicitly rejected. Integration verification continues via the existing `binary_id_enrich.rs::mikebom_itself_does_not_emit_spurious_symbol_fingerprints` test (mikebom uses rustls — should NOT trip any new fingerprint).
+
+**Tests planned**:
+1. `sqlite_full_set_matches` — synthesizes all 10 `sqlite3_*` symbols; asserts one match `{library: "sqlite", matched_count: 10, total_count: 10}`.
+2. `pcre_full_set_matches` — synthesizes all 10 `pcre_*` symbols; asserts `{library: "pcre", matched_count: 10, total_count: 10}`.
+3. `pcre2_full_set_matches` — synthesizes all 10 `pcre2_*_8` symbols; asserts `{library: "pcre2", matched_count: 10, total_count: 10}`.
+4. `gnutls_full_set_matches` — synthesizes all 10 `gnutls_*` symbols; asserts `{library: "gnutls", matched_count: 10, total_count: 10}`.
+5. `sqlite_seven_of_ten_below_threshold` — synthesizes only 7 of 10 SQLite symbols; asserts NO match (under-threshold sentinel).
+
+The existing 3 milestone-096 tests (`openssl_full_set_matches`, `openssl_eight_of_ten_just_matches`, `openssl_seven_of_ten_below_threshold`) continue to pass unchanged.
+
+## §6 — Documented-omission comment block (FR-004)
+
+**Decision**: add a `//`-comment block immediately above the `FINGERPRINTS` const definition (after the existing struct documentation but before the const itself) listing the 4 deliberate omissions with per-library rationale.
+
+**Format**:
+```rust
+// Documented omissions (per milestone-099 §1 + spec.md FR-004):
+//   - boringssl: drop-in OpenSSL ABI replacement; symbol overlap with
+//     openssl prevents reliable disambiguation. Use version-string
+//     scanner's `BoringSSL ` anchor for fork-specific identification.
+//   - libressl: same as boringssl — OpenBSD's OpenSSL fork shares ABI.
+//   - llvm: API surface too broad (hundreds of public-API entry points
+//     across libLLVMCore / libLLVMAnalysis / ...); no stable 10-symbol
+//     slice. Defer until a versioned compiler-libs strategy emerges.
+//   - openjdk: launcher binary doesn't statically link JDK APIs (those
+//     live in libjvm.so loaded via JNI). Symbol fingerprinting at the
+//     launcher level yields no signal. Defer indefinitely.
+const FINGERPRINTS: &[SymbolFingerprint] = &[ ... ];
+```
+
+**Rationale**: future maintainers see the decision tree without re-litigating each library. Constitution X transparency at the source-code level.
+
+## Coverage map
+
+| Spec section | Resolution |
+|--------------|------------|
+| FR-001 (4 new libraries) | §1 + §2 → sqlite, pcre, pcre2, gnutls locked with 10 symbols each |
+| FR-002 (canonical prefixes) | §2 → `sqlite3_*` / `pcre_*` / `pcre2_*_8` / `gnutls_*` |
+| FR-003 (slug consistency with CuratedLibrary) | §4 → all 4 slugs already exist; composite-evidence works automatically |
+| FR-004 (documented omissions) | §1 + §6 → 4 rationales in-source comment block |
+| FR-005 (no new Cargo deps) | by-construction — pure const-table addition |
+| FR-006 (production code scope) | §6 → single-file delta to `symbol_fingerprint.rs` |
+| FR-007 (8/10 threshold preserved) | §2 → uniform across all 7 libraries |
+| FR-008 (composite-evidence merge unchanged) | §4 → no code changes needed |
+| FR-009 (golden regen ≤1-spurious bound) | inherits from milestone-096 SC-007 |
+| FR-010 (unit tests per new library) | §5 → 4 happy-path tests + 1 under-threshold guard |
+| SC-001/SC-002/SC-003 (per-library emission) | §5 → unit tests validate via synthetic symbol sets |
+| SC-004 (composite-evidence emits ONE component) | §4 → milestone-096 Q1 merge handles this |
+| SC-005 (pre-PR gate clean) | by-construction |
+| SC-006 (4 new tests pass + mikebom-self regression) | §5 |
+| SC-007 (≤1-spurious golden regen) | §3 (PCRE2 8-bit only) + §2 (distinctive prefixes) bounds spurious-match probability |
+| SC-008 (zero new deps) | by-construction |
+| Constitution V audit | N/A — no new properties / parity-catalog rows |
+| Constitution X transparency | §6 → omissions documented in-source |
+
+All open spec questions resolved. Ready for Phase 1 (data-model + contracts + quickstart).

--- a/specs/099-symbol-fingerprint-expand/spec.md
+++ b/specs/099-symbol-fingerprint-expand/spec.md
@@ -1,0 +1,136 @@
+# Feature Specification: Symbol-fingerprint table expansion to 7 libraries
+
+**Feature Branch**: `099-symbol-fingerprint-expand`
+**Created**: 2026-05-13
+**Status**: Draft
+**Input**: User description: "milestone 099 — expand the symbol-fingerprint scanner from the milestone-096 v1 starter set (openssl/zlib/libcurl) to match the broader version-string coverage. Add sqlite, pcre, pcre2, gnutls fingerprints — 10 symbols each, 8/10 match threshold, ELF only. Document why boringssl/libressl/llvm/openjdk are deliberately excluded. Zero new Cargo deps."
+
+## Background
+
+Milestone 096 introduced the symbol-fingerprint scanner with a v1 starter set of 3 libraries: openssl, zlib, libcurl — each with 10 well-known public-API symbols and an 80% match threshold. This is the same scanner that emits `pkg:generic/<lib>` components (no version) on ELF binaries where the embedded-version-string scanner misses (e.g., the version string is stripped, never emitted, or hidden inside compressed data).
+
+The version-string scanner covers a broader 11-library set: openssl, boringssl, zlib, sqlite, curl, pcre, pcre2, gnutls, libressl, llvm, openjdk. The symmetry gap between the two scanners means a binary that statically links **sqlite** but has its version string stripped emits no identification at all — even though sqlite's public-API symbols (`sqlite3_open`, `sqlite3_prepare_v2`, etc.) are highly distinctive and easily fingerprintable.
+
+This milestone closes the gap for the four libraries that are both **fingerprintable** and **valuable to identify**: sqlite, pcre (PCRE 8.x), pcre2 (PCRE 10.x), gnutls. The remaining four — boringssl, libressl, llvm, openjdk — are documented as deliberate omissions with rationale (BoringSSL/LibreSSL share OpenSSL's symbol set making per-library disambiguation unreliable at the symbol level; LLVM has too broad an API surface for a useful 10-symbol fingerprint; OpenJDK isn't a C library so symbol fingerprinting doesn't apply to its compiled launcher binary).
+
+**Scope framing**: this is a *pure data-table expansion*. The scanner code path is unchanged from milestone 096 — `symbol_fingerprint::scan(symbol_names: &[String])` already iterates the `FINGERPRINTS` table, applies the 8/10 threshold, and emits `SymbolFingerprintMatch` records. The only code change is appending 4 new entries to the const table + 4 new unit tests verifying each fingerprint matches its target library's expected symbol set. Zero new Cargo dependencies. Zero changes outside `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs`. Zero changes to the existing composite-evidence merge or PURL emission shape.
+
+**What this is NOT**: this is not a new identification technique, not a new evidence channel, not a new property. The CDX `evidence.identity[].methods[].technique` and the `mikebom:evidence-kind = symbol-fingerprint` annotation remain unchanged. Operators consuming SBOMs continue to use the same query patterns (`components[?(@.purl=="pkg:generic/sqlite")]`); they just get more hits when binaries actually link these libraries.
+
+Out of scope: PE / Mach-O symbol fingerprinting (milestone 096 deferred those; they remain deferred — `.dynsym` is ELF-specific, and PE Export Directory + Mach-O `LC_DYSYMTAB` parsing involves enough new code that it deserves its own milestone). Confidence-tier tuning (still 0.4 per milestone 096 FR-004). Symbol-fingerprint-only CPE candidate emission (milestone 097 FR-004 explicitly suppresses these to avoid wildcard-version false-positive floods; that policy is preserved).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Operator scans a stripped binary that statically links SQLite and sees a SQLite component (Priority: P1)
+
+An operator has a stripped ELF binary that statically links SQLite (typical pattern for self-contained CLI tools — `fossil`, `litecli`, `sqlite-utils`-frozen, every embedded-database CLI). Today: mikebom emits no SQLite signal because the version string `"3.45.1 ..."` was stripped from `.rodata`. With this milestone: mikebom matches the 10-symbol SQLite fingerprint (8 of 10 symbols required, all `sqlite3_*`-prefixed and highly distinctive), emits `pkg:generic/sqlite` with `mikebom:evidence-kind = symbol-fingerprint` and `mikebom:fingerprint-symbols-matched = 9/10` (or however many matched).
+
+**Why this priority**: SQLite is one of the most-statically-linked C libraries in the wild. Stripped CLI binaries often retain their `.dynsym` (needed for dynamic linker fixups against libc) so the `sqlite3_*` symbols are present even when the version string has been removed. This single library closes a meaningful unknown-binary identification gap.
+
+**Independent Test**: build a small C test program that statically links SQLite, strip the version string but keep `.dynsym`, scan with mikebom. Expect `pkg:generic/sqlite` component with `mikebom:evidence-kind = symbol-fingerprint` and `mikebom:fingerprint-symbols-matched ≥ 8/10`. Toolchain-graceful-skip if `sqlite-dev` or `cc` unavailable.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ELF binary whose `.dynsym` table contains `sqlite3_open`, `sqlite3_close`, `sqlite3_exec`, `sqlite3_prepare_v2`, `sqlite3_step`, `sqlite3_finalize`, `sqlite3_bind_int`, `sqlite3_column_text`, `sqlite3_errmsg`, `sqlite3_libversion` (all 10), **When** mikebom scans the file, **Then** the SBOM contains `pkg:generic/sqlite` with `mikebom:fingerprint-symbols-matched = "10/10"`.
+2. **Given** an ELF binary whose `.dynsym` contains 8 of the 10 SQLite fingerprint symbols (any 8), **When** mikebom scans it, **Then** the SBOM still emits `pkg:generic/sqlite` (8/10 matches the threshold) with `mikebom:fingerprint-symbols-matched = "8/10"`.
+3. **Given** an ELF binary whose `.dynsym` contains 7 of the 10 SQLite fingerprint symbols (below threshold), **When** mikebom scans it, **Then** the SBOM emits NO `pkg:generic/sqlite` component from the symbol-fingerprint path (under-threshold means we don't claim identification).
+4. **Given** an ELF binary that ALSO emits a version-string match for SQLite (i.e., `.rodata` retained the `"SQLite version 3.45.1"` literal AND `.dynsym` matched the fingerprint), **When** mikebom scans it, **Then** the composite-evidence merge per milestone-096 Q1 produces ONE component (`pkg:generic/sqlite@3.45.1`) with the symbol-fingerprint recorded as a `mikebom:fingerprint-symbols-matched` annotation on the same component — not two separate components.
+
+---
+
+### User Story 2 — Operator scans a binary that exports PCRE 8.x or PCRE 10.x symbols (Priority: P2)
+
+An operator has an ELF binary that statically links PCRE — either the legacy PCRE 8.x library (`pcre_*` prefix) or the modern PCRE 10.x library (`pcre2_*_8` prefix for the 8-bit width). The two libraries are independent — they have separate NVD CPE namespaces (`pcre:pcre` for 8.x, `pcre:pcre2` for 10.x) — and binaries link one or the other, not both. The milestone-096 / earlier version-string scanner already disambiguates them by anchor (`PCRE ` vs `PCRE2 `); this milestone extends the same disambiguation to the symbol-fingerprint scanner.
+
+**Why this priority**: P2 because PCRE is less universally statically linked than SQLite (most apps use libc regex), but the symbol-fingerprint distinguishes 8.x from 10.x with high confidence — the prefix difference (`pcre_compile` vs `pcre2_compile_8`) is the disambiguator.
+
+**Independent Test**: build a C test program that links `libpcre.a` (PCRE 8.x) — confirm `pkg:generic/pcre` (NOT `pcre2`) emits. Repeat with `libpcre2-8.a` (PCRE 10.x) — confirm `pkg:generic/pcre2` emits.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ELF binary whose `.dynsym` exports the PCRE 8.x public-API symbols (`pcre_compile`, `pcre_exec`, `pcre_free`, etc. — 8 of 10), **When** mikebom scans it, **Then** the SBOM emits `pkg:generic/pcre` (NOT `pkg:generic/pcre2`).
+2. **Given** an ELF binary whose `.dynsym` exports the PCRE 10.x public-API symbols (`pcre2_compile_8`, `pcre2_match_8`, etc. — 8 of 10), **When** mikebom scans it, **Then** the SBOM emits `pkg:generic/pcre2` (NOT `pkg:generic/pcre`).
+3. **Given** an unusual binary that statically links BOTH PCRE 8.x and PCRE 10.x (rare but legal — e.g., a polyglot library bundling both versions), **When** mikebom scans it, **Then** the SBOM emits BOTH `pkg:generic/pcre` AND `pkg:generic/pcre2` as separate components.
+
+---
+
+### User Story 3 — Operator scans a binary that statically links GnuTLS (Priority: P2)
+
+An operator has an ELF binary that statically links GnuTLS (Mozilla's NSS-alternative TLS implementation, common in GNU-aligned distros). The fingerprint set targets GnuTLS's stable public API: `gnutls_init`, `gnutls_deinit`, `gnutls_handshake`, etc. — all `gnutls_*`-prefixed for high distinctiveness.
+
+**Why this priority**: P2 because GnuTLS is less universal than OpenSSL but is the dominant alternative on debian-derived systems where OpenSSL licensing concerns drove adoption. Statically-linked GnuTLS is rarer than statically-linked OpenSSL but worth covering for parity.
+
+**Independent Test**: build a C test program that links `libgnutls.a`, scan with mikebom. Expect `pkg:generic/gnutls` component with `mikebom:fingerprint-symbols-matched ≥ 8/10`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ELF binary whose `.dynsym` exports the GnuTLS public-API symbols (`gnutls_init`, `gnutls_deinit`, `gnutls_handshake`, etc. — 8 of 10), **When** mikebom scans it, **Then** the SBOM emits `pkg:generic/gnutls`.
+2. **Given** an ELF binary that exports both GnuTLS AND OpenSSL symbols (some hybrid TLS-stack binaries link both as fallback options), **When** mikebom scans it, **Then** the SBOM emits BOTH `pkg:generic/openssl` AND `pkg:generic/gnutls` as separate components — independent fingerprints, independent emissions.
+
+---
+
+### Edge Cases
+
+- **Library name collision** (e.g., a custom library happens to define a function called `pcre_compile`): the 8-of-10 match threshold makes accidental collisions extremely unlikely — a custom library would need to also define `pcre_exec`, `pcre_free`, `pcre_study`, `pcre_version`, `pcre_fullinfo`, `pcre_compile2`, and one more of `pcre_get_substring` / `pcre_dfa_exec` / `pcre_jit_exec`. The combined probability is vanishingly small. Documented; no special-case handling.
+- **PCRE 8.x and 10.x co-resident**: the `pcre_*` and `pcre2_*_8` prefixes are disjoint at the symbol-name level. A binary linking both libraries gets two separate fingerprint matches; the SBOM emits both components per US2 acceptance scenario 3.
+- **Version-string + symbol-fingerprint composite for SQLite/PCRE/PCRE2/GnuTLS**: the milestone-096 Q1 composite-evidence merge per `binary/mod.rs::read()` keys on lowercase library name. The version-string scanner uses slugs `sqlite`, `pcre`, `pcre2`, `gnutls` (from `CuratedLibrary::slug()`); this milestone uses the same slugs in the fingerprint table. Composite-merge works automatically; one component per library per binary.
+- **OpenSSL fork at symbol level**: BoringSSL and LibreSSL both expose the OpenSSL ABI by design (drop-in replacement). A binary statically linking BoringSSL or LibreSSL will trip the OpenSSL fingerprint and emit `pkg:generic/openssl`. This is the documented behavior — operators wanting fork-specific identification rely on the version-string scanner where the anchor `"BoringSSL "` or `"LibreSSL "` is distinctive. Symbol-fingerprinting cannot distinguish the forks reliably.
+- **Stripped `.dynsym` (rare; `strip --strip-all` keeps it, but `strip --discard-all` removes it)**: the scanner reads `.dynsym` via `object::read::File::dynamic_symbols()`; binaries with no `.dynsym` produce an empty symbol set and no fingerprint matches fire. Same behavior as milestone 096 — pre-existing edge case.
+- **Symbols present but versioned via GNU symbol versioning** (e.g., `sqlite3_open@@GLIBC_2.2.5`-style decoration): the `object` crate strips version suffixes before exposing the symbol name to the iterator. Verified by milestone-096's existing tests on real binaries. No change needed.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `FINGERPRINTS` const table in `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs` MUST grow from 3 entries (openssl, zlib, libcurl) to **7 entries** by adding 4 new libraries: sqlite, pcre, pcre2, gnutls. Each new entry MUST follow the same shape: `library_name: &'static str`, `symbols: &'static [&'static str]` (10 entries), `required_symbol_count: usize` (= 8 = 80% threshold per milestone-096 FR-004).
+- **FR-002**: The 4 new symbol sets MUST consist of public-API functions documented in each library's headers (no internal/private symbols) and use the library-canonical prefix for distinctiveness: `sqlite3_*` (SQLite), `pcre_*` (PCRE 8.x), `pcre2_*_8` (PCRE 10.x), `gnutls_*` (GnuTLS).
+- **FR-003**: Library slugs in the `FINGERPRINTS` table MUST match the slugs produced by `version_strings::CuratedLibrary::slug()` so the milestone-096 Q1 composite-evidence merge correctly collapses version-string + symbol-fingerprint matches for the same library on the same binary into ONE component. Required slugs: `sqlite`, `pcre`, `pcre2`, `gnutls`.
+- **FR-004**: Documented-omission allowlist MUST grow from 1 entry (`boringssl` per milestone 097) to **5 entries**: `boringssl`, `libressl`, `llvm`, `openjdk`, plus a placeholder slot for future additions. The list lives in-source as a `//` comment block above the `FINGERPRINTS` table with per-library rationale (BoringSSL/LibreSSL share OpenSSL's symbol set → unreliable disambiguation; LLVM has too broad an API surface for a useful 10-symbol fingerprint; OpenJDK isn't a C library so symbol fingerprinting doesn't apply).
+- **FR-005**: No new Cargo dependencies. Pure const-table addition + unit tests using the existing `String::new(...)` test harness from milestone 096.
+- **FR-006**: Production code changes confined to `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs`. No changes to `binary/mod.rs`, no changes to `entry.rs`, no changes to `generate/*`, no changes to the parity catalog (no new `mikebom:*` properties).
+- **FR-007**: The 8-of-10 match threshold per milestone-096 FR-004 MUST apply uniformly to all 7 libraries. No per-library threshold tuning in v1.
+- **FR-008**: Composite-evidence merge with version-string matches per milestone-096 Q1 MUST work for all 4 new libraries without code changes — the merge keys on lowercase library name, and the slug naming convention is preserved per FR-003.
+- **FR-009**: Goldens MAY regenerate if any existing fixture contains a binary triggering one of the 4 new fingerprints. Per milestone-096 SC-007, the ≤1-spurious-match bound across the 9 existing ecosystem fixtures continues to apply — at most 1 spurious match across all 7 libraries.
+- **FR-010**: 4 new unit tests in `symbol_fingerprint::tests`: one per new library. Each test synthesizes the library's full 10-symbol set, calls `scan()`, asserts a single match with the right library name and `matched_count == 10`. Plus an under-threshold test verifying a 7-of-10 symbol set produces NO match.
+
+### Key Entities
+
+- **Symbol fingerprint entry**: a `(library_name, symbols[10], required_symbol_count)` triple in the `FINGERPRINTS` const table. Library name is lowercase ASCII matching `CuratedLibrary::slug()`. Symbols are exact-string public-API function names from the library's headers. Threshold is uniformly 8 (= 80% of 10).
+- **Documented-omission rationale**: in-source `//` comment per omitted library explaining why no fingerprint exists. Helps future maintainers understand the decision tree.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator scanning a fixture that statically links SQLite (and has its version string stripped) sees `pkg:generic/sqlite` in the emitted SBOM with `mikebom:evidence-kind = symbol-fingerprint`.
+- **SC-002**: An operator scanning a fixture that statically links PCRE 8.x sees `pkg:generic/pcre` (not `pcre2`); an operator scanning a fixture that statically links PCRE 10.x sees `pkg:generic/pcre2` (not `pcre`).
+- **SC-003**: An operator scanning a fixture that statically links GnuTLS sees `pkg:generic/gnutls` in the emitted SBOM.
+- **SC-004**: The composite-evidence merge from milestone-096 Q1 produces ONE component (not two) when both version-string and symbol-fingerprint matches fire for any of the 4 new libraries on the same binary.
+- **SC-005**: `./scripts/pre-pr.sh` clean post-implementation — zero clippy warnings, every test target reports `0 failed`. `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1` opt-in also passes (no new emission paths; conformance unchanged).
+- **SC-006**: 4 new unit tests pass; the existing 3 milestone-096 tests continue to pass; no regression in the existing `binary_id_enrich.rs::mikebom_itself_does_not_emit_spurious_symbol_fingerprints` test (mikebom itself uses rustls so it should NOT trip any of the 4 new fingerprints either).
+- **SC-007**: Existing-ecosystem golden regen scope bounded — at most 1 component per existing golden gains a new symbol-fingerprint emission across the 9 ecosystem fixtures (matches milestone-096 SC-007 ≤1-spurious-bound semantics).
+- **SC-008**: Zero new Cargo dependencies (FR-005).
+
+## Assumptions
+
+- The 4 chosen libraries (sqlite, pcre, pcre2, gnutls) cover the high-value gap between the milestone-096 symbol-fingerprint set and the broader milestone-026 version-string set. Operators with niche static-linking patterns (boost, libpng, freetype, etc.) require both scanners to support those libraries first — out of scope for this milestone.
+- The 8-of-10 threshold is correctly calibrated per milestone-096 FR-004. No threshold tuning in this milestone; tune at a separate milestone if false-positive data emerges.
+- Symbol names in each library's public API are stable across versions — `sqlite3_open` has shipped since SQLite 3.0.0 in 2004; `gnutls_init` since GnuTLS 1.0 in 2004. Selecting 10 long-stable symbols per library bounds the regression risk from upstream API changes.
+- The mikebom binary itself (built with rustls, not OpenSSL/GnuTLS/etc.) does NOT export any of these 7 fingerprint sets at 8/10 strength. Verified at implementation time; the SC-007 spurious-bound test guards regressions.
+
+## Dependencies
+
+- **Milestone 096** (binary-id enrichment) — provides the `symbol_fingerprint.rs` module + `scan()` function + composite-evidence merge this milestone extends. Direct dependency on the FINGERPRINTS table shape.
+- **Milestone 026** (version-string easy-4 cohort) — defines the `CuratedLibrary::slug()` values (`sqlite`, `pcre`, `pcre2`, `gnutls`) this milestone matches for composite-evidence merge.
+
+## Out of Scope
+
+- **PE Export Directory + Mach-O `LC_DYSYMTAB` symbol fingerprinting**. ELF only in v1; the milestone-096 Out-of-Scope clause for PE/Mach-O remains in force.
+- **CPE candidate emission for symbol-fingerprint-only components**. Milestone-097 FR-004 explicitly suppresses these to avoid wildcard-version false-positive floods. Preserved.
+- **Confidence-tier tuning** (e.g., raising SQLite's confidence above 0.4 because its prefix is distinctive). Out of scope; the heuristic-tier is uniform across all symbol-fingerprint emissions per milestone-096 conventions.
+- **Additional libraries beyond the v1 starter set** (libpng, freetype, boost, libssh2, nghttp2, etc.). These require version-string-scanner support first; out of scope until that milestone lands.
+- **BoringSSL / LibreSSL fork-specific fingerprinting**. The forks share the OpenSSL ABI by design; symbol fingerprinting cannot reliably distinguish them. Operators wanting fork identity rely on the milestone-026 version-string scanner where the anchors `"BoringSSL "` / `"LibreSSL "` are distinctive.
+- **LLVM fingerprinting**. LLVM is a compiler infrastructure project with hundreds of public-API entry points; selecting any stable 10-symbol subset is unreliable (different mikebom releases would pick different 10-symbol slices). Skip.
+- **OpenJDK fingerprinting**. OpenJDK's "binary" is the `java` launcher, which doesn't statically link the JDK as a C library — the JDK lives in `libjvm.so` loaded via JNI. Symbol fingerprinting on the launcher doesn't yield OpenJDK identification. Defer until milestone-026's OpenJDK version-string extraction is the sole signal.
+- **Per-library symbol-fingerprint-count metric** (e.g., `mikebom:fingerprint-strength = high|medium|low` based on prefix distinctiveness). Constitution X transparency is satisfied by the existing `mikebom:fingerprint-symbols-matched = N/10` annotation; finer-grained signals are operator policy, not data.
+- **Symbol-fingerprint scanning at runtime** via eBPF observation. Different signal channel; orthogonal to static binary inspection.

--- a/specs/099-symbol-fingerprint-expand/tasks.md
+++ b/specs/099-symbol-fingerprint-expand/tasks.md
@@ -1,0 +1,252 @@
+---
+description: "Task list for milestone 099 — symbol-fingerprint table expansion to 7 libraries"
+---
+
+# Tasks: Symbol-fingerprint table expansion
+
+**Input**: Design documents from `/Users/mlieberman/Projects/mikebom/specs/099-symbol-fingerprint-expand/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/fingerprint-expansion-contracts.md, quickstart.md
+
+**Tests**: Included. 5 new unit tests per data-model.md (4 happy-path + 1 under-threshold) + 1 extension to the existing milestone-096 mikebom-self regression test.
+
+**Organization**: Three user stories each add 1-2 library fingerprints to the same file (`symbol_fingerprint.rs`). The single-file convergence means US1 → US2 → US3 land sequentially within the file; tests within each user story remain parallel-safe. Documented-omission comment block is the only foundational task (Phase 2).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files OR different test functions in the same file)
+- **[Story]**: User story this task belongs to (US1–US3)
+- File paths are workspace-relative.
+
+## Path Conventions
+
+Production code under `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs` (extends milestone-096's FINGERPRINTS const table). One regression-test extension in `mikebom-cli/tests/binary_id_enrich.rs`. Zero changes outside these two files (FR-006).
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Verify environment + confirm preconditions before touching production code.
+
+- [X] T001 Confirm working branch is `099-symbol-fingerprint-expand`. Run `git status` + `git log -1 --oneline`; verify branch was created by `/speckit-specify` and main is at post-PR-#206 (alpha.32 release) or later.
+- [X] T002 Confirm baseline pre-PR gate passes. Run `./scripts/pre-pr.sh` once on the unchanged tree; expect `>>> all pre-PR checks passed.` Isolates any post-edit failure as introduced by milestone 099.
+- [X] T003 Audit existing `symbol_fingerprint.rs` + verify slug consistency per research §4. Run:
+    ```bash
+    grep -nE 'CuratedLibrary::Sqlite|CuratedLibrary::Pcre|CuratedLibrary::GnuTls|=> "sqlite"|=> "pcre"|=> "gnutls"' \
+        mikebom-cli/src/scan_fs/binary/version_strings.rs | head -6
+    grep -nE 'const FINGERPRINTS|struct SymbolFingerprint' \
+        mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs | head -3
+    grep -nE 'matches!\(purl,' mikebom-cli/tests/binary_id_enrich.rs | head -3
+    ```
+    Expected: `=> "sqlite"`, `=> "pcre"`, `=> "pcre2"`, `=> "gnutls"` all present in `CuratedLibrary::slug()`; `const FINGERPRINTS` defined in `symbol_fingerprint.rs`; existing `matches!(purl, ...)` lookup in `binary_id_enrich.rs::mikebom_itself_does_not_emit_spurious_symbol_fingerprints` for openssl/zlib/libcurl.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the documented-omission `//` comment block above the `FINGERPRINTS` array. This is a single one-shot edit that explains the deliberate exclusions (boringssl, libressl, llvm, openjdk) for all three user stories' future maintainers. Lands once; benefits all three USs.
+
+- [X] T004 Add documented-omission comment block immediately above `const FINGERPRINTS: &[SymbolFingerprint] = &[` in `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs` per `data-model.md §symbol_fingerprint.rs — extension shape` + `research.md §6`. The block names each of the 4 omissions (boringssl, libressl, llvm, openjdk) with per-library rationale. Format: `//` comments, no doc-comment markers (the docs already exist on the `SymbolFingerprint` struct above).
+
+**Checkpoint**: After T004, the omission rationale lives in-source for future maintainer visibility. The FINGERPRINTS table itself is unchanged; US1/US2/US3 each add their respective rows in the user-story phases that follow.
+
+---
+
+## Phase 3: User Story 1 — SQLite fingerprint (Priority: P1) 🎯 MVP
+
+**Goal**: Add the `sqlite` row to `FINGERPRINTS`. After landing US1, an ELF binary that statically links SQLite (with `.dynsym` retained but version string stripped) emits `pkg:generic/sqlite` with `mikebom:evidence-kind = symbol-fingerprint`.
+
+**Independent Test**: synthesize a symbol set containing all 10 SQLite fingerprint symbols; call `symbol_fingerprint::scan()`; expect one match with `library = "sqlite"`, `matched_count = 10`, `total_count = 10`. Plus the under-threshold test (7/10) verifies the 8-of-10 gate.
+
+### Implementation for User Story 1
+
+- [X] T005 [US1] Append the SQLite row to `FINGERPRINTS` in `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs` per `data-model.md §symbol_fingerprint.rs — extension shape`. 10 symbols: `sqlite3_open`, `sqlite3_close`, `sqlite3_exec`, `sqlite3_prepare_v2`, `sqlite3_step`, `sqlite3_finalize`, `sqlite3_bind_int`, `sqlite3_column_text`, `sqlite3_errmsg`, `sqlite3_libversion`. `required_symbol_count: 8`.
+
+### Tests for User Story 1
+
+- [X] T006 [P] [US1] Add unit test `sqlite_full_set_matches` to `mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs::tests` per `data-model.md`. Synthesizes all 10 SQLite symbols, calls `scan()`, asserts one match with `library == "sqlite"` and `matched_count == 10`.
+- [X] T007 [P] [US1] Add unit test `sqlite_seven_of_ten_below_threshold` to `symbol_fingerprint::tests` per `data-model.md`. Synthesizes only 7 of 10 SQLite symbols, asserts `scan()` returns empty Vec (under-threshold sentinel — Contract 2).
+- [X] T008 [US1] Verify Contracts 1 + 2 for SQLite from `contracts/fingerprint-expansion-contracts.md`. Run:
+    ```bash
+    cargo +stable test -p mikebom --bin mikebom \
+        --no-fail-fast sqlite_full_set_matches \
+        sqlite_seven_of_ten_below_threshold 2>&1 | grep "test result:"
+    # Expected: ok. 2 passed.
+    ```
+
+**Checkpoint**: US1 complete. MVP — SQLite identification now works on stripped binaries.
+
+---
+
+## Phase 4: User Story 2 — PCRE 8.x + PCRE 10.x fingerprints (Priority: P2)
+
+**Goal**: Add the `pcre` and `pcre2` rows to `FINGERPRINTS`. After landing US2, an ELF binary statically linking PCRE 8.x emits `pkg:generic/pcre`; a binary linking PCRE 10.x emits `pkg:generic/pcre2`. The two libraries are disambiguated by their distinct symbol prefixes (`pcre_*` vs `pcre2_*_8`).
+
+**Independent Test**: synthesize the PCRE 8.x symbol set → match on `pcre` (not `pcre2`). Synthesize the PCRE 10.x set → match on `pcre2` (not `pcre`). Both libraries' fingerprints are independent at the symbol-prefix level.
+
+### Implementation for User Story 2
+
+- [X] T009 [US2] Append the PCRE 8.x + PCRE 10.x rows to `FINGERPRINTS` in `symbol_fingerprint.rs` per `data-model.md`. PCRE 8.x symbols: `pcre_compile`, `pcre_exec`, `pcre_free`, `pcre_study`, `pcre_get_substring`, `pcre_version`, `pcre_fullinfo`, `pcre_compile2`, `pcre_dfa_exec`, `pcre_jit_exec`. PCRE 10.x symbols (8-bit width only per research §3): `pcre2_compile_8`, `pcre2_match_8`, `pcre2_match_data_create_8`, `pcre2_substring_get_byname_8`, `pcre2_substring_get_bynumber_8`, `pcre2_get_ovector_pointer_8`, `pcre2_code_free_8`, `pcre2_match_data_free_8`, `pcre2_compile_context_create_8`, `pcre2_set_compile_extra_options_8`. Both with `required_symbol_count: 8`. Include an inline `//` comment on the pcre2 row noting "8-bit width variant only; 16/32-bit deferred per research §3".
+
+### Tests for User Story 2
+
+- [X] T010 [P] [US2] Add unit test `pcre_full_set_matches` to `symbol_fingerprint::tests` per `data-model.md`. Synthesizes all 10 PCRE 8.x symbols, asserts match on `library == "pcre"` with `matched_count == 10`.
+- [X] T011 [P] [US2] Add unit test `pcre2_full_set_matches` to `symbol_fingerprint::tests` per `data-model.md`. Synthesizes all 10 PCRE 10.x symbols, asserts match on `library == "pcre2"` with `matched_count == 10`.
+- [X] T012 [US2] Verify Contracts 1 + 3 for PCRE from `contracts/fingerprint-expansion-contracts.md`. Run:
+    ```bash
+    cargo +stable test -p mikebom --bin mikebom \
+        --no-fail-fast pcre_full_set_matches \
+        pcre2_full_set_matches 2>&1 | grep "test result:"
+    # Expected: ok. 2 passed.
+
+    # Implicit cross-match check: `pcre_full_set_matches` asserts
+    # `library == "pcre"` not "pcre2" — the test body verifies the
+    # disambiguation per Contract 3.
+    ```
+
+**Checkpoint**: US2 complete. PCRE 8.x and PCRE 10.x both identifiable on stripped binaries; the prefix-distinctiveness disambiguates the two libraries automatically.
+
+---
+
+## Phase 5: User Story 3 — GnuTLS fingerprint (Priority: P2)
+
+**Goal**: Add the `gnutls` row to `FINGERPRINTS`. After landing US3, an ELF binary statically linking GnuTLS emits `pkg:generic/gnutls`.
+
+**Independent Test**: synthesize the GnuTLS symbol set → match on `gnutls` with `matched_count == 10`.
+
+### Implementation for User Story 3
+
+- [X] T013 [US3] Append the GnuTLS row to `FINGERPRINTS` in `symbol_fingerprint.rs` per `data-model.md`. 10 symbols: `gnutls_init`, `gnutls_deinit`, `gnutls_handshake`, `gnutls_record_send`, `gnutls_record_recv`, `gnutls_global_init`, `gnutls_global_deinit`, `gnutls_set_default_priority`, `gnutls_credentials_set`, `gnutls_session_set_ptr`. `required_symbol_count: 8`.
+
+### Tests for User Story 3
+
+- [X] T014 [P] [US3] Add unit test `gnutls_full_set_matches` to `symbol_fingerprint::tests` per `data-model.md`. Synthesizes all 10 GnuTLS symbols, asserts match on `library == "gnutls"` with `matched_count == 10`.
+- [X] T015 [US3] Verify Contract 1 for GnuTLS from `contracts/fingerprint-expansion-contracts.md`. Run:
+    ```bash
+    cargo +stable test -p mikebom --bin mikebom \
+        --no-fail-fast gnutls_full_set_matches 2>&1 | grep "test result:"
+    # Expected: ok. 1 passed.
+    ```
+
+**Checkpoint**: US3 complete. The 4 new libraries (sqlite/pcre/pcre2/gnutls) all emit identification from symbol-fingerprint scanning on stripped binaries.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Extend the existing milestone-096 mikebom-self regression test to guard against future spurious matches on the 4 new libraries; diff-scope audit; pre-PR gate.
+
+- [X] T016 [P] Extend the assertion list in `mikebom-cli/tests/binary_id_enrich.rs::mikebom_itself_does_not_emit_spurious_symbol_fingerprints` per `quickstart.md` Recipe 3. The existing `matches!(purl, ...)` arm currently checks for `pkg:generic/openssl`, `pkg:generic/zlib`, `pkg:generic/libcurl`. Add `pkg:generic/sqlite`, `pkg:generic/pcre`, `pkg:generic/pcre2`, `pkg:generic/gnutls` to the same arm. Mikebom uses rustls (not OpenSSL/SQLite/PCRE/GnuTLS) so the extended assertion should continue to pass — closes SC-006's regression guard.
+- [X] T017 Verify Contract 6 — diff scope guardrails. Run:
+    ```bash
+    # No new Cargo deps (FR-005 / SC-008):
+    git diff --name-only main | grep -E '^Cargo\.(lock|toml)$' | wc -l
+    # Expected: 0
+
+    # Production code outside symbol_fingerprint.rs:
+    git diff --name-only main | grep -E '^mikebom-cli/src/' \
+      | grep -vE '^mikebom-cli/src/scan_fs/binary/symbol_fingerprint\.rs$' \
+      | wc -l
+    # Expected: 0
+
+    # Golden regen scope (FR-009 / SC-007):
+    git diff --stat mikebom-cli/tests/fixtures/golden/ | tail -1
+    # Expected: empty (no existing fixture binaries statically link sqlite/pcre/gnutls)
+
+    # Diff scope allowlist:
+    git diff --name-only main | sort
+    # Expected:
+    #   CLAUDE.md                                                  (auto-updated)
+    #   mikebom-cli/src/scan_fs/binary/symbol_fingerprint.rs
+    #   mikebom-cli/tests/binary_id_enrich.rs                      (regression test)
+    #   specs/099-symbol-fingerprint-expand/...
+    ```
+- [X] T018 Run the mandatory pre-PR gate per Contract 7. Run `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 ./scripts/pre-pr.sh`. Expect: `>>> all pre-PR checks passed.` with zero clippy warnings and zero test failures across the workspace. The 5 new symbol_fingerprint tests pass; the existing 3 milestone-096 tests continue to pass; the extended `binary_id_enrich.rs` mikebom-self test passes (mikebom doesn't link any of the 7 tracked libraries).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies. Start immediately.
+- **Foundational (Phase 2)**: T004 adds the omission comment block — non-blocking for the 3 USs (USs can land their rows before or after T004; landing T004 first is just cleaner for code-review).
+- **US1 (Phase 3, P1, MVP)**: Independent at file level. Adds 1 row + 2 tests.
+- **US2 (Phase 4, P2)**: Independent at file level. Adds 2 rows + 2 tests. Soft-depends on US1 having appended its row first only for diff-locality (same file region).
+- **US3 (Phase 5, P2)**: Independent at file level. Adds 1 row + 1 test.
+- **Polish (Phase 6)**: Depends on US1+US2+US3 implementation tasks complete (so all 4 new libraries are in the table when T016 extends the regression test).
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent at file level. T005 appends one row.
+- **US2 (P2)**: Independent at file level. T009 appends two rows.
+- **US3 (P2)**: Independent at file level. T013 appends one row.
+
+(The 3 user stories share the same const-table region in `symbol_fingerprint.rs`. Diff-wise they land in sequence within the file; behavior-wise each is independently testable.)
+
+### Within Each User Story
+
+- US1: T005 (impl) → T006-T007 (tests, parallel-safe) → T008 (verify).
+- US2: T009 (impl, 2 rows) → T010-T011 (tests, parallel-safe) → T012 (verify).
+- US3: T013 (impl) → T014 (test) → T015 (verify).
+
+### Parallel Opportunities
+
+- T006 / T007 / T010 / T011 / T014 — 5 parallel-safe test additions across all three stories (different test functions, same module file — Rust allows multiple functions in one file without ordering constraints).
+- T016 (regression test) is parallel-safe with T017 (diff audit) once Phase 5 is complete.
+
+---
+
+## Parallel Example: Phase 3-5 unit tests
+
+```bash
+# After T005, T009, T013 land (the 4 const-table rows), all 5 unit
+# tests can be added in any order:
+Task: "Add unit test sqlite_full_set_matches (T006)"
+Task: "Add unit test sqlite_seven_of_ten_below_threshold (T007)"
+Task: "Add unit test pcre_full_set_matches (T010)"
+Task: "Add unit test pcre2_full_set_matches (T011)"
+Task: "Add unit test gnutls_full_set_matches (T014)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only)
+
+The user's headline ask is "expand symbol-fingerprint coverage". SQLite is the most-statically-linked C library in CLI tooling — covering it alone moves the needle measurably. MVP path:
+
+1. Phase 1: Setup (T001-T003)
+2. Phase 2: Foundational (T004 omission comment block)
+3. Phase 3: US1 (T005-T008) — SQLite row + 2 tests + verify
+4. Phase 6 partial: T016 (regression test extension for sqlite only) + T018 (pre-PR gate)
+5. **STOP and VALIDATE**: scan a statically-linked SQLite binary if available; confirm `pkg:generic/sqlite` appears.
+
+US2 + US3 layer on after MVP-validation. The full milestone delivers all 4 libraries in a single PR.
+
+### Incremental Delivery (recommended)
+
+Single PR shipping all three stories — the surface (~110 lines new code) is small enough that splitting adds noise. Total estimated time: ~30 min single-developer.
+
+### Single-Developer Strategy
+
+1. T001-T003 (setup, ~3 min)
+2. T004 (omission comment block, ~2 min)
+3. T005-T008 (US1 sqlite, ~7 min — row + 2 tests + verify)
+4. T009-T012 (US2 pcre + pcre2, ~10 min — 2 rows + 2 tests + verify)
+5. T013-T015 (US3 gnutls, ~5 min — row + 1 test + verify)
+6. T016-T018 (Polish, ~5 min — regression-test extension + diff audit + pre-PR gate)
+
+Total: ~32 minutes single-developer focus.
+
+---
+
+## Notes
+
+- [P] markers = different test functions OR different files with no shared edit-dependency.
+- [Story] label maps task to user story for traceability.
+- All 3 USs converge on the same `symbol_fingerprint.rs` file but at distinct row-positions in the `FINGERPRINTS` table; each US's row addition is an independent diff hunk.
+- T004 (omission comment block) is foundational because it documents WHY libraries aren't in the table — it doesn't add functionality. Could land in US1 if a strict per-US phase is preferred; treating it as foundational separates the documentation work from the per-library code-add work for cleaner code review.
+- Pre-PR gate (T018) MUST run with `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1` per CLAUDE.md SBOM-spec-touching-changes rule. Even though this milestone touches no emission paths, the workspace-wide test gate is the safety net.
+- Commit boundary suggestion: single commit (US1+US2+US3+Polish in one PR). Surface is small enough that splitting adds noise.
+- Avoid: tuning the 8/10 threshold per library (FR-007 says uniform across all 7), expanding the table beyond the 4 listed libraries (per spec out-of-scope), or adding PE/Mach-O symbol fingerprinting (per spec out-of-scope).


### PR DESCRIPTION
## Summary

- Symbol-fingerprint coverage grows **3 → 7 libraries**: openssl/zlib/libcurl (existing) + **sqlite, pcre, pcre2, gnutls** (new).
- 4 documented omissions (boringssl/libressl/llvm/openjdk) with in-source rationale.
- 5 new unit tests + 1 line extension to the existing mikebom-self regression guard.

## Why

Milestone 096 shipped a 3-library symbol-fingerprint set while the milestone-026 version-string scanner covered 11 libraries. The coverage gap meant a stripped ELF binary statically linking SQLite (or PCRE, or GnuTLS) — with `.dynsym` retained but the version string removed — emitted **no identification at all**. SQLite is one of the most-statically-linked C libraries in CLI tooling; closing that gap moves the needle on unknown-binary identification meaningfully.

## Symbol sets

| Library | Prefix | Why |
|---------|--------|-----|
| sqlite | `sqlite3_*` | Near-zero collision risk; most-statically-linked C library in CLIs; API stable since 2004 |
| pcre | `pcre_*` | PCRE 8.x; API frozen as of 8.45 (final 8.x release, 2021) |
| pcre2 | `pcre2_*_8` | PCRE 10.x (8-bit width — dominant variant); 16/32-bit deferred |
| gnutls | `gnutls_*` | OpenSSL alternative common on Debian-derived distros; API stable since GnuTLS 3.0 |

PCRE 8.x / 10.x disambiguation is automatic — the `pcre_*` and `pcre2_*_8` symbol sets are disjoint, so a binary linking one cannot hit the other's 8-of-10 threshold.

## Documented omissions

- **boringssl** / **libressl**: drop-in OpenSSL ABI replacements; symbol overlap with openssl prevents reliable disambiguation. Use the version-string scanner's `BoringSSL ` / `LibreSSL ` anchors instead.
- **llvm**: API surface too broad (hundreds of public-API entry points across `libLLVM*`); no stable 10-symbol slice. Defer.
- **openjdk**: launcher binary doesn't statically link JDK APIs (those live in `libjvm.so` loaded via JNI). Symbol fingerprinting at the launcher level yields no signal.

## Composite-evidence merge

Works automatically. The 4 new library slugs (`sqlite`, `pcre`, `pcre2`, `gnutls`) already exist in `version_strings::CuratedLibrary::slug()`, so the milestone-096 Q1 merge in `binary/mod.rs::read()` keys on the same lowercase strings without any code changes.

## Scope guardrails

- **Zero new Cargo deps** (FR-005 ✓)
- **Production code confined** to `scan_fs/binary/symbol_fingerprint.rs` (FR-006 ✓); regression-test extension is one `matches!` arm expansion
- **Zero golden regen** — no existing ecosystem fixture statically links the 4 new libraries (FR-009 / SC-007 ✓)
- **No new properties / parity-catalog rows / emission paths** — milestone-096's existing `mikebom:evidence-kind = symbol-fingerprint` annotation infrastructure handles all 7 libraries identically

## Test plan

- [x] `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 ./scripts/pre-pr.sh` → `>>> all pre-PR checks passed.`
- [x] 15/15 `symbol_fingerprint::tests` pass (10 milestone-096 + 5 new)
- [x] `binary_id_enrich.rs::mikebom_itself_does_not_emit_spurious_symbol_fingerprints` passes for all 7 libraries — mikebom (rustls-based) doesn't link any of them
- [x] Full workspace `cargo test`: every target `0 failed`
- [x] Clippy: zero warnings
- [x] Diff scope: only `symbol_fingerprint.rs` + the regression-test extension + spec docs + `CLAUDE.md` (auto-updated)
- [x] No `Cargo.toml`/`Cargo.lock` changes; no goldens regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)