### PR TITLE
fix(docker): remove pre-FROM ARG TARGETARCH so post-FROM picks up buildx value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,18 @@
 # `sbom generate` paths, no special privileges are needed and the
 # nonroot user is sufficient.
 
-ARG TARGETARCH
 FROM gcr.io/distroless/cc-debian12:nonroot
 
+# TARGETARCH is auto-populated by buildx with the per-platform value
+# (`amd64` / `arm64`) when building multi-arch with
+# `--platform linux/amd64,linux/arm64`. Declaring it AFTER FROM lets
+# buildx populate it for this stage.
+#
+# DO NOT also declare it BEFORE FROM. A pre-FROM ARG creates a global
+# scope with no value (we never pass --build-arg TARGETARCH), and the
+# post-FROM `ARG TARGETARCH` would inherit that empty value rather
+# than buildx's auto-set platform value, leaving `${TARGETARCH}`
+# empty in the COPY below.
 ARG TARGETARCH
 
 # Copy the per-arch tarball staging directory into /mikebom. The


### PR DESCRIPTION
## Summary

The v0.1.0-alpha.36 release workflow re-run [26464909878](https://github.com/kusari-sandbox/mikebom/actions/runs/26464909878) (after #248 landed) failed again in the multi-arch container build, this time with a different symptom:

```
#11 [linux/amd64 2/3] COPY /staging/ /mikebom/
#11 ERROR: failed to calculate checksum of ref ...: "/staging": not found
```

The COPY source resolved to `/staging/` (leading slash) instead of `amd64/staging/` — meaning `${TARGETARCH}` expanded to empty even though buildx labeled the stage `[linux/amd64 2/3]`.

## Root cause

The Dockerfile declared `ARG TARGETARCH` **both before and after FROM**:

```dockerfile
ARG TARGETARCH         ← global scope, no value (we never pass --build-arg)
FROM gcr.io/distroless/cc-debian12:nonroot
ARG TARGETARCH         ← stage scope, intended to receive buildx auto-value

COPY ${TARGETARCH}/staging/ /mikebom/
```

Per the [Dockerfile reference](https://docs.docker.com/reference/dockerfile/#arg), a post-FROM `ARG <name>` without a default value **inherits from the pre-FROM declaration**. Since we never pass `--build-arg TARGETARCH=...`, the pre-FROM scope binds TARGETARCH to the empty string. The post-FROM ARG then inherits that empty value, **shadowing** buildx's auto-populated per-platform value.

Result: `${TARGETARCH}` expands to empty, the COPY source becomes `/staging/`, the build context doesn't have anything at that path, build fails.

## Fix

Delete the pre-FROM `ARG TARGETARCH`. The Dockerfile doesn't reference `${TARGETARCH}` in the FROM line, so the pre-FROM declaration is dead weight. With it gone, buildx's auto-populated per-platform value reaches the post-FROM scope unshadowed.

Also: add a docstring on the surviving post-FROM ARG explaining why future maintainers should NOT re-add the pre-FROM declaration. The bug is subtle and the diff alone wouldn't make the constraint obvious.

## What this means for alpha.36

This is the second issue uncovered in PR #243's container-image plumbing (after #248's `mv` glob fix). The first failure masked this until it was resolved. After merge, the maintainer plans to re-tag `v0.1.0-alpha.36` forward to the merge commit a second time (same destructive-but-clean approach as #248) to publish the container image.

## Test plan

- [ ] After merge: delete + recreate `v0.1.0-alpha.36` tag on this PR's merge commit; verify `release.yml` run completes green; verify image at `ghcr.io/kusari-sandbox/mikebom:v0.1.0-alpha.36` (and `:latest`, `:0.1.0-alpha.36`) and cosign signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)