### PR TITLE
ci: extend cargo sanity-check to all 10 rustup-cleanup sites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,18 +77,33 @@ jobs:
       # That action caches `$CARGO_HOME/bin` and on cache-hit restores
       # `rustup-init` — undoing this cleanup if it runs before. Verified
       # via PR #217 macOS failure logs (2026-05-15).
-      - name: Remove rustup-init (prevents `cargo +stable` dispatch race)
+      - name: Remove rustup-init + verify cargo works (`cargo +stable` dispatch race)
         shell: bash
         run: |
           rm -f "$HOME/.cargo/bin/rustup-init" "$HOME/.cargo/bin/rustup-init.exe"
-          # Verification — fail loudly if removal didn't take so the
-          # next `cargo +stable` doesn't produce the same opaque error.
+          # Sanity-check that cargo itself dispatches as cargo — catches
+          # the polluted-cache shape where ~/.cargo/bin/cargo IS the
+          # rustup-init body under a different filename (observed on
+          # the PR #217 macOS realistic-projects lane). The plain
+          # `rm rustup-init` doesn't catch this; only a behavioral check
+          # of the cargo binary does.
+          if ! cargo --version > /dev/null 2>&1; then
+            echo "ERROR: \`cargo --version\` fails — \$HOME/.cargo/bin/cargo is not a working cargo proxy."
+            echo "--- ls -la \$HOME/.cargo/bin/ ---"
+            ls -la "$HOME/.cargo/bin/" || true
+            echo "--- file \$HOME/.cargo/bin/cargo ---"
+            file "$HOME/.cargo/bin/cargo" || true
+            echo "--- cargo --version output ---"
+            cargo --version 2>&1 || true
+            exit 1
+          fi
+          echo "cargo --version OK: $(cargo --version)"
           if [ -e "$HOME/.cargo/bin/rustup-init" ] || [ -e "$HOME/.cargo/bin/rustup-init.exe" ]; then
-            echo "ERROR: rustup-init still present after rm — cargo +<channel> will route to the installer."
+            echo "ERROR: rustup-init still present after rm."
             ls -la "$HOME/.cargo/bin/" || true
             exit 1
           fi
-          echo "rustup-init absent from \$HOME/.cargo/bin (good); cargo +<channel> will dispatch to rustup."
+          echo "rustup-init absent from \$HOME/.cargo/bin (good)."
 
       # Milestone 090 — fixture-repo cache. mikebom-cli/build.rs
       # clones https://github.com/kusari-sandbox/mikebom-test-fixtures
@@ -264,12 +279,23 @@ jobs:
       # See lint-and-test job for the rationale. MUST run AFTER
       # Swatinem/rust-cache or its $CARGO_HOME/bin restore re-creates
       # rustup-init.
-      - name: Remove rustup-init (prevents `cargo +stable` dispatch race)
+      - name: Remove rustup-init + verify cargo works (`cargo +stable` dispatch race)
         shell: bash
         run: |
           rm -f "$HOME/.cargo/bin/rustup-init" "$HOME/.cargo/bin/rustup-init.exe"
+          if ! cargo --version > /dev/null 2>&1; then
+            echo "ERROR: \`cargo --version\` fails — \$HOME/.cargo/bin/cargo is not a working cargo proxy."
+            echo "--- ls -la \$HOME/.cargo/bin/ ---"
+            ls -la "$HOME/.cargo/bin/" || true
+            echo "--- file \$HOME/.cargo/bin/cargo ---"
+            file "$HOME/.cargo/bin/cargo" || true
+            echo "--- cargo --version output ---"
+            cargo --version 2>&1 || true
+            exit 1
+          fi
+          echo "cargo --version OK: $(cargo --version)"
           if [ -e "$HOME/.cargo/bin/rustup-init" ] || [ -e "$HOME/.cargo/bin/rustup-init.exe" ]; then
-            echo "ERROR: rustup-init still present after rm — cargo +<channel> will route to the installer."
+            echo "ERROR: rustup-init still present after rm."
             ls -la "$HOME/.cargo/bin/" || true
             exit 1
           fi
@@ -323,12 +349,23 @@ jobs:
       # fixes the root cause (rustup-init left on PATH alongside
       # rustup) on every lane. MUST run AFTER Swatinem/rust-cache or
       # its $CARGO_HOME/bin restore re-creates rustup-init.
-      - name: Remove rustup-init (prevents `cargo +stable` dispatch race)
+      - name: Remove rustup-init + verify cargo works (`cargo +stable` dispatch race)
         shell: bash
         run: |
           rm -f "$HOME/.cargo/bin/rustup-init" "$HOME/.cargo/bin/rustup-init.exe"
+          if ! cargo --version > /dev/null 2>&1; then
+            echo "ERROR: \`cargo --version\` fails — \$HOME/.cargo/bin/cargo is not a working cargo proxy."
+            echo "--- ls -la \$HOME/.cargo/bin/ ---"
+            ls -la "$HOME/.cargo/bin/" || true
+            echo "--- file \$HOME/.cargo/bin/cargo ---"
+            file "$HOME/.cargo/bin/cargo" || true
+            echo "--- cargo --version output ---"
+            cargo --version 2>&1 || true
+            exit 1
+          fi
+          echo "cargo --version OK: $(cargo --version)"
           if [ -e "$HOME/.cargo/bin/rustup-init" ] || [ -e "$HOME/.cargo/bin/rustup-init.exe" ]; then
-            echo "ERROR: rustup-init still present after rm — cargo +<channel> will route to the installer."
+            echo "ERROR: rustup-init still present after rm."
             ls -la "$HOME/.cargo/bin/" || true
             exit 1
           fi
@@ -416,12 +453,23 @@ jobs:
       # `rustup-init` left by either invocation OR by a cache-hit
       # `$CARGO_HOME/bin` restore is cleaned up before the first
       # `cargo +stable` call.
-      - name: Remove rustup-init (prevents `cargo +stable` dispatch race)
+      - name: Remove rustup-init + verify cargo works (`cargo +stable` dispatch race)
         shell: bash
         run: |
           rm -f "$HOME/.cargo/bin/rustup-init" "$HOME/.cargo/bin/rustup-init.exe"
+          if ! cargo --version > /dev/null 2>&1; then
+            echo "ERROR: \`cargo --version\` fails — \$HOME/.cargo/bin/cargo is not a working cargo proxy."
+            echo "--- ls -la \$HOME/.cargo/bin/ ---"
+            ls -la "$HOME/.cargo/bin/" || true
+            echo "--- file \$HOME/.cargo/bin/cargo ---"
+            file "$HOME/.cargo/bin/cargo" || true
+            echo "--- cargo --version output ---"
+            cargo --version 2>&1 || true
+            exit 1
+          fi
+          echo "cargo --version OK: $(cargo --version)"
           if [ -e "$HOME/.cargo/bin/rustup-init" ] || [ -e "$HOME/.cargo/bin/rustup-init.exe" ]; then
-            echo "ERROR: rustup-init still present after rm — cargo +<channel> will route to the installer."
+            echo "ERROR: rustup-init still present after rm."
             ls -la "$HOME/.cargo/bin/" || true
             exit 1
           fi

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -54,8 +54,19 @@ jobs:
         shell: bash
         run: |
           rm -f "$HOME/.cargo/bin/rustup-init" "$HOME/.cargo/bin/rustup-init.exe"
+          if ! cargo --version > /dev/null 2>&1; then
+            echo "ERROR: \`cargo --version\` fails — \$HOME/.cargo/bin/cargo is not a working cargo proxy."
+            echo "--- ls -la \$HOME/.cargo/bin/ ---"
+            ls -la "$HOME/.cargo/bin/" || true
+            echo "--- file \$HOME/.cargo/bin/cargo ---"
+            file "$HOME/.cargo/bin/cargo" || true
+            echo "--- cargo --version output ---"
+            cargo --version 2>&1 || true
+            exit 1
+          fi
+          echo "cargo --version OK: $(cargo --version)"
           if [ -e "$HOME/.cargo/bin/rustup-init" ] || [ -e "$HOME/.cargo/bin/rustup-init.exe" ]; then
-            echo "ERROR: rustup-init still present after rm — cargo +<channel> will route to the installer."
+            echo "ERROR: rustup-init still present after rm."
             ls -la "$HOME/.cargo/bin/" || true
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,19 @@ jobs:
         shell: bash
         run: |
           rm -f "$HOME/.cargo/bin/rustup-init" "$HOME/.cargo/bin/rustup-init.exe"
+          if ! cargo --version > /dev/null 2>&1; then
+            echo "ERROR: \`cargo --version\` fails — \$HOME/.cargo/bin/cargo is not a working cargo proxy."
+            echo "--- ls -la \$HOME/.cargo/bin/ ---"
+            ls -la "$HOME/.cargo/bin/" || true
+            echo "--- file \$HOME/.cargo/bin/cargo ---"
+            file "$HOME/.cargo/bin/cargo" || true
+            echo "--- cargo --version output ---"
+            cargo --version 2>&1 || true
+            exit 1
+          fi
+          echo "cargo --version OK: $(cargo --version)"
           if [ -e "$HOME/.cargo/bin/rustup-init" ] || [ -e "$HOME/.cargo/bin/rustup-init.exe" ]; then
-            echo "ERROR: rustup-init still present after rm — cargo +<channel> will route to the installer."
+            echo "ERROR: rustup-init still present after rm."
             ls -la "$HOME/.cargo/bin/" || true
             exit 1
           fi
@@ -99,8 +110,19 @@ jobs:
         shell: bash
         run: |
           rm -f "$HOME/.cargo/bin/rustup-init" "$HOME/.cargo/bin/rustup-init.exe"
+          if ! cargo --version > /dev/null 2>&1; then
+            echo "ERROR: \`cargo --version\` fails — \$HOME/.cargo/bin/cargo is not a working cargo proxy."
+            echo "--- ls -la \$HOME/.cargo/bin/ ---"
+            ls -la "$HOME/.cargo/bin/" || true
+            echo "--- file \$HOME/.cargo/bin/cargo ---"
+            file "$HOME/.cargo/bin/cargo" || true
+            echo "--- cargo --version output ---"
+            cargo --version 2>&1 || true
+            exit 1
+          fi
+          echo "cargo --version OK: $(cargo --version)"
           if [ -e "$HOME/.cargo/bin/rustup-init" ] || [ -e "$HOME/.cargo/bin/rustup-init.exe" ]; then
-            echo "ERROR: rustup-init still present after rm — cargo +<channel> will route to the installer."
+            echo "ERROR: rustup-init still present after rm."
             ls -la "$HOME/.cargo/bin/" || true
             exit 1
           fi
@@ -197,8 +219,19 @@ jobs:
         shell: bash
         run: |
           rm -f "$HOME/.cargo/bin/rustup-init" "$HOME/.cargo/bin/rustup-init.exe"
+          if ! cargo --version > /dev/null 2>&1; then
+            echo "ERROR: \`cargo --version\` fails — \$HOME/.cargo/bin/cargo is not a working cargo proxy."
+            echo "--- ls -la \$HOME/.cargo/bin/ ---"
+            ls -la "$HOME/.cargo/bin/" || true
+            echo "--- file \$HOME/.cargo/bin/cargo ---"
+            file "$HOME/.cargo/bin/cargo" || true
+            echo "--- cargo --version output ---"
+            cargo --version 2>&1 || true
+            exit 1
+          fi
+          echo "cargo --version OK: $(cargo --version)"
           if [ -e "$HOME/.cargo/bin/rustup-init" ] || [ -e "$HOME/.cargo/bin/rustup-init.exe" ]; then
-            echo "ERROR: rustup-init still present after rm — cargo +<channel> will route to the installer."
+            echo "ERROR: rustup-init still present after rm."
             ls -la "$HOME/.cargo/bin/" || true
             exit 1
           fi
@@ -276,8 +309,19 @@ jobs:
         shell: bash
         run: |
           rm -f "$HOME/.cargo/bin/rustup-init" "$HOME/.cargo/bin/rustup-init.exe"
+          if ! cargo --version > /dev/null 2>&1; then
+            echo "ERROR: \`cargo --version\` fails — \$HOME/.cargo/bin/cargo is not a working cargo proxy."
+            echo "--- ls -la \$HOME/.cargo/bin/ ---"
+            ls -la "$HOME/.cargo/bin/" || true
+            echo "--- file \$HOME/.cargo/bin/cargo ---"
+            file "$HOME/.cargo/bin/cargo" || true
+            echo "--- cargo --version output ---"
+            cargo --version 2>&1 || true
+            exit 1
+          fi
+          echo "cargo --version OK: $(cargo --version)"
           if [ -e "$HOME/.cargo/bin/rustup-init" ] || [ -e "$HOME/.cargo/bin/rustup-init.exe" ]; then
-            echo "ERROR: rustup-init still present after rm — cargo +<channel> will route to the installer."
+            echo "ERROR: rustup-init still present after rm."
             ls -la "$HOME/.cargo/bin/" || true
             exit 1
           fi
@@ -333,8 +377,19 @@ jobs:
         shell: bash
         run: |
           rm -f "$HOME/.cargo/bin/rustup-init" "$HOME/.cargo/bin/rustup-init.exe"
+          if ! cargo --version > /dev/null 2>&1; then
+            echo "ERROR: \`cargo --version\` fails — \$HOME/.cargo/bin/cargo is not a working cargo proxy."
+            echo "--- ls -la \$HOME/.cargo/bin/ ---"
+            ls -la "$HOME/.cargo/bin/" || true
+            echo "--- file \$HOME/.cargo/bin/cargo ---"
+            file "$HOME/.cargo/bin/cargo" || true
+            echo "--- cargo --version output ---"
+            cargo --version 2>&1 || true
+            exit 1
+          fi
+          echo "cargo --version OK: $(cargo --version)"
           if [ -e "$HOME/.cargo/bin/rustup-init" ] || [ -e "$HOME/.cargo/bin/rustup-init.exe" ]; then
-            echo "ERROR: rustup-init still present after rm — cargo +<channel> will route to the installer."
+            echo "ERROR: rustup-init still present after rm."
             ls -la "$HOME/.cargo/bin/" || true
             exit 1
           fi


### PR DESCRIPTION
## Summary
PR #217 landed the `cargo --version` sanity-check on `realistic-projects.yml` only, where the polluted-Swatinem-cache failure was actually observed. This PR extends the same defense to the other 10 cleanup sites:
- `ci.yml` × 4 (lint-and-test, macOS lint-test, Windows lint-test, ebpf-tracing)
- `release.yml` × 5 (eBPF nightly, x86_64-linux, aarch64-linux, aarch64-macos, x86_64-windows)
- `perf.yml` × 1

## Why
The other sites passed today by luck — their Swatinem cache keys are unique per workflow/job/matrix-entry, so they happened to hold clean snapshots. The moment any of those caches catches a bad write (rm-in-flight during save, dtolnay regression, runner image change, etc.) they'd resurface the exact same opaque error that took ~20 iterations to root-cause.

## What the check does
After `rm -f rustup-init`, run `cargo --version`. If it fails, dump:
- `ls -la ~/.cargo/bin/`
- `file ~/.cargo/bin/cargo`
- raw `cargo --version` output

Then `exit 1` so the run fails fast at the cleanup step instead of producing the opaque `unexpected argument '+stable' found / Usage: rustup-init[EXE]` downstream.

No semantic change on healthy lanes (they all print `cargo --version OK: cargo X.Y.Z (...)`).

## Test plan
- [x] All 4 workflow files parse as valid YAML
- [x] All 11 cleanup sites contain `cargo --version OK` (grep count: realistic 1 + perf 1 + ci 4 + release 5 = 11)
- [x] No leftover old-form ERROR strings
- [ ] CI passes on Linux + macOS + Windows + ebpf-tracing lanes (this PR is itself the test — the sanity check fires on every run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)