### PR TITLE
feat(yocto): add BitBake recipe walker for layer-tree scans

### DIFF
--- a/mikebom-cli/src/scan_fs/package_db/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/mod.rs
@@ -748,6 +748,15 @@ pub fn read_all(
     // AND a manifest for the same image, the installed-DB wins and
     // the manifest's source-mechanism appears in `also-detected-via`.
     out.extend(yocto::manifest::read(rootfs));
+    // Milestone 107 US4: BitBake recipe walker. Emits one
+    // `pkg:bitbake/<recipe>@<version>?layer=<layer>` component per
+    // `.bb` file in a `meta-<vendor>/` layer tree. Filename-only —
+    // no recipe-body parsing, no variable expansion. Lowest tier in
+    // the FR-010 precedence ladder: declarations may never have been
+    // built. Cross-tier collisions (opkg-installed-DB + recipe-tier
+    // both naming the same coord) keep BOTH components because the
+    // PURL ecosystem differs (`pkg:opkg/` vs `pkg:bitbake/`).
+    out.extend(yocto::recipe::read(rootfs));
 
     // Python: venv dist-info + lockfiles + requirements.txt per R13 tiers.
     // No fail-closed: an empty Python section is fine if the scan root

--- a/mikebom-cli/src/scan_fs/package_db/yocto/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/yocto/mod.rs
@@ -3,11 +3,12 @@
 //! Sub-modules:
 //! - `context` — sysroot-vs-rootfs detection (US3, FR-005a)
 //! - `manifest` — `<image>.manifest` reader (US2, FR-003)
-//! - `recipe` — `.bb` filename walker (US4) — added by Phase 5
+//! - `recipe` — `.bb` filename walker (US4, FR-007 + FR-008)
 //!
 //! `context` is consumed by `package_db/opkg.rs` to decide
-//! lifecycle-scope tagging; `manifest` is a standalone reader called
-//! directly from `read_all`.
+//! lifecycle-scope tagging; `manifest` and `recipe` are standalone
+//! readers called directly from `read_all`.
 
 pub(crate) mod context;
 pub mod manifest;
+pub mod recipe;

--- a/mikebom-cli/src/scan_fs/package_db/yocto/recipe.rs
+++ b/mikebom-cli/src/scan_fs/package_db/yocto/recipe.rs
@@ -1,0 +1,371 @@
+//! BitBake recipe walker (milestone 107 US4, FR-007, FR-008).
+//!
+//! Walks the scan target for `.bb` recipe files in Yocto/OE layer
+//! directories and emits one component per recipe, drawn from the
+//! filename pattern `<name>_<version>.bb` without parsing the recipe
+//! body. This is the lowest-authority Yocto reader — recipes declared
+//! by a layer may never have been selected by any image build — but
+//! it's the only signal for a layer-tree scan with no build artifacts
+//! present (security researchers auditing a vendor `meta-*/` layer
+//! before adoption).
+//!
+//! Per FR-007: filename-only emission, no BitBake variable expansion.
+//! Recipes whose filenames contain unexpanded `${...}` (typically
+//! shared-base recipes like `${PN}_${PV}.bb`) are silently skipped
+//! with a `tracing::warn!` per FR-008.
+//!
+//! Per FR-010 precedence: `BitbakeRecipe` is the lowest tier (2) —
+//! installed-DB readers and image-manifest readers both outrank it.
+
+use std::path::{Path, PathBuf};
+
+use mikebom_common::types::purl::{encode_purl_segment, Purl};
+use regex::Regex;
+
+use super::super::PackageDbEntry;
+
+const RECIPE_FILENAME_REGEX: &str =
+    r"^(?P<name>[a-zA-Z0-9_\-\+\.]+)_(?P<version>[a-zA-Z0-9_\-\+\.\~]+)\.bb$";
+
+/// Walk the scan target for `.bb` recipe files and emit one
+/// `PackageDbEntry` per recipe. Bounded to depth 8 (matches the
+/// established source-tree-walker convention) to avoid runaway
+/// traversal in deep monorepos.
+pub fn read(rootfs: &Path) -> Vec<PackageDbEntry> {
+    let Ok(regex) = Regex::new(RECIPE_FILENAME_REGEX) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    walk(rootfs, 0, 8, &regex, &mut out);
+    out
+}
+
+fn walk(dir: &Path, depth: usize, max_depth: usize, regex: &Regex, out: &mut Vec<PackageDbEntry>) {
+    if depth > max_depth {
+        return;
+    }
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        let Ok(ft) = entry.file_type() else {
+            continue;
+        };
+        if ft.is_dir() {
+            let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if super::super::project_roots::should_skip_default_descent(name) {
+                continue;
+            }
+            walk(&path, depth + 1, max_depth, regex, out);
+        } else if ft.is_file() {
+            let Some(filename) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if !filename.ends_with(".bb") {
+                continue;
+            }
+            if let Some(entry) = process_recipe(&path, filename, regex) {
+                out.push(entry);
+            }
+        }
+    }
+}
+
+fn process_recipe(path: &Path, filename: &str, regex: &Regex) -> Option<PackageDbEntry> {
+    // FR-008: silently skip recipes whose filenames carry unexpanded
+    // BitBake variable expansion. The literal sequence `${` is the
+    // canonical marker.
+    if filename.contains("${") {
+        tracing::warn!(
+            path = %path.display(),
+            "BitBake recipe filename contains unexpanded variable; skipping per FR-008"
+        );
+        return None;
+    }
+
+    let captures = regex.captures(filename);
+    let (name, version, version_missing) = if let Some(caps) = captures {
+        let name = caps.name("name")?.as_str().to_string();
+        let version = caps.name("version")?.as_str().to_string();
+        (name, version, false)
+    } else {
+        // `.bb` file with no `_<version>` segment (rare; e.g.,
+        // `helloworld.bb`). Per data-model: emit with version="unknown"
+        // and a `mikebom:version-status: "missing"` annotation rather
+        // than dropping.
+        let stem = filename.strip_suffix(".bb")?;
+        if stem.is_empty() {
+            return None;
+        }
+        (stem.to_string(), "unknown".to_string(), true)
+    };
+
+    let layer_name = detect_layer_name(path);
+    let purl = build_bitbake_purl(&name, &version, layer_name.as_deref())?;
+
+    let mut extra_annotations: std::collections::BTreeMap<String, serde_json::Value> =
+        Default::default();
+    extra_annotations.insert(
+        "mikebom:source-mechanism".to_string(),
+        serde_json::Value::String("bitbake-recipe".to_string()),
+    );
+    if let Some(layer) = &layer_name {
+        extra_annotations.insert(
+            "mikebom:layer-name".to_string(),
+            serde_json::Value::String(layer.clone()),
+        );
+    }
+    if version_missing {
+        extra_annotations.insert(
+            "mikebom:version-status".to_string(),
+            serde_json::Value::String("missing".to_string()),
+        );
+    }
+
+    Some(PackageDbEntry {
+        purl,
+        name,
+        version,
+        arch: None,
+        source_path: path.to_string_lossy().into_owned(),
+        depends: Vec::new(),
+        maintainer: None,
+        licenses: Vec::new(),
+        lifecycle_scope: None,
+        requirement_range: None,
+        source_type: None,
+        buildinfo_status: None,
+        evidence_kind: None,
+        binary_class: None,
+        binary_stripped: None,
+        linkage_kind: None,
+        detected_go: None,
+        confidence: None,
+        binary_packed: None,
+        raw_version: None,
+        parent_purl: None,
+        npm_role: None,
+        co_owned_by: None,
+        hashes: Vec::new(),
+        // R13: design-tier (declared but not necessarily built).
+        sbom_tier: Some("design".to_string()),
+        shade_relocation: None,
+        extra_annotations,
+        binary_role: None,
+    })
+}
+
+/// Walk UP from the recipe's directory looking for the enclosing
+/// `meta-<name>/` directory (the layer root). Returns the layer's
+/// directory name without the `meta-` prefix? No — per contract, the
+/// layer's BASENAME verbatim (e.g., `meta-mikebom-fixture`).
+///
+/// Fallback when no `meta-*/` ancestor is found: returns the path
+/// component immediately above the first `recipes-*/` directory.
+/// Returns None when neither pattern matches (caller emits no
+/// `?layer=` qualifier and no `mikebom:layer-name` annotation).
+fn detect_layer_name(recipe_path: &Path) -> Option<String> {
+    // Strategy 1: walk up looking for `meta-<name>/`.
+    let mut cursor = recipe_path.parent();
+    while let Some(dir) = cursor {
+        if let Some(name) = dir.file_name().and_then(|s| s.to_str()) {
+            if name.starts_with("meta-") || name == "meta" {
+                return Some(name.to_string());
+            }
+        }
+        cursor = dir.parent();
+    }
+    // Strategy 2: walk up looking for `recipes-*/` and return its
+    // parent's basename.
+    let mut last_dir: Option<PathBuf> = None;
+    let mut cursor = recipe_path.parent().map(PathBuf::from);
+    while let Some(dir) = &cursor {
+        if let Some(name) = dir.file_name().and_then(|s| s.to_str()) {
+            if name.starts_with("recipes-") {
+                // Return the parent's basename (the "layer root" by
+                // structure even without a `meta-` prefix).
+                return dir
+                    .parent()
+                    .and_then(|p| p.file_name())
+                    .and_then(|s| s.to_str())
+                    .map(str::to_string);
+            }
+        }
+        last_dir = Some(dir.clone());
+        cursor = dir.parent().map(PathBuf::from);
+    }
+    drop(last_dir);
+    None
+}
+
+fn build_bitbake_purl(name: &str, version: &str, layer: Option<&str>) -> Option<Purl> {
+    let purl_str = match layer {
+        Some(l) => format!(
+            "pkg:bitbake/{}@{}?layer={}",
+            encode_purl_segment(name),
+            encode_purl_segment(version),
+            encode_purl_segment(l)
+        ),
+        None => format!(
+            "pkg:bitbake/{}@{}",
+            encode_purl_segment(name),
+            encode_purl_segment(version),
+        ),
+    };
+    Purl::new(&purl_str).ok()
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    fn touch(path: &Path) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, "").unwrap();
+    }
+
+    #[test]
+    fn extracts_name_and_version_from_filename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let recipe = tmp
+            .path()
+            .join("meta-mikebom-fixture")
+            .join("recipes-mikebom")
+            .join("mikebom-fixture-lib")
+            .join("mikebom-fixture-lib_1.2.3.bb");
+        touch(&recipe);
+        let entries = read(tmp.path());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "mikebom-fixture-lib");
+        assert_eq!(entries[0].version, "1.2.3");
+    }
+
+    #[test]
+    fn emits_layer_qualifier_from_meta_ancestor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let recipe = tmp
+            .path()
+            .join("meta-mikebom-fixture")
+            .join("recipes-mikebom")
+            .join("mikebom-fixture-lib")
+            .join("mikebom-fixture-lib_1.2.3.bb");
+        touch(&recipe);
+        let entries = read(tmp.path());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].purl.as_str(),
+            "pkg:bitbake/mikebom-fixture-lib@1.2.3?layer=meta-mikebom-fixture"
+        );
+        assert_eq!(
+            entries[0]
+                .extra_annotations
+                .get("mikebom:layer-name")
+                .and_then(|v| v.as_str()),
+            Some("meta-mikebom-fixture")
+        );
+        assert_eq!(
+            entries[0]
+                .extra_annotations
+                .get("mikebom:source-mechanism")
+                .and_then(|v| v.as_str()),
+            Some("bitbake-recipe")
+        );
+    }
+
+    #[test]
+    fn unexpanded_variables_skipped_silently() {
+        let tmp = tempfile::tempdir().unwrap();
+        touch(
+            &tmp.path()
+                .join("meta-mikebom-fixture")
+                .join("recipes-mikebom")
+                .join("mikebom-fixture-shared")
+                .join("${PN}_${PV}.bb"),
+        );
+        // Also include one valid recipe to confirm the valid one still emits.
+        touch(
+            &tmp.path()
+                .join("meta-mikebom-fixture")
+                .join("recipes-mikebom")
+                .join("mikebom-fixture-real")
+                .join("mikebom-fixture-real_1.0.bb"),
+        );
+        let entries = read(tmp.path());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "mikebom-fixture-real");
+    }
+
+    #[test]
+    fn version_only_filename_emits_unknown_version_annotation() {
+        let tmp = tempfile::tempdir().unwrap();
+        touch(
+            &tmp.path()
+                .join("meta-mikebom-fixture")
+                .join("recipes-mikebom")
+                .join("mikebom-fixture-noversion")
+                .join("mikebom-fixture-noversion.bb"),
+        );
+        let entries = read(tmp.path());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "mikebom-fixture-noversion");
+        assert_eq!(entries[0].version, "unknown");
+        assert_eq!(
+            entries[0]
+                .extra_annotations
+                .get("mikebom:version-status")
+                .and_then(|v| v.as_str()),
+            Some("missing")
+        );
+    }
+
+    #[test]
+    fn bbappend_and_bbclass_files_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        touch(
+            &tmp.path()
+                .join("meta-mikebom-fixture")
+                .join("recipes-mikebom")
+                .join("mikebom-fixture-lib")
+                .join("mikebom-fixture-lib_1.0.bbappend"),
+        );
+        touch(
+            &tmp.path()
+                .join("meta-mikebom-fixture")
+                .join("classes")
+                .join("mikebom-fixture-helper.bbclass"),
+        );
+        // Add one real `.bb` to confirm walker is working but is just
+        // ignoring the .bbappend and .bbclass.
+        touch(
+            &tmp.path()
+                .join("meta-mikebom-fixture")
+                .join("recipes-mikebom")
+                .join("mikebom-fixture-lib")
+                .join("mikebom-fixture-lib_1.0.bb"),
+        );
+        let entries = read(tmp.path());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "mikebom-fixture-lib");
+    }
+
+    #[test]
+    fn git_version_suffix_preserved_in_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        touch(
+            &tmp.path()
+                .join("meta-mikebom-fixture")
+                .join("recipes-mikebom")
+                .join("mikebom-fixture-lib")
+                .join("mikebom-fixture-lib_1.2.3+git0abc123.bb"),
+        );
+        let entries = read(tmp.path());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].version, "1.2.3+git0abc123");
+    }
+}

--- a/mikebom-cli/tests/fixtures/golden_inputs/yocto_recipe_layer/meta-mikebom-fixture/conf/layer.conf
+++ b/mikebom-cli/tests/fixtures/golden_inputs/yocto_recipe_layer/meta-mikebom-fixture/conf/layer.conf
@@ -1,0 +1,6 @@
+# Synthetic BBLAYERS layer.conf for the milestone-107 US4 recipe
+# walker fixture. mikebom does NOT parse this file in milestone 107
+# (recipe walker is filename-only). Present so the directory layout
+# looks authentic to anyone reading the fixture later.
+BBPATH .= ":${LAYERDIR}"
+BBFILE_COLLECTIONS += "mikebom-fixture"

--- a/mikebom-cli/tests/fixtures/golden_inputs/yocto_recipe_layer/meta-mikebom-fixture/recipes-mikebom/mikebom-fixture-app/mikebom-fixture-app_2.0+git1234abcd.bb
+++ b/mikebom-cli/tests/fixtures/golden_inputs/yocto_recipe_layer/meta-mikebom-fixture/recipes-mikebom/mikebom-fixture-app/mikebom-fixture-app_2.0+git1234abcd.bb
@@ -1,0 +1,4 @@
+# Synthetic recipe with git-version suffix. mikebom preserves the
+# suffix verbatim in the emitted PURL version segment.
+SUMMARY = "Fixture app for mikebom milestone 107 recipe-walker test"
+LICENSE = "Apache-2.0"

--- a/mikebom-cli/tests/fixtures/golden_inputs/yocto_recipe_layer/meta-mikebom-fixture/recipes-mikebom/mikebom-fixture-lib/mikebom-fixture-lib_1.2.3.bb
+++ b/mikebom-cli/tests/fixtures/golden_inputs/yocto_recipe_layer/meta-mikebom-fixture/recipes-mikebom/mikebom-fixture-lib/mikebom-fixture-lib_1.2.3.bb
@@ -1,0 +1,3 @@
+# Synthetic BitBake recipe — mikebom only reads the filename.
+SUMMARY = "Fixture lib for mikebom milestone 107 recipe-walker test"
+LICENSE = "MIT"

--- a/mikebom-cli/tests/fixtures/golden_inputs/yocto_recipe_layer/meta-mikebom-fixture/recipes-mikebom/mikebom-fixture-noversion/mikebom-fixture-noversion.bb
+++ b/mikebom-cli/tests/fixtures/golden_inputs/yocto_recipe_layer/meta-mikebom-fixture/recipes-mikebom/mikebom-fixture-noversion/mikebom-fixture-noversion.bb
@@ -1,0 +1,6 @@
+# Synthetic recipe without an _<version> segment. mikebom emits
+# the component with version "unknown" + mikebom:version-status
+# annotation rather than dropping it (per FR-007 + the data-model
+# spec).
+SUMMARY = "Fixture recipe with no version in filename"
+LICENSE = "BSD-3-Clause"

--- a/mikebom-cli/tests/fixtures/golden_inputs/yocto_recipe_layer/meta-mikebom-fixture/recipes-mikebom/mikebom-fixture-shared/${PN}_${PV}.bb
+++ b/mikebom-cli/tests/fixtures/golden_inputs/yocto_recipe_layer/meta-mikebom-fixture/recipes-mikebom/mikebom-fixture-shared/${PN}_${PV}.bb
@@ -1,0 +1,4 @@
+# Synthetic recipe with unexpanded BitBake variables in the
+# filename — mikebom skips this silently per FR-008.
+SUMMARY = "Shared-base recipe; mikebom skips this"
+LICENSE = "Closed"

--- a/mikebom-cli/tests/scan_yocto_recipe.rs
+++ b/mikebom-cli/tests/scan_yocto_recipe.rs
@@ -1,0 +1,143 @@
+//! Integration test for the BitBake recipe walker (milestone 107 US4).
+//!
+//! Companion to the unit tests in `scan_fs::package_db::yocto::recipe::tests`.
+//! Invokes the `mikebom sbom scan` binary against the in-repo
+//! `yocto_recipe_layer/` fixture (a synthetic `meta-mikebom-fixture/`
+//! Yocto layer with 4 recipe files) and asserts:
+//!
+//! - 3 `pkg:bitbake/...` components emerge (the well-formed recipes +
+//!   the no-version recipe; the `${PN}_${PV}.bb` is silently skipped
+//!   per FR-008)
+//! - Each emitted component carries the `?layer=meta-mikebom-fixture`
+//!   qualifier (proves the layer-root detection walked up correctly)
+//! - The no-version recipe emerges with `version: "unknown"` + a
+//!   `mikebom:version-status: "missing"` annotation
+//! - Every emitted component carries
+//!   `mikebom:source-mechanism: "bitbake-recipe"`
+//!
+//! All fixture recipe names use the synthetic `mikebom-fixture-*`
+//! prefix per the milestone-106 convention.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+mod common;
+use common::bin;
+use common::normalize::apply_fake_home_env;
+
+fn fixture() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("golden_inputs")
+        .join("yocto_recipe_layer")
+}
+
+#[test]
+fn yocto_recipe_layer_emits_bitbake_components() {
+    let path = fixture();
+    assert!(path.is_dir(), "fixture missing at {}", path.display());
+
+    let workdir = tempfile::tempdir().expect("workdir tempdir");
+    let fake_home = tempfile::tempdir().expect("fake-home tempdir");
+    let out_path = workdir.path().join("sbom.cdx.json");
+
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    cmd.env("MIKEBOM_FIXED_TIMESTAMP", "2026-01-01T00:00:00Z");
+    cmd.args([
+        "--offline",
+        "sbom",
+        "scan",
+        "--path",
+        path.to_str().unwrap(),
+        "--format",
+        "cyclonedx-json",
+        "--output",
+        out_path.to_str().unwrap(),
+    ]);
+    let output = cmd.output().expect("spawn mikebom");
+    assert!(
+        output.status.success(),
+        "recipe scan unexpectedly failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let bytes = std::fs::read(&out_path).expect("read emitted SBOM");
+    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("parse JSON");
+    let components = json["components"].as_array().expect("components array");
+    let bitbake_components: Vec<&serde_json::Value> = components
+        .iter()
+        .filter(|c| {
+            c["purl"]
+                .as_str()
+                .map(|p| p.starts_with("pkg:bitbake/"))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    assert_eq!(
+        bitbake_components.len(),
+        3,
+        "expected 3 bitbake components (lib + app + noversion; \
+         the ${{PN}}_${{PV}}.bb is silently skipped); got {}: \
+         {bitbake_components:#?}",
+        bitbake_components.len()
+    );
+
+    let bitbake_purls: Vec<&str> = bitbake_components
+        .iter()
+        .filter_map(|c| c["purl"].as_str())
+        .collect();
+
+    let expected = [
+        "pkg:bitbake/mikebom-fixture-lib@1.2.3?layer=meta-mikebom-fixture",
+        // `+` in version becomes `%2B` per the package-url spec via encode_purl_segment.
+        "pkg:bitbake/mikebom-fixture-app@2.0%2Bgit1234abcd?layer=meta-mikebom-fixture",
+        "pkg:bitbake/mikebom-fixture-noversion@unknown?layer=meta-mikebom-fixture",
+    ];
+    for purl in expected {
+        assert!(
+            bitbake_purls.contains(&purl),
+            "expected `{purl}` in output; got: {bitbake_purls:#?}",
+        );
+    }
+
+    // Every emitted component carries the source-mechanism annotation.
+    for component in &bitbake_components {
+        let mechanism = find_property(component, "mikebom:source-mechanism");
+        assert_eq!(
+            mechanism.as_deref(),
+            Some("bitbake-recipe"),
+            "component {component} missing source-mechanism annotation",
+        );
+    }
+
+    // The no-version recipe carries version-status: "missing".
+    let noversion = bitbake_components
+        .iter()
+        .find(|c| {
+            c["purl"]
+                .as_str()
+                .map(|p| p.contains("mikebom-fixture-noversion"))
+                .unwrap_or(false)
+        })
+        .expect("noversion component present");
+    let status = find_property(noversion, "mikebom:version-status");
+    assert_eq!(
+        status.as_deref(),
+        Some("missing"),
+        "noversion component should have version-status=missing; got: {noversion}"
+    );
+}
+
+/// CDX serializes per-component `mikebom:*` annotations as
+/// `properties[]` entries with `name` + `value` keys. This helper
+/// returns the first matching property's `value` as a String.
+fn find_property(component: &serde_json::Value, name: &str) -> Option<String> {
+    component["properties"]
+        .as_array()?
+        .iter()
+        .find(|p| p["name"].as_str() == Some(name))
+        .and_then(|p| p["value"].as_str().map(str::to_string))
+}

--- a/specs/107-yocto-recipe-reader/tasks.md
+++ b/specs/107-yocto-recipe-reader/tasks.md
@@ -131,26 +131,26 @@ Single-project workspace (the mikebom Rust workspace). All source under `mikebom
 
 ### Fixtures + tests
 
-- [ ] T037 [P] [US4] Create fixture tree `mikebom-cli/tests/fixtures/golden_inputs/yocto_recipe_layer/meta-mikebom-fixture/` with 4 `recipes-*/<name>/<name>_<version>.bb` files (one with `+git<sha>` version suffix, one with no `_<version>` segment to exercise the missing-version annotation, two normal). Add one `${PN}_${PV}.bb` to verify the silent-skip path. Include a `conf/layer.conf` (empty is fine) so the layer dir looks authentic.
-- [ ] T038 [P] [US4] Add contract tests in `mikebom-cli/src/scan_fs/package_db/yocto/recipe.rs::tests`: `extracts_name_and_version_from_filename`, `emits_layer_qualifier_from_meta_ancestor`, `unexpanded_variables_skipped_silently`, `version_only_filename_emits_unknown_version_annotation`, `bbappend_and_bbclass_files_ignored`.
+- [X] T037 [P] [US4] Recipe-layer fixture. ✅ `yocto_recipe_layer/meta-mikebom-fixture/` with 4 `.bb` files: `mikebom-fixture-lib_1.2.3.bb`, `mikebom-fixture-app_2.0+git1234abcd.bb`, `mikebom-fixture-noversion.bb` (no `_<version>`), `${PN}_${PV}.bb` (unexpanded variables — silent-skip path). Plus `conf/layer.conf` for layout authenticity.
+- [X] T038 [P] [US4] Unit tests. ✅ 6 tests in `yocto/recipe.rs::tests`: `extracts_name_and_version_from_filename`, `emits_layer_qualifier_from_meta_ancestor`, `unexpanded_variables_skipped_silently`, `version_only_filename_emits_unknown_version_annotation`, `bbappend_and_bbclass_files_ignored`, `git_version_suffix_preserved_in_version`.
 
 ### Implementation
 
-- [ ] T039 [US4] Create `mikebom-cli/src/scan_fs/package_db/yocto/recipe.rs` per `contracts/bitbake-recipe.md`: implement `pub(super) fn read(rootfs: &Path) -> Vec<PackageDbEntry>` walking the scan tree (max_depth=8 via `walkdir`) for `.bb` files matching the filename regex; skip `.bbappend` and `.bbclass`.
-- [ ] T040 [US4] Implement the filename-extraction regex: `^(?P<name>[a-zA-Z0-9_\-\+\.]+)_(?P<version>[a-zA-Z0-9_\-\+\.\~]+)\.bb$`. Filenames containing `${` (literal unexpanded BitBake variable) match the skip-with-warn path per FR-008.
-- [ ] T041 [US4] Implement layer-root detection: walk UP from the recipe's directory looking for the enclosing `meta-<name>/` directory; the basename becomes the `?layer=<layer>` PURL qualifier. Fall back to "path component above first `recipes-*/` directory" if no `meta-*/` ancestor exists.
-- [ ] T042 [US4] Implement PURL derivation: `pkg:bitbake/<name>@<version>?layer=<layer_name>` via `Purl::new` + `encode_purl_segment`. Layer name passed verbatim into the qualifier.
-- [ ] T043 [US4] Implement `mikebom:version-status: "missing"` annotation for `.bb` files with no `_<version>` segment (rare but legal — e.g. `helloworld.bb`).
-- [ ] T044 [US4] Wire `yocto::recipe::read` into the dispatcher. Order in `read_all`: AFTER yocto-manifest (Phase 4), maintaining the FR-010 precedence order (opkg-installed > yocto-image-manifest > bitbake-recipe).
-- [ ] T045 [US4] Add `SourceMechanism::BitbakeRecipe` variant with `canonical_str` returning `"bitbake-recipe"`. Lowest-precedence among the 107 milestone's three new variants.
+- [X] T039 [US4] `yocto/recipe.rs`. ✅ `pub fn read(rootfs)` walks scan tree (max_depth=8, default-skip-set reused) for `.bb` files; `.bbappend` / `.bbclass` correctly ignored via the `ends_with(".bb")` exact check.
+- [X] T040 [US4] Filename regex. ✅ `^(?P<name>[a-zA-Z0-9_\-\+\.]+)_(?P<version>[a-zA-Z0-9_\-\+\.\~]+)\.bb$`. Pre-regex `filename.contains("${")` check captures FR-008 silent-skip path.
+- [X] T041 [US4] Layer-root detection. ✅ Walks UP from recipe path looking for `meta-<name>/` or bare `meta/` directory. Falls back to "path component above first `recipes-*/`" when no `meta-*/` ancestor.
+- [X] T042 [US4] PURL derivation. ✅ `pkg:bitbake/<name>@<version>?layer=<layer>` via `Purl::new` + `encode_purl_segment` on all three segments. `+` in version (git suffix) correctly encodes to `%2B`.
+- [X] T043 [US4] Version-status annotation. ✅ `.bb` filenames without `_<version>` segment emit with `version="unknown"` + `mikebom:version-status: "missing"` annotation.
+- [X] T044 [US4] Wire into dispatcher. ✅ `out.extend(yocto::recipe::read(rootfs))` inserted in `read_all` after the yocto::manifest call. FR-010 ordering preserved (opkg-installed > yocto-image-manifest > bitbake-recipe).
+- [X] T045 [US4] `SourceMechanism::BitbakeRecipe`. ✅ Already added in PR #294's enum extension. `canonical_str` returns `"bitbake-recipe"`. Tier 2 (lowest, declaration-only).
 
 ### Integration test
 
-- [ ] T046 [P] [US4] Add integration test `mikebom-cli/tests/scan_yocto_recipe.rs`: end-to-end binary scan of `yocto_recipe_layer/` fixture; assert 3 components emerge (4 well-formed recipes minus the 1 that's skipped with no-version annotation = 3 valid; or assert 4 components emerge with one carrying `mikebom:version-status` = "missing" — depends on T043's exact handling); assert `${PN}_${PV}.bb` recipe is silently skipped; assert PURL `?layer=meta-mikebom-fixture` qualifier present on all emitted entries.
+- [X] T046 [P] [US4] `tests/scan_yocto_recipe.rs`. ✅ End-to-end scan of the 4-recipe fixture; asserts exactly 3 `pkg:bitbake/...` components emerge (the `${PN}_${PV}.bb` is silently skipped per FR-008); verifies the no-version recipe carries `mikebom:version-status: "missing"`; verifies all 3 carry the `?layer=meta-mikebom-fixture` qualifier; verifies all 3 carry `mikebom:source-mechanism: "bitbake-recipe"`.
 
 ### Polyglot + PR
 
-- [ ] T047 [US4] Run `./scripts/pre-pr.sh` clean. Open PR titled `feat(yocto): add BitBake recipe walker for layer-tree scans (closes #NEW3)`.
+- [X] T047 [US4] Pre-PR gate. ✅ `./scripts/pre-pr.sh` clean. 6 new unit + 1 new integration test pass; all 1722+ existing tests still pass.
 
 **Checkpoint**: US4 shippable. Layer-tree audit scans emerge with one component per declared recipe.
 


### PR DESCRIPTION
## Summary

Milestone 107 **US4**. mikebom now scans Yocto/OE layer repositories (`meta-<vendor>/` directory trees, pre-build) and emits one component per `.bb` recipe file. Useful for supply-chain pre-screening of vendor layers before adoption.

Builds on PR #294 (which already added the `BitbakeRecipe` variant to the `SourceMechanism` enum).

## What's in this PR

**New module** `mikebom-cli/src/scan_fs/package_db/yocto/recipe.rs`:

- `pub fn read(rootfs: &Path) -> Vec<PackageDbEntry>` walks the scan tree (max_depth=8 via std::fs::read_dir + the established `project_roots::should_skip_default_descent` skip set) for `.bb` files. `.bbappend` and `.bbclass` files are silently ignored (the `ends_with(\".bb\")` exact check excludes them).
- Filename-only parse via regex `^(?P<name>[a-zA-Z0-9_\\-\\+\\.]+)_(?P<version>[a-zA-Z0-9_\\-\\+\\.\\~]+)\\.bb$`. Recipe body is NOT parsed (FR-007 explicit scope boundary).
- Per FR-008: filenames containing the literal `${` (unexpanded BitBake variable expansion) are silently skipped with a `tracing::warn!` — no placeholder component, no `unresolved` sentinel.
- `.bb` files with no `_<version>` segment (rare; e.g. `helloworld.bb`) emit with `version=\"unknown\"` + a `mikebom:version-status: \"missing\"` annotation per the data-model.

**Layer-root detection**: walks UP from each recipe's directory looking for the enclosing `meta-<name>/` (or bare `meta/`) directory. Basename becomes the `?layer=<layer>` PURL qualifier + `mikebom:layer-name` annotation. Fallback when no `meta-*/` ancestor: returns the path component immediately above the first `recipes-*/` directory.

**PURL**: `pkg:bitbake/<name>@<version>?layer=<layer>`. All segments percent-encoded via `encode_purl_segment` — `+` in git-suffix versions correctly encodes to `%2B` (verified by the integration test's `mikebom-fixture-app_2.0+git1234abcd.bb` → `pkg:bitbake/...@2.0%2Bgit1234abcd?layer=meta-mikebom-fixture`).

**Wiring**: `yocto/mod.rs` adds `pub mod recipe;`; `read_all` calls `yocto::recipe::read(rootfs)` AFTER the manifest reader, preserving the FR-010 precedence order (opkg-installed > yocto-image-manifest > bitbake-recipe).

**Cross-tier interaction**: when the same scan contains both an opkg-installed-DB stanza AND a `.bb` recipe for the same logical package, BOTH components emit because the PURL ecosystem differs (`pkg:opkg/...?arch=<a>` vs `pkg:bitbake/...?layer=<l>`). The milestone-105 dedup pipeline collapses same-canonical-PURL emissions only; different ecosystems retain distinct identities.

## Test plan

- [x] 6 unit tests in `recipe::tests`: `extracts_name_and_version_from_filename`, `emits_layer_qualifier_from_meta_ancestor`, `unexpanded_variables_skipped_silently`, `version_only_filename_emits_unknown_version_annotation`, `bbappend_and_bbclass_files_ignored`, `git_version_suffix_preserved_in_version`
- [x] 1 integration test in `tests/scan_yocto_recipe.rs`: end-to-end scan of `yocto_recipe_layer/` fixture (4 `.bb` files; 1 with unexpanded `${PN}_${PV}` and 1 with no version segment). Verifies exactly 3 components emerge (silent skip of the unexpanded recipe); verifies `+git<sha>` → `%2B` PURL encoding; verifies missing-version annotation; verifies all 3 carry `mikebom:source-mechanism: \"bitbake-recipe\"` + `?layer=meta-mikebom-fixture` qualifier
- [x] Full `./scripts/pre-pr.sh` clean
- [x] No new Cargo dependencies (uses workspace `regex`)
- [x] All fixture recipe names use the synthetic `mikebom-fixture-*` prefix

## Out of scope (subsequent milestone-107 phases)

- Polish: `docs/ecosystems.md` update, FR-011 offline audit, SC-006 + SC-007 polyglot/cross-reader regression tests → Phase 6 PR
- Release: alpha.43 cut → Phase 7 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)