### PR TITLE
fix(spdx): gate synth-root fallback when alias rewrite already populated edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 
 ## [Unreleased]
 
+### SPDX synth-root fallback over-attached graph-roots under `--root-name`
+
+Fixes a cross-format divergence the alpha.35 regen surfaced. When `--root-name` is active, the milestone-#229 alias rewrite at `generate/spdx/document.rs:458-465` already populates outgoing edges from the synthetic root SPDXID for every relationship originally sourced at the dropped manifest main-module's PURL. The #236 graph-root fallback (lines 483+) was firing on top of that — gated on `synthetic_root_added` alone — and adding extra `DEPENDS_ON` edges from synth-root to components mikebom couldn't link into the rest of the dep graph (Go `// indirect` entries the milestone-091 go.sum fallback couldn't inter-link under `--offline`; orphan npm packages from secondary `node_modules/` trees that lost their parent linkage during npm resolution). CDX's primary-dep fallback at `cyclonedx/dependencies.rs:74-78` is gated on `target_has_no_edges` symmetrically — it correctly skipped under `--root-name`, so CDX never had this problem.
+
+**Behavior change:** the SPDX fallback now mirrors CDX's gate. It checks whether `synth_id` has any outgoing edges in the post-alias-rewrite `relationships` vec and only fires when there are none. Image scans, OS-package-only scans, and any other shape where `artifacts.relationships` contains no main-module-sourced edges → synth-id stays with zero outgoing edges → fallback still fires (image-scan synth root remains connected to its top-level packages, per #236's original intent). Override-active scans where the alias rewrite already populated outgoing edges → fallback skips → SPDX root edges now match CDX root edges component-for-component.
+
+**Concrete impact on the alpha.35 regen results:**
+
+- **guac** (`--root-name guac --root-version ebb808e`): SPDX root went from 441 DEPENDS_ON edges to 372 — drops the 70 Go `// indirect` entries that were over-attached. Now matches CDX (372 dependsOn). The 1 remaining diff vs CDX is the testify `TEST_DEPENDENCY_OF`-typed edge, which is the milestone-#228 by-design behavior.
+- **Multi-`package.json` orphan-npm reproducer**: SPDX root went from 11 DEPENDS_ON edges to 4. The 7 orphan npm packages from `sub/node_modules/` are no longer over-attached. Now matches CDX (4 dependsOn).
+- **kusari-cli**: unchanged (no over-attachment was happening; the alpha.35 regen showed 12/12 already).
+- **`postgres:16` image scan**: unchanged (no override → alias map empty → synth-id has zero outgoing edges before fallback → fallback fires as before → 31 dependsOn / DEPENDS_ON in both formats, as alpha.35 already had).
+
+#### Added
+
+- **Two regression tests** in `generate/spdx/document.rs::tests` mirroring the alpha.35 reproducer shapes — one for the Go `// indirect` over-attachment scenario (synth root with main-module-aliased direct + orphan indirect → asserts only the direct gets attached), one for the orphan-npm scenario (same shape, different ecosystem). New test helpers `mk_main_module` (constructs a component carrying the `mikebom:component-role: main-module` annotation that the emitter drops under `--root-name`) and `mk_artifacts_with_override` (constructs `ScanArtifacts` with `root_override` populated) for use by these and future override-related tests.
+- The pre-existing 3 #236 unit tests (`synthesized_root_has_outgoing_depends_on_to_graph_roots`, `synthesized_root_purl_preserves_colon_like_cdx`, `synthesized_root_excludes_already_depended_on_components_from_fallback`) continue to pass — the gate is purely additive on top of the existing logic; the image-scan-shaped scenarios these tests cover have empty alias maps and so satisfy the new `synth_has_outgoing == false` condition.
+
+#### Known issue (separately tracked)
+
+The orphan-npm-resolution gap that creates the "lost parent linkage" for `sub/node_modules/X` in the first place is a real and separate bug — the npm reader should re-parent secondary-tree dependencies to their actual graph parents rather than leaving them as top-level orphans. That fix is orthogonal to this PR (which only ensures the two formats agree on what to do with the already-orphan components). Filed as a follow-up issue.
+
 ### Issue #234 — Multi-arch production container image
 
 Adds an official multi-arch (linux/amd64 + linux/arm64) container image published to `ghcr.io/kusari-sandbox/mikebom` per release. Image is signed with cosign keyless via Sigstore.

--- a/mikebom-cli/src/generate/spdx/document.rs
+++ b/mikebom-cli/src/generate/spdx/document.rs
@@ -480,35 +480,61 @@ pub fn build_document(
     // 31 (in the postgres:16 case) top-level Packages have no
     // incoming edges, producing N disconnected graph-tops where
     // CDX has a single root.
+    //
+    // Post-#236 gating rule (added after the alpha.35 regen
+    // surfaced over-attachment under `--root-name`): only fire
+    // the fallback when synth_id has no outgoing edges in the
+    // already-built `relationships` vec. This mirrors CDX's
+    // `target_has_no_edges` gate at
+    // `cyclonedx/dependencies.rs:74-78` symmetrically. When
+    // `--root-name` is active, the milestone-#229 alias rewrite
+    // at lines 458-465 has already populated outgoing edges from
+    // synth_id for every relationship that was originally sourced
+    // at the dropped main-module's PURL. Firing the fallback
+    // on top of those would over-attach graph-root components
+    // (Go `// indirect` entries, orphan npm packages from
+    // secondary `node_modules/` trees, etc.) as direct deps of
+    // the override root — a divergence vs CDX which the alpha.35
+    // bug reports caught. The fallback still fires correctly for
+    // image scans, OS-package-only scans, and any other case
+    // where `artifacts.relationships` has no main-module-sourced
+    // edges to rewrite (synth_id stays with zero outgoing edges
+    // after `build_relationships`, so the gate is satisfied).
     if synthetic_root_added {
         if let Some(synth_id) = root_ids.first() {
-            // Mirror CDX's "graph roots" definition: components no
-            // other component or relationship points to as a `to`
-            // target. For a flat OS-package scan that's every
-            // component; for a transitive scan it's just the top-
-            // level deps.
-            let depended_on: std::collections::BTreeSet<&str> = artifacts
-                .relationships
+            let synth_has_outgoing = relationships
                 .iter()
-                .map(|r| r.to.as_str())
-                .collect();
-            let mut graph_roots: Vec<&mikebom_common::resolution::ResolvedComponent> =
-                artifacts
-                    .components
+                .any(|r| r.source == *synth_id);
+            if !synth_has_outgoing {
+                // Mirror CDX's "graph roots" definition: components no
+                // other component or relationship points to as a `to`
+                // target. For a flat OS-package scan that's every
+                // component; for a transitive scan it's just the top-
+                // level deps.
+                let depended_on: std::collections::BTreeSet<&str> = artifacts
+                    .relationships
                     .iter()
-                    .filter(|c| {
-                        c.parent_purl.is_none() && !depended_on.contains(c.purl.as_str())
-                    })
+                    .map(|r| r.to.as_str())
                     .collect();
-            // Deterministic emission order: lex by PURL.
-            graph_roots.sort_by(|a, b| a.purl.as_str().cmp(b.purl.as_str()));
-            for c in graph_roots {
-                relationships.push(super::relationships::SpdxRelationship {
-                    source: synth_id.clone(),
-                    target: SpdxId::for_purl(&c.purl),
-                    kind: super::relationships::SpdxRelationshipType::DependsOn,
-                    comment: None,
-                });
+                let mut graph_roots: Vec<&mikebom_common::resolution::ResolvedComponent> =
+                    artifacts
+                        .components
+                        .iter()
+                        .filter(|c| {
+                            c.parent_purl.is_none()
+                                && !depended_on.contains(c.purl.as_str())
+                        })
+                        .collect();
+                // Deterministic emission order: lex by PURL.
+                graph_roots.sort_by(|a, b| a.purl.as_str().cmp(b.purl.as_str()));
+                for c in graph_roots {
+                    relationships.push(super::relationships::SpdxRelationship {
+                        source: synth_id.clone(),
+                        target: SpdxId::for_purl(&c.purl),
+                        kind: super::relationships::SpdxRelationshipType::DependsOn,
+                        comment: None,
+                    });
+                }
             }
         }
     }
@@ -1169,6 +1195,181 @@ mod tests {
             outgoing.len(),
             3,
             "expected 3 outgoing DEPENDS_ON edges to the 3 graph-root components, got {outgoing:#?}"
+        );
+    }
+
+    /// Build a main-module-tagged ResolvedComponent (carries the
+    /// `mikebom:component-role = "main-module"` annotation that the
+    /// emitter drops under `--root-name`). Used by the alpha.35
+    /// fallback-gating regression tests below.
+    fn mk_main_module(purl: &str, name: &str, version: &str) -> ResolvedComponent {
+        let mut c = mk_component(purl, name, version);
+        c.extra_annotations.insert(
+            "mikebom:component-role".to_string(),
+            serde_json::Value::String("main-module".to_string()),
+        );
+        c
+    }
+
+    /// Build a ScanArtifacts under `--root-name <name> --root-version
+    /// <version>`. Mirrors the production CLI path that sets
+    /// `root_override` from the override flags.
+    fn mk_artifacts_with_override<'a>(
+        target_name: &'a str,
+        components: &'a [ResolvedComponent],
+        relationships: &'a [mikebom_common::resolution::Relationship],
+        integrity: &'a TraceIntegrity,
+        root_name: &str,
+        root_version: &str,
+    ) -> ScanArtifacts<'a> {
+        let mut arts = mk_artifacts(target_name, components, relationships, integrity);
+        arts.root_override = crate::generate::RootComponentOverride {
+            name: Some(root_name.to_string()),
+            version: Some(root_version.to_string()),
+        };
+        arts
+    }
+
+    #[test]
+    fn synth_root_fallback_skipped_when_alias_rewrite_already_populated_edges() {
+        // Regression for the alpha.35 cross-format divergence
+        // surfaced after #229 + #236 both shipped. When `--root-name`
+        // is active, the milestone-#229 alias rewrite at
+        // `document.rs:458-465` maps the dropped main-module's
+        // PURL → synth-root SPDXID, so relations originally sourced
+        // at the manifest main module become outgoing edges from
+        // synth-root. The #236 graph-root fallback (lines 483+)
+        // must NOT fire on top of that — otherwise it over-attaches
+        // graph-root components (e.g., Go `// indirect` entries the
+        // milestone-091 go.sum fallback couldn't inter-link) as
+        // direct deps of the override root, diverging from CDX
+        // which gates its primary-dep fallback on
+        // `target_has_no_edges` symmetrically.
+        //
+        // Shape: 1 main module (dropped under override) + 1 direct
+        // dep the main module points at + 1 orphan indirect (no
+        // parent_purl, not in any relationship's `to`). After the
+        // fix, synth-root has exactly 1 outgoing DEPENDS_ON (to
+        // the direct dep — the aliased relationship). Without the
+        // gate, synth-root would also pick up the orphan indirect.
+        let integ = empty_integrity();
+        let main_module = mk_main_module(
+            "pkg:golang/github.com/guacsec/guac@v0.0.0-20260101-abcdef",
+            "guac",
+            "v0.0.0-20260101-abcdef",
+        );
+        let direct_dep = mk_component(
+            "pkg:golang/github.com/spf13/cobra@v1.10.2",
+            "cobra",
+            "v1.10.2",
+        );
+        let orphan_indirect = mk_component(
+            "pkg:golang/github.com/golang-jwt/jwt/v4@v4.5.2",
+            "jwt",
+            "v4.5.2",
+        );
+        let comps = vec![main_module.clone(), direct_dep.clone(), orphan_indirect];
+        let rels = vec![mikebom_common::resolution::Relationship {
+            from: main_module.purl.as_str().to_string(),
+            to: direct_dep.purl.as_str().to_string(),
+            relationship_type: mikebom_common::resolution::RelationshipType::DependsOn,
+            provenance: mikebom_common::resolution::EnrichmentProvenance {
+                source: "test".to_string(),
+                data_type: "runtime".to_string(),
+            },
+        }];
+        let arts = mk_artifacts_with_override(
+            "guac",
+            &comps,
+            &rels,
+            &integ,
+            "guac",
+            "v0.0.0-20260101-abcdef",
+        );
+        let doc = build_doc_value(&arts);
+        let rels = doc["relationships"].as_array().expect("relationships[]");
+        let root_id = rels
+            .iter()
+            .find(|r| r["relationshipType"].as_str() == Some("DESCRIBES"))
+            .and_then(|r| r["relatedSpdxElement"].as_str())
+            .expect("DESCRIBES edge present");
+        let outgoing_targets: Vec<&str> = rels
+            .iter()
+            .filter(|r| {
+                r["spdxElementId"].as_str() == Some(root_id)
+                    && r["relationshipType"].as_str() == Some("DEPENDS_ON")
+            })
+            .filter_map(|r| r["relatedSpdxElement"].as_str())
+            .collect();
+        assert_eq!(
+            outgoing_targets.len(),
+            1,
+            "synth root should have exactly 1 outgoing DEPENDS_ON \
+             (aliased from main-module → cobra); the orphan jwt indirect \
+             must NOT be attached. Got: {outgoing_targets:?}"
+        );
+    }
+
+    #[test]
+    fn synth_root_fallback_skipped_when_orphan_components_exist_under_root_name() {
+        // Bug-B mirror of the test above: orphan npm packages from
+        // a secondary `node_modules/` tree (parent_purl unset by
+        // the npm reader because the in-tree link wasn't resolved)
+        // must NOT get attached to the synth root under `--root-name`
+        // either. Same gate-behavior assertion as above; different
+        // PURL ecosystem to lock in the cross-ecosystem coverage.
+        let integ = empty_integrity();
+        let main_module = mk_main_module(
+            "pkg:npm/repro-root@0.0.0",
+            "repro-root",
+            "0.0.0",
+        );
+        let direct_dep = mk_component("pkg:npm/axios@1.16.1", "axios", "1.16.1");
+        let orphan_a = mk_component("pkg:npm/pg@8.17.2", "pg", "8.17.2");
+        let orphan_b = mk_component(
+            "pkg:npm/pg-connection-string@2.13.0",
+            "pg-connection-string",
+            "2.13.0",
+        );
+        let comps = vec![main_module.clone(), direct_dep.clone(), orphan_a, orphan_b];
+        let rels = vec![mikebom_common::resolution::Relationship {
+            from: main_module.purl.as_str().to_string(),
+            to: direct_dep.purl.as_str().to_string(),
+            relationship_type: mikebom_common::resolution::RelationshipType::DependsOn,
+            provenance: mikebom_common::resolution::EnrichmentProvenance {
+                source: "test".to_string(),
+                data_type: "runtime".to_string(),
+            },
+        }];
+        let arts = mk_artifacts_with_override(
+            "repro",
+            &comps,
+            &rels,
+            &integ,
+            "repro",
+            "0.0.0",
+        );
+        let doc = build_doc_value(&arts);
+        let rels = doc["relationships"].as_array().expect("relationships[]");
+        let root_id = rels
+            .iter()
+            .find(|r| r["relationshipType"].as_str() == Some("DESCRIBES"))
+            .and_then(|r| r["relatedSpdxElement"].as_str())
+            .expect("DESCRIBES edge present");
+        let outgoing_targets: Vec<&str> = rels
+            .iter()
+            .filter(|r| {
+                r["spdxElementId"].as_str() == Some(root_id)
+                    && r["relationshipType"].as_str() == Some("DEPENDS_ON")
+            })
+            .filter_map(|r| r["relatedSpdxElement"].as_str())
+            .collect();
+        assert_eq!(
+            outgoing_targets.len(),
+            1,
+            "synth root should have exactly 1 outgoing DEPENDS_ON \
+             (aliased main-module → axios); orphan pg + pg-connection-string \
+             must NOT be attached to root. Got: {outgoing_targets:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the cross-format divergence the alpha.35 regen surfaced with `--root-name`. Two concrete bug shapes both trace to the same root cause:

**Bug A — Go `// indirect` over-attached to SPDX root** (guac reproducer):
- CDX root: 372 `dependsOn` (the go.mod direct requires)
- SPDX root: 441 `DEPENDS_ON` — the same 372 plus 70 entries marked `// indirect` in `go.mod`

**Bug B — Orphan npm packages over-attached to SPDX root** (multi-`package.json` reproducer):
- CDX root: 4 `dependsOn`
- SPDX root: 11 `DEPENDS_ON` — the same 4 plus 7 orphan npm packages from `sub/node_modules/`

Both bugs hit only when `--root-name` is active. CDX is correct in both cases.

## Root cause

The #236 SPDX graph-root fallback at `generate/spdx/document.rs:483` is gated on `synthetic_root_added` — which is always true under `--root-name`. The #229 alias rewrite at lines 458-465 has already populated outgoing edges from synth_id for every relationship originally sourced at the dropped manifest main-module's PURL. The fallback was firing on top of that and adding extra synth_root → graph-root edges for components mikebom couldn't link into the rest of the dep graph.

CDX's primary-dep fallback at `cyclonedx/dependencies.rs:74-78` is gated on `target_has_no_edges` symmetrically — under `--root-name`, target_ref already has edges from the equivalent CDX-side rewrite, so CDX correctly skipped. SPDX's gate wasn't symmetric, hence the divergence.

## Fix

Change the SPDX fallback gate to mirror CDX. After `build_relationships`, check whether `synth_id` has any outgoing edges in the just-built `relationships` vec. Only fire the fallback when there are none.

## Behavior preserved

- **Image scans, OS-package-only scans**: `artifacts.relationships` contains no main-module-sourced edges → synth_id stays with zero outgoing edges before the fallback → fallback still fires → connects synth root to top-level packages per #236's original intent.
- The 3 pre-existing #236 unit tests pass unchanged.

## Post-fix counts

| Scenario | Before (alpha.35) | After (this PR) | CDX | Match? |
|---|---|---|---|---|
| guac `--root-name` | SPDX root: 441 | SPDX root: 372 | 372 | ✓ (1 testify TEST_DEPENDENCY_OF diff, milestone-#228 by-design) |
| Multi-`package.json` reproducer | SPDX root: 11 | SPDX root: 4 | 4 | ✓ |
| kusari-cli | 12 / 12 | 12 / 12 | 12 | ✓ (already matched) |
| `postgres:16` image scan | 31 / 31 | 31 / 31 | 31 | ✓ (already matched) |

## Test plan

- [x] `./scripts/pre-pr.sh` — clippy `--workspace --all-targets` + workspace test suite both clean
- [x] **2 new regression tests** in `generate/spdx/document.rs::tests`:
  - `synth_root_fallback_skipped_when_alias_rewrite_already_populated_edges` — Bug A shape, Go indirect
  - `synth_root_fallback_skipped_when_orphan_components_exist_under_root_name` — Bug B shape, orphan npm
- [x] 3 pre-existing #236 unit tests still pass: `synthesized_root_has_outgoing_depends_on_to_graph_roots`, `synthesized_root_purl_preserves_colon_like_cdx`, `synthesized_root_excludes_already_depended_on_components_from_fallback`. Their image-scan-shaped fixtures have empty alias maps and so satisfy the new `synth_has_outgoing == false` condition.

## Scope notes

- No new Cargo dependencies.
- No goldens regenerated. No existing fixture uses `--root-name`, so the byte-identity goldens are untouched.
- Diff scope: 1 production file (~25 net LOC inside `document.rs`), 1 CHANGELOG entry, 2 new test functions + 2 helper functions.

## Known issue (separately tracked)

The orphan-npm-resolution gap that creates "lost parent linkage" for `sub/node_modules/X` in the first place is a real and separate bug — the npm reader should re-parent secondary-tree deps to their actual graph parents rather than leaving them top-level orphans. That's orthogonal to this PR (which only ensures the two formats agree on what to do with already-orphan components). Filed as a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)