### PR TITLE
feat(gradle): add gradle.lockfile + buildscript reader (closes #277)

### DIFF
--- a/mikebom-cli/src/scan_fs/package_db/gradle/lockfile.rs
+++ b/mikebom-cli/src/scan_fs/package_db/gradle/lockfile.rs
@@ -1,0 +1,296 @@
+//! Parser for `gradle.lockfile` / `buildscript-gradle.lockfile` files.
+//!
+//! Format (per Gradle dependency-locking docs, stable since 6.0):
+//!
+//! ```text
+//! # This is a Gradle generated file for dependency locking.
+//! # Manual edits can break the build and are not advised.
+//! # This file is expected to be part of source control.
+//! com.google.guava:guava:32.1.3-jre=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+//! org.jetbrains.kotlin:kotlin-stdlib:1.9.20=compileClasspath,runtimeClasspath
+//! empty=annotationProcessor,kapt
+//! ```
+//!
+//! - `#`-prefixed lines: skipped (file header).
+//! - `empty=...` line: skipped (Gradle's marker for "configurations
+//!   resolved with zero deps"; not a real coord).
+//! - All other lines: `<group>:<name>:<version>=<config1>,<config2>,...`.
+//!
+//! PURLs emitted as `pkg:maven/<group>/<name>@<version>` — same scheme as
+//! the existing `maven.rs` reader, so downstream enrichment via deps.dev
+//! applies without changes.
+//!
+//! Filename selects lifecycle scope: `gradle.lockfile` → runtime (no
+//! scope); `buildscript-gradle.lockfile` → `LifecycleScope::Build`.
+
+use std::path::Path;
+
+use mikebom_common::resolution::LifecycleScope;
+use mikebom_common::types::purl::{encode_purl_segment, Purl};
+
+use super::super::PackageDbEntry;
+
+const BUILDSCRIPT_FILENAME: &str = "buildscript-gradle.lockfile";
+
+/// Parse a single Gradle lockfile and return one `PackageDbEntry` per
+/// resolved coordinate. Returns empty on read failure or when the file
+/// contains no resolvable entries (e.g. only the header lines).
+pub(super) fn read_gradle_lockfile(path: &Path) -> Vec<PackageDbEntry> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "failed to read Gradle lockfile (skipping; FR-015)"
+            );
+            return Vec::new();
+        }
+    };
+    let source_path = path.to_string_lossy().to_string();
+    let is_buildscript = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|n| n == BUILDSCRIPT_FILENAME)
+        .unwrap_or(false);
+    let lifecycle_scope = if is_buildscript {
+        Some(LifecycleScope::Build)
+    } else {
+        None
+    };
+
+    let mut out = Vec::new();
+    for raw_line in text.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if line.starts_with("empty=") {
+            continue;
+        }
+        let Some((coord, configs)) = line.split_once('=') else {
+            tracing::warn!(
+                path = %path.display(),
+                line = %raw_line,
+                "Gradle lockfile line missing `=` separator; skipping"
+            );
+            continue;
+        };
+        let segments: Vec<&str> = coord.split(':').collect();
+        // Need at least 3 segments. For paths with extra `:` chars (rare
+        // but legal — Gradle docs allow it for classifier-tagged coords)
+        // join the leading parts as group and take the last two as
+        // name + version.
+        if segments.len() < 3 {
+            tracing::warn!(
+                path = %path.display(),
+                line = %raw_line,
+                "Gradle lockfile entry has fewer than 3 colon-separated segments; skipping"
+            );
+            continue;
+        }
+        let version = segments[segments.len() - 1].trim();
+        let name = segments[segments.len() - 2].trim();
+        let group = segments[..segments.len() - 2].join(":");
+        let group = group.trim();
+        if group.is_empty() || name.is_empty() || version.is_empty() {
+            tracing::warn!(
+                path = %path.display(),
+                line = %raw_line,
+                "Gradle lockfile entry has empty group/name/version; skipping"
+            );
+            continue;
+        }
+
+        let Some(purl) = build_maven_purl(group, name, version) else {
+            tracing::warn!(
+                path = %path.display(),
+                line = %raw_line,
+                "Gradle lockfile coord produced invalid PURL; skipping"
+            );
+            continue;
+        };
+
+        let mut extra_annotations: std::collections::BTreeMap<String, serde_json::Value> =
+            Default::default();
+        let configs_value = configs.trim();
+        if !configs_value.is_empty() {
+            extra_annotations.insert(
+                "mikebom:gradle-configurations".to_string(),
+                serde_json::Value::String(configs_value.to_string()),
+            );
+        }
+
+        out.push(PackageDbEntry {
+            purl,
+            name: name.to_string(),
+            version: version.to_string(),
+            arch: None,
+            source_path: source_path.clone(),
+            depends: Vec::new(),
+            maintainer: None,
+            licenses: Vec::new(),
+            lifecycle_scope,
+            requirement_range: None,
+            source_type: None,
+            buildinfo_status: None,
+            evidence_kind: None,
+            binary_class: None,
+            binary_stripped: None,
+            linkage_kind: None,
+            detected_go: None,
+            confidence: None,
+            binary_packed: None,
+            raw_version: None,
+            parent_purl: None,
+            npm_role: None,
+            co_owned_by: None,
+            hashes: Vec::new(),
+            sbom_tier: Some("source".to_string()),
+            shade_relocation: None,
+            extra_annotations,
+            binary_role: None,
+        });
+    }
+    out
+}
+
+fn build_maven_purl(group: &str, name: &str, version: &str) -> Option<Purl> {
+    Purl::new(&format!(
+        "pkg:maven/{}/{}@{}",
+        encode_purl_segment(group),
+        encode_purl_segment(name),
+        encode_purl_segment(version),
+    ))
+    .ok()
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    const HEADER: &str = "\
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+";
+
+    fn write_lockfile(tmp: &Path, name: &str, body: &str) -> std::path::PathBuf {
+        let path = tmp.join(name);
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn emits_basic_maven_components() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = format!(
+            "{HEADER}\
+com.google.guava:guava:32.1.3-jre=compileClasspath,runtimeClasspath
+org.jetbrains.kotlin:kotlin-stdlib:1.9.20=compileClasspath,runtimeClasspath
+"
+        );
+        let path = write_lockfile(tmp.path(), "gradle.lockfile", &body);
+        let entries = read_gradle_lockfile(&path);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(
+            entries[0].purl.as_str(),
+            "pkg:maven/com.google.guava/guava@32.1.3-jre"
+        );
+        assert_eq!(entries[0].name, "guava");
+        assert_eq!(entries[0].version, "32.1.3-jre");
+        assert!(entries[0].lifecycle_scope.is_none());
+        assert_eq!(
+            entries[1].purl.as_str(),
+            "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@1.9.20"
+        );
+        assert!(entries[1].lifecycle_scope.is_none());
+    }
+
+    #[test]
+    fn buildscript_tagged_build_lifecycle_scope() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = format!(
+            "{HEADER}\
+org.springframework.boot:org.springframework.boot.gradle.plugin:3.2.0=classpath
+"
+        );
+        let path = write_lockfile(tmp.path(), "buildscript-gradle.lockfile", &body);
+        let entries = read_gradle_lockfile(&path);
+        assert_eq!(entries.len(), 1);
+        assert!(matches!(
+            entries[0].lifecycle_scope,
+            Some(LifecycleScope::Build)
+        ));
+        assert_eq!(
+            entries[0].purl.as_str(),
+            "pkg:maven/org.springframework.boot/org.springframework.boot.gradle.plugin@3.2.0"
+        );
+    }
+
+    #[test]
+    fn header_lines_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Only the header — should yield zero entries, not parse-fail.
+        let path = write_lockfile(tmp.path(), "gradle.lockfile", HEADER);
+        let entries = read_gradle_lockfile(&path);
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn empty_configs_line_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        // `empty=...` lines indicate a resolved configuration with zero
+        // deps — must not be misparsed into a `pkg:maven/empty` coord.
+        let body = format!(
+            "{HEADER}\
+empty=annotationProcessor,kapt
+com.google.guava:guava:32.1.3-jre=runtimeClasspath
+"
+        );
+        let path = write_lockfile(tmp.path(), "gradle.lockfile", &body);
+        let entries = read_gradle_lockfile(&path);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "guava");
+    }
+
+    #[test]
+    fn configurations_recorded_in_annotation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = format!(
+            "{HEADER}\
+com.google.guava:guava:32.1.3-jre=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+"
+        );
+        let path = write_lockfile(tmp.path(), "gradle.lockfile", &body);
+        let entries = read_gradle_lockfile(&path);
+        assert_eq!(entries.len(), 1);
+        let configs = entries[0]
+            .extra_annotations
+            .get("mikebom:gradle-configurations")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert_eq!(
+            configs,
+            "compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath"
+        );
+    }
+
+    #[test]
+    fn malformed_lines_warned_and_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Mixed valid + malformed entries; the valid one must still emit.
+        let body = format!(
+            "{HEADER}\
+not-a-real-coord
+group-only:=runtimeClasspath
+com.google.guava:guava:32.1.3-jre=runtimeClasspath
+"
+        );
+        let path = write_lockfile(tmp.path(), "gradle.lockfile", &body);
+        let entries = read_gradle_lockfile(&path);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "guava");
+    }
+}

--- a/mikebom-cli/src/scan_fs/package_db/gradle/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/gradle/mod.rs
@@ -1,0 +1,49 @@
+//! Gradle source-tree reader (milestone 106 US3, closes #277).
+//!
+//! Gradle projects on disk emit dependency lockfiles in one of two shapes:
+//!
+//! - `gradle.lockfile` — application/library runtime classpath
+//! - `buildscript-gradle.lockfile` — build-script (plugin) classpath
+//!
+//! Both files share a single line-oriented format. The filename alone
+//! determines the lifecycle scope of the entries — runtime (no scope) vs
+//! build — which the existing milestone-052 emission path then translates
+//! into native CDX / SPDX 2.3 / SPDX 3 fields.
+//!
+//! Per spec FR-005 + FR-006 + Contract `gradle-lockfile.md`. PURLs are
+//! emitted as `pkg:maven/<group>/<name>@<version>` so existing deps.dev
+//! and Maven-side enrichment downstream applies without changes.
+//!
+//! Cross-platform (no `#[cfg(unix)]`); zero new Cargo deps. Parse failures
+//! emit `tracing::warn!` and yield zero components for that file (FR-015).
+
+pub(super) mod lockfile;
+
+use std::path::Path;
+
+use super::PackageDbEntry;
+
+/// Walk `rootfs` for `gradle.lockfile` and `buildscript-gradle.lockfile`
+/// files; parse each one; return all emitted entries. Empty when neither
+/// file appears anywhere in the scan tree.
+pub fn read(rootfs: &Path) -> Vec<PackageDbEntry> {
+    let cfg = super::project_roots::WalkConfig {
+        max_depth: 6,
+        is_project_root: &|dir: &Path| {
+            dir.join("gradle.lockfile").is_file()
+                || dir.join("buildscript-gradle.lockfile").is_file()
+        },
+        should_skip: &|name: &str| super::project_roots::should_skip_default_descent(name),
+    };
+    let mut out = Vec::new();
+    for project_dir in super::project_roots::walk_for_project_roots(rootfs, &cfg) {
+        for filename in ["gradle.lockfile", "buildscript-gradle.lockfile"] {
+            let path = project_dir.join(filename);
+            if !path.is_file() {
+                continue;
+            }
+            out.extend(lockfile::read_gradle_lockfile(&path));
+        }
+    }
+    out
+}

--- a/mikebom-cli/src/scan_fs/package_db/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/mod.rs
@@ -21,6 +21,7 @@ pub mod file_hashes;
 pub mod gem;
 pub mod go_binary;
 pub mod golang;
+pub mod gradle;
 pub mod maven;
 pub mod maven_sidecar;
 pub mod npm;
@@ -822,6 +823,14 @@ pub fn read_all(
         scan_target_name,
     );
     out.extend(maven_entries);
+    // Milestone 106 US3 (closes #277): Gradle source-tree readers
+    // (`gradle.lockfile` + `buildscript-gradle.lockfile`). Emits
+    // `pkg:maven/<g>/<a>@<v>` PURLs so it shares deps.dev enrichment
+    // with the existing Maven path. Buildscript entries carry
+    // `LifecycleScope::Build` so the existing milestone-052 emission
+    // path tags them `scope: "excluded"` (CDX) /
+    // `BUILD_DEPENDENCY_OF` (SPDX 2.3) automatically.
+    out.extend(gradle::read(rootfs));
     // Cargo is fail-closed on v1/v2 lockfiles (FR-040), mirroring the
     // npm v1 refusal pattern.
     out.extend(cargo::read(rootfs, include_dev)?);

--- a/mikebom-cli/tests/fixtures/golden_inputs/gradle_lockfile/buildscript_classpath/buildscript-gradle.lockfile
+++ b/mikebom-cli/tests/fixtures/golden_inputs/gradle_lockfile/buildscript_classpath/buildscript-gradle.lockfile
@@ -1,0 +1,6 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.springframework.boot:org.springframework.boot.gradle.plugin:3.2.0=classpath
+io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.4=classpath
+empty=

--- a/mikebom-cli/tests/fixtures/golden_inputs/gradle_lockfile/multi_config/gradle.lockfile
+++ b/mikebom-cli/tests/fixtures/golden_inputs/gradle_lockfile/multi_config/gradle.lockfile
@@ -1,0 +1,7 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+com.google.guava:guava:32.1.3-jre=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.slf4j:slf4j-api:2.0.9=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-api:5.10.1=testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor

--- a/mikebom-cli/tests/fixtures/golden_inputs/gradle_lockfile/runtime_only/gradle.lockfile
+++ b/mikebom-cli/tests/fixtures/golden_inputs/gradle_lockfile/runtime_only/gradle.lockfile
@@ -1,0 +1,6 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+com.google.guava:guava:32.1.3-jre=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-stdlib:1.9.20=compileClasspath,runtimeClasspath
+empty=annotationProcessor,kapt

--- a/mikebom-cli/tests/scan_gradle_lockfile.rs
+++ b/mikebom-cli/tests/scan_gradle_lockfile.rs
@@ -1,0 +1,102 @@
+//! Integration test for the Gradle lockfile reader (milestone 106 US3, issue #277).
+//!
+//! Companion to the unit tests in `scan_fs::package_db::gradle::lockfile::tests`
+//! (which exercise `read_gradle_lockfile` directly). This test invokes the
+//! `mikebom sbom scan --path <fixture>` binary against the in-repo
+//! `gradle_lockfile/runtime_only/` and `gradle_lockfile/buildscript_classpath/`
+//! fixtures to verify the dispatcher integration — `gradle::read` is called
+//! from `read_all`, the project-roots walker finds both lockfile filenames,
+//! and the emitted SBOM contains the expected `pkg:maven/...` components
+//! plus the build-lifecycle scope on the buildscript fixture.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+mod common;
+use common::bin;
+use common::normalize::apply_fake_home_env;
+
+fn fixture(subdir: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("golden_inputs")
+        .join("gradle_lockfile")
+        .join(subdir)
+}
+
+fn run_scan(path: &std::path::Path) -> serde_json::Value {
+    let workdir = tempfile::tempdir().expect("workdir tempdir");
+    let fake_home = tempfile::tempdir().expect("fake-home tempdir");
+    let out_path = workdir.path().join("sbom.cdx.json");
+
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    cmd.env("MIKEBOM_FIXED_TIMESTAMP", "2026-01-01T00:00:00Z");
+    cmd.args([
+        "--offline",
+        "sbom",
+        "scan",
+        "--path",
+        path.to_str().unwrap(),
+        "--format",
+        "cyclonedx-json",
+        "--output",
+        out_path.to_str().unwrap(),
+    ]);
+    let output = cmd.output().expect("spawn mikebom");
+    assert!(
+        output.status.success(),
+        "gradle scan unexpectedly failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let bytes = std::fs::read(&out_path).expect("read emitted SBOM");
+    serde_json::from_slice(&bytes).expect("parse JSON")
+}
+
+#[test]
+fn gradle_lockfile_runtime_only_emits_maven_components() {
+    let path = fixture("runtime_only");
+    assert!(path.is_dir(), "fixture missing at {}", path.display());
+    let json = run_scan(&path);
+    let components = json["components"].as_array().expect("components array");
+    let maven_purls: Vec<&str> = components
+        .iter()
+        .filter_map(|c| c["purl"].as_str())
+        .filter(|p| p.starts_with("pkg:maven/"))
+        .collect();
+    assert!(
+        maven_purls.contains(&"pkg:maven/com.google.guava/guava@32.1.3-jre"),
+        "expected guava in output; got: {maven_purls:?}",
+    );
+    assert!(
+        maven_purls
+            .contains(&"pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@1.9.20"),
+        "expected kotlin-stdlib in output; got: {maven_purls:?}",
+    );
+}
+
+#[test]
+fn gradle_lockfile_buildscript_tags_build_scope() {
+    let path = fixture("buildscript_classpath");
+    assert!(path.is_dir(), "fixture missing at {}", path.display());
+    let json = run_scan(&path);
+    let components = json["components"].as_array().expect("components array");
+    let springboot = components
+        .iter()
+        .find(|c| {
+            c["purl"]
+                .as_str()
+                .map(|p| {
+                    p == "pkg:maven/org.springframework.boot/org.springframework.boot.gradle.plugin@3.2.0"
+                })
+                .unwrap_or(false)
+        })
+        .expect("springboot plugin component present");
+    // Milestone 052 emission path maps LifecycleScope::Build -> CDX "excluded".
+    assert_eq!(
+        springboot["scope"].as_str(),
+        Some("excluded"),
+        "buildscript entry should be tagged scope=excluded; got: {springboot}",
+    );
+}

--- a/specs/106-ecosystem-coverage-expansion/tasks.md
+++ b/specs/106-ecosystem-coverage-expansion/tasks.md
@@ -128,21 +128,21 @@ Single-project workspace (the mikebom Rust workspace). All source under `mikebom
 
 ### Fixtures + tests
 
-- [ ] T032 [P] [US3] Create fixture tree `mikebom-cli/tests/fixtures/golden_inputs/gradle_lockfile/` with 3 sub-fixtures: `runtime_only/` (just `gradle.lockfile`), `buildscript_classpath/` (just `buildscript-gradle.lockfile`), `multi_config/` (entries with multiple `compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath` configurations).
-- [ ] T033 [P] [US3] Add contract tests in `mikebom-cli/src/scan_fs/package_db/gradle/lockfile.rs`: `emits_basic_maven_components`, `buildscript_tagged_build_lifecycle_scope`, `header_lines_skipped`, `empty_configs_line_skipped`.
+- [X] T032 [P] [US3] Create fixture tree. ✅ Three sub-fixtures: `runtime_only/` (gradle.lockfile with 2 libs + `empty=` line), `buildscript_classpath/` (buildscript-gradle.lockfile with 2 plugins), `multi_config/` (3 deps with multi-configuration tags including test classpaths).
+- [X] T033 [P] [US3] Add contract tests. ✅ 6 unit tests in `scan_fs/package_db/gradle/lockfile.rs::tests`: `emits_basic_maven_components`, `buildscript_tagged_build_lifecycle_scope`, `header_lines_skipped`, `empty_configs_line_skipped`, `configurations_recorded_in_annotation`, `malformed_lines_warned_and_skipped`. Plus 2 integration tests at `tests/scan_gradle_lockfile.rs`: `gradle_lockfile_runtime_only_emits_maven_components`, `gradle_lockfile_buildscript_tags_build_scope`.
 
 ### Implementation
 
-- [ ] T034 [US3] Create new directory + module: `mikebom-cli/src/scan_fs/package_db/gradle/mod.rs` and `gradle/lockfile.rs`. Declare in `package_db/mod.rs`: `pub(super) mod gradle;`.
-- [ ] T035 [US3] Implement `pub fn parse_lockfile(path: &Path) -> Result<Vec<GradleLockEntry>>` using `std::str::Lines`. Per `contracts/gradle-lockfile.md` parsing rules: skip lines starting with `#`, skip `empty=...` lines, split on `=` then split LHS on `:` into exactly 3 parts (group, name, version).
-- [ ] T036 [US3] Implement PURL derivation: `pkg:maven/<group>/<name>@<version>`. Group with dots is preserved as-is (matches existing maven.rs convention).
-- [ ] T037 [US3] Implement lifecycle-scope mapping: filename-based — `buildscript-gradle.lockfile` → `lifecycle_scope: Some(LifecycleScope::Build)`; `gradle.lockfile` → `None`. The existing milestone-052 `generate/cyclonedx/builder.rs:590-605` handles the CDX `scope: "excluded"` + SPDX `BUILD_DEPENDENCY_OF` emission automatically.
-- [ ] T038 [US3] Wire `gradle::lockfile::read` into the dispatcher at `mikebom-cli/src/scan_fs/package_db/mod.rs::read_all`. File-pattern trigger: either `gradle.lockfile` OR `buildscript-gradle.lockfile` anywhere in the scan tree.
+- [X] T034 [US3] Create new directory + module. ✅ `mikebom-cli/src/scan_fs/package_db/gradle/mod.rs` (dispatcher entry) + `gradle/lockfile.rs` (parser). Declared in `package_db/mod.rs` as `pub mod gradle;` (matching the other ecosystem readers' visibility — `pub(super)` would prevent the dispatcher from referring to it via `gradle::read`).
+- [X] T035 [US3] Implement line parser. ✅ `read_gradle_lockfile(path)` reads file → `text.lines()` iteration → skips `#`-prefix + blank + `empty=...` lines → splits on `=` once → splits LHS on `:` (joins all but the last two segments as group, supporting deep-namespaced coords gracefully).
+- [X] T036 [US3] Implement PURL derivation. ✅ Local `build_maven_purl(group, name, version)` mirrors `maven.rs:1842`'s pattern: `Purl::new(format!("pkg:maven/{}/{}@{}", encode_purl_segment(g), encode_purl_segment(n), encode_purl_segment(v)))`.
+- [X] T037 [US3] Implement lifecycle-scope mapping. ✅ Filename equality check against `BUILDSCRIPT_FILENAME` → `Some(LifecycleScope::Build)` for the buildscript variant; `None` for `gradle.lockfile`. Confirmed by integration test that this emits CDX `scope: "excluded"` (milestone-052 path at `generate/cyclonedx/builder.rs:590-605`).
+- [X] T038 [US3] Wire into dispatcher. ✅ `out.extend(gradle::read(rootfs));` inserted after the maven readers and before cargo in `read_all`. The reader's project-root walker (max_depth=6, default-skip set from `project_roots.rs`) finds both lockfile filenames anywhere in the scan tree.
 
 ### Polyglot + goldens
 
-- [ ] T039 [P] [US3] Generate goldens for gradle_lockfile fixtures (CDX + SPDX 2.3 + SPDX 3).
-- [ ] T040 [US3] Run `./scripts/pre-pr.sh` clean. Open PR titled `feat(gradle): add gradle.lockfile + buildscript reader (closes #277)`.
+- [ ] T039 [P] [US3] Generate goldens for gradle_lockfile fixtures (CDX + SPDX 2.3 + SPDX 3). ⏳ Deferred to follow-up (same rationale as T019 uv / T030 bun): emission shape is identical to the existing maven path's; the milestone-052 lifecycle-scope tagging is exercised by the existing maven-test-scope golden suite. Will add dedicated gradle goldens if any parity round-trip skew surfaces.
+- [X] T040 [US3] Run `./scripts/pre-pr.sh` clean. ✅ Pre-PR gate clean. 8 new tests pass (6 unit + 2 integration); 1633 existing tests still pass.
 
 **Checkpoint**: US3 is shippable. JVM projects with Gradle dependency locking scan cleanly.
 


### PR DESCRIPTION
## Summary

Milestone 106 **US3** (`Gradle`). mikebom now scans JVM projects that use Gradle dependency locking. Previously, source-tree scans of Gradle projects produced empty Java SBOMs because the existing Maven path only sees post-build JARs.

- New reader at `mikebom-cli/src/scan_fs/package_db/gradle/`, handling both `gradle.lockfile` (runtime classpath) and `buildscript-gradle.lockfile` (build-script classpath) via a single parser.
- Wired into `read_all` after the Maven readers — gradle emits `pkg:maven/<group>/<name>@<version>` PURLs, so downstream deps.dev enrichment applies without changes.
- Reuses the existing `project_roots::walk_for_project_roots` infrastructure (max_depth=6 + default skip set) so both lockfile filenames are found anywhere in the scan tree.

Closes #277.

## What's in this PR

- **Parser** (`gradle/lockfile.rs`): line-oriented over the well-documented Gradle format `group:name:version=<configurations>`. Skips `#`-prefixed header lines, blank lines, and the `empty=...` marker. Malformed lines emit `tracing::warn!` and continue (FR-015).
- **PURL derivation**: `pkg:maven/<group>/<name>@<version>` via the existing `encode_purl_segment` helper. Group with dots (`com.google.guava`) preserved as-is. Deep-namespaced coords with extra `:` chars handled gracefully (all-but-last-two segments joined as group).
- **Lifecycle scope** (FR-006): filename-driven — `buildscript-gradle.lockfile` → `Some(LifecycleScope::Build)`; `gradle.lockfile` → `None`. The existing milestone-052 emission path at `generate/cyclonedx/builder.rs:590-605` translates Build → CDX `scope: \"excluded\"` and `BUILD_DEPENDENCY_OF` (SPDX 2.3) automatically — no new emission code needed.
- **Annotation**: `mikebom:gradle-configurations` carries the raw comma-joined configuration list (e.g. `\"compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath\"`) — informational, lets downstream consumers filter.

## Test plan

- [x] 6 unit tests pass in `scan_fs::package_db::gradle::lockfile::tests`: `emits_basic_maven_components`, `buildscript_tagged_build_lifecycle_scope`, `header_lines_skipped`, `empty_configs_line_skipped`, `configurations_recorded_in_annotation`, `malformed_lines_warned_and_skipped`
- [x] 2 integration tests pass in `tests/scan_gradle_lockfile.rs`: end-to-end binary scan verifying both runtime (basic + scoped) and buildscript (CDX `scope: \"excluded\"`) emission shapes
- [x] Full `./scripts/pre-pr.sh` clean
- [x] No new Cargo dependencies

## Out of scope

- Dedicated CDX/SPDX byte-identity goldens — emission shape is identical to the existing maven path; the milestone-052 lifecycle-scope tagging is already exercised by the maven test-scope golden suite. Will add dedicated gradle goldens if any parity round-trip skew surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)