### PR TITLE
fix(release): glob extracted dir only when staging container tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,8 +467,12 @@ jobs:
             tarball=$(ls mikebom-*.tar.gz)
             tar -xzf "$tarball"
             # The tarball contains one directory named mikebom-<tag>-<target>;
-            # rename it to `staging` for the Dockerfile COPY.
-            mv mikebom-* staging
+            # rename it to `staging` for the Dockerfile COPY. The glob
+            # `mikebom-*/` (trailing slash) restricts the match to the
+            # extracted directory only, excluding the tarball file itself —
+            # without the trailing slash, `mv` sees both as sources and
+            # errors because the `staging` destination doesn't exist yet.
+            mv mikebom-*/ staging
             ls -la staging/
             cd ../..
           done


### PR DESCRIPTION
## Summary

The `v0.1.0-alpha.36` release workflow run [26461712744](https://github.com/kusari-sandbox/mikebom/actions/runs/26461712744) failed in the `publish-multi-arch-container-image` job. All other artifacts (5 per-platform binary tarballs, the [GitHub Release](https://github.com/kusari-sandbox/mikebom/releases/tag/v0.1.0-alpha.36) page) published cleanly; only the container image step needs to retry with this fix.

## Root cause

The bash glob `mv mikebom-* staging` in the "Extract tarballs into per-arch staging dirs" step matched **two sources** rather than one:

```
mikebom-v0.1.0-alpha.36-x86_64-unknown-linux-gnu.tar.gz   (file)
mikebom-v0.1.0-alpha.36-x86_64-unknown-linux-gnu/         (dir)
```

When `mv` receives multiple sources, it requires the destination to be an **existing** directory. `staging` is what we're creating, so it didn't exist yet → exit 1 with `mv: target 'staging': No such file or directory`.

This is the first time the job has run against a real tag. PR #243 added the job and shipped today (2026-05-26) in the same window as the alpha.36 release; PR-CI doesn't trigger `release.yml` (it's gated on `push: tags:`), so the bug was latent until the tag pushed.

## Fix

Trailing slash on the glob (`mikebom-*/`) restricts the match to directories only, excluding the tarball file. `mv` then sees a single source and renames it to the destination as intended.

## Deployment

The fix needs to be on a tagged commit for `release.yml` to re-run with the corrected step. Three options for getting alpha.36's container image actually published:

1. **Move the tag forward** (delete + recreate `v0.1.0-alpha.36` on the merge commit of this PR). The GitHub Release artifacts already match the binary content; re-firing produces the missing container image and overwrites the (currently empty) `:latest` tag.
2. **Cut alpha.37 as a CI-only patch release**. Leaves alpha.36 as a "binaries-only" release in the historical record. Slightly more churn but no tag-history rewriting.
3. **Add `workflow_dispatch` to `release.yml`** as a follow-up so future partial failures can be retried without retag.

Deferring to the maintainer on which path; this PR just gates the fix.

## Test plan

- [x] Verified the new glob locally:
  ```
  $ touch mikebom-v0.1.0.tar.gz && mkdir mikebom-v0.1.0/
  $ echo mikebom-*       # → matches both
  mikebom-v0.1.0 mikebom-v0.1.0.tar.gz
  $ echo mikebom-*/      # → matches only the directory
  mikebom-v0.1.0/
  ```
- [ ] Re-trigger `release.yml` after merge using the chosen deployment path above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)