### PR TITLE
fix(npm): stop emitting edges for peerDependencies (declarative, not install)

### DIFF
--- a/mikebom-cli/src/scan_fs/package_db/npm/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/mod.rs
@@ -307,15 +307,17 @@ fn apply_nameless_secondary_umbrella(
         if main_module_dirs.iter().any(|d| d == project_root) {
             continue;
         }
-        // Collect declared dep names from all four standard sections.
-        // dependencies + peerDependencies + optionalDependencies are
-        // always emitted; devDependencies only when include_dev (same
-        // pattern as parse_root_package_json).
+        // Collect declared dep names. dependencies +
+        // optionalDependencies are always emitted; devDependencies
+        // only when include_dev (same pattern as
+        // parse_root_package_json). `peerDependencies` is
+        // intentionally skipped — declarative-not-install
+        // relationship (matches Tier A / Tier B walkers + trivy/
+        // syft).
         let mut declared_dep_names: Vec<String> = Vec::new();
         let sections: &[(&str, bool)] = &[
             ("dependencies", true),
             ("devDependencies", include_dev),
-            ("peerDependencies", true),
             ("optionalDependencies", true),
         ];
         for (section, gate) in sections {

--- a/mikebom-cli/src/scan_fs/package_db/npm/package_lock.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/package_lock.rs
@@ -165,10 +165,18 @@ pub(crate) fn parse_package_lock(
         // (name → version-pinned-string) pairs.
         let mut depends_set: std::collections::BTreeMap<String, String> =
             std::collections::BTreeMap::new();
+        // Skip `peerDependencies` — semantically declarative ("the
+        // consumer should have X installed"), not an install
+        // relationship. npm v7+ auto-installs peers as a convenience,
+        // but the SBOM `dependsOn` / `DEPENDS_ON` slot means "X
+        // depends on Y" not "X expects Y to be present." Trivy and
+        // syft also skip peer-edges. If a peer-installed package is
+        // genuinely orphan in the dep graph, the orphan signal is
+        // the correct one — the consumer (root or a direct
+        // requirer) should declare the dep explicitly.
         for section in &[
             "dependencies",
             "devDependencies",
-            "peerDependencies",
             "optionalDependencies",
         ] {
             if let Some(deps) = tbl.get(*section).and_then(|v| v.as_object()) {
@@ -668,10 +676,19 @@ mod tests {
     // --- post-#263 follow-up: peer/optional sections + deeper nesting -----
 
     #[test]
-    fn peer_dependencies_get_version_pinned_too() {
-        // A package declares `pathe` via `peerDependencies` and has
-        // a nested install at `<parent>/node_modules/pathe`. The
-        // version pin should fire just like for regular dependencies.
+    fn peer_dependencies_are_skipped_declarative_not_install() {
+        // peerDependencies are declarative — they express "the
+        // consumer should have X" not "this package depends on X."
+        // npm v7+ auto-installs peers as a convenience, but the
+        // SBOM `dependsOn` slot means "X depends on Y" not "X
+        // expects Y to be present." Trivy and syft also skip
+        // peer-edges; mikebom matches.
+        //
+        // Reproducer: mlly declares `pathe` ONLY via
+        // peerDependencies (no regular dependency). Even though
+        // pathe is installed at multiple paths, mlly should NOT
+        // emit any edge to pathe — let the package that ACTUALLY
+        // requires pathe declare the edge instead.
         let lockfile = serde_json::json!({
             "lockfileVersion": 3,
             "packages": {
@@ -686,8 +703,8 @@ mod tests {
         let entries = parse_package_lock(&lockfile, "/tmp/lock.json", false);
         let mlly = entries.iter().find(|e| e.name == "mlly").expect("mlly");
         assert!(
-            mlly.depends.contains(&"pathe 2.0.3".to_string()),
-            "mlly's peerDependencies pathe should pin to the nested install; got: {:?}",
+            mlly.depends.is_empty(),
+            "`mlly` only declares `pathe` via peerDependencies — no edge should emit; got: {:?}",
             mlly.depends
         );
     }
@@ -744,16 +761,18 @@ mod tests {
     #[test]
     fn deps_in_multiple_sections_get_deduped_with_version_pin_preferred() {
         // Some packages legitimately list the same dep in multiple
-        // sections (e.g., peer + optional, or peer + dep). When
-        // both forms resolve, the version-pinned form should win
-        // over the bare-name form in the deduplicated output.
+        // sections (e.g., dep + optional). When both forms resolve,
+        // the version-pinned form should win over the bare-name
+        // form in the deduplicated output. peerDependencies is
+        // skipped entirely (declarative-not-install) so the dedup
+        // case is now restricted to dep / dev / optional.
         let lockfile = serde_json::json!({
             "lockfileVersion": 3,
             "packages": {
                 "node_modules/foo": {
                     "version": "1.0.0",
                     "dependencies": { "bar": "^1.0.0" },
-                    "peerDependencies": { "bar": "^1.0.0" }
+                    "optionalDependencies": { "bar": "^1.0.0" }
                 },
                 "node_modules/foo/node_modules/bar": { "version": "1.5.0" }
             }

--- a/mikebom-cli/src/scan_fs/package_db/npm/walk.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/walk.rs
@@ -121,10 +121,11 @@ fn walk_node_modules(
         // deterministic ordering.
         let mut depends_set: std::collections::BTreeSet<String> =
             std::collections::BTreeSet::new();
+        // Skip `peerDependencies` — declarative, not an install
+        // relationship. See package_lock.rs for the full rationale.
         for section in &[
             "dependencies",
             "devDependencies",
-            "peerDependencies",
             "optionalDependencies",
         ] {
             if let Some(obj) = parsed.get(*section).and_then(|v| v.as_object()) {
@@ -345,11 +346,14 @@ pub(crate) fn build_npm_main_module_entry(
     // prefix (representing the project root), so the first
     // successful lookup is the hoisted `node_modules/<dep>` —
     // which IS what the root sees per npm's resolver algorithm.
+    // Skip `peerDependencies` — declarative, not install-relational.
+    // Even for the root project, peer deps express an EXPECTATION
+    // about the consumer (which is the user themselves at this
+    // level — meaningless to express as an install edge).
     let mut dep_names: Vec<String> = Vec::new();
     for section in [
         "dependencies",
         "devDependencies",
-        "peerDependencies",
         "optionalDependencies",
     ] {
         if let Some(obj) = parsed.get(section).and_then(|v| v.as_object()) {


### PR DESCRIPTION
## Summary

PR #267 / alpha.40 extended the npm reader to walk all four standard dep sections — `dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies` — when building `entry.depends`. The user flagged that peerDependencies are semantically **declarative** (the consumer is expected to install X) rather than **install-relational** (this package depends on X). The SBOM `dependsOn` / `DEPENDS_ON` slot means "X depends on Y" not "X expects Y to be present."

Trivy and syft also skip peer-edges; mikebom matches.

## Fix

Drop peerDependencies from the walked sections in three locations:

- `parse_package_lock` (Tier A lockfile parser)
- `walk_node_modules` (Tier B installed-tree walker)
- `apply_nameless_secondary_umbrella` (the secondary-pkgjson umbrella pass)

`build_npm_main_module_entry` (synth root builder) also drops peer. For the root project, peerDependencies still express an expectation about a consumer — but the root IS the consumer at this level, so peers there are meaningless to express as install edges.

## Molcajete validation

| Stage | Orphans | Total edges |
|---|---|---|
| alpha.40 (with peer-walking) | 0 | 1368 |
| This PR (peer-walking removed) | **0** | **1217** (151 spurious peer-edges dropped) |

Every package that was reachable via a peer-edge in alpha.40 is also reachable via a real dep/dev/optional edge from some other parent. The peer-edges were pure noise, not load-bearing.

## Test coverage

Updated 2 tests:

| Test | Change |
|---|---|
| `peer_dependencies_are_skipped_declarative_not_install` | Renamed from `peer_dependencies_get_version_pinned_too`. Asserts a package declaring `pathe` ONLY via peerDependencies emits NO edges to pathe |
| `deps_in_multiple_sections_get_deduped_with_version_pin_preferred` | Changed peer + dep to optional + dep (peer is now skipped) |

All 19 lockfile-parser tests pass; pre-PR clean.

## Test plan

- [x] `./scripts/pre-pr.sh` clean
- [x] 19/19 lockfile-parser tests pass
- [x] Molcajete corpus: orphan count unchanged (0); 151 spurious edges removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)