### PR TITLE
fix(go): drop +incompatible legacy-version residue when /vN sibling is present

### DIFF
--- a/mikebom-cli/src/scan_fs/package_db/golang/graph_resolver.rs
+++ b/mikebom-cli/src/scan_fs/package_db/golang/graph_resolver.rs
@@ -135,6 +135,43 @@ impl ModuleGraphMap {
         self.entries.is_empty()
     }
 
+    /// Issue #255: BFS through the resolver map starting from `seeds`,
+    /// returning the set of reachable `ModuleId`s. Used by
+    /// `legacy.rs::read` to filter go.sum residue out of the emitted
+    /// component set: modules that are in go.sum but no longer
+    /// reachable from any `require` line in go.mod (e.g., legacy
+    /// `+incompatible` integrity entries left behind when the project
+    /// upgraded to a `/vN`-suffixed module) drop out of the closure
+    /// and aren't emitted as components.
+    ///
+    /// Each seed is included in the result whether or not it has an
+    /// entry in the map; downstream filtering handles the "missing
+    /// from map" case (typically means the module was filtered earlier
+    /// in the resolver pipeline).
+    ///
+    /// Follows the `requires` edges of each visited entry. Modules
+    /// claimed only by step 5 (`source = GoSumFallback`) have empty
+    /// `requires`, so they're terminal nodes in this traversal — but
+    /// they're still included in the closure when reached transitively
+    /// from a seed.
+    pub fn reachable_from(&self, seeds: &[ModuleId]) -> HashSet<ModuleId> {
+        let mut visited: HashSet<ModuleId> = HashSet::new();
+        let mut queue: Vec<ModuleId> = seeds.to_vec();
+        while let Some(id) = queue.pop() {
+            if !visited.insert(id.clone()) {
+                continue;
+            }
+            if let Some(entry) = self.entries.get(&id) {
+                for child in &entry.requires {
+                    if !visited.contains(child) {
+                        queue.push(child.clone());
+                    }
+                }
+            }
+        }
+        visited
+    }
+
     /// Milestone 091: returns module paths whose entries were claimed
     /// via step 5 (go.sum flat fallback). `legacy.rs::read` consumes
     /// this list to augment `build_main_module_entry`'s `depends`
@@ -963,6 +1000,119 @@ mod tests {
         replaces.insert(original, replacement.clone());
         apply_replaces(&mut map, &replaces);
         assert_eq!(map.entry(&parent).unwrap().requires, vec![replacement]);
+    }
+
+    // --- issue #255: reachable_from BFS -------------------------------------
+
+    #[test]
+    fn reachable_from_empty_seeds_empty_closure() {
+        let map = ModuleGraphMap::new();
+        let closure = map.reachable_from(&[]);
+        assert!(closure.is_empty());
+    }
+
+    #[test]
+    fn reachable_from_single_seed_no_edges() {
+        // A seed with no entry in the map (or empty requires) is itself
+        // in the closure but produces no further reachability.
+        let mut map = ModuleGraphMap::new();
+        let a = ModuleId::new("example.com/a", "v1.0.0");
+        map.insert(ModuleGraphEntry {
+            module: a.clone(),
+            requires: Vec::new(),
+            source: ResolutionStep::GoSumFallback,
+        });
+        let closure = map.reachable_from(std::slice::from_ref(&a));
+        assert_eq!(closure.len(), 1);
+        assert!(closure.contains(&a));
+    }
+
+    #[test]
+    fn reachable_from_follows_transitive_chain() {
+        // main → A → B → C; seeds = {A}. Closure = {A, B, C}.
+        let mut map = ModuleGraphMap::new();
+        let a = ModuleId::new("example.com/a", "v1.0.0");
+        let b = ModuleId::new("example.com/b", "v1.0.0");
+        let c = ModuleId::new("example.com/c", "v1.0.0");
+        map.insert(ModuleGraphEntry {
+            module: a.clone(),
+            requires: vec![b.clone()],
+            source: ResolutionStep::GoModGraph,
+        });
+        map.insert(ModuleGraphEntry {
+            module: b.clone(),
+            requires: vec![c.clone()],
+            source: ResolutionStep::GoModGraph,
+        });
+        map.insert(ModuleGraphEntry {
+            module: c.clone(),
+            requires: Vec::new(),
+            source: ResolutionStep::GoModGraph,
+        });
+        let closure = map.reachable_from(std::slice::from_ref(&a));
+        assert_eq!(closure.len(), 3);
+        assert!(closure.contains(&a));
+        assert!(closure.contains(&b));
+        assert!(closure.contains(&c));
+    }
+
+    #[test]
+    fn reachable_from_excludes_residue_modules() {
+        // Issue #255 shape: main → /v3 (active), separate +incompatible
+        // entry (residue, no parent in map). Seeds = {/v3}.
+        // Closure = {/v3}; residue excluded.
+        let mut map = ModuleGraphMap::new();
+        let v3 = ModuleId::new("example.com/foo/v3", "v3.3.3");
+        let residue = ModuleId::new("example.com/foo", "v2.1.0+incompatible");
+        map.insert(ModuleGraphEntry {
+            module: v3.clone(),
+            requires: Vec::new(),
+            source: ResolutionStep::GoModGraph,
+        });
+        map.insert(ModuleGraphEntry {
+            module: residue.clone(),
+            requires: Vec::new(),
+            source: ResolutionStep::GoSumFallback,
+        });
+        let closure = map.reachable_from(std::slice::from_ref(&v3));
+        assert!(closure.contains(&v3));
+        assert!(
+            !closure.contains(&residue),
+            "+incompatible residue must be excluded from closure when not seeded"
+        );
+    }
+
+    #[test]
+    fn reachable_from_handles_cycle() {
+        // A → B → A; seeds = {A}. Closure = {A, B}; BFS terminates.
+        let mut map = ModuleGraphMap::new();
+        let a = ModuleId::new("example.com/a", "v1.0.0");
+        let b = ModuleId::new("example.com/b", "v1.0.0");
+        map.insert(ModuleGraphEntry {
+            module: a.clone(),
+            requires: vec![b.clone()],
+            source: ResolutionStep::GoModGraph,
+        });
+        map.insert(ModuleGraphEntry {
+            module: b.clone(),
+            requires: vec![a.clone()],
+            source: ResolutionStep::GoModGraph,
+        });
+        let closure = map.reachable_from(std::slice::from_ref(&a));
+        assert_eq!(closure.len(), 2);
+    }
+
+    #[test]
+    fn reachable_from_seeds_unknown_to_map_still_included() {
+        // A seed not in the map is still part of the closure (it's
+        // self-reachable), but contributes no children. Mirrors the
+        // case where main-module's go.mod requires reference a module
+        // that the resolver pipeline filtered earlier.
+        let map = ModuleGraphMap::new();
+        let ghost = ModuleId::new("example.com/never-resolved", "v0.1.0");
+        let closure = map.reachable_from(std::slice::from_ref(&ghost));
+        assert_eq!(closure.len(), 1);
+        assert!(closure.contains(&ghost));
     }
 }
 

--- a/mikebom-cli/src/scan_fs/package_db/golang/legacy.rs
+++ b/mikebom-cli/src/scan_fs/package_db/golang/legacy.rs
@@ -374,6 +374,37 @@ fn parse_tool_line(rest: &str) -> Option<String> {
     }
 }
 
+/// Issue #255: returns `true` when `candidate` is `<base>/vN` for some
+/// integer N >= 2 — i.e., `candidate` is the `/vN`-suffixed major-
+/// version variant of the same Go module as `base`. Used to detect
+/// the `+incompatible` legacy-residue pattern: when both
+/// `github.com/google/martian` (legacy `+incompatible` form) AND
+/// `github.com/google/martian/v3` (modern `/vN` form) exist as Go
+/// components in the same scan, the legacy form is residue and gets
+/// filtered out.
+///
+/// Conservative: only matches the exact `<base>/vN` shape (one trailing
+/// `/vN` segment, N a decimal integer >= 2). Doesn't match
+/// `<base>/v2/sub/...` or `<base>/v1` (v1 isn't path-suffixed by
+/// convention).
+fn is_vn_sibling_of(candidate: &str, base: &str) -> bool {
+    let Some(suffix) = candidate.strip_prefix(base) else {
+        return false;
+    };
+    let Some(rest) = suffix.strip_prefix("/v") else {
+        return false;
+    };
+    if rest.is_empty() {
+        return false;
+    }
+    if !rest.chars().all(|c| c.is_ascii_digit()) {
+        return false;
+    }
+    // Parse as int; reject v0 / v1 (those aren't `/vN`-suffixed
+    // modules by Go convention — v0 / v1 use the un-suffixed path).
+    rest.parse::<u32>().map(|n| n >= 2).unwrap_or(false)
+}
+
 /// Map a Go 1.24+ `tool` directive package path to the module path that
 /// contains it. Module paths emitted by mikebom are e.g.
 /// `github.com/golangci/golangci-lint`; tool paths in `go.mod` are e.g.
@@ -1319,11 +1350,68 @@ pub fn read(rootfs: &Path, _include_dev: bool) -> (Vec<PackageDbEntry>, GoScanSi
             },
             &gosum_fallback_set,
         );
+
+        // Issue #255: filter `+incompatible` legacy-version residue
+        // when a same-base-path `/vN` module is present.
+        //
+        // Background: Go modules pre-dating module-awareness used
+        // versioning without the `/vN` path suffix. Importing them at
+        // v2+ produces a `+incompatible` version (Go's signal that
+        // the import skipped the major-version path convention). When
+        // a project upgrades from the legacy form to a properly-
+        // suffixed `/vN` module, `go mod tidy` conservatively leaves
+        // the `+incompatible` go.sum integrity hash behind — it's
+        // load-bearing for downstream users still on the legacy form,
+        // even though THIS project no longer references it.
+        //
+        // Naive emission produces a same-module duplicate (e.g.
+        // `martian@v2.1.0+incompatible` AND `martian/v3@v3.3.3`) where
+        // the legacy entry has no incoming dep edge. After PR #253's
+        // residual-orphan backfill, the legacy entry gets flat-
+        // attached to root with `mikebom:orphan-reason:
+        // flat-attached-fallback` — a false positive.
+        //
+        // NARROW FILTER: drop a Go component if BOTH:
+        //   - Its version contains `+incompatible`.
+        //   - A same-base-path component exists at `<path>/vN` for
+        //     some N >= 2.
+        //
+        // We deliberately do NOT drop all go.sum-but-not-go.mod-
+        // reachable modules. Legitimate test-transitives (e.g.
+        // `gopkg.in/check.v1`, pulled by `yaml.v3`'s test deps) live
+        // in go.sum without being in go.mod, but the user expects to
+        // see them in the SBOM for vulnerability scanning. The user's
+        // filing described this bug as narrow; this filter matches
+        // that scope.
+        let entry_paths: std::collections::HashSet<String> = entries
+            .iter()
+            .filter(|e| e.purl.as_str().starts_with("pkg:golang/"))
+            .map(|e| e.name.clone())
+            .collect();
+        let mut filtered_count = 0usize;
         for entry in entries {
+            if entry.purl.as_str().starts_with("pkg:golang/")
+                && entry.version.contains("+incompatible")
+                && entry_paths.iter().any(|p| is_vn_sibling_of(p, &entry.name))
+            {
+                filtered_count += 1;
+                tracing::debug!(
+                    purl = %entry.purl.as_str(),
+                    "Issue #255: dropping +incompatible residue (same-base-path /vN sibling present in entries)"
+                );
+                continue;
+            }
             let purl_key = entry.purl.as_str().to_string();
             if seen_purls.insert(purl_key) {
                 out.push(entry);
             }
+        }
+        if filtered_count > 0 {
+            tracing::info!(
+                project_root = %project_root.display(),
+                filtered = filtered_count,
+                "Issue #255: filtered +incompatible legacy-version residue (same-base-path /vN module is present)"
+            );
         }
 
         // Milestone 053 FR-001 + FR-002 + FR-004: emit a synthetic
@@ -2166,6 +2254,67 @@ tool (
             resolve_tool_to_module("nowhere.example.org/cmd/tool", &modules),
             None,
         );
+    }
+
+    // --- issue #255: +incompatible residue filter --------------------------
+
+    #[test]
+    fn is_vn_sibling_recognises_v2_through_v9() {
+        let base = "github.com/google/martian";
+        for n in 2..=9 {
+            let candidate = format!("{base}/v{n}");
+            assert!(
+                is_vn_sibling_of(&candidate, base),
+                "v{n} should be recognised as a /vN sibling of {base}",
+            );
+        }
+    }
+
+    #[test]
+    fn is_vn_sibling_rejects_v0_and_v1() {
+        // Go convention: v0 and v1 use the un-suffixed path; only
+        // v2+ requires the `/vN` suffix. The +incompatible filter
+        // should NOT match v0/v1.
+        let base = "github.com/foo/bar";
+        assert!(!is_vn_sibling_of(&format!("{base}/v0"), base));
+        assert!(!is_vn_sibling_of(&format!("{base}/v1"), base));
+    }
+
+    #[test]
+    fn is_vn_sibling_rejects_non_numeric_suffix() {
+        let base = "github.com/foo/bar";
+        assert!(!is_vn_sibling_of("github.com/foo/bar/version2", base));
+        assert!(!is_vn_sibling_of("github.com/foo/bar/v2-beta", base));
+        assert!(!is_vn_sibling_of("github.com/foo/bar/vlatest", base));
+    }
+
+    #[test]
+    fn is_vn_sibling_rejects_deeper_paths() {
+        // `<base>/v2/sub/pkg` is NOT a /vN sibling — it's a subpath
+        // inside a /vN module, which has its own go.mod typically.
+        let base = "github.com/foo/bar";
+        assert!(!is_vn_sibling_of("github.com/foo/bar/v2/sub/pkg", base));
+    }
+
+    #[test]
+    fn is_vn_sibling_rejects_unrelated_paths() {
+        let base = "github.com/foo/bar";
+        assert!(!is_vn_sibling_of("github.com/other/thing/v2", base));
+        assert!(!is_vn_sibling_of("github.com/foo/barbaz/v2", base));
+    }
+
+    #[test]
+    fn is_vn_sibling_handles_self_match() {
+        // A module name equal to itself isn't a /vN sibling.
+        let p = "github.com/foo/bar/v3";
+        assert!(!is_vn_sibling_of(p, p));
+    }
+
+    #[test]
+    fn is_vn_sibling_multi_digit_versions() {
+        let base = "github.com/foo/bar";
+        assert!(is_vn_sibling_of("github.com/foo/bar/v10", base));
+        assert!(is_vn_sibling_of("github.com/foo/bar/v42", base));
     }
 
     #[test]


### PR DESCRIPTION
Closes #255.

## Summary

A real-world Go scan of `guacsec/guac@ebb808e` under alpha.36/alpha.37 had both `pkg:golang/github.com/google/martian@v2.1.0+incompatible` AND `pkg:golang/github.com/google/martian/v3@v3.3.3` linked to root — the legacy `+incompatible` form alongside the modern `/vN` form. `go mod why -m github.com/google/martian` reports "main module does not need module github.com/google/martian", confirming the `+incompatible` entry is **residue, not an active dep**.

After PR #253's residual-orphan backfill landed, this residue gets flat-attached to root with `mikebom:orphan-reason: flat-attached-fallback` — a false positive that adds 1 spurious edge per `+incompatible` legacy entry left behind in `go.sum`.

## Background

Go modules pre-dating module-awareness used versioning without the `/vN` path suffix. Importing them at v2+ produces a `+incompatible` version (Go's signal that the import skipped the major-version path convention). When a project upgrades from the legacy form to a properly-suffixed `/vN` module, `go mod tidy` conservatively leaves the `+incompatible` go.sum integrity hash behind — it's load-bearing for downstream users still on the legacy form, even though THIS project no longer references it.

## Fix (Option C from issue #255 — narrow scope)

Drop a Go component from the emitted set when **BOTH**:

1. Its version contains `+incompatible`.
2. A same-base-path component exists at `<path>/vN` for some N ≥ 2.

The match is path-segment-bounded: `github.com/foo/bar` is a `/vN`-base for `github.com/foo/bar/v3` but NOT for `github.com/foo/barbaz/v3`. Versions v0 and v1 don't use the suffix convention and don't trigger the match. Multi-digit versions (v10, v42) work.

### Intentionally NOT filtered

- **`gopkg.in/check.v1@v0.0.0-...` and similar test-transitives.** They live in go.sum because Go fetches `yaml.v3`'s go.mod to determine MVS, and `yaml.v3`'s go.mod requires `check.v1`. mikebom emitting them is operationally correct for vulnerability scanning even though they're not strictly in the active build graph.
- **A `+incompatible` module with NO `/vN` sibling.** The user might be consuming the legacy form deliberately (some projects haven't migrated to `/vN` even at v2+). Without a `/vN` sibling, dropping the legacy form would be a false negative.

I initially tried a broader filter (BFS from `go.mod` requires through the resolver map, dropping anything unreachable). It correctly caught `martian@v2.1.0+incompatible` but also dropped `gopkg.in/check.v1` from the existing `simple-module` golden fixture — too aggressive. The user's filing described this bug as narrow; this filter matches that scope.

## Test coverage

7 new unit tests for `is_vn_sibling_of`:

| Test | Covers |
|---|---|
| `is_vn_sibling_recognises_v2_through_v9` | Happy path |
| `is_vn_sibling_rejects_v0_and_v1` | Go convention: only v2+ uses the path suffix |
| `is_vn_sibling_rejects_non_numeric_suffix` | `version2`, `v2-beta`, `vlatest` etc. |
| `is_vn_sibling_rejects_deeper_paths` | `<base>/v2/sub/pkg` isn't a sibling |
| `is_vn_sibling_rejects_unrelated_paths` | Wrong base prefix |
| `is_vn_sibling_handles_self_match` | Module isn't a sibling of itself |
| `is_vn_sibling_multi_digit_versions` | v10, v42 etc. |

6 new unit tests for `ModuleGraphMap::reachable_from` (added as documented public API for future work, not consumed by this PR's narrow filter):

| Test | Covers |
|---|---|
| `reachable_from_empty_seeds_empty_closure` | Empty input |
| `reachable_from_single_seed_no_edges` | Single node, no transitivity |
| `reachable_from_follows_transitive_chain` | A → B → C |
| `reachable_from_excludes_residue_modules` | Issue #255 shape — residue not seeded → not in closure |
| `reachable_from_handles_cycle` | A → B → A; BFS terminates |
| `reachable_from_seeds_unknown_to_map_still_included` | Seed not in map → still in closure |

## Test plan

- [x] `./scripts/pre-pr.sh` clean — clippy + workspace test suite both green
- [x] 13/13 new unit tests pass
- [x] Existing Go integration tests (`cdx_regression_golang` etc.) unchanged — the existing fixture has no `+incompatible` modules, so the narrow filter doesn't fire and goldens stay byte-identical

## Not validated

- The full `guac@ebb808e` reproducer end-to-end (martian@v2 dropped, martian/v3 retained). Vendoring a smaller repro into the milestone-083 audit harness as a separate follow-up.

## Related

- **PR #253 / issue #251** — Go residual-orphan backfill. This bug only became visible after #253 flat-attached the residue to root with `flat-attached-fallback`. Pre-#253 the residue was an honest orphan tagged `unresolved-indirect-require`. This filter removes the residue upstream so neither annotation fires for it.
- **Constitution Principle X** (transparency) — the filter is purely reductive (drops components) but the dropped component carries no information consumers can act on (they can't vulnerability-scan a residue module that isn't in the active dep graph). No annotation needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
