### PR TITLE
fix(npm): walk up node_modules tree to resolve all deps to version-pinned PURLs (66 → 0 orphans on molcajete)

### DIFF
--- a/mikebom-cli/src/scan_fs/package_db/npm/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/mod.rs
@@ -959,9 +959,16 @@ mod tests {
                         == Some("main-module")
             })
             .expect("repro-root main-module entry must exist");
+        // Post walk-up resolution: axios is version-pinned via the
+        // lockfile (build_npm_main_module_entry walks up
+        // node_modules). schemalint comes from the nameless-secondary
+        // umbrella pass which still emits bare-name strings.
         assert!(
-            primary.depends.contains(&"axios".to_string()),
-            "primary should still have its declared direct deps: {:?}",
+            primary
+                .depends
+                .iter()
+                .any(|d| d == "axios" || d == "axios 1.7.0"),
+            "primary should still have its declared direct dep axios (bare or version-pinned): {:?}",
             primary.depends
         );
         assert!(

--- a/mikebom-cli/src/scan_fs/package_db/npm/package_lock.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/package_lock.rs
@@ -173,14 +173,26 @@ pub(crate) fn parse_package_lock(
         ] {
             if let Some(deps) = tbl.get(*section).and_then(|v| v.as_object()) {
                 for dep_name in deps.keys() {
-                    let nested_key = format!("{path_key}/node_modules/{dep_name}");
-                    let resolved = if let Some(nested_version) =
-                        path_versions.get(nested_key.as_str())
-                    {
-                        format!("{dep_name} {nested_version}")
-                    } else {
-                        dep_name.clone()
-                    };
+                    // Walk up the node_modules tree from this entry,
+                    // mirroring npm's resolution algorithm: a package
+                    // at `<...>/<parent>/.../X` resolves a declared
+                    // dep `Y` by checking
+                    // `<parent>/.../X/node_modules/Y` first, then
+                    // walking up to `<parent>/.../node_modules/Y`,
+                    // etc., until the top-level hoisted
+                    // `node_modules/Y`. Whichever level finds Y
+                    // first wins. Pre-fix only the immediate child
+                    // path was checked, with bare-name fallback that
+                    // the edge resolver's last-write-wins lookup
+                    // could resolve to the wrong version when
+                    // multiple installs of the same package exist.
+                    let resolved = resolve_dep_via_node_modules_walk(
+                        path_key,
+                        dep_name,
+                        &path_versions,
+                    )
+                    .map(|version| format!("{dep_name} {version}"))
+                    .unwrap_or_else(|| dep_name.clone());
                     // BTreeMap preserves deterministic order + dedup.
                     // If the same dep_name appears in multiple
                     // sections, the version-pinned form (if any)
@@ -312,6 +324,53 @@ pub(crate) fn parse_package_lock(
 /// `node_modules/foo` or `node_modules/@scope/bar` or deeply nested
 /// `node_modules/foo/node_modules/bar`. The real name is always the
 /// segment (or scope+segment) that follows the LAST `node_modules/`.
+/// Walk up the `node_modules/<...>` path tree from `parent_path_key`,
+/// returning the version of `dep_name` at the closest ancestor that
+/// has a matching `node_modules/<dep_name>` install. Mirrors npm's
+/// actual resolution algorithm.
+///
+/// For example, given:
+/// - `parent_path_key = "node_modules/foo/node_modules/bar"`
+/// - `dep_name = "baz"`
+///
+/// The lookup order is:
+/// 1. `node_modules/foo/node_modules/bar/node_modules/baz`
+/// 2. `node_modules/foo/node_modules/baz`
+/// 3. `node_modules/baz` (hoisted)
+///
+/// Returns `None` if `dep_name` isn't installed at any level. This
+/// is rare in well-formed lockfiles but can happen when a dep is
+/// declared but not actually resolved (e.g., `optionalDependencies`
+/// that failed install).
+fn resolve_dep_via_node_modules_walk<'a>(
+    parent_path_key: &str,
+    dep_name: &str,
+    path_versions: &std::collections::HashMap<&'a str, &'a str>,
+) -> Option<&'a str> {
+    let mut prefix = parent_path_key;
+    loop {
+        let candidate = format!("{prefix}/node_modules/{dep_name}");
+        if let Some(version) = path_versions.get(candidate.as_str()) {
+            return Some(*version);
+        }
+        // Walk up: find the last "/node_modules/" segment; the
+        // ancestor's path_key is the prefix BEFORE that occurrence.
+        // When no "/node_modules/" remains, we've passed the root
+        // package's own dir — try the top-level hoisted location
+        // `node_modules/<dep>` as the final step.
+        if let Some(idx) = prefix.rfind("/node_modules/") {
+            prefix = &prefix[..idx];
+        } else {
+            // Top-level hoisted lookup. `prefix` at this point is
+            // something like `node_modules/<pkg>` (or `node_modules`
+            // for the unusual case of a recursive call up from a
+            // top-level dir). Try `node_modules/<dep>`.
+            let top = format!("node_modules/{dep_name}");
+            return path_versions.get(top.as_str()).copied();
+        }
+    }
+}
+
 fn derive_name_from_path_key(key: &str) -> String {
     let idx = match key.rfind("node_modules/") {
         Some(i) => i + "node_modules/".len(),
@@ -501,10 +560,14 @@ mod tests {
     }
 
     #[test]
-    fn hoisted_only_dep_emits_bare_name() {
-        // Sanity: when there's no nested install, depends stays as
-        // bare name (existing behavior — matches the hoisted version
-        // via the name-only resolver key).
+    fn hoisted_only_dep_resolves_to_hoisted_version_pin() {
+        // When there's no nested install, depends walks up to the
+        // hoisted node_modules/<dep> entry and pins to its version.
+        // (Pre-walk-up fix: this returned bare-name, relying on the
+        // edge resolver's name_to_purl last-write-wins lookup —
+        // which produces the wrong version when multiple parents
+        // pin different versions of the same package. The walk-up
+        // produces a deterministic version-pinned reference.)
         let lockfile = serde_json::json!({
             "lockfileVersion": 3,
             "packages": {
@@ -519,8 +582,8 @@ mod tests {
         let mlly = entries.iter().find(|e| e.name == "mlly").expect("mlly");
         assert_eq!(
             mlly.depends,
-            vec!["pathe".to_string()],
-            "without a nested install, depends should be the bare name"
+            vec!["pathe 1.1.2".to_string()],
+            "walk-up resolution should find the hoisted pathe@1.1.2 and pin"
         );
     }
 
@@ -597,8 +660,8 @@ mod tests {
         sorted.sort();
         assert_eq!(
             sorted,
-            vec!["a 2.5.0".to_string(), "b".to_string()],
-            "nested dep version-pinned; hoisted dep stays bare-name"
+            vec!["a 2.5.0".to_string(), "b 3.0.0".to_string()],
+            "nested dep version-pinned to nested; hoisted dep version-pinned to hoisted (walk-up)"
         );
     }
 
@@ -702,6 +765,49 @@ mod tests {
             vec!["bar 1.5.0".to_string()],
             "deduped depends should contain only the version-pinned form, not both bare and pinned; got: {:?}",
             foo.depends
+        );
+    }
+
+    #[test]
+    fn walk_up_resolution_picks_hoisted_when_parent_lacks_nested() {
+        // Real-world molcajete bug: d3-dsv declares `commander: "7"`
+        // and has NO nested commander; a DIFFERENT parent
+        // (editorconfig) has a nested `commander@10.0.1`. Pre-walk-
+        // up fix, d3-dsv's bare-name "commander" fell through to
+        // name_to_purl's last-write-wins, which picked v10 instead
+        // of the hoisted v7. Walk-up resolution correctly pins
+        // d3-dsv → commander@7.2.0.
+        let lockfile = serde_json::json!({
+            "lockfileVersion": 3,
+            "packages": {
+                "node_modules/commander": { "version": "7.2.0" },
+                "node_modules/d3-dsv": {
+                    "version": "3.0.1",
+                    "dependencies": { "commander": "7" }
+                },
+                "node_modules/editorconfig": {
+                    "version": "1.0.4",
+                    "dependencies": { "commander": "^10.0.0" }
+                },
+                "node_modules/editorconfig/node_modules/commander": {
+                    "version": "10.0.1"
+                }
+            }
+        });
+        let entries = parse_package_lock(&lockfile, "/tmp/lock.json", false);
+
+        let d3 = entries.iter().find(|e| e.name == "d3-dsv").expect("d3-dsv");
+        assert_eq!(
+            d3.depends,
+            vec!["commander 7.2.0".to_string()],
+            "d3-dsv must pin to hoisted commander@7.2.0 (no nested install), not the unrelated nested commander@10"
+        );
+
+        let edit = entries.iter().find(|e| e.name == "editorconfig").expect("editorconfig");
+        assert_eq!(
+            edit.depends,
+            vec!["commander 10.0.1".to_string()],
+            "editorconfig must pin to its own nested commander@10.0.1"
         );
     }
 

--- a/mikebom-cli/src/scan_fs/package_db/npm/package_lock.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/package_lock.rs
@@ -135,34 +135,76 @@ pub(crate) fn parse_package_lock(
             .map(|h| vec![h])
             .unwrap_or_default();
 
-        // Issue #262: resolve each declared dep against the nested-
-        // path tree first, falling back to bare-name. When a parent
-        // at `node_modules/<parent>` has a nested child at
-        // `node_modules/<parent>/node_modules/<dep>`, emit the
-        // version-qualified `<dep> <version>` form so the edge
+        // Issue #262 + follow-up: resolve each declared dep against
+        // the nested-path tree first, falling back to bare-name.
+        // When a parent at `node_modules/<parent>` has a nested
+        // child at `node_modules/<parent>/node_modules/<dep>`, emit
+        // the version-qualified `<dep> <version>` form so the edge
         // resolver in `scan_fs/mod.rs` matches the nested install
         // rather than the hoisted version. Bare-name form is kept
         // for deps that resolve to the hoisted version (no nested
         // child exists for this parent). Mirrors cargo's milestone-
         // 087 disambiguation pattern (issue #172).
-        let depends: Vec<String> = tbl
-            .get("dependencies")
-            .and_then(|v| v.as_object())
-            .map(|deps| {
-                deps.keys()
-                    .map(|dep_name| {
-                        // Look up nested child: `<this_path>/node_modules/<dep_name>`.
-                        // Scoped packages (`@scope/pkg`) follow the same path shape.
-                        let nested_key = format!("{path_key}/node_modules/{dep_name}");
-                        if let Some(nested_version) = path_versions.get(nested_key.as_str()) {
-                            format!("{dep_name} {nested_version}")
-                        } else {
-                            dep_name.clone()
+        //
+        // Walks ALL four standard npm dep sections — `dependencies`,
+        // `devDependencies`, `peerDependencies`,
+        // `optionalDependencies`. The original PR #263 walked only
+        // `dependencies`, leaving packages declared via peer/optional
+        // sections orphan when they had nested installs. npm's
+        // resolver hoists or nests packages from any of the four
+        // sections uniformly — peer/optional declarations result in
+        // the same `node_modules/<parent>/node_modules/<dep>` install
+        // shape as regular `dependencies`, and the parent's
+        // `package.json` is the authoritative source for the
+        // version-spec the consumer needs.
+        //
+        // Deduplication: a single dep CAN appear in multiple
+        // sections (e.g., peer + optional, or dep + dev) — the
+        // version pin is the same in either case (the nested
+        // install path is shared). A HashSet collects unique
+        // (name → version-pinned-string) pairs.
+        let mut depends_set: std::collections::BTreeMap<String, String> =
+            std::collections::BTreeMap::new();
+        for section in &[
+            "dependencies",
+            "devDependencies",
+            "peerDependencies",
+            "optionalDependencies",
+        ] {
+            if let Some(deps) = tbl.get(*section).and_then(|v| v.as_object()) {
+                for dep_name in deps.keys() {
+                    let nested_key = format!("{path_key}/node_modules/{dep_name}");
+                    let resolved = if let Some(nested_version) =
+                        path_versions.get(nested_key.as_str())
+                    {
+                        format!("{dep_name} {nested_version}")
+                    } else {
+                        dep_name.clone()
+                    };
+                    // BTreeMap preserves deterministic order + dedup.
+                    // If the same dep_name appears in multiple
+                    // sections, the version-pinned form (if any)
+                    // wins via the existing-or-insert pattern:
+                    // version-pinned strings contain a space, bare
+                    // names don't — prefer the more specific form.
+                    use std::collections::btree_map::Entry;
+                    match depends_set.entry(dep_name.clone()) {
+                        Entry::Vacant(v) => {
+                            v.insert(resolved);
                         }
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+                        Entry::Occupied(mut o) => {
+                            // Prefer version-pinned over bare-name.
+                            if o.get().chars().filter(|c| *c == ' ').count() == 0
+                                && resolved.contains(' ')
+                            {
+                                *o.get_mut() = resolved;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        let depends: Vec<String> = depends_set.into_values().collect();
 
         out.push(PackageDbEntry {
             purl,
@@ -558,5 +600,159 @@ mod tests {
             vec!["a 2.5.0".to_string(), "b".to_string()],
             "nested dep version-pinned; hoisted dep stays bare-name"
         );
+    }
+
+    // --- post-#263 follow-up: peer/optional sections + deeper nesting -----
+
+    #[test]
+    fn peer_dependencies_get_version_pinned_too() {
+        // A package declares `pathe` via `peerDependencies` and has
+        // a nested install at `<parent>/node_modules/pathe`. The
+        // version pin should fire just like for regular dependencies.
+        let lockfile = serde_json::json!({
+            "lockfileVersion": 3,
+            "packages": {
+                "node_modules/pathe": { "version": "1.1.2" },
+                "node_modules/mlly": {
+                    "version": "1.0.0",
+                    "peerDependencies": { "pathe": "^2.0.0" }
+                },
+                "node_modules/mlly/node_modules/pathe": { "version": "2.0.3" }
+            }
+        });
+        let entries = parse_package_lock(&lockfile, "/tmp/lock.json", false);
+        let mlly = entries.iter().find(|e| e.name == "mlly").expect("mlly");
+        assert!(
+            mlly.depends.contains(&"pathe 2.0.3".to_string()),
+            "mlly's peerDependencies pathe should pin to the nested install; got: {:?}",
+            mlly.depends
+        );
+    }
+
+    #[test]
+    fn optional_dependencies_get_version_pinned_too() {
+        // optionalDependencies fsevents — a classic real-world case.
+        let lockfile = serde_json::json!({
+            "lockfileVersion": 3,
+            "packages": {
+                "node_modules/fsevents": { "version": "2.3.0" },
+                "node_modules/chokidar": {
+                    "version": "3.5.0",
+                    "optionalDependencies": { "fsevents": "~2.3.0" }
+                },
+                "node_modules/chokidar/node_modules/fsevents": { "version": "2.3.3" }
+            }
+        });
+        let entries = parse_package_lock(&lockfile, "/tmp/lock.json", false);
+        let chokidar = entries.iter().find(|e| e.name == "chokidar").expect("chokidar");
+        assert!(
+            chokidar.depends.contains(&"fsevents 2.3.3".to_string()),
+            "chokidar's optionalDependencies fsevents should pin to nested; got: {:?}",
+            chokidar.depends
+        );
+    }
+
+    #[test]
+    fn dev_dependencies_get_version_pinned_too() {
+        let lockfile = serde_json::json!({
+            "lockfileVersion": 3,
+            "packages": {
+                "node_modules/jest-helper": { "version": "1.0.0" },
+                "node_modules/mocha": {
+                    "version": "10.2.0",
+                    "dev": true,
+                    "devDependencies": { "jest-helper": "^2.0.0" }
+                },
+                "node_modules/mocha/node_modules/jest-helper": {
+                    "version": "2.5.0",
+                    "dev": true
+                }
+            }
+        });
+        let entries = parse_package_lock(&lockfile, "/tmp/lock.json", true);
+        let mocha = entries.iter().find(|e| e.name == "mocha").expect("mocha");
+        assert!(
+            mocha.depends.contains(&"jest-helper 2.5.0".to_string()),
+            "mocha's devDependencies jest-helper should pin to nested; got: {:?}",
+            mocha.depends
+        );
+    }
+
+    #[test]
+    fn deps_in_multiple_sections_get_deduped_with_version_pin_preferred() {
+        // Some packages legitimately list the same dep in multiple
+        // sections (e.g., peer + optional, or peer + dep). When
+        // both forms resolve, the version-pinned form should win
+        // over the bare-name form in the deduplicated output.
+        let lockfile = serde_json::json!({
+            "lockfileVersion": 3,
+            "packages": {
+                "node_modules/foo": {
+                    "version": "1.0.0",
+                    "dependencies": { "bar": "^1.0.0" },
+                    "peerDependencies": { "bar": "^1.0.0" }
+                },
+                "node_modules/foo/node_modules/bar": { "version": "1.5.0" }
+            }
+        });
+        let entries = parse_package_lock(&lockfile, "/tmp/lock.json", false);
+        let foo = entries.iter().find(|e| e.name == "foo").expect("foo");
+        assert_eq!(
+            foo.depends,
+            vec!["bar 1.5.0".to_string()],
+            "deduped depends should contain only the version-pinned form, not both bare and pinned; got: {:?}",
+            foo.depends
+        );
+    }
+
+    #[test]
+    fn deep_nesting_resolves_at_each_level() {
+        // Three-level chain: pkg-a → pkg-b → pkg-c, all nested
+        // under each other due to version conflicts up the tree.
+        //
+        // node_modules/pkg-a/                v1
+        //   node_modules/pkg-b/              v2 (nested under pkg-a)
+        //     node_modules/pkg-c/            v3 (nested under pkg-b under pkg-a)
+        //
+        // Each entry's depends should pin to the child at its own
+        // nested level — verifying the lookup `<path>/node_modules/<dep>`
+        // correctly resolves arbitrarily-deep chains.
+        let lockfile = serde_json::json!({
+            "lockfileVersion": 3,
+            "packages": {
+                "node_modules/pkg-a": {
+                    "version": "1.0.0",
+                    "dependencies": { "pkg-b": "^2.0.0" }
+                },
+                "node_modules/pkg-a/node_modules/pkg-b": {
+                    "version": "2.0.0",
+                    "dependencies": { "pkg-c": "^3.0.0" }
+                },
+                "node_modules/pkg-a/node_modules/pkg-b/node_modules/pkg-c": {
+                    "version": "3.0.0"
+                }
+            }
+        });
+        let entries = parse_package_lock(&lockfile, "/tmp/lock.json", false);
+
+        let a = entries.iter().find(|e| e.name == "pkg-a").expect("pkg-a");
+        assert_eq!(a.depends, vec!["pkg-b 2.0.0".to_string()]);
+
+        let b = entries
+            .iter()
+            .find(|e| e.name == "pkg-b" && e.version == "2.0.0")
+            .expect("pkg-b at v2");
+        assert_eq!(
+            b.depends,
+            vec!["pkg-c 3.0.0".to_string()],
+            "level-2 nested entry should pin its level-3 nested child; got: {:?}",
+            b.depends
+        );
+
+        let c = entries
+            .iter()
+            .find(|e| e.name == "pkg-c" && e.version == "3.0.0")
+            .expect("pkg-c at v3");
+        assert!(c.depends.is_empty(), "leaf entry has no deps");
     }
 }

--- a/mikebom-cli/src/scan_fs/package_db/npm/walk.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/walk.rs
@@ -334,12 +334,18 @@ pub(crate) fn build_npm_main_module_entry(
     );
     let source_path = format!("path+file://{}", project_root.display());
     // Collect direct-dep names from the four npm dep sections per
-    // FR-007. The existing edge-emission loop in scan_fs/mod.rs
-    // resolves these to PURLs via name_to_purl; dangling-target deps
-    // (e.g., workspace `*` ranges that resolve to in-tree members
-    // but the names happen to differ) are silently dropped per the
-    // existing convention.
-    let mut depends: Vec<String> = Vec::new();
+    // FR-007. If a `package-lock.json` is present alongside the
+    // manifest, version-pin each dep via the same walk-up
+    // resolution `parse_package_lock` uses — this ensures the
+    // root's bare-name dep strings like "@eslint/js" don't fall
+    // through to the edge resolver's last-write-wins lookup (which
+    // produces the wrong version when multiple installs of the
+    // same package exist, e.g. a hoisted v9.21.0 alongside a
+    // nested v8.57.1 under eslint@8). The walk-up starts at empty
+    // prefix (representing the project root), so the first
+    // successful lookup is the hoisted `node_modules/<dep>` —
+    // which IS what the root sees per npm's resolver algorithm.
+    let mut dep_names: Vec<String> = Vec::new();
     for section in [
         "dependencies",
         "devDependencies",
@@ -348,10 +354,69 @@ pub(crate) fn build_npm_main_module_entry(
     ] {
         if let Some(obj) = parsed.get(section).and_then(|v| v.as_object()) {
             for key in obj.keys() {
-                depends.push(key.clone());
+                dep_names.push(key.clone());
             }
         }
     }
+    // Pre-build the lockfile path_versions index (cheap: parses the
+    // lockfile once; only fires when a lockfile is present
+    // alongside the manifest, which is the typical npm project
+    // layout). Falls back to bare-name emission when no lockfile
+    // exists (library packages without committed lockfiles).
+    let path_versions: std::collections::HashMap<String, String> = project_root
+        .join("package-lock.json")
+        .canonicalize()
+        .ok()
+        .and_then(|p| std::fs::read_to_string(&p).ok())
+        .and_then(|t| serde_json::from_str::<serde_json::Value>(&t).ok())
+        .and_then(|root| {
+            root.get("packages")
+                .and_then(|v| v.as_object())
+                .map(|packages| {
+                    let mut out: std::collections::HashMap<String, String> =
+                        std::collections::HashMap::with_capacity(packages.len());
+                    for (k, v) in packages {
+                        if k.is_empty() {
+                            continue;
+                        }
+                        if let Some(tbl) = v.as_object() {
+                            if tbl.get("link").and_then(|v| v.as_bool()) == Some(true) {
+                                continue;
+                            }
+                            if let Some(version) =
+                                tbl.get("version").and_then(|v| v.as_str())
+                            {
+                                if !version.is_empty() {
+                                    out.insert(k.clone(), version.to_string());
+                                }
+                            }
+                        }
+                    }
+                    out
+                })
+        })
+        .unwrap_or_default();
+    let depends: Vec<String> = dep_names
+        .into_iter()
+        .map(|dep_name| {
+            // Walk up from the empty prefix (root). The first
+            // successful lookup is the hoisted `node_modules/<dep>`.
+            let mut prefix: &str = "";
+            loop {
+                let candidate = format!("{prefix}/node_modules/{dep_name}");
+                let candidate = candidate.trim_start_matches('/');
+                if let Some(version) = path_versions.get(candidate) {
+                    return format!("{dep_name} {version}");
+                }
+                if let Some(idx) = prefix.rfind("/node_modules/") {
+                    prefix = &prefix[..idx];
+                } else {
+                    // Reached the top — no install found anywhere.
+                    return dep_name;
+                }
+            }
+        })
+        .collect();
     Some(PackageDbEntry {
         purl,
         name: name.to_string(),

--- a/mikebom-cli/src/scan_fs/package_db/npm/walk.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/walk.rs
@@ -113,11 +113,27 @@ fn walk_node_modules(
             })
             .into_iter()
             .collect();
-        let depends = parsed
-            .get("dependencies")
-            .and_then(|v| v.as_object())
-            .map(|obj| obj.keys().cloned().collect())
-            .unwrap_or_default();
+        // Walk all four standard npm dep sections — Tier B's
+        // installed-tree walker uses the dep's OWN package.json as
+        // the source of truth, and packages declared via
+        // peer/optional sections must contribute incoming edges
+        // just like regular dependencies. BTreeSet for dedup +
+        // deterministic ordering.
+        let mut depends_set: std::collections::BTreeSet<String> =
+            std::collections::BTreeSet::new();
+        for section in &[
+            "dependencies",
+            "devDependencies",
+            "peerDependencies",
+            "optionalDependencies",
+        ] {
+            if let Some(obj) = parsed.get(*section).and_then(|v| v.as_object()) {
+                for key in obj.keys() {
+                    depends_set.insert(key.clone());
+                }
+            }
+        }
+        let depends: Vec<String> = depends_set.into_iter().collect();
         let maintainer = extract_author_string(&parsed);
         // Feature 005 US1: tag entries emitted from inside npm's own
         // bundled tree with `npm_role=internal`. `in_npm_internals` is

--- a/mikebom-cli/tests/transitive_parity_npm.rs
+++ b/mikebom-cli/tests/transitive_parity_npm.rs
@@ -12,17 +12,27 @@ use transitive_parity_common::*;
 
 const FIXTURE_SUBPATH: &str = "npm";
 
-// Baseline was 150 at alpha.24. After issue #262's nested-version-
-// pinning fix (alpha.38+), three edges from dev-scope parents
-// (morgan, basic-auth, mocha's nested debug) that previously
-// resolved via bare-name last-write-wins to hoisted runtime targets
-// now correctly resolve to their nested dev-scope targets. The
-// new edges are emitted as `DEV_DEPENDENCY_OF` (reversed direction)
-// rather than `DEPENDS_ON`, so they're not counted by
-// `extract_edges_spdx_2_3`. The 3-edge shift is a wire-format
-// reclassification, not a real edge loss — the underlying dep
-// relationships are still present.
-const EXPECTED_MIKEBOM_EDGE_COUNT: usize = 147;
+// Baseline was 150 at alpha.24.
+//
+// Shift 150 → 147 (issue #262 / PR #263, alpha.38): 3 edges from
+// dev-scope parents that previously resolved via bare-name
+// last-write-wins to hoisted runtime targets now correctly resolve
+// to their nested dev-scope targets and emit as `DEV_DEPENDENCY_OF`
+// (not counted by `extract_edges_spdx_2_3`).
+//
+// Shift 147 → 155 (npm walk-up resolution follow-up, alpha.40):
+// the lockfile parser + main-module builder now do FULL walk-up
+// node_modules resolution (mirroring npm's resolver algorithm).
+// Bare-name fallback effectively never fires, so every dep with
+// an actual install in node_modules emits a version-pinned PURL
+// reference. Recovers 8 edges that were previously routed via
+// last-write-wins to wrong-version targets (dev-scope nested ones,
+// which then routed as `DEV_DEPENDENCY_OF` rather than
+// `DEPENDS_ON`). Net effect: more edges land in `DEPENDS_ON`
+// (counted) because their now-correctly-pinned targets are Runtime
+// instead of the wrong Dev version. Confirms reachability invariant
+// on the molcajete corpus (66 orphans → 0 post-fix).
+const EXPECTED_MIKEBOM_EDGE_COUNT: usize = 155;
 
 const EXPECTED_REPRESENTATIVE_EDGES: &[(&str, &str)] = &[
     // Confirmed in mikebom output — accepts pulls in mime-types.


### PR DESCRIPTION
## Summary

User validated alpha.39 against their `~/Projects/molcajete` corpus and reported **66 orphan components** entirely explained by two open bugs (optionalDependencies + remaining nested multi-version). Investigating end-to-end against the real lockfile (9600 lines, 119 nested entries, multiple multi-version packages like commander, debug, ms, ansi-styles, etc.) traced both bugs to a **single underlying issue**, and the fix takes the orphan count from **66 → 0**.

## Root cause

mikebom's npm reader emitted `entry.depends` as bare names like `"commander"` when the immediate-child path lookup `<parent>/node_modules/<dep>` didn't match. The edge resolver at `scan_fs/mod.rs:375-420` resolved bare names via a `name_to_purl` last-write-wins HashMap — producing the **wrong version** when multiple installs of the same package existed in the tree.

Concrete repro: `d3-dsv` declares `commander: "7"` and has NO nested commander. A DIFFERENT parent (`editorconfig`) has a nested `commander@10.0.1`. Pre-fix, mikebom's bare-name fallback sent `d3-dsv → commander@10` (wrong — d3-dsv needs the hoisted v7). The hoisted `commander@7.2.0` had no incoming edge — orphan.

The same shape produced 66 orphan components on molcajete: `commander`, `debug`, `ms`, `encodeurl`, `statuses`, `picomatch`, `ansi-regex`, `ansi-styles`, `brace-expansion`, `emoji-regex`, `tr46`, `webidl-conversions`, `glob`, `@eslint/js`, `@opentelemetry/*`, etc.

## Fix

Walk up the `node_modules` tree to resolve every declared dep, mirroring npm's actual resolution algorithm. For a parent at `node_modules/<a>/.../<x>` declaring dep `Y`:

1. Try `<a>/.../<x>/node_modules/Y`
2. Try `<a>/.../node_modules/Y`
3. ...
4. Top-level `node_modules/Y` (hoisted)

Whichever path finds Y FIRST wins. Bare-name fallback only fires for deps that aren't installed anywhere (rare for well-formed lockfiles — usually means `optionalDependencies` that didn't install on this platform).

Applied to **BOTH**:

1. `package_lock.rs::parse_package_lock` (Tier A — lockfile-driven path).
2. `walk.rs::build_npm_main_module_entry` (synth root's main-module emission). The latter previously bypassed all version-pinning because it doesn't go through `parse_package_lock`; this PR makes it read the lockfile and walk-up-resolve its own depends.

Plus walks ALL four standard npm dep sections (`dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`) — the original PR #263 only walked `dependencies`, leaving packages declared via peer/optional sections orphan even when they had nested installs (canonical example: `optionalDependencies fsevents`).

## Molcajete validation

| Stage | Orphans |
|---|---|
| alpha.39 (pre-fix) | **66** |
| Commit 1 (peer/optional + dev walk) | 19 |
| Commit 2 (full walk-up resolution) | **0** |

The two remaining orphans on commit 1 (`@eslint/js@9.21.0`, `@rollup/rollup-linux-x64-gnu@4.17.2`) were both root-declared deps where the synth main-module's bare-name strings fell through to the edge resolver's last-write-wins, picking wrong-version nested variants. Commit 2's walk-up resolution from the root's empty prefix finds the hoisted versions correctly.

## Transitive-parity baseline shift

`transitive_parity_npm`'s `EXPECTED_MIKEBOM_EDGE_COUNT` shifts **147 → 155**. The +8 edges are recovered routings where bare-name last-write-wins was previously sending parents to dev-scoped nested variants (causing those edges to emit as `DEV_DEPENDENCY_OF` and not count in the extractor). With proper version-pinning, these edges now correctly target Runtime hoisted variants and emit as `DEPENDS_ON`.

## Test coverage

8 new unit tests in `package_lock.rs::tests`:

| Test | Covers |
|---|---|
| `peer_dependencies_get_version_pinned_too` | peerDependencies section walked + nested pin |
| `optional_dependencies_get_version_pinned_too` | optionalDependencies (fsevents shape) |
| `dev_dependencies_get_version_pinned_too` | devDependencies walked + nested pin |
| `deps_in_multiple_sections_get_deduped_with_version_pin_preferred` | Dedup when same dep in dep + peer |
| `deep_nesting_resolves_at_each_level` | 3-level chain pkg-a → pkg-b → pkg-c |
| `walk_up_resolution_picks_hoisted_when_parent_lacks_nested` | The d3-dsv → commander@7 vs editorconfig → commander@10 real-world bug |
| `hoisted_only_dep_resolves_to_hoisted_version_pin` (renamed + updated) | Walk-up finds hoisted; no bare-name fallback |
| `mixed_nested_and_hoisted_deps_are_disambiguated` (updated) | Both nested and hoisted forms get version-pinned |

19/19 lockfile-parser tests pass; pre-PR clean.

## Test plan

- [x] `./scripts/pre-pr.sh` clean
- [x] 19/19 lockfile-parser tests pass
- [x] molcajete corpus: 66 → 0 orphans confirmed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
