### PR TITLE
test(inspector): vulnerable dep — DO NOT MERGE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
- "time",
+ "time 0.3.47",
 ]
 
 [[package]]
@@ -2046,6 +2046,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "time 0.1.40",
  "tokio",
  "toml",
  "tracing",
@@ -3026,6 +3027,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
@@ -3523,7 +3530,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_with_macros",
- "time",
+ "time 0.3.47",
 ]
 
 [[package]]
@@ -3949,6 +3956,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
+dependencies = [
+ "libc",
+ "redox_syscall 0.1.57",
+ "winapi",
 ]
 
 [[package]]
@@ -4567,6 +4585,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4574,6 +4608,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4950,7 +4990,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror 1.0.69",
- "time",
+ "time 0.3.47",
 ]
 
 [[package]]

--- a/mikebom-cli/Cargo.toml
+++ b/mikebom-cli/Cargo.toml
@@ -101,6 +101,13 @@ tempfile = "3"
 toml = "0.8"
 uuid = { version = "1", features = ["v4"] }
 
+# !!! TEST-ONLY — VERIFY KUSARI INSPECTOR FLAGS THIS !!!
+# `time = "=0.1.40"` is known-vulnerable: RUSTSEC-2020-0071
+# (segfault in `localtime_r` under certain conditions). This PR
+# is a deliberate test of Inspector's dep-scanning gate and
+# MUST NOT BE MERGED. Revert before any landing of unrelated work.
+time = "=0.1.40"
+
 base64 = "0.22"
 # Milestone 010 — RFC 4648 base32 encoding for deterministic SPDX IDs
 # (SPDXRef-Package-<base32(SHA-256(purl))[..16]>) and document


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE.** This PR exists ONLY to verify Kusari Inspector flags known-vulnerable dependencies on a real PR. Close + delete the branch when verification is complete.

## What's in the PR

Adds `time = "=0.1.40"` as a direct dependency on \`mikebom-cli\`.

`time v0.1.40` is in the GitHub Advisory Database under **RUSTSEC-2020-0071** (segfault in \`localtime_r\` under certain Unix configurations; fixed in `time >= 0.2.23`).

## Expected behavior

- ✅ Kusari Inspector should flag this PR as HIGH/CRITICAL severity due to the pinned vulnerable version.
- ✅ Inspector's PR comment should name the advisory ID and link to the GHSA.
- ✅ The Inspector status check should report FAILURE.
- ⚠️ Standard CI lanes (Linux/macOS/Windows clippy + test) will still run and probably pass — `time v0.1.40` compiles cleanly, the vuln is at runtime.

## Verification checklist

- [ ] Inspector posts a PR comment within ~30 seconds of PR creation.
- [ ] The comment names "RUSTSEC-2020-0071" or equivalent advisory ID.
- [ ] The "Kusari Inspector" status check reports FAILURE (not SUCCESS).
- [ ] If branch protection is configured with Inspector as a required check, the merge button is disabled.

## Cleanup

After verification, close this PR (don't merge) and delete the branch:

\`\`\`bash
gh pr close <this-pr-number> --delete-branch
\`\`\`