### PR TITLE
fix: re-wire SPDX root → direct-dep edges under --root-name (fixes #229)

### DIFF
--- a/mikebom-cli/src/generate/spdx/document.rs
+++ b/mikebom-cli/src/generate/spdx/document.rs
@@ -253,6 +253,13 @@ pub fn build_document(
     // logic then falls through to the synthesize_root path with
     // the operator-supplied identity (clean replacement).
     let override_active = artifacts.root_override.is_active();
+    // Issue #229: capture the dropped main-module PURLs so the
+    // relationship builder can alias them to the synthesized root's
+    // SPDXID — otherwise dep edges sourced at those PURLs vanish
+    // (their PURL is no longer in the components view, so the
+    // resolver silently drops them) and the new root ends up
+    // orphaned from the dependency graph.
+    let mut dropped_main_module_purls: Vec<String> = Vec::new();
     let filtered_components_owned: Option<Vec<mikebom_common::resolution::ResolvedComponent>> =
         if override_active {
             let mut keep: Vec<mikebom_common::resolution::ResolvedComponent> =
@@ -269,6 +276,7 @@ pub fn build_document(
                         "override is set; dropping manifest-derived main-module component '{}' from emitted SBOM (per milestone 077 clean-replacement; see GitHub issue #151)",
                         c.purl
                     );
+                    dropped_main_module_purls.push(c.purl.as_str().to_string());
                 } else {
                     keep.push(c.clone());
                 }
@@ -439,8 +447,21 @@ pub fn build_document(
         packages.insert(0, root_pkg);
     }
 
+    // Issue #229: when override is active, alias every dropped
+    // main-module PURL to the synthesized root's SPDXID so dep
+    // edges originally sourced at those PURLs are rewritten to
+    // source from the new root. In the non-override path the alias
+    // list is empty and behavior is unchanged.
+    let purl_aliases: Vec<(String, SpdxId)> =
+        match (override_active, root_ids.first()) {
+            (true, Some(root_id)) => dropped_main_module_purls
+                .iter()
+                .map(|p| (p.clone(), root_id.clone()))
+                .collect(),
+            _ => Vec::new(),
+        };
     let relationships =
-        super::relationships::build_relationships(artifacts, &root_ids);
+        super::relationships::build_relationships(artifacts, &root_ids, &purl_aliases);
 
     // Two creator entries: a `Tool:` identifying mikebom (used
     // throughout the document as the `annotator` field on every

--- a/mikebom-cli/src/generate/spdx/relationships.rs
+++ b/mikebom-cli/src/generate/spdx/relationships.rs
@@ -89,9 +89,22 @@ pub struct SpdxRelationship {
 ///    implicitly carries `CONTAINED_BY` as the inverse — consumers
 ///    get both readings). Orphans (parent_purl points nowhere
 ///    resolvable) are dropped rather than producing dangling edges.
+///
+/// `purl_aliases` (issue #229): alias entries `(dropped_purl, new_id)`
+/// used when milestone 077's `--root-name` override has filtered the
+/// manifest-derived main-module Package out of `packages[]` and
+/// replaced it with a synthesized root carrying a different PURL.
+/// Without this alias step, dependency edges sourced at the dropped
+/// main-module's PURL silently disappear (the PURL is no longer in
+/// `artifacts.components`, so the resolver falls through the "PURL
+/// not present" branch), leaving the new root with zero outgoing
+/// edges. Inserting the alias rewrites those edges to source from the
+/// synthetic root's SPDXID, preserving CDX↔SPDX parity. Pass `&[]`
+/// when no override is active.
 pub fn build_relationships(
     artifacts: &ScanArtifacts<'_>,
     roots: &[SpdxId],
+    purl_aliases: &[(String, SpdxId)],
 ) -> Vec<SpdxRelationship> {
     let mut out: Vec<SpdxRelationship> = Vec::new();
 
@@ -116,6 +129,11 @@ pub fn build_relationships(
     let mut purl_to_id: BTreeMap<String, SpdxId> = BTreeMap::new();
     for c in artifacts.components {
         purl_to_id.insert(c.purl.as_str().to_string(), SpdxId::for_purl(&c.purl));
+    }
+    // Aliases override component-derived entries when both exist —
+    // override callers pass `(dropped_main_module_purl, synthetic_id)`.
+    for (purl, id) in purl_aliases {
+        purl_to_id.insert(purl.clone(), id.clone());
     }
 
     // 2. Dependency edges.
@@ -171,12 +189,20 @@ pub fn build_relationships(
     // 3. Containment edges from parent_purl. Top-level PURLs (set of
     //    components with `parent_purl = None`) are the only valid
     //    parent targets; orphan pointers are dropped.
-    let top_level: std::collections::HashSet<&str> = artifacts
+    //
+    //    Issue #229: aliased PURLs (dropped main-module → synthetic
+    //    root) also count as valid containment parents, so children
+    //    whose `parent_purl` references a filtered-out main module
+    //    are re-parented to the new root instead of being dropped.
+    let mut top_level: std::collections::HashSet<&str> = artifacts
         .components
         .iter()
         .filter(|c| c.parent_purl.is_none())
         .map(|c| c.purl.as_str())
         .collect();
+    for (purl, _) in purl_aliases {
+        top_level.insert(purl.as_str());
+    }
     for c in artifacts.components {
         let Some(parent_purl) = c.parent_purl.as_deref() else {
             continue;
@@ -306,7 +332,7 @@ mod tests {
         let comps: Vec<ResolvedComponent> = vec![];
         let arts = mk_artifacts(&comps, &[], &integ);
         let root = SpdxId::synthetic_root("AAAAAAAAAAAAAAAA");
-        let rels = build_relationships(&arts, std::slice::from_ref(&root));
+        let rels = build_relationships(&arts, std::slice::from_ref(&root), &[]);
         assert_eq!(rels.len(), 1);
         assert_eq!(rels[0].source, SpdxId::document());
         assert_eq!(rels[0].target, root);
@@ -328,7 +354,7 @@ mod tests {
         let rels_arr = [rel];
         let arts = mk_artifacts(&comps, &rels_arr, &integ);
         let root = SpdxId::for_purl(&comps[0].purl);
-        let rels = build_relationships(&arts, std::slice::from_ref(&root));
+        let rels = build_relationships(&arts, std::slice::from_ref(&root), &[]);
         let dep = rels
             .iter()
             .find(|r| r.kind == SpdxRelationshipType::DependsOn)
@@ -352,7 +378,7 @@ mod tests {
         let rels_arr = [rel];
         let arts = mk_artifacts(&comps, &rels_arr, &integ);
         let root = SpdxId::for_purl(&comps[0].purl);
-        let rels = build_relationships(&arts, std::slice::from_ref(&root));
+        let rels = build_relationships(&arts, std::slice::from_ref(&root), &[]);
         let dev = rels
             .iter()
             .find(|r| r.kind == SpdxRelationshipType::DevDependencyOf)
@@ -371,7 +397,7 @@ mod tests {
         let comps = vec![parent, child];
         let arts = mk_artifacts(&comps, &[], &integ);
         let root = SpdxId::for_purl(&comps[0].purl);
-        let rels = build_relationships(&arts, std::slice::from_ref(&root));
+        let rels = build_relationships(&arts, std::slice::from_ref(&root), &[]);
         let contains = rels
             .iter()
             .find(|r| r.kind == SpdxRelationshipType::Contains)
@@ -389,10 +415,93 @@ mod tests {
         let comps = vec![child];
         let arts = mk_artifacts(&comps, &[], &integ);
         let root = SpdxId::synthetic_root("AAAAAAAAAAAAAAAA");
-        let rels = build_relationships(&arts, std::slice::from_ref(&root));
+        let rels = build_relationships(&arts, std::slice::from_ref(&root), &[]);
         // Only the DESCRIBES edge; the orphan containment is dropped.
         assert_eq!(rels.len(), 1);
         assert_eq!(rels[0].kind, SpdxRelationshipType::Describes);
+    }
+
+    #[test]
+    fn purl_alias_rewrites_depends_on_source_to_synthetic_root() {
+        // Issue #229 regression: when --root-name drops the manifest-
+        // derived main module and synthesizes a new root, dep edges
+        // sourced at the dropped PURL must be rewritten to source from
+        // the synthetic root's SPDXID (otherwise the new root ends up
+        // orphaned from the dependency graph, and the SPDX output
+        // diverges from CDX). Only `direct_dep` is in the components
+        // view here — the old main module's PURL is gone, but its
+        // outgoing edge is present in `relationships`; the alias step
+        // is what reconnects it.
+        let direct_dep = mk_component("pkg:cargo/dep@1", "dep", "1");
+        let rel = Relationship {
+            from: "pkg:cargo/old-main@1".to_string(),
+            to: direct_dep.purl.as_str().to_string(),
+            relationship_type: RelationshipType::DependsOn,
+            provenance: prov(),
+        };
+        let integ = empty_integrity();
+        let comps = vec![direct_dep];
+        let rels_arr = [rel];
+        let arts = mk_artifacts(&comps, &rels_arr, &integ);
+        let synth_root = SpdxId::synthetic_root("FFFFFFFFFFFFFFFF");
+        let aliases = vec![("pkg:cargo/old-main@1".to_string(), synth_root.clone())];
+        let rels = build_relationships(&arts, std::slice::from_ref(&synth_root), &aliases);
+        let dep = rels
+            .iter()
+            .find(|r| r.kind == SpdxRelationshipType::DependsOn)
+            .expect("DEPENDS_ON edge present after alias rewrite");
+        assert_eq!(dep.source, synth_root, "edge source rewritten to synthetic root");
+        assert_eq!(dep.target, SpdxId::for_purl(&comps[0].purl));
+    }
+
+    #[test]
+    fn purl_alias_rewrites_reversed_dev_dependency_of_target() {
+        // Issue #229: the alias also has to win for direction-reversed
+        // edges (DevDependsOn / BuildDependsOn / TestDependsOn).
+        // Internal `(old-main DevDependsOn dep)` becomes SPDX
+        // `(dep) DEV_DEPENDENCY_OF (synthetic-root)` after the alias.
+        let direct_dep = mk_component("pkg:npm/dep@1", "dep", "1");
+        let rel = Relationship {
+            from: "pkg:npm/old-main@1".to_string(),
+            to: direct_dep.purl.as_str().to_string(),
+            relationship_type: RelationshipType::DevDependsOn,
+            provenance: prov(),
+        };
+        let integ = empty_integrity();
+        let comps = vec![direct_dep];
+        let rels_arr = [rel];
+        let arts = mk_artifacts(&comps, &rels_arr, &integ);
+        let synth_root = SpdxId::synthetic_root("DEADBEEFDEADBEEF");
+        let aliases = vec![("pkg:npm/old-main@1".to_string(), synth_root.clone())];
+        let rels = build_relationships(&arts, std::slice::from_ref(&synth_root), &aliases);
+        let dev = rels
+            .iter()
+            .find(|r| r.kind == SpdxRelationshipType::DevDependencyOf)
+            .expect("DEV_DEPENDENCY_OF edge present");
+        assert_eq!(dev.source, SpdxId::for_purl(&comps[0].purl));
+        assert_eq!(dev.target, synth_root, "edge target rewritten to synthetic root");
+    }
+
+    #[test]
+    fn purl_alias_rewrites_containment_parent_to_synthetic_root() {
+        // Issue #229: a child whose parent_purl pointed at the
+        // dropped main module should be re-parented to the synthetic
+        // root via the alias step (otherwise the CONTAINS edge is
+        // dropped as orphan).
+        let mut child = mk_component("pkg:maven/x/y/child@1", "child", "1");
+        child.parent_purl = Some("pkg:maven/x/y/old-main@1".to_string());
+        let integ = empty_integrity();
+        let comps = vec![child];
+        let arts = mk_artifacts(&comps, &[], &integ);
+        let synth_root = SpdxId::synthetic_root("CAFEBABE12345678");
+        let aliases = vec![("pkg:maven/x/y/old-main@1".to_string(), synth_root.clone())];
+        let rels = build_relationships(&arts, std::slice::from_ref(&synth_root), &aliases);
+        let contains = rels
+            .iter()
+            .find(|r| r.kind == SpdxRelationshipType::Contains)
+            .expect("CONTAINS edge present after alias rewrite");
+        assert_eq!(contains.source, synth_root);
+        assert_eq!(contains.target, SpdxId::for_purl(&comps[0].purl));
     }
 
     #[test]
@@ -410,7 +519,7 @@ mod tests {
         let rels_arr = [rel];
         let arts = mk_artifacts(&comps, &rels_arr, &integ);
         let root = SpdxId::for_purl(&comps[0].purl);
-        let rels = build_relationships(&arts, std::slice::from_ref(&root));
+        let rels = build_relationships(&arts, std::slice::from_ref(&root), &[]);
         // Only the DESCRIBES edge remains.
         assert_eq!(rels.len(), 1);
     }

--- a/mikebom-cli/src/generate/spdx/v3_document.rs
+++ b/mikebom-cli/src/generate/spdx/v3_document.rs
@@ -48,6 +48,13 @@ pub fn build_document(
     // The downstream pick_root_iri then synthesizes a root from the
     // override values verbatim.
     let override_active = scan.root_override.is_active();
+    // Issue #229: capture the dropped main-module PURLs so the
+    // post-`pick_root_iri` alias step (below) can map them to the
+    // synthesized root IRI in `package_iri_by_purl`. Without this
+    // dependency edges sourced at those PURLs silently disappear in
+    // `build_dependency_relationships`, leaving the new root with
+    // zero outgoing edges (parity break vs CycloneDX).
+    let mut dropped_main_module_purls: Vec<String> = Vec::new();
     let filtered_components_owned: Option<Vec<ResolvedComponent>> =
         if override_active {
             let mut keep: Vec<ResolvedComponent> = Vec::with_capacity(scan.components.len());
@@ -63,6 +70,7 @@ pub fn build_document(
                         "override is set; dropping manifest-derived main-module component '{}' from emitted SBOM (per milestone 077 clean-replacement; see GitHub issue #151)",
                         c.purl
                     );
+                    dropped_main_module_purls.push(c.purl.as_str().to_string());
                 } else {
                     keep.push(c.clone());
                 }
@@ -247,7 +255,7 @@ pub fn build_document(
     // Two-pass Package build: (a) precompute the PURL → IRI
     // lookup, (b) build agents against the lookup, (c) build
     // Packages with agent attachments inlined.
-    let package_iri_by_purl =
+    let mut package_iri_by_purl =
         super::v3_packages::build_iri_lookup(scan.components, &doc_iri);
 
     let agent_build = super::v3_agents::build_agents(
@@ -301,6 +309,19 @@ pub fn build_document(
         &mut packages,
         scan.components,
     );
+
+    // Issue #229: when --root-name produced a synthesized root, alias
+    // every dropped main-module PURL → synthesized root IRI so dep
+    // edges originally sourced at those PURLs get rewritten to source
+    // from the new root in build_dependency_relationships. Mirrors the
+    // SPDX 2.3 alias path in `relationships.rs`.
+    if synthetic_root_added {
+        if let Some(synth_iri) = root_iris.first().cloned() {
+            for purl in &dropped_main_module_purls {
+                package_iri_by_purl.insert(purl.clone(), synth_iri.clone());
+            }
+        }
+    }
 
     // 3. SpdxDocument (placed in the graph before the per-element
     // sections so a JSON-walker reading top-down hits the document

--- a/mikebom-cli/tests/identifiers_root_component_override.rs
+++ b/mikebom-cli/tests/identifiers_root_component_override.rs
@@ -631,3 +631,149 @@ fn override_orthogonal_to_other_identifier_flags() {
     // If serde isn't present (fixture variation), the test of slot
     // (iv) is moot — slots (i)-(iii) still verify orthogonality.
 }
+
+// ---------------------------------------------------------------------
+// Issue #229 — root-name must preserve the dependency-graph wiring
+// between the synthesized root and the manifest's direct dependencies
+// in SPDX 2.3 and SPDX 3, not just CycloneDX.
+// ---------------------------------------------------------------------
+
+#[test]
+fn root_override_preserves_root_outgoing_edges_in_all_formats() {
+    // Pre-fix behaviour: in CDX the renamed root inherited the
+    // manifest-derived main-module's `dependsOn` edges (via the
+    // primary-dependency fallback in cyclonedx/dependencies.rs).
+    // In SPDX 2.3 + SPDX 3 the edges silently vanished because
+    // `build_relationships` resolves edge sources via a PURL→ID map
+    // built from `artifacts.components` only — the dropped main
+    // module's PURL was no longer in that map, so its outgoing
+    // edges fell through the "PURL not present" branch.
+    let fake_home = tempfile::tempdir().unwrap();
+    let fixture = build_cargo_fixture_named("foo-internal", "0.5.1");
+
+    // --- CycloneDX (the known-good baseline) -------------------------
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        fixture.path(),
+        &["--root-name", "widget-svc", "--root-version", "1.2.3"],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let root_ref = cdx["metadata"]["component"]["bom-ref"]
+        .as_str()
+        .expect("metadata.component.bom-ref present");
+    let cdx_root_deps: Vec<String> = cdx["dependencies"]
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .find(|d| d["ref"].as_str() == Some(root_ref))
+        .and_then(|d| d["dependsOn"].as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        !cdx_root_deps.is_empty(),
+        "CDX baseline: synthesized root must have outgoing dependsOn edges; got {cdx_root_deps:?}"
+    );
+
+    // --- SPDX 2.3 ----------------------------------------------------
+    let spdx = run_scan_returning_json(
+        fake_home.path(),
+        fixture.path(),
+        &["--root-name", "widget-svc", "--root-version", "1.2.3"],
+        "spdx-2.3-json",
+        "out.spdx.json",
+    );
+    let rels = spdx["relationships"].as_array().expect("relationships[]");
+    let root_spdxid = rels
+        .iter()
+        .find(|r| r["relationshipType"].as_str() == Some("DESCRIBES"))
+        .and_then(|r| r["relatedSpdxElement"].as_str())
+        .expect("DESCRIBES edge present");
+    let mut spdx_root_deps: Vec<String> = Vec::new();
+    let packages = spdx["packages"].as_array().expect("packages[]");
+    for r in rels {
+        if r["spdxElementId"].as_str() == Some(root_spdxid)
+            && r["relationshipType"].as_str() == Some("DEPENDS_ON")
+        {
+            let target = r["relatedSpdxElement"].as_str().unwrap_or("");
+            let pkg = packages
+                .iter()
+                .find(|p| p["SPDXID"].as_str() == Some(target));
+            if let Some(p) = pkg {
+                let purl = p["externalRefs"]
+                    .as_array()
+                    .and_then(|arr| {
+                        arr.iter()
+                            .find(|r| r["referenceType"].as_str() == Some("purl"))
+                    })
+                    .and_then(|r| r["referenceLocator"].as_str())
+                    .unwrap_or("");
+                spdx_root_deps.push(purl.to_string());
+            }
+        }
+    }
+    assert!(
+        !spdx_root_deps.is_empty(),
+        "issue #229 (SPDX 2.3): synthesized root must have outgoing DEPENDS_ON edges; got {spdx_root_deps:?}"
+    );
+    assert_eq!(
+        spdx_root_deps.iter().collect::<std::collections::BTreeSet<_>>(),
+        cdx_root_deps.iter().collect::<std::collections::BTreeSet<_>>(),
+        "issue #229: SPDX 2.3 root outgoing edges must match CDX exactly",
+    );
+
+    // --- SPDX 3.0.1 --------------------------------------------------
+    let spdx3 = run_scan_returning_json(
+        fake_home.path(),
+        fixture.path(),
+        &["--root-name", "widget-svc", "--root-version", "1.2.3"],
+        "spdx-3-json",
+        "out.spdx3.json",
+    );
+    let graph = spdx3["@graph"].as_array().expect("@graph");
+    let root_iri = graph
+        .iter()
+        .find(|e| e["type"].as_str() == Some("SpdxDocument"))
+        .and_then(|d| d["rootElement"].as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .expect("SpdxDocument.rootElement present");
+    let mut spdx3_root_deps: Vec<String> = Vec::new();
+    for e in graph {
+        let ty = e["type"].as_str().unwrap_or("");
+        if ty != "Relationship" && ty != "LifecycleScopedRelationship" {
+            continue;
+        }
+        if e["from"].as_str() != Some(root_iri) {
+            continue;
+        }
+        if e["relationshipType"].as_str() != Some("dependsOn") {
+            continue;
+        }
+        let to_iris: Vec<&str> = e["to"]
+            .as_array()
+            .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
+        for iri in to_iris {
+            let purl = graph
+                .iter()
+                .find(|p| p["spdxId"].as_str() == Some(iri))
+                .and_then(|p| p["software_packageUrl"].as_str())
+                .unwrap_or("");
+            spdx3_root_deps.push(purl.to_string());
+        }
+    }
+    assert!(
+        !spdx3_root_deps.is_empty(),
+        "issue #229 (SPDX 3): synthesized root must have outgoing dependsOn edges; got {spdx3_root_deps:?}"
+    );
+    assert_eq!(
+        spdx3_root_deps.iter().collect::<std::collections::BTreeSet<_>>(),
+        cdx_root_deps.iter().collect::<std::collections::BTreeSet<_>>(),
+        "issue #229: SPDX 3 root outgoing edges must match CDX exactly",
+    );
+}


### PR DESCRIPTION
## Summary

- Closes #229. `--root-name` produced an SPDX root that was orphaned from the dependency graph: zero outgoing `DEPENDS_ON` (SPDX 2.3) / `dependsOn` (SPDX 3) edges from the synthesized root, while the CDX root was correctly wired via its primary-dependency fallback.
- Root cause: the SPDX emitters filter the manifest-derived main module out of `packages[]` when override is active, but `build_relationships` / `build_dependency_relationships` resolve edge sources via a PURL→ID map built from `artifacts.components` only — the dropped main module's PURL was no longer in that map, so its outgoing edges fell through the "PURL not present" branch.
- Fix: pass the dropped main-module PURL(s) through as aliases mapped to the synthetic root's SPDXID / IRI. The alias is inserted into the PURL→ID map (and, for SPDX 2.3, into the containment-edge `top_level` set) so dep edges and CONTAINS edges sourced at the dropped main module resolve to the synthetic root. Direction-reversing variants (`DEV/BUILD/TEST_DEPENDENCY_OF`) get rewritten on the target side automatically because the alias wins for either lookup.

## Test plan

- [x] `./scripts/pre-pr.sh` — clippy `--workspace --all-targets` + `cargo +stable test --workspace` both clean
- [x] 3 new unit tests in `mikebom-cli/src/generate/spdx/relationships.rs` covering `DEPENDS_ON`, reversed `DEV_DEPENDENCY_OF`, and `CONTAINS` alias rewrites
- [x] 1 new integration test `root_override_preserves_root_outgoing_edges_in_all_formats` in `identifiers_root_component_override.rs` — asserts byte-set parity of root outgoing edges across CDX, SPDX 2.3, SPDX 3 against a cargo fixture
- [x] Manual repro on issue command (`--root-name kusari-cli` against a tiny cargo project): before the fix the SPDX 2.3 and SPDX 3 roots had 0 outgoing edges; after the fix both formats emit the same 2 edges (`→ anyhow`, `→ serde`) that CDX has

## Scope notes

- Only the milestone-077 override path is touched — when no override is active the alias list is empty and behavior is bit-for-bit unchanged (byte-identity goldens unaffected; pre-PR `cargo test --workspace` is the proof).
- Independent from #228 (which drops some specific child PURLs' incoming edges); that is a separate bug in the polyglot edge-resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)