### PR TITLE
feat(fingerprints): wire multi-source orchestrator into scan path (milestone 110 Phase 5-Slim PR 3)

### DIFF
--- a/mikebom-cli/src/scan_fs/binary/fingerprints/multi_source.rs
+++ b/mikebom-cli/src/scan_fs/binary/fingerprints/multi_source.rs
@@ -37,14 +37,35 @@ use super::record::CorpusRecordV2;
 use super::source_config::{CorpusSource, CorpusSourceId};
 use super::source_sha::CorpusSha;
 
-/// Outcome of `fetch_and_load_multi_source`. Records carry the merged
-/// v2 records from every successful source; `per_source` lets callers
-/// surface diagnostics for the partial-failure case.
+/// Outcome of `fetch_and_load_multi_source`. Each `SourceLoadStatus`
+/// carries the records that came from its source so the matcher can
+/// stamp the right `source_id` onto each `MatchResult`. Use
+/// `merged_records()` for callers that just want the flat union.
 #[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct MultiSourceLoadResult {
-    pub records: Vec<CorpusRecordV2>,
     pub per_source: Vec<SourceLoadStatus>,
+}
+
+#[allow(dead_code)]
+impl MultiSourceLoadResult {
+    /// Total record count across all successful sources.
+    pub(crate) fn total_record_count(&self) -> usize {
+        self.per_source.iter().map(|s| s.records.len()).sum()
+    }
+
+    /// Iterator over `(source_id, records)` pairs for sources that
+    /// contributed at least one record. The matcher loop dispatches
+    /// per-pair so each match's `source_id` reflects where its record
+    /// came from.
+    pub(crate) fn record_groups(
+        &self,
+    ) -> impl Iterator<Item = (&CorpusSourceId, &[CorpusRecordV2])> {
+        self.per_source
+            .iter()
+            .filter(|s| !s.records.is_empty())
+            .map(|s| (&s.source_id, s.records.as_slice()))
+    }
 }
 
 #[allow(dead_code)]
@@ -53,6 +74,10 @@ pub(crate) struct SourceLoadStatus {
     pub source_id: CorpusSourceId,
     pub url: String,
     pub outcome: SourceOutcome,
+    /// Records loaded from this source. Empty for failed sources +
+    /// for sources that fetched OK but contained zero v2 records (the
+    /// v1-only state, common for the milestone-108 default today).
+    pub records: Vec<CorpusRecordV2>,
 }
 
 #[allow(dead_code)]
@@ -116,7 +141,6 @@ pub(crate) fn fetch_and_load_multi_source(
     offline: bool,
     sha_override: Option<CorpusSha>,
 ) -> MultiSourceLoadResult {
-    let mut records: Vec<CorpusRecordV2> = Vec::new();
     let mut per_source: Vec<SourceLoadStatus> = Vec::with_capacity(sources.len());
     for source in sources {
         let outcome = if is_milestone_108_default(source) {
@@ -124,7 +148,7 @@ pub(crate) fn fetch_and_load_multi_source(
         } else {
             fetch_and_load_arbitrary(source, offline)
         };
-        match &outcome {
+        let records = match &outcome {
             SourceOutcome::Loaded { content_sha, record_count } => {
                 tracing::info!(
                     source_url = %source.url,
@@ -133,7 +157,6 @@ pub(crate) fn fetch_and_load_multi_source(
                     record_count,
                     "fingerprint corpus source loaded",
                 );
-                // Load records and merge.
                 let recs = if is_milestone_108_default(source) {
                     loader::load_v2_records_from_cache(content_sha)
                 } else {
@@ -142,9 +165,7 @@ pub(crate) fn fetch_and_load_multi_source(
                         content_sha,
                     )
                 };
-                if let Ok(mut recs) = recs {
-                    records.append(&mut recs);
-                }
+                recs.unwrap_or_default()
             }
             SourceOutcome::SkippedOffline => {
                 tracing::warn!(
@@ -152,6 +173,7 @@ pub(crate) fn fetch_and_load_multi_source(
                     "fingerprint corpus source skipped (offline mode + no usable cache); \
                      other sources unaffected. Run without --offline to fetch this source.",
                 );
+                Vec::new()
             }
             SourceOutcome::Failed { category, message } => {
                 tracing::warn!(
@@ -161,15 +183,17 @@ pub(crate) fn fetch_and_load_multi_source(
                     "fingerprint corpus source failed; skipping this source for this scan. \
                      Other sources unaffected.",
                 );
+                Vec::new()
             }
-        }
+        };
         per_source.push(SourceLoadStatus {
             source_id: source.source_id.clone(),
             url: source.url.clone(),
             outcome,
+            records,
         });
     }
-    MultiSourceLoadResult { records, per_source }
+    MultiSourceLoadResult { per_source }
 }
 
 fn is_milestone_108_default(source: &CorpusSource) -> bool {
@@ -454,11 +478,19 @@ mod tests {
             fetch_and_load_multi_source(&[source_a, source_b], false, None);
 
         // Both sources contributed records.
-        assert_eq!(result.records.len(), 2, "expected one record per source");
-        let mut ids: Vec<String> = result.records.iter().map(|r| r.id.clone()).collect();
+        assert_eq!(
+            result.total_record_count(),
+            2,
+            "expected one record per source"
+        );
+        let mut ids: Vec<String> = result
+            .per_source
+            .iter()
+            .flat_map(|s| s.records.iter().map(|r| r.id.clone()))
+            .collect();
         ids.sort();
         assert_eq!(ids, vec!["liba-1.0".to_string(), "libb-1.0".to_string()]);
-        // Per-source status: both Loaded.
+        // Per-source view: each Loaded with exactly its own record.
         assert_eq!(result.per_source.len(), 2);
         for s in &result.per_source {
             assert!(
@@ -466,7 +498,12 @@ mod tests {
                 "expected Loaded with 1 record; got {:?}",
                 s.outcome
             );
+            assert_eq!(s.records.len(), 1);
         }
+        // The `record_groups` iterator visits each (source_id, records)
+        // pair exactly once for the matcher loop.
+        let groups: Vec<_> = result.record_groups().collect();
+        assert_eq!(groups.len(), 2);
 
         unsafe {
             std::env::remove_var("MIKEBOM_FINGERPRINTS_CACHE_DIR");
@@ -505,12 +542,15 @@ mod tests {
         let result = fetch_and_load_multi_source(&[good, bad], false, None);
 
         // Good source still loaded; bad source recorded as Failed.
-        assert_eq!(result.records.len(), 1);
-        assert_eq!(result.records[0].id, "libgood-1.0");
+        assert_eq!(result.total_record_count(), 1);
+        assert_eq!(result.per_source[0].records.len(), 1);
+        assert_eq!(result.per_source[0].records[0].id, "libgood-1.0");
         assert!(matches!(
             result.per_source[0].outcome,
             SourceOutcome::Loaded { .. }
         ));
+        // Failed source has zero records.
+        assert!(result.per_source[1].records.is_empty());
         match &result.per_source[1].outcome {
             SourceOutcome::Failed { category, .. } => {
                 assert_eq!(*category, SourceFailureCategory::NetworkUnreachable);

--- a/mikebom-cli/src/scan_fs/binary/mod.rs
+++ b/mikebom-cli/src/scan_fs/binary/mod.rs
@@ -146,24 +146,38 @@ pub fn read(
         None
     };
 
-    // Milestone 110 Phase 4 Slice B-2 — load v2 records from the same
-    // per-SHA cache directory the v1 path uses. Coexists with the v1
-    // corpus: a single cache directory MAY contain a mix of v1 and v2
-    // records (peek-at-schema_version dispatch lives in loader.rs).
-    // When no v2 records are present (the current milestone-108 state),
-    // this returns an empty Vec and the v2 matcher path is a no-op.
-    let external_v2_records: Vec<fingerprints::record::CorpusRecordV2> =
+    // Milestone 110 Phase 5-Slim PR 3 — dispatch v2 record loading
+    // through the multi-source orchestrator. Behavior matrix:
+    //
+    //   - No `--fingerprints-source` configured: orchestrator runs
+    //     with `[milestone_108_default]` as the only source. This is
+    //     functionally identical to the milestone-108 single-source
+    //     path (cache-hit short-circuits the re-fetch); byte-identity
+    //     goldens are preserved.
+    //   - One or more `--fingerprints-source` configured: orchestrator
+    //     fetches each source in turn (default + extras, minus the
+    //     default if `--fingerprints-source-no-default` is set),
+    //     keeps records grouped per source so the matcher stamps the
+    //     right `source_id` on each `MatchResult`.
+    //
+    // FR-007 / FR-008 / FR-012a remain deferred per the slim slice.
+    let v2_records_by_source: Vec<(fingerprints::source_config::CorpusSourceId, Vec<fingerprints::record::CorpusRecordV2>)> =
         if external_corpus.is_some() {
-            let sha = fingerprints_opts
-                .sha_override
-                .unwrap_or_else(fingerprints::source_sha::CorpusSha::build_time_embedded);
-            fingerprints::loader::load_v2_records_from_cache(&sha).unwrap_or_default()
+            let sources = fingerprints_opts.sources.materialize();
+            let result = fingerprints::multi_source::fetch_and_load_multi_source(
+                &sources,
+                fingerprints_opts.offline,
+                fingerprints_opts.sha_override,
+            );
+            result
+                .per_source
+                .into_iter()
+                .filter(|s| !s.records.is_empty())
+                .map(|s| (s.source_id, s.records))
+                .collect()
         } else {
             Vec::new()
         };
-    let v2_source_id = fingerprints::source_config::CorpusSourceId::from_raw(
-        fingerprints::source_config::CorpusSourceId::MILESTONE_108_DEFAULT.to_string(),
-    );
 
     // Milestone 109 — build the source-tier attribution registry exactly
     // once per scan when the operator opted in via `--fingerprints-corpus`.
@@ -591,7 +605,13 @@ pub fn read(
             // the v1 emission. Cross-tier collision handling +
             // mikebom:also-detected-via cross-references ship in a
             // follow-on slice (Phase 6 / US4).
-            if !external_v2_records.is_empty() {
+            // Milestone 110 Phase 5-Slim PR 3 — dispatch the matcher
+            // per source so each `MatchResult` carries the correct
+            // `source_id` for downstream annotation emission. When
+            // no extras are configured this loop runs once with the
+            // milestone-108 default's records, preserving the existing
+            // single-source behavior.
+            if !v2_records_by_source.is_empty() {
                 let artifact = fingerprints::v2_bridge::binary_artifact_from_scan(
                     &scan.symbol_names,
                     &scan.string_region,
@@ -599,15 +619,19 @@ pub fn read(
                     scan.macho_uuid.as_deref(),
                     scan.pe_pdb_id.as_deref(),
                 );
-                let v2_results = fingerprints::matcher::match_binary(
-                    &artifact,
-                    &external_v2_records,
-                    None, // self-identity ladder lands Phase 6.
-                    &v2_source_id,
-                );
-                for r in v2_results {
-                    let key = r.purl.name().to_lowercase();
-                    by_library.entry(key).or_insert_with(|| v2_match_to_entry(&r, &path));
+                for (source_id, records) in &v2_records_by_source {
+                    let v2_results = fingerprints::matcher::match_binary(
+                        &artifact,
+                        records,
+                        None, // self-identity ladder lands Phase 6.
+                        source_id,
+                    );
+                    for r in v2_results {
+                        let key = r.purl.name().to_lowercase();
+                        by_library
+                            .entry(key)
+                            .or_insert_with(|| v2_match_to_entry(&r, &path));
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

Phase 5-Slim PR 3 of 3 for milestone 110. **Stacked on top of PR #323** (which is stacked on #322). When the lower PRs merge, this PR's base will retarget to main and the diff will collapse to just PR 3's ~150-line glue change.

This is the wire-up PR — `scan_fs/binary/mod.rs` now dispatches through the multi-source orchestrator built in PR 2. With no `--fingerprints-source` configured, the orchestrator runs with just the milestone-108 default and is functionally equivalent to the prior single-source path (cache-hit short-circuits the re-fetch). The 33 byte-identity goldens + the existing `fingerprints_v2_e2e` test serve as the no-extras regression gate.

## What lands

- **`multi_source.rs`**: `SourceLoadStatus` now carries `records: Vec<CorpusRecordV2>` directly so each source's contribution is grouped. New `MultiSourceLoadResult::record_groups()` iterator yields `(source_id, records)` pairs for the matcher loop. `total_record_count()` replaces the top-level flat `records` field. Tests updated for the new shape.
- **`scan_fs/binary/mod.rs`**: replaces the single-source v2 load (`load_v2_records_from_cache(&sha)`) with `fetch_and_load_multi_source(sources, offline, sha_override)`. The per-binary matcher loop now iterates per source group, calling `matcher::match_binary` once per source with its records + `source_id`. Each emitted `MatchResult` therefore carries the correct source_id annotation.

## Behavior matrix

| Config | v2 path |
|---|---|
| no `--fingerprints-source` | orchestrator runs with `[milestone_108_default]`; semantically identical to prior single-source path |
| `--fingerprints-source X` | orchestrator fetches `[default, X]`; matcher dispatches twice (once per source group) |
| `--fingerprints-source X --fingerprints-source-no-default` | orchestrator fetches `[X]` only |

The v1 records (legacy milestone-108 corpus) continue through the existing single-source path; v1/no_default interaction is a known follow-on edge case (uncommon in practice — operators using `--fingerprints-source-no-default` typically also disable the v1 path implicitly because they have no v1 records).

## Deferred (per slim-slice scope, will land in a follow-on)

- **FR-007** bearer-token auth per source
- **FR-008** per-source cosign allowed-issuers
- **FR-012a** 24-hour TTL cache freshness
- Multi-source CLI integration test (the unit-level orchestrator tests in PR 2 + the byte-identity goldens cover the wire-up; an end-to-end test that runs `mikebom sbom scan --fingerprints-source <wiremock-url>` is a polish-PR item)
- `--fingerprints-source-no-default` honoring on the v1 corpus

## Test plan

- [x] `cargo +stable clippy --workspace --all-targets` — zero warnings
- [x] `cargo +stable test --workspace` — full workspace green
- [x] Byte-identity goldens (33) — unchanged
- [x] `fingerprints_v2_e2e` integration test — unchanged (proves the no-extras orchestrator path is functionally equivalent to the prior single-source path)
- [x] `fingerprints_v1_regression` — unchanged
- [x] PR 2's `merges_records_across_two_arbitrary_sources` + `partial_failure_still_loads_succeeding_sources` — still pass under the per-source-records restructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)