### PR TITLE
chore(108): mark Phase 3 (US1 polish) complete

### DIFF
--- a/specs/108-fingerprint-corpus/tasks.md
+++ b/specs/108-fingerprint-corpus/tasks.md
@@ -88,9 +88,12 @@ Single-project workspace (the mikebom Rust workspace). Mikebom-cli code under `m
 
 ### Polish for sibling-repo
 
-- [ ] T030 [US1] Validate the bootstrap PR's CI works end-to-end by opening a deliberate-failure test PR (e.g., `corpus/test-record.json` missing the `min_symbols` field) and confirming the CI blocks the merge. Delete the test PR after verification.
-- [ ] T031 [US1] Document the contribution flow in `kusari-sandbox/mikebom-fingerprints/CONTRIBUTING.md` with a worked example: "Adding libxml2 — symbols selection, min_symbols rationale, PR template". Reviewer guidelines spelled out.
-- [ ] T032 [US1] Add a `validate-locally` script (`scripts/validate.sh`) that runs the same checks the CI does, so contributors can pre-flight their PRs without pushing.
+- [X] T030 [US1] Validate the bootstrap PR's CI works end-to-end by opening a deliberate-failure test PR (e.g., `corpus/test-record.json` missing the `min_symbols` field) and confirming the CI blocks the merge. Delete the test PR after verification.
+  - **Verified**: opened `kusari-sandbox/mikebom-fingerprints#2` (`chore/ci-deliberate-failure-test-T030`) with `corpus/mikebom-ci-test.json` deliberately omitting `min_symbols`. The `schema + invariants` check failed in 10s on `missingProperty: 'min_symbols'` ([log](https://github.com/kusari-sandbox/mikebom-fingerprints/actions/runs/26831486186/job/79113732411)). PR closed (not merged); branch deleted both locally and on origin. Branch protection (1 approving review + green `schema + invariants` required + strict) would refuse a merge attempt independently.
+- [X] T031 [US1] Document the contribution flow in `kusari-sandbox/mikebom-fingerprints/CONTRIBUTING.md` with a worked example: "Adding libxml2 — symbols selection, min_symbols rationale, PR template". Reviewer guidelines spelled out.
+  - **Already completed** in the original sibling-repo bootstrap PR (`kusari-sandbox/mikebom-fingerprints#1`). `CONTRIBUTING.md` (157 lines) includes the libxml2 worked example, the `min_symbols` rule-of-thumb table, symbol-selection do/don'ts, the PR title format (`add fingerprint: <library>`), the PR body template, and reviewer guidelines. No additional work needed.
+- [X] T032 [US1] Add a `validate-locally` script (`scripts/validate.sh`) that runs the same checks the CI does, so contributors can pre-flight their PRs without pushing.
+  - **Already completed** in the original sibling-repo bootstrap PR (`kusari-sandbox/mikebom-fingerprints#1`). `scripts/validate.sh` runs ajv-cli `--strict=true --spec=draft2020` per-library + against the index, then invokes `scripts/validate-invariants.sh` — bit-for-bit the same as the CI workflow. Pre-flight-verified against the T030 deliberate-failure fixture: exits 1 with the same ajv error CI emits.
 
 **Checkpoint**: US1 shippable. The contribution flow is documented + the CI gate proven by both successful + deliberate-fail PRs.
 


### PR DESCRIPTION
## Summary

Marks Phase 3 (User Story 1 — Maintainer contribution flow) of milestone 108 complete in `specs/108-fingerprint-corpus/tasks.md`.

No code changes; tasks.md-only.

## T030 verification

Opened deliberate-failure PR `kusari-sandbox/mikebom-fingerprints#2`:

- Branch: `chore/ci-deliberate-failure-test-T030`
- Fixture: `corpus/mikebom-ci-test.json` deliberately omits the required `min_symbols` field
- Result: `schema + invariants` check **failed in 10s** with the expected ajv error:
  ```
  corpus/mikebom-ci-test.json invalid
  [
    {
      instancePath: '',
      schemaPath: '#/required',
      keyword: 'required',
      params: { missingProperty: 'min_symbols' },
      message: \"must have required property 'min_symbols'\"
    }
  ]
  ```
  ([job log](https://github.com/kusari-sandbox/mikebom-fingerprints/actions/runs/26831486186/job/79113732411))
- PR closed (not merged); branch deleted on origin

Validates the end-to-end CI gate on the sibling repo. Branch protection (1 approving review + green `schema + invariants` required + strict) would refuse a merge attempt independently of CI status.

## T031 + T032

Already completed during the original sibling-repo bootstrap PR (`kusari-sandbox/mikebom-fingerprints#1`):

- **T031**: `CONTRIBUTING.md` ships the libxml2 worked example, `min_symbols` rule-of-thumb table, symbol-selection do/don'ts, PR title format, PR body template, and reviewer guidelines (157 lines).
- **T032**: `scripts/validate.sh` runs ajv-cli `--strict=true --spec=draft2020` per-library + against the index, then invokes `scripts/validate-invariants.sh` — same checks as the CI workflow. Pre-flight-verified against the T030 deliberate-failure fixture: exits 1 with the same ajv error CI emits.

Both are marked complete with explanatory notes in tasks.md so the audit trail is preserved.

## US1 status

Shippable. The contribution flow is documented + the CI gate is proven by both the successful bootstrap PR AND the deliberate-failure test PR.

## Next

Phase 4 (US2 — operator opt-in to external corpus): adds the `--fingerprints-corpus` flag, fetch path, cache-miss handling, and SBOM annotation stamping. Lands in a subsequent PR.

## Test plan

- [x] `./scripts/pre-pr.sh` n/a — no code changes
- [x] tasks.md still renders correctly (3 boxes ticked, completion notes inline)
- [ ] CI green (lint + test lanes pass over the unchanged code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)