### PR TITLE
feat(binary): PE export-table extraction for the fingerprint matcher

### DIFF
--- a/mikebom-cli/src/scan_fs/binary/pe.rs
+++ b/mikebom-cli/src/scan_fs/binary/pe.rs
@@ -154,6 +154,64 @@ pub fn parse_linker_version<'a, Pe: ImageNtHeaders>(
     format!("{}.{}", opt.major_linker_version(), opt.minor_linker_version())
 }
 
+/// Milestone 109 — PE export-table extraction for the symbol-
+/// fingerprint matcher. PE binaries don't have ELF's `.dynsym` or
+/// Mach-O's `LC_SYMTAB` externals; the exported names live in
+/// `IMAGE_EXPORT_DIRECTORY` (a.k.a. the export data directory).
+///
+/// What this catches: DLLs that re-export a statically-embedded
+/// library's API (the canonical fingerprint-matcher target on
+/// Windows — wrapper DLLs around third-party C libraries). EXEs
+/// built with `/EXPORT:` or `__declspec(dllexport)` also surface
+/// their exports here.
+///
+/// What this MISSES: a typical stripped Windows EXE that uses
+/// zlib internally without re-exporting its API has an EMPTY
+/// export table. The fingerprint matcher has nothing to match
+/// against in that case. Same shape as the ELF/Mach-O scanners —
+/// they identify libraries from EXPORTED symbols, not internal
+/// references. Operators wanting to identify statically-embedded
+/// libraries in stripped Windows EXEs should pair the fingerprint
+/// matcher with the milestone-026 embedded-version-string scanner
+/// (which works on any binary format regardless of export table).
+///
+/// Returns symbol names as `String` with empty-name + missing-name
+/// entries dropped. PE export names are conventionally ASCII /
+/// UTF-8; `from_utf8_lossy` keeps malformed bytes from blocking the
+/// scan.
+///
+/// Cross-architecture: works for both PE32 (x86) and PE32+ (x64 +
+/// ARM64) via the same magic-byte dispatch as `parse_pe_identity`.
+pub fn extract_pe_export_names(bytes: &[u8]) -> Vec<String> {
+    match detect_pe_magic(bytes) {
+        Some(PE32_MAGIC) => match PeFile32::parse(bytes) {
+            Ok(file) => collect_export_names(&file),
+            Err(_) => Vec::new(),
+        },
+        Some(PE32_PLUS_MAGIC) => match PeFile64::parse(bytes) {
+            Ok(file) => collect_export_names(&file),
+            Err(_) => Vec::new(),
+        },
+        _ => Vec::new(),
+    }
+}
+
+fn collect_export_names<'a, Pe: ImageNtHeaders>(
+    file: &PeFile<'a, Pe, &'a [u8]>,
+) -> Vec<String> {
+    let Ok(Some(table)) = file.export_table() else {
+        return Vec::new();
+    };
+    let Ok(exports) = table.exports() else {
+        return Vec::new();
+    };
+    exports
+        .into_iter()
+        .filter_map(|e| e.name.map(|n| String::from_utf8_lossy(n).into_owned()))
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
 fn machine_to_str(value: u16) -> &'static str {
     match value {
         pe::IMAGE_FILE_MACHINE_I386 => "i386",
@@ -515,5 +573,60 @@ mod tests {
             Some("0.0"),
             "FR-003: always-emit, '0.0' on zeroed optional-header bytes"
         );
+    }
+
+    // ====================================================================
+    // Milestone 109 — PE export-table extraction
+    // ====================================================================
+
+    /// Garbage / non-PE bytes return empty. Defensive guard: the
+    /// scan-binary dispatcher only calls into `extract_pe_export_names`
+    /// for binaries already classified as `class == "pe"`, but the
+    /// helper should never panic on unrelated input.
+    #[test]
+    fn extract_pe_export_names_returns_empty_for_non_pe_bytes() {
+        assert!(extract_pe_export_names(b"this is not a PE binary at all").is_empty());
+        assert!(extract_pe_export_names(b"").is_empty());
+        assert!(extract_pe_export_names(&[0u8; 4096]).is_empty());
+    }
+
+    /// A minimal PE with no IMAGE_EXPORT_DIRECTORY at all returns
+    /// empty. This is the typical stripped-EXE case — common on
+    /// Windows for binaries that statically embed a library without
+    /// re-exporting its API. Documents the false-negative-by-design
+    /// behavior of the fingerprint matcher on this class of binary.
+    #[test]
+    fn extract_pe_export_names_returns_empty_for_pe_without_export_table() {
+        let img = build_minimal_pe(
+            true,
+            pe::IMAGE_FILE_MACHINE_AMD64,
+            pe::IMAGE_SUBSYSTEM_WINDOWS_CUI,
+            None,
+        );
+        // Verify the fixture is a valid parseable PE first (sanity:
+        // the helper's empty return must come from the missing
+        // export table, not from a malformed image).
+        let (_, machine, _, linker) = parse_pe_identity(&img);
+        assert_eq!(machine.as_deref(), Some("amd64"));
+        assert_eq!(linker.as_deref(), Some("0.0"));
+        // Now the actual assertion.
+        assert!(
+            extract_pe_export_names(&img).is_empty(),
+            "PE with no IMAGE_EXPORT_DIRECTORY must yield empty export names"
+        );
+    }
+
+    /// Same as the 64-bit case but for PE32 (x86). The dispatch
+    /// branch is separate (`PeFile32::parse` vs `PeFile64::parse`)
+    /// so the test covers both code paths.
+    #[test]
+    fn extract_pe_export_names_returns_empty_for_pe32_without_export_table() {
+        let img = build_minimal_pe(
+            false,
+            pe::IMAGE_FILE_MACHINE_I386,
+            pe::IMAGE_SUBSYSTEM_WINDOWS_CUI,
+            None,
+        );
+        assert!(extract_pe_export_names(&img).is_empty());
     }
 }

--- a/mikebom-cli/src/scan_fs/binary/scan.rs
+++ b/mikebom-cli/src/scan_fs/binary/scan.rs
@@ -241,9 +241,12 @@ pub(super) fn scan_binary(path: &Path, bytes: &[u8]) -> Option<BinaryScan> {
     //   exactly one leading underscore so `_crc32` matches the
     //   `crc32` entry in the fingerprint corpus.
     //
-    // - PE: deferred. PE's export table is a separate
-    //   `IMAGE_EXPORT_DIRECTORY` shape, not the standard symbol
-    //   table — needs distinct extraction. Tracked separately.
+    // - PE: read `IMAGE_EXPORT_DIRECTORY` via the milestone-109
+    //   `pe::extract_pe_export_names` helper. PE exports live in
+    //   the data directory, not the COFF symbol table; needs a
+    //   distinct dispatch from ELF/Mach-O. Catches DLLs that
+    //   re-export wrapped library APIs; stripped EXEs with no
+    //   export table return empty.
     let symbol_names = if class == "elf" {
         use object::Object;
         use object::ObjectSymbol;
@@ -265,6 +268,8 @@ pub(super) fn scan_binary(path: &Path, bytes: &[u8]) -> Option<BinaryScan> {
             .filter(|s| !s.is_empty())
             .map(|s| strip_macho_underscore_prefix(&s).to_string())
             .collect()
+    } else if class == "pe" {
+        super::pe::extract_pe_export_names(bytes)
     } else {
         Vec::new()
     };


### PR DESCRIPTION
## Summary

Closes the cross-platform story for the symbol-fingerprint scanner: ELF (milestone 099) + Mach-O ([#305](https://github.com/kusari-sandbox/mikebom/pull/305)) + **PE** (this PR). The corpus content itself stays unchanged — pure extraction-side addition. Operators on Windows can now use \`--fingerprints-corpus\` without a Linux container.

## What this catches (and doesn't)

PE binaries don't have ELF's \`.dynsym\` or Mach-O's \`LC_SYMTAB\` externals — exports live in \`IMAGE_EXPORT_DIRECTORY\`. The new \`pe::extract_pe_export_names\` reads that directory via \`object::PeFile::export_table()\`.

**Catches**: DLLs that re-export a statically-embedded library's API. The canonical fingerprint-matcher target on Windows — wrapper DLLs around third-party C libraries (e.g., a DLL that statically links + re-exports zlib's \`crc32\`/\`deflate\`/etc.). EXEs built with \`/EXPORT:\` or \`__declspec(dllexport)\` also surface their exports.

**Misses**: a typical stripped Windows EXE that uses zlib internally without re-exporting its API has an EMPTY export table. Same shape as the ELF/Mach-O scanners — they identify libraries from EXPORTED symbols, not internal references. Operators wanting to identify statically-embedded libraries in stripped EXEs should pair the fingerprint matcher with the milestone-026 embedded-version-string scanner (which works on any binary format regardless of export table).

## Implementation

- \`pe::extract_pe_export_names(bytes) -> Vec<String>\` dispatches PE32 vs PE32+ via the same magic-byte path as \`parse_pe_identity\`.
- \`collect_export_names\` does the iteration. Drops missing-name exports + empty strings. \`String::from_utf8_lossy\` keeps malformed export names from blocking the scan.
- \`scan.rs::scan_binary\` adds the third branch alongside ELF + Mach-O — when \`class == \"pe\"\`, calls \`super::pe::extract_pe_export_names(bytes)\`. The matcher loop in \`binary::read()\` is unchanged; it just sees more symbol names on more binary formats now.

## Tests

3 new unit tests:

- \`extract_pe_export_names_returns_empty_for_non_pe_bytes\` — defensive: garbage / empty / all-zero bytes don't panic.
- \`extract_pe_export_names_returns_empty_for_pe_without_export_table\` — a parseable PE32+ with no \`IMAGE_EXPORT_DIRECTORY\` returns empty. Documents the false-negative-by-design behavior on stripped EXEs.
- \`extract_pe_export_names_returns_empty_for_pe32_without_export_table\` — same case for PE32 (x86). Covers the \`PeFile32::parse\` dispatch branch.

The richer \"PE WITH export table → matches the fingerprint corpus\" case isn't covered by a synthetic-PE unit test (would require ~100 LOC extending \`build_minimal_pe\` to construct an \`IMAGE_EXPORT_DIRECTORY\` + name-pointer table). Verifying that half end-to-end needs a real cross-compiled Windows DLL with statically-linked zlib — deferred to manual operator testing on Windows hosts.

## Pre-PR gate

- \`./scripts/pre-pr.sh\` clean (clippy + workspace tests).
- 33 byte-identity goldens unchanged (PE binaries don't appear in the existing goldens).
- 16 pe-module tests pass (13 existing + 3 new).

## No new dependencies

Zero additions to \`Cargo.toml\`. Uses existing \`object 0.36\` PE accessors.

## Follow-up

After merge: update the cmake-demo README (again!) to drop \"PE deferred\" framing and note that Windows is now first-class.

## Test plan

- [x] \`./scripts/pre-pr.sh\` clean locally
- [x] 33 byte-identity goldens unchanged
- [x] 3 new unit tests pass
- [ ] CI green (lint + test + ebpf-feature lanes)
- [ ] Manual: cross-compile a Windows DLL with statically-linked zlib + scan with \`--fingerprints-corpus\` (deferred to a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)