### PR TITLE
fix: declare workspace repository so cargo-binstall can render pkg-url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ resolver = "2"
 version = "0.1.0-alpha.34"
 edition = "2021"
 license = "Apache-2.0"
+repository = "https://github.com/kusari-sandbox/mikebom"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/mikebom-cli/Cargo.toml
+++ b/mikebom-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "mikebom"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "mikebom"

--- a/mikebom-common/Cargo.toml
+++ b/mikebom-common/Cargo.toml
@@ -3,6 +3,7 @@ name = "mikebom-common"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [features]
 default = ["std"]


### PR DESCRIPTION
## Summary
- Closes #226 — `cargo binstall --git https://github.com/kusari-sandbox/mikebom mikebom` (documented in README) is currently broken.
- `mikebom-cli/Cargo.toml`'s `[package.metadata.binstall].pkg-url` template references `{ repo }`, but `[package].repository` was never declared. binstall can't render the URL, falls back to crates.io install, and fails because mikebom isn't published there.
- Fix: declare `repository` once in `[workspace.package]` and inherit it in both `mikebom-cli` and `mikebom-common`, matching the existing `version` / `edition` / `license` inheritance pattern. `xtask` (internal task runner, never published) correctly does not inherit.

## Validation
- [x] `cargo +stable metadata --no-deps` now exposes `repository = "https://github.com/kusari-sandbox/mikebom"` on `mikebom` and `mikebom-common`; `xtask` remains `None`.
- [x] `./scripts/pre-pr.sh` — clippy clean + full workspace test suite green.
- [ ] **Post-merge follow-up**: after the next release (alpha.35+), test `cargo binstall --git https://github.com/kusari-sandbox/mikebom mikebom` end-to-end on macOS arm64 and Linux x86_64. cargo-binstall on Apple Silicon will likely try `universal2-apple-darwin` first (404s cleanly since we only publish `aarch64-apple-darwin`) and fall back — confirm the fallback fires.

## Note
This fix is for **future** releases. cargo-binstall pulls metadata from the tagged commit's `Cargo.toml`, so alpha.34 (already published) will still need a manual download. Anyone hitting the broken binstall on alpha.34 can use the direct-download path from `docs/user-guide/installation.md` until alpha.35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)