### PR TITLE
feat(fingerprints): multi-source fetch + cache + loader merge (milestone 110 Phase 5-Slim PR 2)

### DIFF
--- a/mikebom-cli/src/scan_fs/binary/fingerprints/cache.rs
+++ b/mikebom-cli/src/scan_fs/binary/fingerprints/cache.rs
@@ -26,6 +26,7 @@
 
 use std::path::PathBuf;
 
+use super::source_config::CorpusSourceId;
 use super::source_sha::CorpusSha;
 
 const CACHE_ENV_OVERRIDE: &str = "MIKEBOM_FINGERPRINTS_CACHE_DIR";
@@ -68,6 +69,48 @@ pub(crate) fn cache_dir_for_sha(sha: &CorpusSha) -> PathBuf {
 #[allow(dead_code)]
 pub(crate) fn cache_hit(sha: &CorpusSha) -> bool {
     cache_dir_for_sha(sha)
+        .join("corpus")
+        .join("index.json")
+        .is_file()
+}
+
+// =====================================================================
+// Per-source cache layout (milestone 110 Phase 5-Slim PR 2)
+// =====================================================================
+//
+// Milestone-110 sources beyond the milestone-108 default get nested
+// `<source-id>/<content-sha>/corpus/` paths. The milestone-108 default
+// keeps the flat `<content-sha>/corpus/` layout to preserve existing
+// caches — no migration; no re-fetch on upgrade. See the PR-2 commit
+// message for the decision rationale.
+//
+// `<source-id>` comes from `CorpusSourceId::from_url(source.url)`.
+// `<content-sha>` is computed at fetch time over the response body
+// (research R3 + the operator's locked Source-SHA-Model choice).
+// Mixing the two layouts on disk is safe because the per-source prefix
+// (a 16-char BASE32 hash) cannot collide with a 40-hex SHA used by
+// the milestone-108 layout.
+
+/// Cache directory for a per-source content SHA.
+/// Layout: `<cache-root>/<source-id>/<content-sha>/`.
+#[allow(dead_code)]
+pub(crate) fn cache_dir_for_source(
+    source_id: &CorpusSourceId,
+    content_sha: &CorpusSha,
+) -> PathBuf {
+    cache_root()
+        .join(source_id.as_str())
+        .join(content_sha.to_full_hex())
+}
+
+/// True when the per-source cache contains a loadable corpus for the
+/// given source + content SHA combination.
+#[allow(dead_code)]
+pub(crate) fn cache_hit_for_source(
+    source_id: &CorpusSourceId,
+    content_sha: &CorpusSha,
+) -> bool {
+    cache_dir_for_source(source_id, content_sha)
         .join("corpus")
         .join("index.json")
         .is_file()
@@ -184,6 +227,53 @@ mod tests {
         assert_eq!(removed.len(), 2);
         assert!(!tmp.path().join(SAMPLE_SHA).exists());
         assert!(!tmp.path().join(ALT_SHA).exists());
+        unsafe {
+            std::env::remove_var(CACHE_ENV_OVERRIDE);
+        }
+    }
+
+    // ============================================================
+    // Per-source layout tests (milestone 110 Phase 5-Slim PR 2)
+    // ============================================================
+
+    #[test]
+    fn cache_dir_for_source_nests_source_id_then_sha() {
+        let _g = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let path_str = tmp.path().to_string_lossy().into_owned();
+        unsafe {
+            std::env::set_var(CACHE_ENV_OVERRIDE, &path_str);
+        }
+        let source_id = CorpusSourceId::from_url("https://corpus.example/x.tar.gz");
+        let sha = CorpusSha::from_hex(SAMPLE_SHA).unwrap();
+        let dir = cache_dir_for_source(&source_id, &sha);
+        // <root>/<source-id>/<full-sha>/
+        let expected = tmp.path().join(source_id.as_str()).join(SAMPLE_SHA);
+        assert_eq!(dir, expected);
+        unsafe {
+            std::env::remove_var(CACHE_ENV_OVERRIDE);
+        }
+    }
+
+    #[test]
+    fn cache_hit_for_source_requires_index_json() {
+        let _g = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let path_str = tmp.path().to_string_lossy().into_owned();
+        unsafe {
+            std::env::set_var(CACHE_ENV_OVERRIDE, &path_str);
+        }
+        let source_id = CorpusSourceId::from_url("https://corpus.example/x.tar.gz");
+        let sha = CorpusSha::from_hex(SAMPLE_SHA).unwrap();
+        // Missing dir → no hit.
+        assert!(!cache_hit_for_source(&source_id, &sha));
+        // Dir present but no index.json → still no hit.
+        let dir = cache_dir_for_source(&source_id, &sha).join("corpus");
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(!cache_hit_for_source(&source_id, &sha));
+        // index.json present → hit.
+        std::fs::write(dir.join("index.json"), r#"{"version":1,"entries":[]}"#).unwrap();
+        assert!(cache_hit_for_source(&source_id, &sha));
         unsafe {
             std::env::remove_var(CACHE_ENV_OVERRIDE);
         }

--- a/mikebom-cli/src/scan_fs/binary/fingerprints/fetch.rs
+++ b/mikebom-cli/src/scan_fs/binary/fingerprints/fetch.rs
@@ -9,9 +9,11 @@ use std::io::Read;
 use std::path::Path;
 use std::time::Duration;
 
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 use super::cache;
+use super::source_config::{CorpusSource, CorpusSourceId};
 use super::source_sha::CorpusSha;
 
 const PRODUCTION_BASE_URL: &str = "https://github.com";
@@ -291,6 +293,232 @@ fn corpus_filename_from_tar_path(path: &Path) -> Option<String> {
         return None;
     }
     Some(name.to_string())
+}
+
+// =====================================================================
+// Per-source arbitrary-URL fetcher (milestone 110 Phase 5-Slim PR 2)
+// =====================================================================
+//
+// `fetch_arbitrary_source` downloads a corpus tarball directly from a
+// caller-supplied URL (no SHA-pinned URL construction like the
+// milestone-108 default), computes a content SHA-256 over the response
+// body, and extracts to the per-source cache path
+// `<cache_root>/<source-id>/<content-sha>/corpus/`. Returns the
+// computed content SHA so the caller can persist it for later loads.
+//
+// What this fetcher does NOT yet do (deferred to follow-on slices):
+// - bearer-token auth (FR-007): no `Authorization` header is attached
+// - sigstore signature verification (FR-008): the archive is trusted
+//   on the strength of TLS alone, matching the milestone-108 default's
+//   current production posture
+// - TTL-based cache freshness (FR-012a): a cache hit is "exists"; no
+//   mtime / last_used.touch is consulted
+
+/// Result of a per-source fetch attempt. Returned by
+/// `fetch_arbitrary_source` so the orchestrator can record per-source
+/// status without needing a second filesystem stat.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FetchedSourceOutcome {
+    pub content_sha: CorpusSha,
+    /// True when the bytes were re-fetched from the network; false
+    /// when an existing per-source cache directory satisfied the
+    /// request without I/O. Phase 5-Slim has no TTL, so this becomes
+    /// `false` only when an upstream caller pre-populated the cache
+    /// (e.g. a previous scan in the same session) — the production
+    /// scan path always re-fetches at scan startup.
+    pub from_network: bool,
+}
+
+/// Fetch a single arbitrary corpus source. Production entry point for
+/// PR-2's orchestrator. Reads `source.url` directly and writes to the
+/// per-source cache path.
+#[allow(dead_code)]
+pub(crate) fn fetch_arbitrary_source(
+    source: &CorpusSource,
+) -> Result<FetchedSourceOutcome, FetchError> {
+    let cache_root = cache::cache_root();
+    fetch_arbitrary_source_to(source, &cache_root)
+}
+
+/// Internal helper that production + tests share. `cache_root` lets
+/// tests redirect writes into a tempdir. Wraps the blocking reqwest
+/// client in a fresh OS thread for the same reason as
+/// `fetch_corpus_to` (avoid panicking inside a tokio runtime).
+#[allow(dead_code)]
+pub(crate) fn fetch_arbitrary_source_to(
+    source: &CorpusSource,
+    cache_root: &Path,
+) -> Result<FetchedSourceOutcome, FetchError> {
+    let source = source.clone();
+    let cache_root = cache_root.to_path_buf();
+    std::thread::scope(|s| {
+        s.spawn(move || fetch_arbitrary_source_blocking(&source, &cache_root))
+            .join()
+            .map_err(|_| FetchError::Network("fetch thread panicked".to_string()))?
+    })
+}
+
+fn fetch_arbitrary_source_blocking(
+    source: &CorpusSource,
+    cache_root: &Path,
+) -> Result<FetchedSourceOutcome, FetchError> {
+    tracing::info!(
+        source_url = %source.url,
+        source_id = %source.source_id,
+        "fetching multi-source fingerprint corpus",
+    );
+    let client = build_client()?;
+    // Reuse the same retry / Retry-After policy as the milestone-108
+    // default fetcher; per-source error categorization happens at the
+    // orchestrator layer (PR-2 multi_source.rs).
+    let response = perform_get_arbitrary_with_retry(&client, &source.url)?;
+    let body = response
+        .bytes()
+        .map_err(|e| FetchError::Network(e.to_string()))?;
+
+    let content_sha = sha256_of(&body);
+    extract_to_source_cache(&source.source_id, &content_sha, &body, cache_root)?;
+    Ok(FetchedSourceOutcome {
+        content_sha,
+        from_network: true,
+    })
+}
+
+/// Per-source variant of `perform_get_with_retry` that does NOT
+/// translate 404 into the milestone-108 `NotFound { sha }` variant
+/// (an arbitrary source URL's 404 is just an HTTP error, not a
+/// SHA-pinning bug). Other-4xx still no-retry; 5xx + 429 + network
+/// errors still retry per the milestone-108 policy.
+fn perform_get_arbitrary_with_retry(
+    client: &reqwest::blocking::Client,
+    url: &str,
+) -> Result<reqwest::blocking::Response, FetchError> {
+    let mut last_status: Option<u16> = None;
+    for attempt in 0..MAX_RETRY_ATTEMPTS {
+        match client.get(url).send() {
+            Ok(response) => {
+                let status = response.status();
+                if status.is_success() {
+                    return Ok(response);
+                }
+                if status.as_u16() == 429 {
+                    let retry_after = response
+                        .headers()
+                        .get(reqwest::header::RETRY_AFTER)
+                        .and_then(|v| v.to_str().ok())
+                        .and_then(|s| s.parse::<u64>().ok())
+                        .map(|secs| Duration::from_secs(secs).min(RETRY_AFTER_CAP))
+                        .unwrap_or_else(|| backoff_for(attempt));
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        sleep_secs = retry_after.as_secs(),
+                        url,
+                        "arbitrary corpus source rate-limited; sleeping per Retry-After",
+                    );
+                    std::thread::sleep(retry_after);
+                    last_status = Some(429);
+                    continue;
+                }
+                if status.is_server_error() {
+                    let sleep = backoff_for(attempt);
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        status = status.as_u16(),
+                        sleep_secs = sleep.as_secs(),
+                        url,
+                        "arbitrary corpus source server error; retrying",
+                    );
+                    std::thread::sleep(sleep);
+                    last_status = Some(status.as_u16());
+                    continue;
+                }
+                return Err(FetchError::HttpError {
+                    status: status.as_u16(),
+                    attempts: attempt + 1,
+                });
+            }
+            Err(e) => {
+                let sleep = backoff_for(attempt);
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    error = %e,
+                    sleep_secs = sleep.as_secs(),
+                    url,
+                    "arbitrary corpus source network error; retrying",
+                );
+                if attempt + 1 == MAX_RETRY_ATTEMPTS {
+                    return Err(FetchError::Network(e.to_string()));
+                }
+                std::thread::sleep(sleep);
+            }
+        }
+    }
+    Err(FetchError::HttpError {
+        status: last_status.unwrap_or(0),
+        attempts: MAX_RETRY_ATTEMPTS,
+    })
+}
+
+fn sha256_of(bytes: &[u8]) -> CorpusSha {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for b in &digest[..] {
+        hex.push_str(&format!("{b:02x}"));
+    }
+    // The CorpusSha type historically holds 40 hex chars (git-style)
+    // because the milestone-108 default URL is constructed from a
+    // 40-char Git SHA. For content-addressed cache keys we truncate
+    // the sha256 to its leading 40 hex chars — collision resistance
+    // is still 160 bits, well above the cache-key needs. The leading
+    // bytes give the same locality + alphabet so the existing path-
+    // building helpers (`to_full_hex`, `to_short_hex`) keep working.
+    let truncated = &hex[..40];
+    CorpusSha::from_hex(truncated).expect("sha256 hex is always valid")
+}
+
+fn extract_to_source_cache(
+    source_id: &CorpusSourceId,
+    content_sha: &CorpusSha,
+    body: &[u8],
+    cache_root: &Path,
+) -> Result<(), FetchError> {
+    let source_root = cache_root.join(source_id.as_str());
+    std::fs::create_dir_all(&source_root).map_err(|e| FetchError::Io(e.to_string()))?;
+
+    let staging = source_root.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
+    let staging_corpus = staging.join("corpus");
+    std::fs::create_dir_all(&staging_corpus)
+        .map_err(|e| FetchError::Io(e.to_string()))?;
+
+    if let Err(e) = extract_corpus_into(body, &staging_corpus) {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(e);
+    }
+
+    let dest = source_root.join(content_sha.to_full_hex());
+    if dest.exists() {
+        let _ = std::fs::remove_dir_all(&staging);
+        tracing::debug!(
+            source_id = %source_id,
+            content_sha = %content_sha.to_full_hex(),
+            "concurrent writer beat us to the per-source cache; using existing entry",
+        );
+        return Ok(());
+    }
+    std::fs::rename(&staging, &dest).map_err(|e| {
+        if dest.exists() {
+            let _ = std::fs::remove_dir_all(&staging);
+            return FetchError::Io(format!(
+                "concurrent writer race (cleaned up staging): {e}"
+            ));
+        }
+        let _ = std::fs::remove_dir_all(&staging);
+        FetchError::Io(e.to_string())
+    })?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -613,5 +841,158 @@ mod tests {
             "mikebom-fingerprints-fff39c6/corpus/file.txt"
         ))
         .is_none());
+    }
+
+    // ============================================================
+    // Per-source arbitrary-URL fetcher tests (Phase 5-Slim PR 2)
+    // ============================================================
+
+    fn build_arbitrary_corpus_tarball() -> Vec<u8> {
+        // Same payload shape as the milestone-108 tarball but with a
+        // generic wrapper directory name + a single v2 record.
+        let mut tar_bytes: Vec<u8> = Vec::new();
+        {
+            let enc = flate2::write::GzEncoder::new(
+                &mut tar_bytes,
+                flate2::Compression::default(),
+            );
+            let mut builder = tar::Builder::new(enc);
+            let wrapper = "extras-v2/";
+            for name in ["index.json", "libxyz.json"] {
+                let payload: &[u8] = match name {
+                    "index.json" => br#"{"version":1,"entries":[{"library":"libxyz","path":"libxyz.json"}]}"#,
+                    "libxyz.json" => br#"{
+                        "id":"libxyz-1.0",
+                        "purl":"pkg:github/example/libxyz@1.0.0",
+                        "version_range":"1.0",
+                        "indicators":{
+                            "exported_symbols":{
+                                "type":"symbol-set",
+                                "required":["xyz_init","xyz_run","xyz_done"],
+                                "min_match":2,
+                                "confidence_baseline":0.70
+                            }
+                        },
+                        "provenance":{
+                            "tier":"manual-curation",
+                            "extracted_from":"https://example.com/libxyz",
+                            "extracted_from_sha256":"0000000000000000000000000000000000000000000000000000000000000000",
+                            "extraction_toolchain":"test-fixture",
+                            "extracted_at":"2026-06-01T12:00:00Z"
+                        },
+                        "schema_version":2
+                    }"#,
+                    _ => unreachable!(),
+                };
+                let mut header = tar::Header::new_gnu();
+                header.set_path(format!("{wrapper}corpus/{name}")).unwrap();
+                header.set_size(payload.len() as u64);
+                header.set_mode(0o644);
+                header.set_cksum();
+                builder.append(&header, payload).unwrap();
+            }
+            let mut enc = builder.into_inner().unwrap();
+            enc.flush().unwrap();
+            enc.finish().unwrap();
+        }
+        tar_bytes
+    }
+
+    #[test]
+    fn fetch_arbitrary_source_writes_to_per_source_layout() {
+        let _g = env_lock();
+        let tarball = build_arbitrary_corpus_tarball();
+        let tarball_for_mock = tarball.clone();
+        let harness = WiremockHarness::new(|rt, server| {
+            rt.block_on(async {
+                Mock::given(method("GET"))
+                    .and(path_regex(r"/.+\.tar\.gz"))
+                    .respond_with(
+                        ResponseTemplate::new(200)
+                            .set_body_bytes(tarball_for_mock.clone())
+                            .insert_header("content-type", "application/x-gzip"),
+                    )
+                    .mount(server)
+                    .await;
+            });
+        });
+        let tmp = tempfile::tempdir().unwrap();
+        let url = format!("{}/extras.tar.gz", harness.base_url);
+        let source = CorpusSource::unauthenticated(url.clone());
+        let outcome = fetch_arbitrary_source_to(&source, tmp.path()).unwrap();
+
+        // Per-source layout: <root>/<source-id>/<content-sha>/corpus/...
+        let dest = tmp
+            .path()
+            .join(source.source_id.as_str())
+            .join(outcome.content_sha.to_full_hex())
+            .join("corpus");
+        assert!(dest.join("index.json").exists());
+        assert!(dest.join("libxyz.json").exists());
+        // Content SHA is derived from the body — passing the same
+        // bytes twice yields the same key.
+        let outcome2 = fetch_arbitrary_source_to(&source, tmp.path()).unwrap();
+        assert_eq!(outcome.content_sha, outcome2.content_sha);
+    }
+
+    #[test]
+    fn fetch_arbitrary_source_returns_http_error_on_4xx() {
+        let _g = env_lock();
+        let harness = WiremockHarness::new(|rt, server| {
+            rt.block_on(async {
+                Mock::given(method("GET"))
+                    .and(path_regex(r"/.+\.tar\.gz"))
+                    .respond_with(ResponseTemplate::new(403))
+                    .mount(server)
+                    .await;
+            });
+        });
+        let tmp = tempfile::tempdir().unwrap();
+        let url = format!("{}/private.tar.gz", harness.base_url);
+        let source = CorpusSource::unauthenticated(url);
+        let err = fetch_arbitrary_source_to(&source, tmp.path()).unwrap_err();
+        assert!(matches!(err, FetchError::HttpError { status: 403, .. }));
+        // No partial cache written.
+        let entries: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn fetch_arbitrary_source_cleans_up_on_malformed_archive() {
+        let _g = env_lock();
+        let bad_tarball = build_invalid_tarball_with_no_corpus_entries();
+        let harness = WiremockHarness::new(|rt, server| {
+            rt.block_on(async {
+                Mock::given(method("GET"))
+                    .and(path_regex(r"/.+\.tar\.gz"))
+                    .respond_with(
+                        ResponseTemplate::new(200)
+                            .set_body_bytes(bad_tarball.clone())
+                            .insert_header("content-type", "application/x-gzip"),
+                    )
+                    .mount(server)
+                    .await;
+            });
+        });
+        let tmp = tempfile::tempdir().unwrap();
+        let url = format!("{}/extras.tar.gz", harness.base_url);
+        let source = CorpusSource::unauthenticated(url);
+        let err = fetch_arbitrary_source_to(&source, tmp.path()).unwrap_err();
+        assert!(matches!(err, FetchError::Extraction(_)));
+        // No staging dir left behind under the source-id parent.
+        let source_root = tmp.path().join(source.source_id.as_str());
+        if source_root.exists() {
+            let leftover: Vec<_> = std::fs::read_dir(&source_root)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .collect();
+            assert!(
+                leftover.is_empty(),
+                "expected empty source root after extraction failure; got {leftover:?}"
+            );
+        }
     }
 }

--- a/mikebom-cli/src/scan_fs/binary/fingerprints/loader.rs
+++ b/mikebom-cli/src/scan_fs/binary/fingerprints/loader.rs
@@ -28,6 +28,7 @@ use thiserror::Error;
 
 use super::cache;
 use super::record::{CorpusRecordV2, FingerprintRecord};
+use super::source_config::CorpusSourceId;
 use super::source_sha::CorpusSha;
 
 #[allow(dead_code)]
@@ -156,6 +157,46 @@ pub(crate) fn load_v2_records_from_cache(
     sha: &CorpusSha,
 ) -> Result<Vec<CorpusRecordV2>, LoaderError> {
     let dir = cache::cache_dir_for_sha(sha);
+    let corpus_dir = dir.join("corpus");
+    let index_path = corpus_dir.join("index.json");
+
+    let index_text = std::fs::read_to_string(&index_path).map_err(|_| {
+        LoaderError::CacheNotFound {
+            path: index_path.display().to_string(),
+        }
+    })?;
+
+    let index: CorpusIndex = serde_json::from_str(&index_text).map_err(|e| {
+        LoaderError::CacheCorrupt {
+            path: index_path.display().to_string(),
+            reason: format!("index.json parse failed: {e}"),
+        }
+    })?;
+
+    if index.version != 1 {
+        return Err(LoaderError::CacheCorrupt {
+            path: index_path.display().to_string(),
+            reason: format!("unsupported index version: {}", index.version),
+        });
+    }
+
+    Ok(load_per_library_v2_records(&corpus_dir, &index))
+}
+
+/// Load v2 records from a per-source cache directory (milestone 110
+/// Phase 5-Slim PR 2). Same parsing logic as `load_v2_records_from_cache`
+/// but reads from `<cache-root>/<source-id>/<content-sha>/corpus/`
+/// instead of `<cache-root>/<content-sha>/corpus/`.
+///
+/// Returns an empty Vec for a per-source cache that happens to contain
+/// only v1 records — the multi-source orchestrator (PR-2 multi_source.rs)
+/// treats that as "this source has no v2 contribution" and continues.
+#[allow(dead_code)]
+pub(crate) fn load_v2_records_from_source_cache(
+    source_id: &CorpusSourceId,
+    content_sha: &CorpusSha,
+) -> Result<Vec<CorpusRecordV2>, LoaderError> {
+    let dir = cache::cache_dir_for_source(source_id, content_sha);
     let corpus_dir = dir.join("corpus");
     let index_path = corpus_dir.join("index.json");
 
@@ -575,6 +616,108 @@ mod tests {
         }
         let err = load_v2_records_from_cache(&sha).unwrap_err();
         assert!(matches!(err, LoaderError::CacheNotFound { .. }));
+        unsafe {
+            std::env::remove_var("MIKEBOM_FINGERPRINTS_CACHE_DIR");
+        }
+    }
+
+    // ============================================================
+    // Per-source loader tests (milestone 110 Phase 5-Slim PR 2)
+    // ============================================================
+
+    fn setup_per_source_cache(
+        source_id: &CorpusSourceId,
+        content_sha: &CorpusSha,
+        v2_libs: &[&str],
+    ) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        let corpus_dir = tmp
+            .path()
+            .join(source_id.as_str())
+            .join(content_sha.to_full_hex())
+            .join("corpus");
+        std::fs::create_dir_all(&corpus_dir).unwrap();
+        for lib in v2_libs {
+            write_v2_record(&corpus_dir, &format!("{lib}-1.0"), lib);
+        }
+        write_index(&corpus_dir, v2_libs);
+        tmp
+    }
+
+    #[test]
+    fn per_source_loader_reads_nested_layout() {
+        let _g = env_lock();
+        let source_id = CorpusSourceId::from_url("https://corpus.example/extras.tar.gz");
+        let sha = CorpusSha::from_hex(SAMPLE_SHA).unwrap();
+        let tmp = setup_per_source_cache(&source_id, &sha, &["libfoo", "libbar"]);
+        let path_str = tmp.path().to_string_lossy().into_owned();
+        unsafe {
+            std::env::set_var("MIKEBOM_FINGERPRINTS_CACHE_DIR", &path_str);
+        }
+        let records = load_v2_records_from_source_cache(&source_id, &sha).unwrap();
+        assert_eq!(records.len(), 2);
+        let mut ids: Vec<String> = records.iter().map(|r| r.id.clone()).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["libbar-1.0".to_string(), "libfoo-1.0".to_string()]);
+        unsafe {
+            std::env::remove_var("MIKEBOM_FINGERPRINTS_CACHE_DIR");
+        }
+    }
+
+    #[test]
+    fn per_source_loader_returns_not_found_for_missing_layout() {
+        let _g = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let path_str = tmp.path().to_string_lossy().into_owned();
+        unsafe {
+            std::env::set_var("MIKEBOM_FINGERPRINTS_CACHE_DIR", &path_str);
+        }
+        let source_id = CorpusSourceId::from_url("https://corpus.example/nope.tar.gz");
+        let sha = CorpusSha::from_hex(SAMPLE_SHA).unwrap();
+        let err = load_v2_records_from_source_cache(&source_id, &sha).unwrap_err();
+        assert!(matches!(err, LoaderError::CacheNotFound { .. }));
+        unsafe {
+            std::env::remove_var("MIKEBOM_FINGERPRINTS_CACHE_DIR");
+        }
+    }
+
+    #[test]
+    fn per_source_and_flat_layouts_coexist() {
+        // The milestone-108 default uses the flat `<sha>/` layout;
+        // arbitrary sources nest under `<source-id>/<sha>/`. Both
+        // must load cleanly from the same cache root in one scan.
+        let _g = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let path_str = tmp.path().to_string_lossy().into_owned();
+        unsafe {
+            std::env::set_var("MIKEBOM_FINGERPRINTS_CACHE_DIR", &path_str);
+        }
+        // Flat layout for the milestone-108 default.
+        let default_sha = CorpusSha::from_hex(SAMPLE_SHA).unwrap();
+        let default_dir = tmp.path().join(default_sha.to_full_hex()).join("corpus");
+        std::fs::create_dir_all(&default_dir).unwrap();
+        write_v2_record(&default_dir, "openssl-1.0", "openssl");
+        write_index(&default_dir, &["openssl"]);
+        // Nested layout for an arbitrary source.
+        let arb_source_id = CorpusSourceId::from_url("https://corpus.example/extra.tar.gz");
+        let arb_sha =
+            CorpusSha::from_hex("0123456789abcdef0123456789abcdef01234567").unwrap();
+        let arb_dir = tmp
+            .path()
+            .join(arb_source_id.as_str())
+            .join(arb_sha.to_full_hex())
+            .join("corpus");
+        std::fs::create_dir_all(&arb_dir).unwrap();
+        write_v2_record(&arb_dir, "libxyz-1.0", "libxyz");
+        write_index(&arb_dir, &["libxyz"]);
+
+        let default_recs = load_v2_records_from_cache(&default_sha).unwrap();
+        assert_eq!(default_recs.len(), 1);
+        assert_eq!(default_recs[0].id, "openssl-1.0");
+        let extra_recs =
+            load_v2_records_from_source_cache(&arb_source_id, &arb_sha).unwrap();
+        assert_eq!(extra_recs.len(), 1);
+        assert_eq!(extra_recs[0].id, "libxyz-1.0");
         unsafe {
             std::env::remove_var("MIKEBOM_FINGERPRINTS_CACHE_DIR");
         }

--- a/mikebom-cli/src/scan_fs/binary/fingerprints/mod.rs
+++ b/mikebom-cli/src/scan_fs/binary/fingerprints/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod confidence;
 pub(crate) mod fetch;
 pub(crate) mod loader;
 pub(crate) mod matcher;
+pub(crate) mod multi_source;
 pub(crate) mod record;
 pub(crate) mod self_identity;
 pub(crate) mod source_config;

--- a/mikebom-cli/src/scan_fs/binary/fingerprints/multi_source.rs
+++ b/mikebom-cli/src/scan_fs/binary/fingerprints/multi_source.rs
@@ -1,0 +1,525 @@
+//! Multi-source corpus orchestrator (milestone 110 Phase 5-Slim PR 2).
+//!
+//! Given a `&[CorpusSource]` materialized by [`crate::scan_fs::binary::
+//! fingerprints::source_config::Sources::materialize`], this module:
+//!   - Fetches each source's tarball (the milestone-108 default via
+//!     the build-time-embedded SHA path; arbitrary sources via the
+//!     new content-SHA path)
+//!   - Loads v2 records from each per-source cache directory
+//!   - Merges the results into a single `Vec<CorpusRecordV2>`
+//!   - Records per-source success / failure status with the
+//!     `contracts/cli-flags.md` SC-005 categorization
+//!
+//! Behavior matrix (PR-2 of the slim slice):
+//!
+//! | Source                  | Offline | Fetch path                | Loader path                          |
+//! |-------------------------|---------|---------------------------|--------------------------------------|
+//! | milestone-108 default   | false   | `fetch::fetch_corpus`     | `load_v2_records_from_cache`         |
+//! | milestone-108 default   | true    | skip                      | `load_v2_records_from_cache` (cache) |
+//! | arbitrary               | false   | `fetch_arbitrary_source`  | `load_v2_records_from_source_cache`  |
+//! | arbitrary               | true    | skip + warn               | n/a                                  |
+//!
+//! What this orchestrator does NOT yet do (deferred to follow-on slices):
+//!   - bearer-token auth per source (FR-007)
+//!   - sigstore signature verification (FR-008)
+//!   - 24-hour TTL cache freshness (FR-012a) — non-default sources are
+//!     re-fetched every scan in Phase 5-Slim, matching the user-locked
+//!     "defer TTL" scope
+//!
+//! PR-2 lands this code as DEAD CODE behind `#[allow(dead_code)]`;
+//! PR-3 wires `load_corpus` to dispatch here when extras are
+//! configured.
+
+use super::cache;
+use super::fetch;
+use super::loader;
+use super::record::CorpusRecordV2;
+use super::source_config::{CorpusSource, CorpusSourceId};
+use super::source_sha::CorpusSha;
+
+/// Outcome of `fetch_and_load_multi_source`. Records carry the merged
+/// v2 records from every successful source; `per_source` lets callers
+/// surface diagnostics for the partial-failure case.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) struct MultiSourceLoadResult {
+    pub records: Vec<CorpusRecordV2>,
+    pub per_source: Vec<SourceLoadStatus>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) struct SourceLoadStatus {
+    pub source_id: CorpusSourceId,
+    pub url: String,
+    pub outcome: SourceOutcome,
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) enum SourceOutcome {
+    /// Records loaded successfully — either from a fresh fetch or
+    /// from a populated cache. `content_sha` identifies the cache
+    /// directory the records came from.
+    Loaded {
+        content_sha: CorpusSha,
+        record_count: usize,
+    },
+    /// Source skipped — offline mode + arbitrary source (cannot
+    /// resolve content SHA without network).
+    SkippedOffline,
+    /// Source failed; categorized per `contracts/cli-flags.md` SC-005.
+    Failed {
+        category: SourceFailureCategory,
+        message: String,
+    },
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceFailureCategory {
+    /// DNS / connect / timeout / 4xx other than 401-403 / 5xx after retries.
+    NetworkUnreachable,
+    /// Tarball decompression failed or no `corpus/` entries inside.
+    ArchiveMalformed,
+    /// Cache loader rejected the extracted index or records (post-fetch).
+    LoaderRejected,
+    // FR-007 deferred:    MissingCredential, InvalidCredential.
+    // FR-008 deferred:    SignatureMismatch.
+}
+
+impl SourceFailureCategory {
+    /// Human-readable token for SBOM annotations / log lines per
+    /// `contracts/cli-flags.md` SC-005.
+    #[allow(dead_code)]
+    pub(crate) fn token(self) -> &'static str {
+        match self {
+            Self::NetworkUnreachable => "network-unreachable",
+            Self::ArchiveMalformed => "archive-malformed",
+            Self::LoaderRejected => "loader-rejected",
+        }
+    }
+}
+
+/// Fetch + load v2 records from each configured source. Returns
+/// merged records + per-source diagnostics. Per-source failures are
+/// logged via `tracing::warn!` AND captured in `per_source` so the
+/// caller can decide whether to surface them in the SBOM.
+///
+/// The `sha_override` parameter is the milestone-108 US5 runtime SHA
+/// override (`--fingerprints-rev`). It applies ONLY to the milestone-
+/// 108 default source; arbitrary sources resolve their content SHA
+/// from the fetched bytes.
+#[allow(dead_code)]
+pub(crate) fn fetch_and_load_multi_source(
+    sources: &[CorpusSource],
+    offline: bool,
+    sha_override: Option<CorpusSha>,
+) -> MultiSourceLoadResult {
+    let mut records: Vec<CorpusRecordV2> = Vec::new();
+    let mut per_source: Vec<SourceLoadStatus> = Vec::with_capacity(sources.len());
+    for source in sources {
+        let outcome = if is_milestone_108_default(source) {
+            fetch_and_load_default(sha_override, offline)
+        } else {
+            fetch_and_load_arbitrary(source, offline)
+        };
+        match &outcome {
+            SourceOutcome::Loaded { content_sha, record_count } => {
+                tracing::info!(
+                    source_url = %source.url,
+                    source_id = %source.source_id,
+                    content_sha = %content_sha.to_full_hex(),
+                    record_count,
+                    "fingerprint corpus source loaded",
+                );
+                // Load records and merge.
+                let recs = if is_milestone_108_default(source) {
+                    loader::load_v2_records_from_cache(content_sha)
+                } else {
+                    loader::load_v2_records_from_source_cache(
+                        &source.source_id,
+                        content_sha,
+                    )
+                };
+                if let Ok(mut recs) = recs {
+                    records.append(&mut recs);
+                }
+            }
+            SourceOutcome::SkippedOffline => {
+                tracing::warn!(
+                    source_url = %source.url,
+                    "fingerprint corpus source skipped (offline mode + no usable cache); \
+                     other sources unaffected. Run without --offline to fetch this source.",
+                );
+            }
+            SourceOutcome::Failed { category, message } => {
+                tracing::warn!(
+                    source_url = %source.url,
+                    category = category.token(),
+                    error = %message,
+                    "fingerprint corpus source failed; skipping this source for this scan. \
+                     Other sources unaffected.",
+                );
+            }
+        }
+        per_source.push(SourceLoadStatus {
+            source_id: source.source_id.clone(),
+            url: source.url.clone(),
+            outcome,
+        });
+    }
+    MultiSourceLoadResult { records, per_source }
+}
+
+fn is_milestone_108_default(source: &CorpusSource) -> bool {
+    source.source_id.as_str() == CorpusSourceId::MILESTONE_108_DEFAULT
+}
+
+fn fetch_and_load_default(sha_override: Option<CorpusSha>, offline: bool) -> SourceOutcome {
+    let sha = sha_override.unwrap_or_else(CorpusSha::build_time_embedded);
+    if cache::cache_hit(&sha) {
+        return load_default_records_or_fail(&sha);
+    }
+    if offline {
+        return SourceOutcome::Failed {
+            category: SourceFailureCategory::NetworkUnreachable,
+            message: "offline mode set; cache empty for milestone-108 default".to_string(),
+        };
+    }
+    match fetch::fetch_corpus(&sha) {
+        Ok(()) => load_default_records_or_fail(&sha),
+        Err(e) => SourceOutcome::Failed {
+            category: categorize_fetch_error(&e),
+            message: e.to_string(),
+        },
+    }
+}
+
+fn load_default_records_or_fail(sha: &CorpusSha) -> SourceOutcome {
+    match loader::load_v2_records_from_cache(sha) {
+        Ok(records) => SourceOutcome::Loaded {
+            content_sha: *sha,
+            record_count: records.len(),
+        },
+        Err(e) => SourceOutcome::Failed {
+            category: SourceFailureCategory::LoaderRejected,
+            message: e.to_string(),
+        },
+    }
+}
+
+fn fetch_and_load_arbitrary(source: &CorpusSource, offline: bool) -> SourceOutcome {
+    if offline {
+        return SourceOutcome::SkippedOffline;
+    }
+    match fetch::fetch_arbitrary_source(source) {
+        Ok(outcome) => load_arbitrary_records_or_fail(source, &outcome.content_sha),
+        Err(e) => SourceOutcome::Failed {
+            category: categorize_fetch_error(&e),
+            message: e.to_string(),
+        },
+    }
+}
+
+fn load_arbitrary_records_or_fail(
+    source: &CorpusSource,
+    content_sha: &CorpusSha,
+) -> SourceOutcome {
+    match loader::load_v2_records_from_source_cache(&source.source_id, content_sha) {
+        Ok(records) => SourceOutcome::Loaded {
+            content_sha: *content_sha,
+            record_count: records.len(),
+        },
+        Err(e) => SourceOutcome::Failed {
+            category: SourceFailureCategory::LoaderRejected,
+            message: e.to_string(),
+        },
+    }
+}
+
+fn categorize_fetch_error(err: &fetch::FetchError) -> SourceFailureCategory {
+    match err {
+        fetch::FetchError::Network(_)
+        | fetch::FetchError::NotFound { .. }
+        | fetch::FetchError::HttpError { .. } => SourceFailureCategory::NetworkUnreachable,
+        fetch::FetchError::Decompression(_)
+        | fetch::FetchError::Extraction(_) => SourceFailureCategory::ArchiveMalformed,
+        fetch::FetchError::Io(_) => SourceFailureCategory::LoaderRejected,
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_failure_category_tokens_are_stable() {
+        // The token strings are part of the operator-facing log
+        // contract per SC-005; pin them here so they don't drift.
+        assert_eq!(
+            SourceFailureCategory::NetworkUnreachable.token(),
+            "network-unreachable"
+        );
+        assert_eq!(
+            SourceFailureCategory::ArchiveMalformed.token(),
+            "archive-malformed"
+        );
+        assert_eq!(
+            SourceFailureCategory::LoaderRejected.token(),
+            "loader-rejected"
+        );
+    }
+
+    #[test]
+    fn is_milestone_108_default_matches_sentinel() {
+        let default_src = CorpusSource::milestone_108_default();
+        assert!(is_milestone_108_default(&default_src));
+        let arbitrary =
+            CorpusSource::unauthenticated("https://corpus.example/x.tar.gz".to_string());
+        assert!(!is_milestone_108_default(&arbitrary));
+    }
+
+    #[test]
+    fn categorize_fetch_error_maps_network_variants() {
+        assert_eq!(
+            categorize_fetch_error(&fetch::FetchError::Network("dns".to_string())),
+            SourceFailureCategory::NetworkUnreachable
+        );
+        assert_eq!(
+            categorize_fetch_error(&fetch::FetchError::NotFound { sha: "abc".to_string() }),
+            SourceFailureCategory::NetworkUnreachable
+        );
+        assert_eq!(
+            categorize_fetch_error(&fetch::FetchError::HttpError {
+                status: 502,
+                attempts: 3,
+            }),
+            SourceFailureCategory::NetworkUnreachable
+        );
+    }
+
+    #[test]
+    fn categorize_fetch_error_maps_archive_variants() {
+        assert_eq!(
+            categorize_fetch_error(&fetch::FetchError::Decompression("bad gz".to_string())),
+            SourceFailureCategory::ArchiveMalformed
+        );
+        assert_eq!(
+            categorize_fetch_error(&fetch::FetchError::Extraction("no entries".to_string())),
+            SourceFailureCategory::ArchiveMalformed
+        );
+    }
+
+    #[test]
+    fn arbitrary_source_skipped_in_offline_mode() {
+        let source =
+            CorpusSource::unauthenticated("https://corpus.example/x.tar.gz".to_string());
+        let outcome = fetch_and_load_arbitrary(&source, true);
+        assert!(matches!(outcome, SourceOutcome::SkippedOffline));
+    }
+
+    // ============================================================
+    // End-to-end orchestration test (Phase 5-Slim PR 2 SC-006-ish)
+    // ============================================================
+    //
+    // Configures TWO arbitrary wiremock-backed sources, suppresses the
+    // milestone-108 default (so the test stays hermetic), runs the
+    // orchestrator, and asserts records from both sources appear in
+    // the merged result. This is the most important PR-2 test — it
+    // proves the merge logic actually merges.
+
+    use std::io::Write;
+    use tokio::runtime::Runtime;
+    use wiremock::matchers::{method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::super::test_env_lock as env_lock;
+
+    struct WiremockHarness {
+        _rt: Runtime,
+        _server: MockServer,
+        base_url: String,
+    }
+
+    impl WiremockHarness {
+        fn new(setup: impl FnOnce(&Runtime, &MockServer)) -> Self {
+            let rt = Runtime::new().unwrap();
+            let server = rt.block_on(async { MockServer::start().await });
+            setup(&rt, &server);
+            let base_url = server.uri();
+            Self {
+                _rt: rt,
+                _server: server,
+                base_url,
+            }
+        }
+    }
+
+    /// Build a v2 corpus tarball containing a single record named
+    /// `<lib>` with one symbol-set indicator. Wrapper dir is generic
+    /// so corpus_filename_from_tar_path's "strip the wrapper" logic
+    /// applies.
+    fn build_minimal_v2_tarball(lib: &str) -> Vec<u8> {
+        let mut tar_bytes: Vec<u8> = Vec::new();
+        {
+            let enc = flate2::write::GzEncoder::new(
+                &mut tar_bytes,
+                flate2::Compression::default(),
+            );
+            let mut builder = tar::Builder::new(enc);
+            let wrapper = "extras-v2/";
+            let index = format!(
+                r#"{{"version":1,"entries":[{{"library":"{lib}","path":"{lib}.json"}}]}}"#
+            );
+            let record = format!(
+                r#"{{
+                    "id":"{lib}-1.0",
+                    "purl":"pkg:github/example/{lib}@1.0.0",
+                    "version_range":"1.0",
+                    "indicators":{{
+                        "exported_symbols":{{
+                            "type":"symbol-set",
+                            "required":["{lib}_init","{lib}_run","{lib}_done"],
+                            "min_match":2,
+                            "confidence_baseline":0.70
+                        }}
+                    }},
+                    "provenance":{{
+                        "tier":"manual-curation",
+                        "extracted_from":"https://example.com/{lib}",
+                        "extracted_from_sha256":"0000000000000000000000000000000000000000000000000000000000000000",
+                        "extraction_toolchain":"test-fixture",
+                        "extracted_at":"2026-06-01T12:00:00Z"
+                    }},
+                    "schema_version":2
+                }}"#
+            );
+            for (name, payload) in [
+                ("index.json", index.as_bytes()),
+                (&format!("{lib}.json"), record.as_bytes()),
+            ] {
+                let mut header = tar::Header::new_gnu();
+                header.set_path(format!("{wrapper}corpus/{name}")).unwrap();
+                header.set_size(payload.len() as u64);
+                header.set_mode(0o644);
+                header.set_cksum();
+                builder.append(&header, payload).unwrap();
+            }
+            let mut enc = builder.into_inner().unwrap();
+            enc.flush().unwrap();
+            enc.finish().unwrap();
+        }
+        tar_bytes
+    }
+
+    fn make_harness_serving(tarball: Vec<u8>) -> WiremockHarness {
+        WiremockHarness::new(|rt, server| {
+            rt.block_on(async {
+                Mock::given(method("GET"))
+                    .and(path_regex(r"/.+\.tar\.gz"))
+                    .respond_with(
+                        ResponseTemplate::new(200)
+                            .set_body_bytes(tarball.clone())
+                            .insert_header("content-type", "application/x-gzip"),
+                    )
+                    .mount(server)
+                    .await;
+            });
+        })
+    }
+
+    #[test]
+    fn merges_records_across_two_arbitrary_sources() {
+        let _g = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let path_str = tmp.path().to_string_lossy().into_owned();
+        unsafe {
+            std::env::set_var("MIKEBOM_FINGERPRINTS_CACHE_DIR", &path_str);
+        }
+
+        let harness_a = make_harness_serving(build_minimal_v2_tarball("liba"));
+        let harness_b = make_harness_serving(build_minimal_v2_tarball("libb"));
+        let source_a = CorpusSource::unauthenticated(format!(
+            "{}/extras-a.tar.gz",
+            harness_a.base_url
+        ));
+        let source_b = CorpusSource::unauthenticated(format!(
+            "{}/extras-b.tar.gz",
+            harness_b.base_url
+        ));
+
+        let result =
+            fetch_and_load_multi_source(&[source_a, source_b], false, None);
+
+        // Both sources contributed records.
+        assert_eq!(result.records.len(), 2, "expected one record per source");
+        let mut ids: Vec<String> = result.records.iter().map(|r| r.id.clone()).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["liba-1.0".to_string(), "libb-1.0".to_string()]);
+        // Per-source status: both Loaded.
+        assert_eq!(result.per_source.len(), 2);
+        for s in &result.per_source {
+            assert!(
+                matches!(s.outcome, SourceOutcome::Loaded { record_count: 1, .. }),
+                "expected Loaded with 1 record; got {:?}",
+                s.outcome
+            );
+        }
+
+        unsafe {
+            std::env::remove_var("MIKEBOM_FINGERPRINTS_CACHE_DIR");
+        }
+    }
+
+    #[test]
+    fn partial_failure_still_loads_succeeding_sources() {
+        let _g = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let path_str = tmp.path().to_string_lossy().into_owned();
+        unsafe {
+            std::env::set_var("MIKEBOM_FINGERPRINTS_CACHE_DIR", &path_str);
+        }
+
+        // One good source, one source that 404s.
+        let harness_good = make_harness_serving(build_minimal_v2_tarball("libgood"));
+        let harness_bad = WiremockHarness::new(|rt, server| {
+            rt.block_on(async {
+                Mock::given(method("GET"))
+                    .and(path_regex(r"/.+\.tar\.gz"))
+                    .respond_with(ResponseTemplate::new(404))
+                    .mount(server)
+                    .await;
+            });
+        });
+        let good = CorpusSource::unauthenticated(format!(
+            "{}/extras-good.tar.gz",
+            harness_good.base_url
+        ));
+        let bad = CorpusSource::unauthenticated(format!(
+            "{}/extras-bad.tar.gz",
+            harness_bad.base_url
+        ));
+
+        let result = fetch_and_load_multi_source(&[good, bad], false, None);
+
+        // Good source still loaded; bad source recorded as Failed.
+        assert_eq!(result.records.len(), 1);
+        assert_eq!(result.records[0].id, "libgood-1.0");
+        assert!(matches!(
+            result.per_source[0].outcome,
+            SourceOutcome::Loaded { .. }
+        ));
+        match &result.per_source[1].outcome {
+            SourceOutcome::Failed { category, .. } => {
+                assert_eq!(*category, SourceFailureCategory::NetworkUnreachable);
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+
+        unsafe {
+            std::env::remove_var("MIKEBOM_FINGERPRINTS_CACHE_DIR");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 5-Slim PR 2 of 3 for milestone 110. **Stacked on top of PR #322**: this PR's base is `110-phase5slim-source-config`, not main. When PR #322 lands, this PR's base will be retargeted to main and the diff will collapse to just PR 2's changes (~1140 lines).

Adds the per-source cache layout, an arbitrary-URL fetcher that computes content-SHA from the response body, a per-source v2 loader, and the `multi_source` orchestrator that fetches each configured source in turn and merges v2 records. **Dead code in production**: PR 3 wires `load_corpus` to dispatch here.

## What lands

- **`cache.rs`**: `cache_dir_for_source(source_id, content_sha)` returns the nested `<root>/<source-id>/<content-sha>/` path; `cache_hit_for_source` parallel of the existing `cache_hit`. Milestone-108 default keeps its flat `<sha>/corpus/` layout (backward compat per locked design choice).
- **`fetch.rs`**: new `fetch_arbitrary_source` + `fetch_arbitrary_source_to` (test-injection variant) downloads any URL, computes SHA-256 of the body, extracts to `<source-id>/<content-sha>/corpus/`. Reuses the existing tar-extraction + retry-on-5xx logic; per-source variant of the retry helper avoids the milestone-108-specific 404→`NotFound { sha }` mapping. New `FetchedSourceOutcome { content_sha, from_network }` return type.
- **`loader.rs`**: new `load_v2_records_from_source_cache(source_id, content_sha)` reads the per-source nested layout; reuses `load_per_library_v2_records`.
- **`multi_source.rs`** (new file): orchestrator `fetch_and_load_multi_source(sources, offline, sha_override)` dispatches per source: milestone-108 sentinel → existing single-source path; arbitrary URL → new per-source path. Returns `MultiSourceLoadResult { records, per_source }` where `per_source` carries the SC-005 failure category (`network-unreachable`, `archive-malformed`, `loader-rejected`) for each source.
- **`mod.rs`**: declares the new `multi_source` module.

## Design notes

- **Content-SHA from response body**: per the locked Source-SHA-Model decision, arbitrary sources compute their cache key by SHA-256 of the fetched bytes (truncated to 40 hex chars to match the existing `CorpusSha` shape — 160 bits is still ample for collision resistance). No `release.json` plumbing; no operator-supplied SHA pin required.
- **No cross-scan cache reuse for arbitrary sources**: with no URL→SHA mapping yet, each scan re-fetches every arbitrary source. The `extract_to_source_cache` writer is idempotent on `<source-id>/<content-sha>/` so concurrent scans of the same source race safely. Cross-scan reuse + TTL is FR-012a (deferred).
- **Sigstore + auth still absent**: FR-007 (bearer-token) + FR-008 (cosign allowed-issuers) deferred. Arbitrary sources fetch unauthenticated with TLS-only trust, matching the milestone-108 default's current production posture.

## Test plan

- [x] `cargo +stable clippy --workspace --all-targets` — zero warnings
- [x] `cargo +stable test --workspace` — all 127 fingerprint tests + full workspace green
- [x] Per-source cache layout tests: `cache_dir_for_source_nests_source_id_then_sha`, `cache_hit_for_source_requires_index_json`, `per_source_and_flat_layouts_coexist`
- [x] Per-source loader tests: `per_source_loader_reads_nested_layout`, `per_source_loader_returns_not_found_for_missing_layout`
- [x] Arbitrary-URL fetcher tests (wiremock): `fetch_arbitrary_source_writes_to_per_source_layout`, `fetch_arbitrary_source_returns_http_error_on_4xx`, `fetch_arbitrary_source_cleans_up_on_malformed_archive`
- [x] Orchestrator end-to-end (two wiremock servers): `merges_records_across_two_arbitrary_sources` proves record-merge across two sources; `partial_failure_still_loads_succeeding_sources` proves the good source still loads when a sibling 404s
- [x] Failure-category classification: `categorize_fetch_error_maps_network_variants`, `categorize_fetch_error_maps_archive_variants`, `source_failure_category_tokens_are_stable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)