### PR TITLE
fix(spdx): image-scan synth root has outgoing DEPENDS_ON + cross-format root PURL parity (#236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 
 ## [Unreleased]
 
+### Issue #236 — image-scan SPDX root no longer orphaned + cross-format root PURL parity
+
+Fixes two related defects in mikebom's emission of a *synthesized* root for scans that have no natural single root (container images, OS-package-only scans, `requirements.txt`- / `Gemfile`-only Python and Ruby projects, and any other case where milestone-053-style main-module annotation isn't set).
+
+**The orphaned-root bug.** Before the fix, when the SPDX 2.3 / SPDX 3 emitters synthesized a placeholder root Package for the scan subject (via `synthesize_root` / `pick_root_iri`), the placeholder had no outgoing `DEPENDS_ON` / `dependsOn` edges. The synthetic root was only the target of the document-level `DESCRIBES` relationship; every top-level package the scan discovered was a graph-top with no incoming dependency edge. A consumer walking the dependency graph from the declared root saw zero direct deps. CDX has not had this problem since milestone 084 (closed via the primary-dependency fallback in `cyclonedx/dependencies.rs:74-99`, which synthesizes `metadata.component.bom-ref → <every component that nothing else depends on>` when the bom-ref has no outgoing edges). This fix mirrors that fallback into both SPDX emitters: when a root is synthesized, mikebom now emits one `DEPENDS_ON` / `dependsOn` edge from the synthesized root SPDXID/IRI to every graph-root component, preserving cross-format parity.
+
+**The root-PURL divergence.** Before the fix, the synthesized-root PURL differed across the three formats for the same scan target. For `postgres:16`, CDX produced `pkg:generic/postgres:16@0.0.0` (via `encode_purl_segment`, which preserves the colon literal — matching the Debian / dpkg convention), SPDX 2.3 produced `pkg:generic/postgres_16@0.0.0` (via `sanitize_for_coord`, which collapses non-alphanumeric to `_`), and SPDX 3 produced `pkg:generic/postgres-16@0.0.0` (via `url_friendly`, which collapses non-alphanumeric to `-`). Three different root identities for the same image. This fix switches both SPDX synthesize-root paths to use `encode_purl_segment` for the PURL (matching CDX), while keeping the format-specific sanitizers for the CPE field (CPE has its own grammar rules). Post-fix, all three formats emit the identical root PURL `pkg:generic/postgres:16@0.0.0`.
+
+**Verified.** Reconfirmed on `alpine:3`: CDX, SPDX 2.3, and SPDX 3 now all show `pkg:generic/alpine:3@0.0.0` as the root identity with 8 outgoing edges each (one per top-level apk package). Both bugs gone.
+
+#### Added
+
+- **Synthetic-root → graph-root `DEPENDS_ON` edges in SPDX 2.3** (`generate/spdx/document.rs:465-507` post `build_relationships` call). Fires only when `synthesize_root` runs; emits edges in deterministic PURL-lex order. Graph roots are defined as the same set CDX uses: components with `parent_purl: None` that aren't the target of any other dep edge.
+- **Synthetic-root → graph-root `dependsOn` `Relationship` elements in SPDX 3** (`generate/spdx/v3_document.rs:609-647`, between containment and license relationships, before the final sort). Same graph-root definition as SPDX 2.3.
+- **Three new unit tests in `generate/spdx/document.rs`** covering the synthesized-root PURL form (colon literal preserved), the synth-root-has-outgoing-edges invariant, and the "already-depended-on components are excluded from the fallback" subtlety that mirrors CDX's `cyclonedx/dependencies.rs:91-95` filter.
+
+#### Changed
+
+- **SPDX 2.3 synthesized-root PURL** switched from `sanitize_for_coord` (collapses `:` → `_`, lowercases) to `encode_purl_segment` (preserves the colon literal). CPE field keeps `sanitize_for_coord` — different grammar rules.
+- **SPDX 3 synthesized-root PURL** switched from `url_friendly` (collapses `:` → `-`) to `encode_purl_segment`. CPE field keeps `url_friendly`.
+- **SPDX 2.3 + SPDX 3 byte-identity goldens regenerated for `apk`, `bazel`, `cargo`, `cmake`, `deb`, `gem`, `pip`** (14 files, +270 lines, -0 lines — purely additive). Each diff is a constant set of synthetic-root → graph-root `DEPENDS_ON` edges. The other 8 SPDX 2.3 / SPDX 3 goldens (`golang`, `maven`, `npm`, `rpm`) are byte-identical to alpha.34 because their fixtures all have a main-module annotation and never hit the `synthesize_root` branch.
+- **Parity-extractor coverage extended** (`parity/extractors/common.rs` + `parity/extractors/cdx.rs`). The pre-fix extractors deliberately skipped synthetic roots from the dep-edge buckets because those roots had no edges to walk; post-fix they're load-bearing edge sources, so the new helper `walk_cdx_components_main_module_and_synth_subject` (used by `cdx_dependency_edges`) and a synth-root inclusion in `spdx_relationship_edges` close that gap. The component-count extractors (A1–A12) still exclude synthetic roots — those rows count real components, not placeholders.
+- **`transitive_parity_gem` baseline bumped 196 → 217** (fastlane has no top-level `.gemspec`, so synthesize_root fires).
+- **`transitive_parity_pip_plain` baseline bumped 0 → 13** (the synthetic 13-pkg requirements.txt fixture). FR-008's "all 3 tools agree on zero" invariant moves to a soft warning — mikebom's CDX has been emitting these edges since milestone 084, and post-fix SPDX agrees with mikebom's own CDX. The `cross_tool_parity_check` continues to surface the divergence-from-Trivy/Syft as informational output.
+- **`transitive_parity_pip_poetry` baseline bumped 62 → 88** (same root cause: poetry fixture lacks the main-module annotation, so synthesize_root fires).
+
 ### Issue #228 — SPDX 2.3 cross-format parity for scoped deps
 
 Adds a `mikebom:lifecycle-scope` annotation to every scoped Package in SPDX 2.3 output and introduces a new `--spdx2-relationship-compat {full|basic}` CLI flag that selects the SPDX 2.3 relationship-type vocabulary the emitter uses for scoped dependency edges (dev / build / test).

--- a/mikebom-cli/src/generate/spdx/document.rs
+++ b/mikebom-cli/src/generate/spdx/document.rs
@@ -445,6 +445,7 @@ pub fn build_document(
     // Prepend the synthetic-root package (if any) so it precedes
     // every component-derived package in the output.
     let mut packages = packages;
+    let synthetic_root_added = synthetic_root.is_some();
     if let Some(root_pkg) = synthetic_root {
         packages.insert(0, root_pkg);
     }
@@ -462,8 +463,55 @@ pub fn build_document(
                 .collect(),
             _ => Vec::new(),
         };
-    let relationships =
+    let mut relationships =
         super::relationships::build_relationships(artifacts, &root_ids, &purl_aliases);
+
+    // Issue #236: when `synthesize_root` fires (multi-top-level
+    // scans with no main-module and no name match — the dominant
+    // case for image scans and OS-package scans), the synthetic
+    // root has no outgoing edges in `artifacts.relationships`. CDX
+    // covers this with the primary-dependency fallback in
+    // `cyclonedx/dependencies.rs:74-99` (synthesize edges from
+    // `metadata.component.bom-ref` to every graph-root component).
+    // We mirror that here so SPDX 2.3 emits a connected graph
+    // rooted at the same synthetic identity. Without this, the
+    // synthetic root is orphaned in `relationships[]` — only the
+    // `DESCRIBES` edge from `SPDXRef-DOCUMENT` reaches it and the
+    // 31 (in the postgres:16 case) top-level Packages have no
+    // incoming edges, producing N disconnected graph-tops where
+    // CDX has a single root.
+    if synthetic_root_added {
+        if let Some(synth_id) = root_ids.first() {
+            // Mirror CDX's "graph roots" definition: components no
+            // other component or relationship points to as a `to`
+            // target. For a flat OS-package scan that's every
+            // component; for a transitive scan it's just the top-
+            // level deps.
+            let depended_on: std::collections::BTreeSet<&str> = artifacts
+                .relationships
+                .iter()
+                .map(|r| r.to.as_str())
+                .collect();
+            let mut graph_roots: Vec<&mikebom_common::resolution::ResolvedComponent> =
+                artifacts
+                    .components
+                    .iter()
+                    .filter(|c| {
+                        c.parent_purl.is_none() && !depended_on.contains(c.purl.as_str())
+                    })
+                    .collect();
+            // Deterministic emission order: lex by PURL.
+            graph_roots.sort_by(|a, b| a.purl.as_str().cmp(b.purl.as_str()));
+            for c in graph_roots {
+                relationships.push(super::relationships::SpdxRelationship {
+                    source: synth_id.clone(),
+                    target: SpdxId::for_purl(&c.purl),
+                    kind: super::relationships::SpdxRelationshipType::DependsOn,
+                    comment: None,
+                });
+            }
+        }
+    }
 
     // Two creator entries: a `Tool:` identifying mikebom (used
     // throughout the document as the `annotator` field on every
@@ -637,11 +685,24 @@ fn synthesize_root(
     // mirrors `metadata.component.cpe` in CDX. Both are synthetic
     // but spec-valid; consumers that want a real PURL/CPE look at
     // the component-level Packages, not the root.
-    let sanitized = sanitize_for_coord(target_name);
+    //
+    // Issue #236: PURL and CPE have different escape rules, so they
+    // are sanitized separately. The PURL uses
+    // `encode_purl_segment` (the same helper CDX uses for its
+    // `metadata.component.purl`), which preserves colon literals
+    // (so `postgres:16` → `postgres:16`, matching CDX). Pre-fix this
+    // path used `sanitize_for_coord` for both, producing
+    // `postgres_16` for the SPDX PURL — a per-format root-identity
+    // divergence the reporter flagged alongside the missing-edges
+    // bug. The CPE keeps `sanitize_for_coord` because the
+    // CPE 2.3 grammar uses `_` as the conventional component
+    // separator-safe filler.
     let version = "0.0.0";
-    let synth_purl = format!("pkg:generic/{sanitized}@{version}");
+    let purl_name = mikebom_common::types::purl::encode_purl_segment(target_name);
+    let synth_purl = format!("pkg:generic/{purl_name}@{version}");
+    let cpe_name = sanitize_for_coord(target_name);
     let synth_cpe =
-        format!("cpe:2.3:a:mikebom:{sanitized}:{version}:*:*:*:*:*:*:*");
+        format!("cpe:2.3:a:mikebom:{cpe_name}:{version}:*:*:*:*:*:*:*");
 
     let root = SpdxPackage {
         spdx_id: id.clone(),
@@ -1010,6 +1071,144 @@ mod tests {
         assert!(
             comment.contains("no lifecycle phases observed"),
             "expected empty-phases degradation; got: {comment}"
+        );
+    }
+
+    // -----------------------------------------------------------
+    // Issue #236 — synthesized-root behavior
+    // -----------------------------------------------------------
+
+    fn build_doc_value(arts: &ScanArtifacts<'_>) -> serde_json::Value {
+        let cfg = crate::generate::OutputConfig {
+            mikebom_version: "0.0.0-test",
+            created: chrono::DateTime::parse_from_rfc3339("2026-05-24T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            overrides: Default::default(),
+        };
+        let doc = build_document(arts, &cfg);
+        serde_json::to_value(&doc).expect("SpdxDocument serializes to JSON")
+    }
+
+    #[test]
+    fn synthesized_root_purl_preserves_colon_like_cdx() {
+        // Issue #236 secondary observation: pre-fix the SPDX
+        // synthesized-root PURL collapsed `:` to `_` via
+        // sanitize_for_coord, producing `pkg:generic/postgres_16@0.0.0`
+        // while CDX emitted `pkg:generic/postgres:16@0.0.0` for the
+        // same image. Post-fix the SPDX PURL uses encode_purl_segment
+        // (the same helper CDX uses) so colon is preserved literal.
+        //
+        // Two components so multi-top-level triggers synthesize_root
+        // (single-top-level uses the lone component as root instead).
+        let integ = empty_integrity();
+        let comps = vec![
+            mk_component("pkg:apk/alpine/busybox@1.36", "busybox", "1.36"),
+            mk_component("pkg:apk/alpine/musl@1.2", "musl", "1.2"),
+        ];
+        let arts = mk_artifacts("postgres:16", &comps, &[], &integ);
+        let doc = build_doc_value(&arts);
+        let packages = doc["packages"].as_array().expect("packages[]");
+        let synth = packages
+            .iter()
+            .find(|p| {
+                p["SPDXID"]
+                    .as_str()
+                    .map(|s| s.starts_with("SPDXRef-DocumentRoot-"))
+                    .unwrap_or(false)
+            })
+            .expect("synthetic root present");
+        let purl = synth["externalRefs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["referenceType"].as_str() == Some("purl"))
+            .and_then(|r| r["referenceLocator"].as_str())
+            .expect("purl externalRef");
+        assert_eq!(
+            purl, "pkg:generic/postgres:16@0.0.0",
+            "synthesized-root PURL must match CDX shape (colon preserved literal)"
+        );
+    }
+
+    #[test]
+    fn synthesized_root_has_outgoing_depends_on_to_graph_roots() {
+        // Issue #236 primary bug: pre-fix the synthesized root had
+        // only the incoming `DESCRIBES` edge — every top-level
+        // component was an orphan graph-top with no incoming
+        // `DEPENDS_ON`. Post-fix the synthesized root has outgoing
+        // `DEPENDS_ON` to every component that nothing else depends
+        // on (CDX's primary-dependency fallback mirrored into SPDX
+        // 2.3).
+        let integ = empty_integrity();
+        // Three top-level components (image-scan-shape: no main
+        // module, no name match, no inter-component edges).
+        let comps = vec![
+            mk_component("pkg:apk/alpine/busybox@1.36", "busybox", "1.36"),
+            mk_component("pkg:apk/alpine/musl@1.2", "musl", "1.2"),
+            mk_component("pkg:apk/alpine/ssl-client@3.18", "ssl-client", "3.18"),
+        ];
+        let arts = mk_artifacts("alpine:3", &comps, &[], &integ);
+        let doc = build_doc_value(&arts);
+        let rels = doc["relationships"].as_array().expect("relationships[]");
+        let root_id = rels
+            .iter()
+            .find(|r| r["relationshipType"].as_str() == Some("DESCRIBES"))
+            .and_then(|r| r["relatedSpdxElement"].as_str())
+            .expect("DESCRIBES edge present");
+        let outgoing: Vec<&str> = rels
+            .iter()
+            .filter(|r| {
+                r["spdxElementId"].as_str() == Some(root_id)
+                    && r["relationshipType"].as_str() == Some("DEPENDS_ON")
+            })
+            .filter_map(|r| r["relatedSpdxElement"].as_str())
+            .collect();
+        assert_eq!(
+            outgoing.len(),
+            3,
+            "expected 3 outgoing DEPENDS_ON edges to the 3 graph-root components, got {outgoing:#?}"
+        );
+    }
+
+    #[test]
+    fn synthesized_root_excludes_already_depended_on_components_from_fallback() {
+        // Mirrors CDX's "components nothing else depends on"
+        // filter. Given a transitive relationship `A → B`, the
+        // synthesized root should only get an edge to A (the graph
+        // root), NOT to B (which is already pointed at by A).
+        let integ = empty_integrity();
+        let comps = vec![
+            mk_component("pkg:apk/alpine/a@1", "a", "1"),
+            mk_component("pkg:apk/alpine/b@1", "b", "1"),
+        ];
+        let rels = vec![mikebom_common::resolution::Relationship {
+            from: "pkg:apk/alpine/a@1".to_string(),
+            to: "pkg:apk/alpine/b@1".to_string(),
+            relationship_type: mikebom_common::resolution::RelationshipType::DependsOn,
+            provenance: mikebom_common::resolution::EnrichmentProvenance {
+                source: "test".to_string(),
+                data_type: "runtime".to_string(),
+            },
+        }];
+        let arts = mk_artifacts("alpine:3", &comps, &rels, &integ);
+        let doc = build_doc_value(&arts);
+        let rels = doc["relationships"].as_array().expect("relationships[]");
+        let root_id = rels
+            .iter()
+            .find(|r| r["relationshipType"].as_str() == Some("DESCRIBES"))
+            .and_then(|r| r["relatedSpdxElement"].as_str())
+            .expect("DESCRIBES edge present");
+        let outgoing_count = rels
+            .iter()
+            .filter(|r| {
+                r["spdxElementId"].as_str() == Some(root_id)
+                    && r["relationshipType"].as_str() == Some("DEPENDS_ON")
+            })
+            .count();
+        assert_eq!(
+            outgoing_count, 1,
+            "synthetic root should get exactly 1 outgoing edge (to graph-root A); B is already depended on by A"
         );
     }
 }

--- a/mikebom-cli/src/generate/spdx/v3_document.rs
+++ b/mikebom-cli/src/generate/spdx/v3_document.rs
@@ -606,6 +606,45 @@ pub fn build_document(
         &doc_iri,
         CREATION_INFO_ID,
     ));
+
+    // Issue #236: when `pick_root_iri` synthesized a root (multi-
+    // top-level scans with no main-module and no name match — the
+    // dominant case for image scans and OS-package scans), the
+    // synthetic root has no outgoing edges in `scan.relationships`.
+    // CDX covers this with the primary-dependency fallback in
+    // `cyclonedx/dependencies.rs:74-99`; we mirror it here for SPDX
+    // 3 so the emitted graph is rooted at the same synthetic
+    // identity. Without this fix the SpdxDocument's `rootElement`
+    // points at a Package no Relationship targets as a source —
+    // the SBOM is structurally valid but the dep graph has N
+    // disconnected graph-tops where CDX has a single root.
+    if synthetic_root_added {
+        if let Some(synth_iri) = root_iris.first() {
+            let depended_on: std::collections::BTreeSet<&str> = scan
+                .relationships
+                .iter()
+                .map(|r| r.to.as_str())
+                .collect();
+            let mut graph_root_iris: Vec<&str> = scan
+                .components
+                .iter()
+                .filter(|c| c.parent_purl.is_none() && !depended_on.contains(c.purl.as_str()))
+                .filter_map(|c| package_iri_by_purl.get(c.purl.as_str()).map(String::as_str))
+                .collect();
+            // Deterministic emission order: lex by IRI.
+            graph_root_iris.sort();
+            for to_iri in graph_root_iris {
+                all_relationships.push(super::v3_relationships::build_relationship(
+                    synth_iri.as_str(),
+                    "dependsOn",
+                    to_iri,
+                    &doc_iri,
+                    CREATION_INFO_ID,
+                ));
+            }
+        }
+    }
+
     all_relationships.extend(license_relationships);
     if !synthetic_root_added {
         let describes_rels = super::v3_relationships::build_describes_relationships(
@@ -807,7 +846,22 @@ fn pick_root_iri(
     // Synthesize a root Package. Mirrors the SPDX 2.3 emitter's
     // synthesize_root behavior — preserves sbomqs scoring parity
     // (a document with no rootElement scores worse).
-    let synth_purl = format!("pkg:generic/{}@0.0.0", url_friendly(scan.target_name));
+    //
+    // Issue #236: PURL and CPE have different escape rules, so they
+    // are sanitized separately. The PURL uses
+    // `encode_purl_segment` (the same helper CDX uses for its
+    // `metadata.component.purl`), which preserves colon literals
+    // (so `postgres:16` → `postgres:16`, matching CDX). Pre-fix
+    // this path used `url_friendly` for both, producing
+    // `postgres-16` for the SPDX 3 PURL — yet a third per-format
+    // root-identity variant alongside CDX's `postgres:16` and the
+    // SPDX 2.3 path's `postgres_16` (also fixed in this milestone).
+    // The CPE keeps `url_friendly` because the CPE 2.3 grammar
+    // uses `-` as the conventional component separator-safe filler.
+    let synth_purl = format!(
+        "pkg:generic/{}@0.0.0",
+        mikebom_common::types::purl::encode_purl_segment(scan.target_name),
+    );
     let synth_iri = format!(
         "{doc_iri}/pkg-root-{}",
         hash_prefix(synth_purl.as_bytes(), 16)

--- a/mikebom-cli/src/parity/extractors/cdx.rs
+++ b/mikebom-cli/src/parity/extractors/cdx.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 
 use super::common::{
     canonicalize_atomic_values, walk_cdx_components,
-    walk_cdx_components_and_main_module,
+    walk_cdx_components_and_main_module, walk_cdx_components_main_module_and_synth_subject,
 };
 
 // ============================================================
@@ -254,9 +254,19 @@ fn cdx_dependency_edges(doc: &Value, dev_only: bool) -> BTreeSet<String> {
     // Build bom-ref → component lookup. Milestone 053: include
     // metadata.component-when-main-module so its outgoing
     // `dependencies[].ref` lookups resolve.
+    //
+    // Issue #236: also include `metadata.component` when it's a
+    // synthetic scan-subject placeholder (no main-module tag) — the
+    // primary-dep fallback at `cyclonedx/dependencies.rs:74-99`
+    // synthesizes edges sourced at the placeholder's bom-ref, and
+    // those edges now have a matching synth-root → top-level edge
+    // in SPDX 2.3 + SPDX 3 (issue-#236 fix). Without the synth
+    // subject in this lookup the CDX bucket would silently drop
+    // those edges and parity tests would see a false-positive
+    // SPDX-vs-CDX divergence.
     let mut comp_by_bomref: std::collections::BTreeMap<String, &Value> =
         std::collections::BTreeMap::new();
-    for c in walk_cdx_components_and_main_module(doc) {
+    for c in walk_cdx_components_main_module_and_synth_subject(doc) {
         if let Some(bref) = c.get("bom-ref").and_then(|v| v.as_str()) {
             comp_by_bomref.insert(bref.to_string(), c);
         }

--- a/mikebom-cli/src/parity/extractors/common.rs
+++ b/mikebom-cli/src/parity/extractors/common.rs
@@ -287,6 +287,26 @@ pub fn walk_cdx_components_and_main_module(doc: &Value) -> Vec<&Value> {
     out
 }
 
+/// Like [`walk_cdx_components_and_main_module`] but also includes
+/// `metadata.component` when it lacks the `mikebom:component-role:
+/// main-module` tag (i.e., it's a synthetic scan-subject
+/// placeholder). Used by dep-edge extractors so the primary-dep
+/// fallback's `target_ref → top-level` edges resolve through the
+/// `bom-ref` lookup (issue #236).
+///
+/// Component-count extractors (A1–A12) must NOT use this — synthetic
+/// placeholders are not real components and shouldn't inflate the
+/// component-count parity. The dep-edge bucket is different: those
+/// edges are now load-bearing in all three formats post-issue-#236
+/// fix, so the synth subject must appear in the lookup.
+pub fn walk_cdx_components_main_module_and_synth_subject(doc: &Value) -> Vec<&Value> {
+    let mut out = walk_cdx_components(doc);
+    if let Some(metadata_component) = doc.get("metadata").and_then(|m| m.get("component")) {
+        out.push(metadata_component);
+    }
+    out
+}
+
 /// Iterate SPDX 2.3 `packages[]`, skipping the synthetic root
 /// (SPDXID begins with `SPDXRef-DocumentRoot-`).
 pub fn walk_spdx23_packages(doc: &Value) -> Vec<&Value> {
@@ -390,7 +410,26 @@ pub(super) fn spdx_relationship_edges(
         let mut out = BTreeSet::new();
         let mut purl_by_spdxid: std::collections::BTreeMap<String, String> =
             std::collections::BTreeMap::new();
-        for p in walk_spdx23_packages(doc) {
+        // Issue #236: include the synthetic root Package in the
+        // SPDXID → PURL lookup so the synth-root → top-level
+        // DEPENDS_ON edges the SPDX 2.3 emitter now produces
+        // resolve and contribute to the dep-edge parity bucket.
+        // Pre-fix `walk_spdx23_packages` skipped the synthetic
+        // root (correct for A-row component-count parity, since
+        // the synth root isn't a real component); the dep-edge
+        // walkers need to see it because it's now a legitimate
+        // edge source.
+        let synth_root_iter = doc
+            .get("packages")
+            .and_then(|v| v.as_array())
+            .into_iter()
+            .flatten()
+            .filter(|p| {
+                p.get("SPDXID")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|s| s.starts_with("SPDXRef-DocumentRoot-"))
+            });
+        for p in walk_spdx23_packages(doc).into_iter().chain(synth_root_iter) {
             let id = match p.get("SPDXID").and_then(|v| v.as_str()) {
                 Some(s) => s,
                 None => continue,

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/apk.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/apk.spdx.json
@@ -175,6 +175,16 @@
       "relatedSpdxElement": "SPDXRef-DocumentRoot-ZSDQF5ZHEODMRWYF",
       "relationshipType": "DESCRIBES",
       "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-DHDBA3PTGCIRJAUV",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-ZSDQF5ZHEODMRWYF"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-NJ6CH7QTZDKJ74FQ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-ZSDQF5ZHEODMRWYF"
     }
   ],
   "spdxVersion": "SPDX-2.3"

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/bazel.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/bazel.spdx.json
@@ -255,6 +255,26 @@
       "relatedSpdxElement": "SPDXRef-DocumentRoot-HBC6GHWSJM6Q3Q7M",
       "relationshipType": "DESCRIBES",
       "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-SFZ6ZH3BHKUFYZNC",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-HBC6GHWSJM6Q3Q7M"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-LM6FBYXSKLDBXQVU",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-HBC6GHWSJM6Q3Q7M"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-NDJKRQLKYSDRTD3Q",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-HBC6GHWSJM6Q3Q7M"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-QUIZBKSWTOAVWLHQ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-HBC6GHWSJM6Q3Q7M"
     }
   ],
   "spdxVersion": "SPDX-2.3"

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/cargo.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/cargo.spdx.json
@@ -585,6 +585,11 @@
       "relatedSpdxElement": "SPDXRef-Package-E3KDPHV32PPHGGT4",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-BKMD7Y4M3VJPWGQM"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-7I3OEASNAR5ZCRZY",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-5ASQV7Q5UGLJI5SG"
     }
   ],
   "spdxVersion": "SPDX-2.3"

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/cmake.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/cmake.spdx.json
@@ -212,6 +212,21 @@
       "relatedSpdxElement": "SPDXRef-DocumentRoot-OZ6XMDQYPIZT4M7G",
       "relationshipType": "DESCRIBES",
       "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-6JWGJCRVPGZ5RSBG",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-OZ6XMDQYPIZT4M7G"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-3ECZZDDDHD3O6FKS",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-OZ6XMDQYPIZT4M7G"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-LXTPKDHC3UVRRT5J",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-OZ6XMDQYPIZT4M7G"
     }
   ],
   "spdxVersion": "SPDX-2.3"

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/deb.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/deb.spdx.json
@@ -177,6 +177,16 @@
       "relatedSpdxElement": "SPDXRef-DocumentRoot-GCMDS7Q5JSXR7KMT",
       "relationshipType": "DESCRIBES",
       "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ZKB4GX3JBL66K2UG",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-GCMDS7Q5JSXR7KMT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-FBZUYFQKGJMH6COB",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-GCMDS7Q5JSXR7KMT"
     }
   ],
   "spdxVersion": "SPDX-2.3"

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/gem.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/gem.spdx.json
@@ -886,6 +886,21 @@
       "relatedSpdxElement": "SPDXRef-Package-4JPHR2PPVHB67S4U",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-TR5HW53UTITK2X66"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-XTKK2VQX4KVZ2WZU",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-34SCOEKBCMBORPRI"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-YWCQDJ2BTHI5GSS3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-34SCOEKBCMBORPRI"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-YNQ5SQJBK7DHJ5GJ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-34SCOEKBCMBORPRI"
     }
   ],
   "spdxVersion": "SPDX-2.3"

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/pip.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/pip.spdx.json
@@ -436,6 +436,21 @@
       "relatedSpdxElement": "SPDXRef-Package-IGBIL3UCACAQFOM3",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-6PK6TYQPA2QWXM26"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ND26YIDZX2IHEVKH",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-SPMV4V3BF7FUEPKR"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-E7GW44NAPCTLSLSL",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-SPMV4V3BF7FUEPKR"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-6PK6TYQPA2QWXM26",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-SPMV4V3BF7FUEPKR"
     }
   ],
   "spdxVersion": "SPDX-2.3"

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/apk.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/apk.spdx3.json
@@ -125,6 +125,26 @@
       "type": "software_Package"
     },
     {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GUTIH7PB5QYX4ONRJHDUAAW4/pkg-root-PEPQMV5CGEDHQJI2",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GUTIH7PB5QYX4ONRJHDUAAW4/rel-D7SSCKGYI6L35QTT",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-GUTIH7PB5QYX4ONRJHDUAAW4/pkg-NJ6CH7QTZDKJ74FQ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GUTIH7PB5QYX4ONRJHDUAAW4/pkg-root-PEPQMV5CGEDHQJI2",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GUTIH7PB5QYX4ONRJHDUAAW4/rel-GBEDCTXMED356DWJ",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-GUTIH7PB5QYX4ONRJHDUAAW4/pkg-DHDBA3PTGCIRJAUV"
+      ],
+      "type": "Relationship"
+    },
+    {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GUTIH7PB5QYX4ONRJHDUAAW4/anno-2YJA7ZEDZ3PZUEP4",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/bazel.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/bazel.spdx3.json
@@ -135,6 +135,46 @@
       "type": "software_Package"
     },
     {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-MIFUEDCNMDTQCVUO4CTBHERO/pkg-root-JRDK72P47VQ5ATJ4",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-MIFUEDCNMDTQCVUO4CTBHERO/rel-EQHKUCMOOWIXEMAR",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-MIFUEDCNMDTQCVUO4CTBHERO/pkg-LM6FBYXSKLDBXQVU"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-MIFUEDCNMDTQCVUO4CTBHERO/pkg-root-JRDK72P47VQ5ATJ4",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-MIFUEDCNMDTQCVUO4CTBHERO/rel-NNFCLU7O6IEFMZ65",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-MIFUEDCNMDTQCVUO4CTBHERO/pkg-QUIZBKSWTOAVWLHQ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-MIFUEDCNMDTQCVUO4CTBHERO/pkg-root-JRDK72P47VQ5ATJ4",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-MIFUEDCNMDTQCVUO4CTBHERO/rel-SWIMYCF25JI2432D",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-MIFUEDCNMDTQCVUO4CTBHERO/pkg-SFZ6ZH3BHKUFYZNC"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-MIFUEDCNMDTQCVUO4CTBHERO/pkg-root-JRDK72P47VQ5ATJ4",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-MIFUEDCNMDTQCVUO4CTBHERO/rel-XRDCKB4LIVFLLIAF",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-MIFUEDCNMDTQCVUO4CTBHERO/pkg-NDJKRQLKYSDRTD3Q"
+      ],
+      "type": "Relationship"
+    },
+    {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-MIFUEDCNMDTQCVUO4CTBHERO/anno-24JI7HUJKG6CVJHV",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/cargo.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/cargo.spdx3.json
@@ -356,6 +356,16 @@
     },
     {
       "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-B4AP7ZTSYUUCESRAYD5WGSYJ/pkg-root-H5VPHAIRCLACRQYQ",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-B4AP7ZTSYUUCESRAYD5WGSYJ/rel-FWUT5RFMSPOMKGHE",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-B4AP7ZTSYUUCESRAYD5WGSYJ/pkg-7I3OEASNAR5ZCRZY"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
       "from": "https://mikebom.kusari.dev/spdx3/doc-B4AP7ZTSYUUCESRAYD5WGSYJ/pkg-CDE3XEXSDOGUXIZT",
       "relationshipType": "dependsOn",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-B4AP7ZTSYUUCESRAYD5WGSYJ/rel-IVRQJ4KESSQYNAGC",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/cmake.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/cmake.spdx3.json
@@ -125,6 +125,36 @@
       "type": "software_Package"
     },
     {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-M5XA6DSIEFJPBKA56QZCIS2T/pkg-root-JTCRM6TWPTUATH5X",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-M5XA6DSIEFJPBKA56QZCIS2T/rel-DLHJQO5VOQJ3ILPS",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-M5XA6DSIEFJPBKA56QZCIS2T/pkg-6JWGJCRVPGZ5RSBG"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-M5XA6DSIEFJPBKA56QZCIS2T/pkg-root-JTCRM6TWPTUATH5X",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-M5XA6DSIEFJPBKA56QZCIS2T/rel-SYFGUE3WT3YKDNPS",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-M5XA6DSIEFJPBKA56QZCIS2T/pkg-3ECZZDDDHD3O6FKS"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-M5XA6DSIEFJPBKA56QZCIS2T/pkg-root-JTCRM6TWPTUATH5X",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-M5XA6DSIEFJPBKA56QZCIS2T/rel-ZWNS6MZBK4VQW4UH",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-M5XA6DSIEFJPBKA56QZCIS2T/pkg-LXTPKDHC3UVRRT5J"
+      ],
+      "type": "Relationship"
+    },
+    {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-M5XA6DSIEFJPBKA56QZCIS2T/anno-2ECXIVPGKEI7GLOW",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/deb.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/deb.spdx3.json
@@ -133,6 +133,26 @@
       "type": "Organization"
     },
     {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-HP4Y3D3UKXGFAMJEEQWTP4A6/pkg-root-PEPQMV5CGEDHQJI2",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-HP4Y3D3UKXGFAMJEEQWTP4A6/rel-HYI4U3KIGYBHKNF5",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-HP4Y3D3UKXGFAMJEEQWTP4A6/pkg-FBZUYFQKGJMH6COB"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-HP4Y3D3UKXGFAMJEEQWTP4A6/pkg-root-PEPQMV5CGEDHQJI2",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-HP4Y3D3UKXGFAMJEEQWTP4A6/rel-YGGQAQH6GHGFSMQJ",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-HP4Y3D3UKXGFAMJEEQWTP4A6/pkg-ZKB4GX3JBL66K2UG"
+      ],
+      "type": "Relationship"
+    },
+    {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-HP4Y3D3UKXGFAMJEEQWTP4A6/anno-6CAT6LHKOHL5LKHS",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/gem.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/gem.spdx3.json
@@ -496,6 +496,16 @@
     },
     {
       "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-7FM3PWJE5BIPQ2R6QFZ645AJ/pkg-root-A7PUMI3DKMBL3GSJ",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-7FM3PWJE5BIPQ2R6QFZ645AJ/rel-GUWPCIKHNAIOUJTJ",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-7FM3PWJE5BIPQ2R6QFZ645AJ/pkg-YNQ5SQJBK7DHJ5GJ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
       "from": "https://mikebom.kusari.dev/spdx3/doc-7FM3PWJE5BIPQ2R6QFZ645AJ/pkg-X445XBQQTVVT2QRP",
       "relationshipType": "dependsOn",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-7FM3PWJE5BIPQ2R6QFZ645AJ/rel-HTXE76ZPZS6YZF2D",
@@ -541,6 +551,26 @@
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-7FM3PWJE5BIPQ2R6QFZ645AJ/rel-OGPXY3QJJJY6ZHQX",
       "to": [
         "https://mikebom.kusari.dev/spdx3/doc-7FM3PWJE5BIPQ2R6QFZ645AJ/pkg-TF7KZG636E2WYOG4"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-7FM3PWJE5BIPQ2R6QFZ645AJ/pkg-root-A7PUMI3DKMBL3GSJ",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-7FM3PWJE5BIPQ2R6QFZ645AJ/rel-R2R7RJK7MDBMCLQY",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-7FM3PWJE5BIPQ2R6QFZ645AJ/pkg-XTKK2VQX4KVZ2WZU"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-7FM3PWJE5BIPQ2R6QFZ645AJ/pkg-root-A7PUMI3DKMBL3GSJ",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-7FM3PWJE5BIPQ2R6QFZ645AJ/rel-RBGM3RVEPG3LDPVS",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-7FM3PWJE5BIPQ2R6QFZ645AJ/pkg-YWCQDJ2BTHI5GSS3"
       ],
       "type": "Relationship"
     },

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/pip.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/pip.spdx3.json
@@ -315,6 +315,26 @@
     },
     {
       "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-YQHJIZTCMZMZJZAGQKLBB53T/pkg-root-O4XGGFIAI4WU3KZ2",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-YQHJIZTCMZMZJZAGQKLBB53T/rel-IMJ2AZPUYTPGGANZ",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-YQHJIZTCMZMZJZAGQKLBB53T/pkg-6PK6TYQPA2QWXM26"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-YQHJIZTCMZMZJZAGQKLBB53T/pkg-root-O4XGGFIAI4WU3KZ2",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-YQHJIZTCMZMZJZAGQKLBB53T/rel-L2PRWGHKCENFHAIF",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-YQHJIZTCMZMZJZAGQKLBB53T/pkg-E7GW44NAPCTLSLSL"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
       "from": "https://mikebom.kusari.dev/spdx3/doc-YQHJIZTCMZMZJZAGQKLBB53T/pkg-6PK6TYQPA2QWXM26",
       "relationshipType": "dependsOn",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-YQHJIZTCMZMZJZAGQKLBB53T/rel-MEOEAGW3GCSIUTO4",
@@ -380,6 +400,16 @@
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-YQHJIZTCMZMZJZAGQKLBB53T/rel-ZN6MZZECDDOGLQLR",
       "to": [
         "https://mikebom.kusari.dev/spdx3/doc-YQHJIZTCMZMZJZAGQKLBB53T/pkg-R4X6ZI7PYUOFDI6S"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-YQHJIZTCMZMZJZAGQKLBB53T/pkg-root-O4XGGFIAI4WU3KZ2",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-YQHJIZTCMZMZJZAGQKLBB53T/rel-ZXMDAZHEOVMZL4ZP",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-YQHJIZTCMZMZJZAGQKLBB53T/pkg-ND26YIDZX2IHEVKH"
       ],
       "type": "Relationship"
     },

--- a/mikebom-cli/tests/transitive_parity_gem.rs
+++ b/mikebom-cli/tests/transitive_parity_gem.rs
@@ -12,7 +12,15 @@ use transitive_parity_common::*;
 
 const FIXTURE_SUBPATH: &str = "gem";
 
-const EXPECTED_MIKEBOM_EDGE_COUNT: usize = 196;
+// Issue #236 bumped the baseline from 196 → 217: fastlane's fixture
+// has only Gemfile + Gemfile.lock (no top-level `.gemspec`), so per
+// milestone 069's FR-002 it doesn't get a main-module annotation,
+// and the SPDX 2.3 emitter falls through to `synthesize_root`. The
+// issue-#236 fix adds `synth-root → graph-root` DEPENDS_ON edges
+// from the synthesized root to every component nothing else depends
+// on (mirrors CDX's primary-dependency fallback). 21 graph-root
+// gems × 1 edge each = 21 new edges; 196 + 21 = 217.
+const EXPECTED_MIKEBOM_EDGE_COUNT: usize = 217;
 
 const EXPECTED_REPRESENTATIVE_EDGES: &[(&str, &str)] = &[
     // Confirmed in mikebom output — fastlane's main module pulls in CFPropertyList.

--- a/mikebom-cli/tests/transitive_parity_pip_plain.rs
+++ b/mikebom-cli/tests/transitive_parity_pip_plain.rs
@@ -20,9 +20,28 @@ use transitive_parity_common::*;
 
 const FIXTURE_SUBPATH: &str = "pip_plain";
 
-/// Per FR-008: plain `requirements.txt` has no transitive structure;
-/// all 3 SBOM tools should emit zero transitive edges.
-const EXPECTED_MIKEBOM_EDGE_COUNT: usize = 0;
+/// Per FR-008: plain `requirements.txt` has no *transitive* structure
+/// — Trivy/Syft emit zero edges from this fixture and that
+/// upstream-limitation invariant is what `cross_tool_parity_check`
+/// warns on below.
+///
+/// Issue #236 bumped the mikebom baseline from 0 → 13. mikebom's CDX
+/// has emitted 13 `metadata.component → <each requirements.txt
+/// package>` edges via the primary-dependency fallback since
+/// milestone 084 (CDX's `cyclonedx/dependencies.rs:74-99`). Pre-fix
+/// SPDX 2.3 had no equivalent and emitted 0, so the baseline reflected
+/// SPDX-only behavior. Post-fix the SPDX 2.3 emitter mirrors the CDX
+/// primary-dep fallback when `synthesize_root` fires (image scans,
+/// OS-package scans, AND Gemfile-only / requirements.txt-only
+/// projects that don't carry a main-module annotation), producing 13
+/// synth-root → graph-root `DEPENDS_ON` edges in this fixture. These
+/// are direct-dep edges (the project depends on each listed package),
+/// not synthesized transitive structure, so FR-008's spirit is
+/// preserved — what changed is that SPDX now agrees with CDX inside
+/// mikebom. mikebom continues to emit MORE edges than Trivy/Syft here
+/// by design (they emit zero); the `cross_tool_parity_check` below
+/// surfaces that as a WARN.
+const EXPECTED_MIKEBOM_EDGE_COUNT: usize = 13;
 
 fn fixture() -> PathBuf {
     fixture_path(FIXTURE_SUBPATH)

--- a/mikebom-cli/tests/transitive_parity_pip_poetry.rs
+++ b/mikebom-cli/tests/transitive_parity_pip_poetry.rs
@@ -11,7 +11,12 @@ use transitive_parity_common::*;
 
 const FIXTURE_SUBPATH: &str = "pip_poetry";
 
-const EXPECTED_MIKEBOM_EDGE_COUNT: usize = 62;
+// Issue #236 bumped the baseline from 62 → 88: pip-poetry projects
+// without a top-level main-module annotation fall through to
+// `synthesize_root`, and the issue-#236 fix adds synth-root →
+// graph-root `DEPENDS_ON` edges (mirrors CDX's primary-dependency
+// fallback). 26 graph-root packages → 26 new edges; 62 + 26 = 88.
+const EXPECTED_MIKEBOM_EDGE_COUNT: usize = 88;
 
 const EXPECTED_REPRESENTATIVE_EDGES: &[(&str, &str)] = &[
     // build → packaging.


### PR DESCRIPTION
## Summary

Closes #236. Bundles the two fixes the reporter flagged for the synthesized-root code path:

1. **Orphaned-root bug** (the reporter's primary complaint): when SPDX 2.3 / SPDX 3 synthesized a placeholder root for a scan with no natural main module (image scans, OS-package-only scans, Gemfile-only / requirements.txt-only projects), the placeholder had **zero outgoing dependency edges**. The 31 top-level packages in `postgres:16` were graph-tops with no incoming edge; consumers walking from the declared root saw zero direct deps. CDX has fired the primary-dependency fallback at `cyclonedx/dependencies.rs:74-99` since milestone 084 (synthesizes `metadata.component.bom-ref → <each component nothing else depends on>` when the bom-ref has no outgoing edges); this PR mirrors that into both SPDX emitters so CDX, SPDX 2.3, and SPDX 3 all produce a connected dep graph rooted at the same synthetic identity.

2. **Cross-format root-PURL divergence** (the reporter's secondary observation, flagged as possibly-separate): pre-fix the synthesized-root PURL differed across the three formats for the same scan target. For `postgres:16`, CDX produced `pkg:generic/postgres:16@0.0.0` (colon literal preserved via `encode_purl_segment`), SPDX 2.3 produced `pkg:generic/postgres_16@0.0.0` (colon → underscore via `sanitize_for_coord`), and SPDX 3 produced `pkg:generic/postgres-16@0.0.0` (colon → dash via `url_friendly`). Three different root identities for the same image. Both SPDX synthesize-root paths now use `encode_purl_segment` for the PURL field while keeping the format-specific sanitizers for the CPE field (CPE has its own grammar rules).

Reconfirmed end-to-end on `alpine:3`: all three formats emit `pkg:generic/alpine:3@0.0.0` as the root identity with 8 outgoing edges each.

## Test plan

- [x] `./scripts/pre-pr.sh` clean — clippy + workspace tests both pass
- [x] 3 new unit tests in `generate/spdx/document.rs` covering the new behavior: synth-root PURL form, synth-root outgoing-edges invariant, "already-depended-on components excluded from the fallback" (mirrors CDX's `cyclonedx/dependencies.rs:91-95` filter)
- [x] Manual reconfirm on `alpine:3`: CDX/SPDX/SPDX3 all emit identical root PURL `pkg:generic/alpine:3@0.0.0` with 8 outgoing edges
- [x] 14 SPDX byte-identity goldens regenerated (apk, bazel, cargo, cmake, deb, gem, pip × both spdx-2.3 and spdx-3). Diffs are purely additive — a constant set of synth-root → graph-root edges. The other 8 goldens (golang, maven, npm, rpm) are byte-identical to alpha.34 because their fixtures carry main-module annotations and don't hit `synthesize_root`.
- [x] Parity extractors updated so `holistic_parity` continues to pass — the pre-fix extractors deliberately skipped synthetic roots from dep-edge buckets (those roots had no edges); post-fix they're load-bearing edge sources. New helper `walk_cdx_components_main_module_and_synth_subject` + synth-root inclusion in `spdx_relationship_edges` close the gap. Component-count extractors (A1-A12) continue to exclude synthetic roots.
- [x] 3 transitive-parity baselines bumped: `transitive_parity_gem` 196 → 217 (fastlane has no top-level `.gemspec`, so `synthesize_root` fires); `transitive_parity_pip_plain` 0 → 13 (synthetic requirements.txt fixture); `transitive_parity_pip_poetry` 62 → 88. Each baseline change has an inline comment explaining the new edges. For `pip_plain`, the FR-008 "all 3 tools agree on zero" invariant moves to a soft WARN via `cross_tool_parity_check`'s informational output — mikebom's CDX has emitted these edges since milestone 084, and post-fix SPDX agrees with mikebom's own CDX. The Trivy/Syft divergence is intentional and surfaced rather than silenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)