### PR TITLE
docs(README): replace "more hardening" line with pre-1.0 stabilization framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mikebom
 
-**NOTE: This tool is in no way production ready. This requires a lot more hardening**
+**NOTE: mikebom is pre-1.0 alpha. The CLI surface, output formats, and per-ecosystem coverage are still being stabilized; expect breaking changes between alpha releases, and expect additional ecosystem readers + binary-analysis surface to keep landing release-over-release.**
 
 A toolkit for working with software bills of materials end-to-end:
 


### PR DESCRIPTION
The previous "no way production ready / needs a lot more hardening" line was honest but didn't tell operators what's actually stabilizing. Replaced with concrete pre-1.0 framing that names the three stabilizing surfaces (CLI, output formats, per-ecosystem coverage) and sets the expectation that more ecosystem readers + binary-analysis surface keep landing release-over-release.

The downstream "Status: pre-1.0 alpha." block + the stable / experimental subcommand split immediately below is unchanged — it already documents which subcommands operators can safely depend on today.

Docs-only; no code touched.