### PR TITLE
feat(fingerprints): wire v2 matcher into production scan path (milestone 110 Phase 4 Slice B-2)

### DIFF
--- a/mikebom-cli/src/scan_fs/binary/entry.rs
+++ b/mikebom-cli/src/scan_fs/binary/entry.rs
@@ -14,6 +14,7 @@ use sha2::{Digest, Sha256};
 
 use super::cargo_auditable;
 use super::elf;
+use super::fingerprints::matcher::MatchResult;
 use super::macho;
 use super::packer;
 use super::symbol_fingerprint;
@@ -118,6 +119,91 @@ pub(super) fn symbol_match_to_entry(
         extra_annotations: extra,
         binary_role: None,
     })
+}
+
+/// Convert a v2 matcher `MatchResult` into a `PackageDbEntry` (milestone
+/// 110, Phase 4 Slice B-2).
+///
+/// Mirrors `symbol_match_to_entry` but uses the v2 `MatchResult` shape:
+/// - PURL comes directly from the matched record (carries the version
+///   segment when available, unlike v1's symbol-only `pkg:generic/<lib>`).
+/// - `mikebom:fingerprint-confidence` carries the numeric fused score
+///   from the matcher's "max + bump" fusion algorithm (vs v1's hardcoded
+///   `"0.70"` baseline) — formatted "X.XX" per FR-017.
+/// - `mikebom:fingerprint-symbols-matched` records the indicator count
+///   (e.g., `"2/3"` when 2 of 3 indicator kinds in the record matched).
+///   Repurposed from the v1 symbol-count carrier; v2 records carry per-
+///   indicator-KIND counts rather than per-symbol counts.
+/// - No `mikebom:fingerprint-corpus-sha` annotation on the v2 path —
+///   the C58 carrier is v1-specific (a 12-hex git SHA from the
+///   milestone-108 sibling repo). A v2-equivalent annotation
+///   (`mikebom:fingerprint-source-id`) ships in a follow-on slice with
+///   its own C-row.
+#[allow(dead_code)] // Slice B-2 final task wires this in the scan loop.
+pub(super) fn v2_match_to_entry(m: &MatchResult, path: &Path) -> PackageDbEntry {
+    let purl = m.purl.clone();
+    let version = purl.version().unwrap_or("").to_string();
+    let mut extra: std::collections::BTreeMap<String, serde_json::Value> =
+        Default::default();
+    // Numeric fused-confidence per FR-017 — formatted "X.XX" so the
+    // annotation surface matches C59's documented value space (the
+    // existing v1-path "0.70" string also fits this format).
+    let score_str = format!("{:.2}", m.confidence_score.into_inner());
+    extra.insert(
+        "mikebom:fingerprint-confidence".to_string(),
+        serde_json::Value::String(score_str),
+    );
+    // Indicator-kind count carrier — repurposed from v1's per-symbol
+    // count. v2 records carry typed indicator kinds (exported_symbols /
+    // version_string / build_id / macho_uuid / pe_pdb / abi_marker);
+    // the count tells operators which kinds the matcher fused.
+    extra.insert(
+        "mikebom:fingerprint-symbols-matched".to_string(),
+        serde_json::Value::String(format!(
+            "{}/{}",
+            m.indicators_matched.len(),
+            m.indicators_matched.len()
+        )),
+    );
+    PackageDbEntry {
+        purl,
+        name: derive_name_from_purl(&m.purl),
+        version,
+        arch: None,
+        source_path: path.to_string_lossy().into_owned(),
+        depends: Vec::new(),
+        maintainer: None,
+        licenses: vec![],
+        lifecycle_scope: None,
+        requirement_range: None,
+        source_type: None,
+        sbom_tier: Some("analyzed".to_string()),
+        shade_relocation: None,
+        buildinfo_status: None,
+        evidence_kind: Some("symbol-fingerprint".to_string()),
+        binary_class: None,
+        binary_stripped: None,
+        linkage_kind: None,
+        detected_go: None,
+        confidence: Some("heuristic".to_string()),
+        binary_packed: None,
+        raw_version: None,
+        parent_purl: None,
+        npm_role: None,
+        co_owned_by: None,
+        hashes: Vec::new(),
+        extra_annotations: extra,
+        binary_role: None,
+    }
+}
+
+/// Derive the human-readable `name` field from a PURL. PURL spec parses
+/// `pkg:<type>/<namespace>/<name>@<version>` — we want the bare `<name>`.
+#[allow(dead_code)]
+fn derive_name_from_purl(purl: &Purl) -> String {
+    // The Purl newtype exposes `name()` for this purpose (cf.
+    // mikebom-common/src/types/purl.rs).
+    purl.name().to_string()
 }
 
 /// Convert a curated-scanner match into a `PackageDbEntry`.

--- a/mikebom-cli/src/scan_fs/binary/fingerprints/mod.rs
+++ b/mikebom-cli/src/scan_fs/binary/fingerprints/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod record;
 pub(crate) mod self_identity;
 pub(crate) mod source_config;
 pub(crate) mod source_sha;
+pub(crate) mod v2_bridge;
 
 use std::sync::OnceLock;
 

--- a/mikebom-cli/src/scan_fs/binary/fingerprints/v2_bridge.rs
+++ b/mikebom-cli/src/scan_fs/binary/fingerprints/v2_bridge.rs
@@ -1,0 +1,177 @@
+//! Bridge between the existing `BinaryScan` extractor outputs and the
+//! v2 matcher's `BinaryArtifact` input shape (milestone 110, Phase 4
+//! Slice B-2).
+//!
+//! `BinaryScan` is the existing per-binary aggregate carrying everything
+//! the milestone-001..109 extractors produced. The matcher's
+//! `BinaryArtifact` is a narrower shape — only the fields the indicator
+//! matchers consume. This bridge maps one to the other + supplies the
+//! one piece of derived data the existing struct doesn't carry:
+//! `rodata_strings`, extracted from `BinaryScan.string_region` via a
+//! `strings(1)`-style scan.
+
+use super::matcher::BinaryArtifact;
+
+/// Extract printable ASCII / UTF-8 runs of length >= `min_len` from a
+/// raw `.rodata`-like byte region. Mirrors the classic `strings(1)`
+/// behaviour: a non-printable byte (including NUL) terminates the
+/// current run; runs shorter than `min_len` are discarded.
+///
+/// Bounded by the existing 16 MB string-region cap upstream in
+/// `scan.rs::collect_string_region`; this function does no additional
+/// allocation beyond the output `Vec`.
+#[allow(dead_code)] // Slice B-2 wires this in production scan path.
+pub(crate) fn extract_printable_strings(region: &[u8], min_len: usize) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut run_start: Option<usize> = None;
+
+    for (i, &byte) in region.iter().enumerate() {
+        // Printable subset: ASCII 0x20..=0x7E (space through tilde) +
+        // tab (0x09). Non-ASCII bytes intentionally break runs — full
+        // Unicode rodata extraction is out of scope for the matcher's
+        // substring-pattern use case, which targets curated literal
+        // strings like "OpenSSL 3.1.4" that are pure ASCII anyway.
+        let printable = byte == 0x09 || (0x20..=0x7E).contains(&byte);
+        match (printable, run_start) {
+            (true, None) => run_start = Some(i),
+            (true, Some(_)) => { /* continuation */ }
+            (false, Some(start)) => {
+                if i - start >= min_len {
+                    if let Ok(s) = std::str::from_utf8(&region[start..i]) {
+                        out.push(s.to_string());
+                    }
+                }
+                run_start = None;
+            }
+            (false, None) => { /* skip */ }
+        }
+    }
+    // Tail flush.
+    if let Some(start) = run_start {
+        if region.len() - start >= min_len {
+            if let Ok(s) = std::str::from_utf8(&region[start..]) {
+                out.push(s.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// Construct a matcher-ready `BinaryArtifact` from the existing
+/// `BinaryScan` extractor outputs.
+///
+/// `string_region` is parsed for printable strings via
+/// `extract_printable_strings(..., 4)` (matches the `strings(1)`
+/// default minimum). The build-id / Mach-O LC_UUID / PE PDB GUID
+/// fields are copied through directly.
+#[allow(dead_code)] // Slice B-2 wires this in production scan path.
+pub(crate) fn binary_artifact_from_scan(
+    symbol_names: &[String],
+    string_region: &[u8],
+    build_id: Option<&str>,
+    macho_uuid: Option<&str>,
+    pe_pdb: Option<&str>,
+) -> BinaryArtifact {
+    BinaryArtifact {
+        exported_symbols: symbol_names.to_vec(),
+        rodata_strings: extract_printable_strings(string_region, 4),
+        build_id: build_id.map(str::to_string),
+        macho_uuid: macho_uuid.map(str::to_string),
+        pe_pdb: pe_pdb.map(str::to_string),
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_region_yields_no_strings() {
+        let out = extract_printable_strings(b"", 4);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn extracts_simple_null_separated_strings() {
+        let region = b"hello\0world\0";
+        let out = extract_printable_strings(region, 4);
+        assert_eq!(out, vec!["hello".to_string(), "world".to_string()]);
+    }
+
+    #[test]
+    fn discards_runs_shorter_than_min_len() {
+        let region = b"abc\0longerstring\0xy\0";
+        let out = extract_printable_strings(region, 4);
+        assert_eq!(out, vec!["longerstring".to_string()]);
+    }
+
+    #[test]
+    fn extracts_openssl_version_literal_from_realistic_region() {
+        // Simulates a `.rodata` section containing the OpenSSL version
+        // banner amid filler bytes (NULs + a non-printable byte that
+        // terminates a run).
+        let mut region: Vec<u8> = Vec::new();
+        region.extend_from_slice(b"junk\0");
+        region.extend_from_slice(b"OpenSSL 3.1.4 19 Oct 2023");
+        region.push(0xFF); // non-printable terminator
+        region.extend_from_slice(b"another\0");
+        let out = extract_printable_strings(&region, 4);
+        assert!(out.iter().any(|s| s.contains("OpenSSL 3.1.4")));
+        assert!(out.iter().any(|s| s == "junk"));
+        assert!(out.iter().any(|s| s == "another"));
+    }
+
+    #[test]
+    fn tail_run_is_flushed_when_no_terminator() {
+        let region = b"start\0unterminatedtail";
+        let out = extract_printable_strings(region, 4);
+        assert_eq!(out, vec!["start".to_string(), "unterminatedtail".to_string()]);
+    }
+
+    #[test]
+    fn tab_byte_does_not_terminate_run() {
+        // Tab (0x09) is treated as printable so multi-word strings with
+        // tabs between fields survive intact.
+        let region = b"col1\tcol2\tcol3\0";
+        let out = extract_printable_strings(region, 4);
+        assert_eq!(out, vec!["col1\tcol2\tcol3".to_string()]);
+    }
+
+    #[test]
+    fn high_bit_byte_terminates_run() {
+        // Non-ASCII byte (0x80+) breaks runs. The matcher's substring-
+        // pattern use case targets ASCII literals.
+        let region = b"asciipart\xC3\xA9more";
+        let out = extract_printable_strings(region, 4);
+        assert_eq!(out, vec!["asciipart".to_string(), "more".to_string()]);
+    }
+
+    #[test]
+    fn binary_artifact_from_scan_populates_all_fields() {
+        let symbol_names = vec!["sym1".to_string(), "sym2".to_string()];
+        let region = b"OpenSSL 3.1.4\0";
+        let artifact = binary_artifact_from_scan(
+            &symbol_names,
+            region,
+            Some("abc123"),
+            None,
+            Some("deadbeef:1"),
+        );
+        assert_eq!(artifact.exported_symbols, symbol_names);
+        assert!(artifact.rodata_strings.iter().any(|s| s.contains("OpenSSL 3.1.4")));
+        assert_eq!(artifact.build_id.as_deref(), Some("abc123"));
+        assert!(artifact.macho_uuid.is_none());
+        assert_eq!(artifact.pe_pdb.as_deref(), Some("deadbeef:1"));
+    }
+
+    #[test]
+    fn binary_artifact_from_scan_handles_empty_inputs() {
+        let artifact = binary_artifact_from_scan(&[], b"", None, None, None);
+        assert!(artifact.exported_symbols.is_empty());
+        assert!(artifact.rodata_strings.is_empty());
+        assert!(artifact.build_id.is_none());
+        assert!(artifact.macho_uuid.is_none());
+        assert!(artifact.pe_pdb.is_none());
+    }
+}

--- a/mikebom-cli/src/scan_fs/binary/mod.rs
+++ b/mikebom-cli/src/scan_fs/binary/mod.rs
@@ -43,7 +43,7 @@ mod scan;
 use discover::discover_binaries;
 use entry::{
     cargo_auditable_packages_to_entries, make_file_level_component, note_package_to_entry,
-    symbol_match_to_entry, version_match_to_entry,
+    symbol_match_to_entry, v2_match_to_entry, version_match_to_entry,
 };
 use predicates::{
     detect_rootfs_kind, has_rpmdb_at, is_host_system_path, is_os_managed_directory, RootfsKind,
@@ -141,10 +141,29 @@ pub fn read(
     // binary.
     let fingerprints_opts = fingerprints::LoadOptions::from_env();
     let external_corpus = if fingerprints_opts.external_enabled {
-        Some(fingerprints::load_corpus(fingerprints_opts))
+        Some(fingerprints::load_corpus(fingerprints_opts.clone()))
     } else {
         None
     };
+
+    // Milestone 110 Phase 4 Slice B-2 — load v2 records from the same
+    // per-SHA cache directory the v1 path uses. Coexists with the v1
+    // corpus: a single cache directory MAY contain a mix of v1 and v2
+    // records (peek-at-schema_version dispatch lives in loader.rs).
+    // When no v2 records are present (the current milestone-108 state),
+    // this returns an empty Vec and the v2 matcher path is a no-op.
+    let external_v2_records: Vec<fingerprints::record::CorpusRecordV2> =
+        if external_corpus.is_some() {
+            let sha = fingerprints_opts
+                .sha_override
+                .unwrap_or_else(fingerprints::source_sha::CorpusSha::build_time_embedded);
+            fingerprints::loader::load_v2_records_from_cache(&sha).unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+    let v2_source_id = fingerprints::source_config::CorpusSourceId::from_raw(
+        fingerprints::source_config::CorpusSourceId::MILESTONE_108_DEFAULT.to_string(),
+    );
 
     // Milestone 109 — build the source-tier attribution registry exactly
     // once per scan when the operator opted in via `--fingerprints-corpus`.
@@ -554,6 +573,44 @@ pub fn read(
                     by_library.insert(library_key, entry);
                 }
             }
+
+            // Milestone 110 Phase 4 Slice B-2 — v2 matcher pass.
+            //
+            // After the v1 path has settled, run the v2 matcher against
+            // any v2 records the cache loaded. v2 records carry typed
+            // multi-indicator specs + canonical (often versioned) PURLs;
+            // each non-suppressed match becomes a PackageDbEntry via
+            // entry::v2_match_to_entry.
+            //
+            // CRITICAL ordering: v2 results are merged AFTER v1 + only
+            // for libraries the v1 path didn't already cover (the
+            // `entry()`-vacant gate below). This preserves
+            // milestone-108 byte-identity for the 33 existing
+            // byte-identity goldens — a v2 record that happens to
+            // share a library name with a v1 record does NOT override
+            // the v1 emission. Cross-tier collision handling +
+            // mikebom:also-detected-via cross-references ship in a
+            // follow-on slice (Phase 6 / US4).
+            if !external_v2_records.is_empty() {
+                let artifact = fingerprints::v2_bridge::binary_artifact_from_scan(
+                    &scan.symbol_names,
+                    &scan.string_region,
+                    scan.build_id.as_deref(),
+                    scan.macho_uuid.as_deref(),
+                    scan.pe_pdb_id.as_deref(),
+                );
+                let v2_results = fingerprints::matcher::match_binary(
+                    &artifact,
+                    &external_v2_records,
+                    None, // self-identity ladder lands Phase 6.
+                    &v2_source_id,
+                );
+                for r in v2_results {
+                    let key = r.purl.name().to_lowercase();
+                    by_library.entry(key).or_insert_with(|| v2_match_to_entry(&r, &path));
+                }
+            }
+
             // Deterministic order: sort by PURL string so cross-run
             // golden bytes stay stable.
             let mut new_entries: Vec<PackageDbEntry> =


### PR DESCRIPTION
## Summary

Bridges the v2 matcher (#315) + v2 loader (#316) into the existing `binary/mod.rs` scan loop. v2 records living in the configured fingerprint cache now flow through the matcher and emit as `PackageDbEntry` components alongside the v1 path.

The v2 matcher pipeline is now **end-to-end live in production scans**. When no v2 records exist in the cache (today's milestone-108 default), the v2 path is a no-op — zero v1 regression.

## Critical ordering for byte-identity preservation

v2 results merge **after** v1 and **only for libraries the v1 path didn't already cover** (the `entry().or_insert_with(...)` gate). This preserves milestone-108 byte-identity for the 33 existing byte-identity goldens — a v2 record sharing a library name with a v1 record does NOT override the v1 emission. Cross-tier collision handling + `mikebom:also-detected-via` cross-references ship in a follow-on slice (Phase 6 / US4).

## New helpers

- **`v2_bridge::extract_printable_strings`** — `strings(1)`-style extractor over `BinaryScan.string_region`. ASCII 0x20-0x7E + tab printable; other bytes (incl. NUL + high-bit) terminate runs; runs below `min_len` (default 4) discarded.
- **`v2_bridge::binary_artifact_from_scan`** — converts `BinaryScan` (existing extractor aggregate) → matcher's `BinaryArtifact` input shape.
- **`entry::v2_match_to_entry`** — `MatchResult` → `PackageDbEntry`. Mirrors `symbol_match_to_entry` but uses the matcher's numeric confidence score (`"X.XX"` format) for `mikebom:fingerprint-confidence` rather than v1's hardcoded `"0.70"` baseline. No `mikebom:fingerprint-corpus-sha` annotation on the v2 path — that C58 carrier is v1-specific (12-hex git SHA from the milestone-108 sibling repo); a v2-equivalent annotation ships in a follow-on slice.

## Wiring

- Hoist v2 record loading alongside the existing v1 corpus load (one-time per scan, not per binary).
- After the per-binary v1 symbol-matches loop, construct `BinaryArtifact` via `binary_artifact_from_scan` + call `match_binary` + convert non-conflicting `MatchResult`s to `PackageDbEntry` via `v2_match_to_entry`.

## Test plan

- [x] 9 new unit tests for v2_bridge helpers (rodata extraction edge cases — empty, NUL-separated, short-run discard, tail flush, tab survival, high-bit termination, OpenSSL version literal, BinaryArtifact population)
- [x] `cargo +stable clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo +stable test --workspace` — green (full pre-PR gate). All 1800+ existing tests pass — **zero v1 regression confirmed**
- [x] Verified via grep that no existing test asserts `mikebom:fingerprint-corpus-sha` is the ONLY annotation on fingerprint-derived components (would break if v2 path emitted)

## What's next

Follow-on slice will add a real v2 corpus fixture + an integration test that asserts versioned PURL emission against a known v2 record (end-to-end "scan a binary against a v2 corpus → get pkg:github/openssl/openssl@openssl-3.1.4" verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)