### PR TITLE
fix(npm): pin nested node_modules deps to their installed versions

### DIFF
--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -410,10 +410,20 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
             // Cargo writes the `<name> <version>` form ONLY when
             // ambiguity exists; single-version deps are still
             // resolved via the existing name-only key above.
-            if ecosystem == "cargo" {
+            //
+            // Issue #262 — same pattern for npm. When a parent
+            // package has a nested `node_modules/<parent>/node_modules/<dep>`
+            // install, the lockfile parser at
+            // `package_db/npm/package_lock.rs` emits the dep as
+            // `<dep> <version>` (instead of bare `<dep>`) so this
+            // disambiguation key resolves to the nested PURL rather
+            // than the hoisted one. Without the nested entry, the
+            // bare-name key from line 380 above still wins (matches
+            // the hoisted version).
+            if ecosystem == "cargo" || ecosystem == "npm" {
                 let nv_key = format!("{} {}", e.name, e.version);
                 name_to_purl.insert(
-                    (ecosystem, normalize_dep_name("cargo", &nv_key)),
+                    (ecosystem, normalize_dep_name(e.purl.ecosystem(), &nv_key)),
                     e.purl.as_str().to_string(),
                 );
             }

--- a/mikebom-cli/src/scan_fs/package_db/npm/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/mod.rs
@@ -1058,4 +1058,62 @@ mod tests {
         // If you rename this, update consumer-side policy AND any
         // future parity-catalog row for the annotation slot.
     }
+
+    // --- issue #262: nested-node_modules version-pinning end-to-end ---------
+
+    #[test]
+    fn nested_node_modules_install_emits_version_pinned_dep_string() {
+        // End-to-end shape: verify the parser change produces a
+        // version-qualified dep string that the scan_fs resolver can
+        // match against the nested PURL. We assert the depends string
+        // form here; the resolver-side wiring (cargo-mirroring
+        // `(npm, "name version")` key in scan_fs/mod.rs:413-420) is
+        // exercised by `cdx_regression` / integration tests at higher
+        // levels.
+        //
+        // Reproducer: mlly@1.0.0 has nested pathe@2.0.3 under
+        // node_modules/mlly/node_modules/pathe; pathe@1.1.2 hoisted
+        // at top-level node_modules/pathe.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package-lock.json"),
+            r#"{
+                "lockfileVersion": 3,
+                "packages": {
+                    "node_modules/pathe": { "version": "1.1.2" },
+                    "node_modules/mlly": {
+                        "version": "1.0.0",
+                        "dependencies": { "pathe": "^2.0.0" }
+                    },
+                    "node_modules/mlly/node_modules/pathe": { "version": "2.0.3" }
+                }
+            }"#,
+        )
+        .unwrap();
+        let out = read(dir.path(), false, crate::scan_fs::ScanMode::Path).unwrap();
+
+        // Both pathes emitted as components.
+        let pathe_versions: Vec<&str> = out
+            .iter()
+            .filter(|e| e.name == "pathe")
+            .map(|e| e.version.as_str())
+            .collect();
+        assert!(pathe_versions.contains(&"1.1.2"), "hoisted pathe should be emitted");
+        assert!(pathe_versions.contains(&"2.0.3"), "nested pathe should be emitted");
+
+        // mlly's depends carries the NESTED pathe's version pin so
+        // the edge resolver routes the edge to pathe@2.0.3 (not
+        // the hoisted 1.1.2).
+        let mlly = out.iter().find(|e| e.name == "mlly").expect("mlly");
+        assert!(
+            mlly.depends.contains(&"pathe 2.0.3".to_string()),
+            "mlly.depends should pin pathe to the NESTED version 2.0.3; got: {:?}",
+            mlly.depends
+        );
+        assert!(
+            !mlly.depends.contains(&"pathe".to_string()),
+            "mlly.depends should NOT carry the bare-name form (would route to hoisted); got: {:?}",
+            mlly.depends
+        );
+    }
 }

--- a/mikebom-cli/src/scan_fs/package_db/npm/package_lock.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/package_lock.rs
@@ -32,6 +32,48 @@ pub(crate) fn parse_package_lock(
     let mut keys: Vec<&String> = packages.keys().collect();
     keys.sort();
 
+    // Issue #262: build a (path_key → version) index up front so each
+    // entry's depends-resolution can look up nested children. npm
+    // installs the same package at multiple paths when version
+    // conflicts force it; `node_modules/foo/node_modules/bar` is
+    // bar's NESTED install (foo's specific version), distinct from
+    // the HOISTED `node_modules/bar`. Without nested-aware
+    // resolution, bare-name dep strings always match the hoisted
+    // version, leaving nested installs as orphans.
+    //
+    // The index is filtered to entries that WILL be emitted as
+    // components — same dev/optional/link filters as the main loop
+    // below. Without this filter, the parser would emit
+    // version-pinned dep strings like "fsevents 2.3.0" for nested
+    // entries that downstream get filtered out (e.g. optional:true),
+    // and the edge resolver would drop the edge as dangling.
+    let mut path_versions: std::collections::HashMap<&str, &str> =
+        std::collections::HashMap::with_capacity(keys.len());
+    for &k in &keys {
+        let Some(entry) = packages[k].as_object() else {
+            continue;
+        };
+        if entry.get("link").and_then(|v| v.as_bool()) == Some(true) {
+            continue;
+        }
+        let entry_is_dev = entry
+            .get("dev")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let entry_is_optional = entry
+            .get("optional")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !include_dev && (entry_is_dev || entry_is_optional) {
+            continue;
+        }
+        if let Some(v) = entry.get("version").and_then(|x| x.as_str()) {
+            if !v.is_empty() {
+                path_versions.insert(k.as_str(), v);
+            }
+        }
+    }
+
     for path_key in keys {
         if path_key.is_empty() {
             // Root project entry — skip.
@@ -93,10 +135,33 @@ pub(crate) fn parse_package_lock(
             .map(|h| vec![h])
             .unwrap_or_default();
 
-        let depends = tbl
+        // Issue #262: resolve each declared dep against the nested-
+        // path tree first, falling back to bare-name. When a parent
+        // at `node_modules/<parent>` has a nested child at
+        // `node_modules/<parent>/node_modules/<dep>`, emit the
+        // version-qualified `<dep> <version>` form so the edge
+        // resolver in `scan_fs/mod.rs` matches the nested install
+        // rather than the hoisted version. Bare-name form is kept
+        // for deps that resolve to the hoisted version (no nested
+        // child exists for this parent). Mirrors cargo's milestone-
+        // 087 disambiguation pattern (issue #172).
+        let depends: Vec<String> = tbl
             .get("dependencies")
             .and_then(|v| v.as_object())
-            .map(|deps| deps.keys().cloned().collect::<Vec<_>>())
+            .map(|deps| {
+                deps.keys()
+                    .map(|dep_name| {
+                        // Look up nested child: `<this_path>/node_modules/<dep_name>`.
+                        // Scoped packages (`@scope/pkg`) follow the same path shape.
+                        let nested_key = format!("{path_key}/node_modules/{dep_name}");
+                        if let Some(nested_version) = path_versions.get(nested_key.as_str()) {
+                            format!("{dep_name} {nested_version}")
+                        } else {
+                            dep_name.clone()
+                        }
+                    })
+                    .collect()
+            })
             .unwrap_or_default();
 
         out.push(PackageDbEntry {
@@ -138,7 +203,67 @@ pub(crate) fn parse_package_lock(
         });
     }
 
-    out
+    // Issue #262 (sub-bug): dedup same-PURL entries preferring
+    // Runtime over Development scope. The same package version can
+    // appear at multiple install paths in a `node_modules/` tree —
+    // typically one dev-scoped path (e.g.,
+    // `node_modules/@babel/core/node_modules/ms`) and one runtime-
+    // scoped path (e.g., `node_modules/send/node_modules/ms`). With
+    // `--include-dev` enabled, the parser previously emitted ALL
+    // such entries and the upstream `seen_purls` dedup at
+    // `mod.rs:118` kept whichever came FIRST alphabetically by
+    // path_key — typically a dev entry (scope-prefixed paths sort
+    // before non-prefixed). This mis-tagged shared packages as Dev
+    // and (pre-#262 fix) didn't matter because the dev-tagged
+    // entries were orphans. After the #262 nested-version-pinning
+    // fix, edges actually land on these dedup'd components, so the
+    // Dev tag triggers `DEV_DEPENDENCY_OF` rewriting — which is
+    // wrong if the package is also used at runtime by other paths.
+    //
+    // Rule: keep the Runtime variant when both Dev and Runtime
+    // variants of the same PURL are present. If only one variant
+    // exists, keep it. Stable across ordering — preserves the
+    // existing seen_purls "first wins" semantic for the same-scope
+    // case.
+    let mut by_purl: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::with_capacity(out.len());
+    let mut keep: Vec<bool> = vec![true; out.len()];
+    for (idx, entry) in out.iter().enumerate() {
+        let purl_str = entry.purl.as_str().to_string();
+        use std::collections::hash_map::Entry;
+        match by_purl.entry(purl_str) {
+            Entry::Vacant(v) => {
+                v.insert(idx);
+            }
+            Entry::Occupied(mut o) => {
+                let existing_idx = *o.get();
+                use mikebom_common::resolution::LifecycleScope;
+                let existing_is_runtime = matches!(
+                    out[existing_idx].lifecycle_scope,
+                    Some(LifecycleScope::Runtime)
+                );
+                let new_is_runtime =
+                    matches!(entry.lifecycle_scope, Some(LifecycleScope::Runtime));
+                if new_is_runtime && !existing_is_runtime {
+                    // Promote the runtime variant; drop the dev one
+                    // from the existing slot.
+                    keep[existing_idx] = false;
+                    *o.get_mut() = idx;
+                } else {
+                    // Existing wins (either also runtime, or both
+                    // dev — first-by-iteration semantic preserved).
+                    keep[idx] = false;
+                }
+            }
+        }
+    }
+    let mut deduped: Vec<PackageDbEntry> = Vec::with_capacity(out.len());
+    for (idx, entry) in out.into_iter().enumerate() {
+        if keep[idx] {
+            deduped.push(entry);
+        }
+    }
+    deduped
 }
 
 /// Derive a package name from a `packages` path key like
@@ -296,5 +421,142 @@ mod tests {
             let res = read(dir.path(), false, crate::scan_fs::ScanMode::Path);
             assert!(res.is_ok(), "v{v} lockfile should parse without refusal");
         }
+    }
+
+    // --- issue #262: nested-node_modules version-pinning --------------------
+
+    #[test]
+    fn nested_dep_emits_version_pinned_string() {
+        // Issue #262 reproducer shape: mlly@1.0.0 depends on pathe;
+        // a NESTED pathe@2.0.3 is installed under mlly's own
+        // node_modules. The hoisted pathe@1.1.2 is also present.
+        // Parser should emit mlly.depends = ["pathe 2.0.3"] so the
+        // edge resolver in scan_fs/mod.rs picks the nested version.
+        let lockfile = serde_json::json!({
+            "lockfileVersion": 3,
+            "packages": {
+                "node_modules/pathe": { "version": "1.1.2" },
+                "node_modules/mlly": {
+                    "version": "1.0.0",
+                    "dependencies": { "pathe": "^2.0.0" }
+                },
+                "node_modules/mlly/node_modules/pathe": { "version": "2.0.3" }
+            }
+        });
+        let entries = parse_package_lock(&lockfile, "/tmp/lock.json", false);
+        let mlly = entries
+            .iter()
+            .find(|e| e.name == "mlly" && e.version == "1.0.0")
+            .expect("mlly entry");
+        assert_eq!(
+            mlly.depends,
+            vec!["pathe 2.0.3".to_string()],
+            "mlly should depend on the NESTED pathe@2.0.3 (version-pinned), not bare 'pathe'"
+        );
+        // Both pathes emitted as separate components.
+        assert!(entries.iter().any(|e| e.name == "pathe" && e.version == "1.1.2"));
+        assert!(entries.iter().any(|e| e.name == "pathe" && e.version == "2.0.3"));
+    }
+
+    #[test]
+    fn hoisted_only_dep_emits_bare_name() {
+        // Sanity: when there's no nested install, depends stays as
+        // bare name (existing behavior — matches the hoisted version
+        // via the name-only resolver key).
+        let lockfile = serde_json::json!({
+            "lockfileVersion": 3,
+            "packages": {
+                "node_modules/pathe": { "version": "1.1.2" },
+                "node_modules/mlly": {
+                    "version": "1.0.0",
+                    "dependencies": { "pathe": "^1.0.0" }
+                }
+            }
+        });
+        let entries = parse_package_lock(&lockfile, "/tmp/lock.json", false);
+        let mlly = entries.iter().find(|e| e.name == "mlly").expect("mlly");
+        assert_eq!(
+            mlly.depends,
+            vec!["pathe".to_string()],
+            "without a nested install, depends should be the bare name"
+        );
+    }
+
+    #[test]
+    fn scoped_package_nested_under_parent_is_version_pinned() {
+        // Scoped packages (`@scope/pkg`) follow the same path shape:
+        // node_modules/<parent>/node_modules/@scope/pkg. Parser must
+        // resolve them too.
+        let lockfile = serde_json::json!({
+            "lockfileVersion": 3,
+            "packages": {
+                "node_modules/@types/node": { "version": "20.0.0" },
+                "node_modules/some-tool": {
+                    "version": "1.0.0",
+                    "dependencies": { "@types/node": "^18.0.0" }
+                },
+                "node_modules/some-tool/node_modules/@types/node": { "version": "18.16.0" }
+            }
+        });
+        let entries = parse_package_lock(&lockfile, "/tmp/lock.json", false);
+        let some_tool = entries.iter().find(|e| e.name == "some-tool").expect("some-tool");
+        assert_eq!(
+            some_tool.depends,
+            vec!["@types/node 18.16.0".to_string()],
+            "scoped package nested under parent should be version-pinned: {:?}",
+            some_tool.depends
+        );
+    }
+
+    #[test]
+    fn multiple_nested_deps_each_version_pinned_independently() {
+        // A parent with two nested deps — each gets its own version-
+        // pinned reference.
+        let lockfile = serde_json::json!({
+            "lockfileVersion": 3,
+            "packages": {
+                "node_modules/foo": {
+                    "version": "1.0.0",
+                    "dependencies": { "a": "^2.0.0", "b": "^3.0.0" }
+                },
+                "node_modules/foo/node_modules/a": { "version": "2.5.0" },
+                "node_modules/foo/node_modules/b": { "version": "3.4.0" }
+            }
+        });
+        let entries = parse_package_lock(&lockfile, "/tmp/lock.json", false);
+        let foo = entries.iter().find(|e| e.name == "foo").expect("foo");
+        let mut sorted = foo.depends.clone();
+        sorted.sort();
+        assert_eq!(
+            sorted,
+            vec!["a 2.5.0".to_string(), "b 3.4.0".to_string()],
+            "each nested dep should be independently version-pinned"
+        );
+    }
+
+    #[test]
+    fn mixed_nested_and_hoisted_deps_are_disambiguated() {
+        // A parent with one nested dep and one hoisted-only dep —
+        // version-pinned vs bare-name forms coexist correctly.
+        let lockfile = serde_json::json!({
+            "lockfileVersion": 3,
+            "packages": {
+                "node_modules/b": { "version": "3.0.0" },
+                "node_modules/foo": {
+                    "version": "1.0.0",
+                    "dependencies": { "a": "^2.0.0", "b": "^3.0.0" }
+                },
+                "node_modules/foo/node_modules/a": { "version": "2.5.0" }
+            }
+        });
+        let entries = parse_package_lock(&lockfile, "/tmp/lock.json", false);
+        let foo = entries.iter().find(|e| e.name == "foo").expect("foo");
+        let mut sorted = foo.depends.clone();
+        sorted.sort();
+        assert_eq!(
+            sorted,
+            vec!["a 2.5.0".to_string(), "b".to_string()],
+            "nested dep version-pinned; hoisted dep stays bare-name"
+        );
     }
 }

--- a/mikebom-cli/tests/transitive_parity_npm.rs
+++ b/mikebom-cli/tests/transitive_parity_npm.rs
@@ -12,7 +12,17 @@ use transitive_parity_common::*;
 
 const FIXTURE_SUBPATH: &str = "npm";
 
-const EXPECTED_MIKEBOM_EDGE_COUNT: usize = 150;
+// Baseline was 150 at alpha.24. After issue #262's nested-version-
+// pinning fix (alpha.38+), three edges from dev-scope parents
+// (morgan, basic-auth, mocha's nested debug) that previously
+// resolved via bare-name last-write-wins to hoisted runtime targets
+// now correctly resolve to their nested dev-scope targets. The
+// new edges are emitted as `DEV_DEPENDENCY_OF` (reversed direction)
+// rather than `DEPENDS_ON`, so they're not counted by
+// `extract_edges_spdx_2_3`. The 3-edge shift is a wire-format
+// reclassification, not a real edge loss — the underlying dep
+// relationships are still present.
+const EXPECTED_MIKEBOM_EDGE_COUNT: usize = 147;
 
 const EXPECTED_REPRESENTATIVE_EDGES: &[(&str, &str)] = &[
     // Confirmed in mikebom output — accepts pulls in mime-types.


### PR DESCRIPTION
Closes #262.

## Summary

When npm's resolver hoists one version of a transitive dep and nests another under its consumer (`node_modules/<parent>/node_modules/<dep>`), the nested install was emitted as a component but had **zero incoming edges** in the dep graph — the lockfile parser populated `entry.depends` with bare names like `"pathe"`, and the edge resolver's `name_to_purl` last-write-wins matched the **hoisted** version, leaving the nested version as an orphan.

Real-world impact: the user's molcajete corpus (Vite + Vitest) had 47 multi-version orphans (`debug` 2.x/4.x, `minimatch` 3.x/9.x, three `@opentelemetry/semantic-conventions` versions, etc.) — ~7% of the dep tree unreachable from root for graph-walking vulnerability scanners.

## Fix

Two changes mirroring cargo's milestone-087 disambiguation pattern (issue #172), plus a related sub-bug uncovered during testing:

### 1. Lockfile parser (`package_db/npm/package_lock.rs`)

Build a `(path_key → version)` index up front. For each entry, when constructing `entry.depends`, check whether a nested child exists at `<this_path>/node_modules/<dep>`. If yes, emit the dep as `"<dep> <version>"` (version-pinned); else bare `"<dep>"` (existing behavior — matches the hoisted version via the name-only resolver key).

### 2. Edge resolver (`scan_fs/mod.rs`)

Register a `(npm, "name version")` key for every npm component, alongside the existing `(npm, "name")` bare-name key. Mirrors the cargo `(cargo, "name version")` key from milestone-087.

### 3. Same-PURL dev/runtime dedup (sub-bug)

When same PURL appears as BOTH dev and runtime variants (`@babel/core/node_modules/ms@2.1.3` dev alongside `send/node_modules/ms@2.1.3` runtime), the upstream `seen_purls` dedup at `mod.rs:118` previously kept whichever came **first alphabetically** — typically a dev variant (scope-prefixed paths sort first). This mis-tagged shared packages as Development. **Inert pre-fix** (the wrongly-tagged variants had no edges). **After #262's version-pinning lands, edges actually land on these dedup'd components**, so the wrong scope tag triggers `DEV_DEPENDENCY_OF` rewriting — making the edge harder to locate in graph walks.

Fix: dedup IN `parse_package_lock` preferring Runtime over Development variants when same PURL appears multiple times. Stable: same-scope collisions preserve existing "first wins" semantics.

## Test coverage

**5 new unit tests** in `package_lock.rs::tests`:

| Test | Covers |
|---|---|
| `nested_dep_emits_version_pinned_string` | Issue #262 reproducer shape — mlly + nested pathe@2.0.3 + hoisted pathe@1.1.2 |
| `hoisted_only_dep_emits_bare_name` | No nested install → bare-name (existing behavior) |
| `scoped_package_nested_under_parent_is_version_pinned` | `@scope/pkg` nested under parent |
| `multiple_nested_deps_each_version_pinned_independently` | Multiple nested deps in one parent |
| `mixed_nested_and_hoisted_deps_are_disambiguated` | Version-pinned and bare-name coexist in one depends list |

**1 new end-to-end test** in `npm::mod::tests`:

- `nested_node_modules_install_emits_version_pinned_dep_string` — full `read()` flow with the user's repro shape; asserts `mlly.depends` carries the nested version pin AND both pathe versions emit as components.

## Transitive-parity baseline shift

`mikebom-cli/tests/transitive_parity_npm.rs`'s `EXPECTED_MIKEBOM_EDGE_COUNT` shifts **150 → 147**. The 3-edge shift is a **wire-format reclassification, not a real edge loss**:

| Source | Pre-fix target | Post-fix target | Pre relationship type | Post relationship type |
|---|---|---|---|---|
| morgan@1.10.0 (dev) | on-finished@2.4.1 (Runtime hoisted) | on-finished@2.3.0 (Dev nested) | DEPENDS_ON | DEV_DEPENDENCY_OF |
| basic-auth@2.0.1 (dev) | safe-buffer@5.2.1 (Runtime hoisted) | safe-buffer@5.1.2 (Dev nested) | DEPENDS_ON | DEV_DEPENDENCY_OF |
| debug@4.3.4 (dev, nested under mocha) | ms@2.0.0 (Runtime hoisted, accidentally via bare-name last-write) | ms@2.1.2 (Dev nested under mocha/debug) | DEPENDS_ON | DEV_DEPENDENCY_OF |

In all three cases:
- Pre-fix routing was **wrong**: bare-name last-write-wins accidentally pointed dev-scope parents at hoisted runtime targets.
- Post-fix routing is **correct**: dev-scope parents point at their actually-installed nested dev-scope targets.

The post-fix edges are emitted as `DEV_DEPENDENCY_OF` (reversed direction) per milestone-228's typed-variant emission — not counted by `extract_edges_spdx_2_3` which only counts forward `DEPENDS_ON` and reverse `DEPENDENCY_OF`. The underlying dep relationships are present in the SBOM and recoverable by consumers that handle typed variants.

## Test plan

- [x] `./scripts/pre-pr.sh` clean
- [x] 13/13 lockfile-parser tests pass
- [x] 49/49 npm tests pass
- [x] 3/3 transitive-parity-npm tests pass (updated baseline)
- [x] All other parity tests (gem, cargo, pip, maven) still pass — they don't exercise the dev/runtime same-version-conflict pattern

## Not validated

- The full `molcajete` corpus shape end-to-end (vite + vitest + 47 multi-version orphans). The unit tests cover the parser shape faithfully; the molcajete fixture vendoring is a follow-up for the milestone-083 audit harness.

## Related

- **Issue #245 / PR #260** — npm secondary-pkgjson umbrella widening. Different code path; orthogonal.
- **Issue #256 / PR #257** — nameless secondary `package.json` umbrella. Same code area; orthogonal trigger.
- **Milestone-087 / issue #172** — cargo's `(cargo, "name version")` resolver key. This PR mirrors the pattern for npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
