### PR TITLE
test(go): add end-to-end regression test for issue #250 tool-directive linkage

### DIFF
--- a/mikebom-cli/src/scan_fs/package_db/golang/legacy.rs
+++ b/mikebom-cli/src/scan_fs/package_db/golang/legacy.rs
@@ -2766,6 +2766,87 @@ tool (
     }
 
     #[test]
+    fn read_links_tool_directive_to_main_module_end_to_end() {
+        // Issue #250 end-to-end regression: the user's reproducer
+        // shape — a Go 1.24+ module with a `tool` directive — should
+        // result in the tool's enclosing module appearing in the
+        // synthesized main-module's `.depends` AND the tool's
+        // component carrying `mikebom:component-role: build-tool`.
+        //
+        // The fix landed in PR #252 (alpha.37); this test pins the
+        // end-to-end behavior so it can't silently regress.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("go.mod"),
+            "module example.com/repro\n\
+             go 1.24\n\
+             require github.com/spf13/cobra v1.10.2\n\
+             tool github.com/golangci/golangci-lint/cmd/golangci-lint\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("go.sum"),
+            "github.com/spf13/cobra v1.10.2 h1:fake=\n\
+             github.com/golangci/golangci-lint v1.64.8 h1:fake=\n",
+        )
+        .unwrap();
+
+        let (entries, _) = read(dir.path(), false);
+
+        // The tool's enclosing module is emitted as a component
+        // (from go.sum).
+        let golangci = entries
+            .iter()
+            .find(|e| e.name == "github.com/golangci/golangci-lint")
+            .expect("golangci-lint component should be emitted from go.sum");
+
+        // Issue #250 (PR #252) tagged: the tool-directive entry's
+        // enclosing module carries `mikebom:component-role:
+        // build-tool` so SBOM consumers can distinguish it from
+        // regular runtime/library deps.
+        assert_eq!(
+            golangci
+                .extra_annotations
+                .get("mikebom:component-role")
+                .and_then(|v| v.as_str()),
+            Some("build-tool"),
+            "tool-directive entry should be tagged build-tool; got: {:?}",
+            golangci.extra_annotations,
+        );
+
+        // The synthesized main-module entry's `.depends` contains
+        // BOTH the runtime direct (cobra) AND the tool's enclosing
+        // module path (golangci-lint).
+        let main = entries
+            .iter()
+            .find(|e| e.name == "example.com/repro")
+            .expect("main-module entry must be emitted");
+        assert!(
+            main.depends
+                .contains(&"github.com/spf13/cobra".to_string()),
+            "main.depends should include cobra (direct require); got: {:?}",
+            main.depends,
+        );
+        assert!(
+            main.depends
+                .contains(&"github.com/golangci/golangci-lint".to_string()),
+            "main.depends should include golangci-lint (tool-directive resolved to its enclosing module); got: {:?}",
+            main.depends,
+        );
+
+        // The tool's component should NOT carry an orphan-reason
+        // annotation (the linkage is established via main's
+        // depends; it's not an orphan).
+        assert!(
+            !golangci
+                .extra_annotations
+                .contains_key("mikebom:orphan-reason"),
+            "tool-directive entry should not be flagged as orphan after #252 fix; got: {:?}",
+            golangci.extra_annotations,
+        );
+    }
+
+    #[test]
     fn read_finds_nested_go_project() {
         let dir = tempfile::tempdir().unwrap();
         let svc = dir.path().join("services").join("api");


### PR DESCRIPTION
## Summary

PR #252 (merged into alpha.37) fixed issue #250 — Go 1.24+ `tool` directive entries are correctly linked to the project root and tagged `mikebom:component-role: build-tool`. The fix added unit tests for the parser (`parse_go_mod`) and the longest-prefix resolver (`resolve_tool_to_module`) but no end-to-end test of the full pipeline.

A user re-surfaced the original bug report against alpha.36 — pre-fix. The fix DOES work against their exact reproducer on alpha.38, which I verified manually. This PR adds the end-to-end regression test so future refactors can't silently regress the linkage.

## What the test covers

Synthetic go.mod + go.sum matching the user's exact reproducer:

```
module example.com/repro
go 1.24
require github.com/spf13/cobra v1.10.2
tool github.com/golangci/golangci-lint/cmd/golangci-lint
```

Assertions:

| Check | Documents |
|---|---|
| `golangci-lint` is emitted as a component | go.sum is the source-of-truth for component emission (Tier A) |
| `golangci-lint` carries `mikebom:component-role: build-tool` | PR #252's per-component tagging |
| `main.depends` contains BOTH `cobra` AND `golangci-lint` | PR #252's longest-prefix resolver path: `golangci-lint/cmd/golangci-lint` → `golangci-lint` |
| `golangci-lint` does NOT carry `mikebom:orphan-reason` | The linkage is established; not flagged as orphan |

## Notes

The test uses synthesized go.mod + go.sum content rather than a real Go module cache, so the runtime resolver's `step1_go_mod_graph` returns `Unavailable` (no `go` subprocess) and step 5 (go.sum fallback) covers component emission. This matches the user's reproducer environment (a real `go mod tidy` runs before the scan, populating go.sum).

## Test plan

- [x] `./scripts/pre-pr.sh` clean
- [x] New test passes
- [x] All other Go tests still pass

## Not modified

- No production code changes; this is test-only.
- The fix already shipped in alpha.37 via PR #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)