### PR TITLE
feat(binding): pkg-alias foundational types + envelope extension (milestone 111 PR 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-03
+Auto-generated from all feature plans. Last updated: 2026-06-09
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -115,6 +115,8 @@ Auto-generated from all feature plans. Last updated: 2026-06-03
 - N/A — all attribution state is in-process for the duration of a single scan; mirrors every milestone since 002. (109-binary-source-purl-binding)
 - Rust stable (workspace toolchain inherited from milestones 001–109; no nightly required for this user-space-only work). (110-pluggable-corpus-v2)
 - Per-host cache at `~/.cache/mikebom/fingerprints/<source-id>/<pinned-sha>/` where `<source-id>` is a stable hash of the source URL (so multiple sources coexist without filename collisions) and `<pinned-sha>` is the archive's content SHA (matching the milestone-090 + milestone-108 pattern). The 24-hour TTL is implemented as a `last_used.touch` sidecar file whose mtime is checked at scan startup; expiry triggers re-fetch but does NOT delete the cache directory (re-fetch may write the same SHA back, in which case the existing dir is reused). (110-pluggable-corpus-v2)
+- Rust stable (workspace toolchain inherited from milestones 001–110; no nightly required for this user-space-only feature). + Existing only — `clap` (the new flag via `ArgAction::Append` derive), `serde`/`serde_json` (additive envelope round-trip), `Purl` newtype from `mikebom-common` (milestone 005 — canonicalization + equality), milestone-072 `SourceDocumentBinding` (the envelope this extends), `tracing` (warn/info logs), `anyhow` (error propagation), `thiserror` (alias-parse error variants). **No new Cargo dependencies.** (111-pkg-alias-binding)
+- N/A — alias declarations are in-process per scan; persisted only inside the emitted SBOM via the extended envelope. No caches, no databases. (111-pkg-alias-binding)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -177,9 +179,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 111-pkg-alias-binding: Added Rust stable (workspace toolchain inherited from milestones 001–110; no nightly required for this user-space-only feature). + Existing only — `clap` (the new flag via `ArgAction::Append` derive), `serde`/`serde_json` (additive envelope round-trip), `Purl` newtype from `mikebom-common` (milestone 005 — canonicalization + equality), milestone-072 `SourceDocumentBinding` (the envelope this extends), `tracing` (warn/info logs), `anyhow` (error propagation), `thiserror` (alias-parse error variants). **No new Cargo dependencies.**
 - 110-pluggable-corpus-v2: Added Rust stable (workspace toolchain inherited from milestones 001–109; no nightly required for this user-space-only work).
 - 109-binary-source-purl-binding: Added Rust stable (workspace toolchain inherited from milestones 001–108; no nightly required for this user-space-only attribution layer). + existing only — `std::fs::canonicalize` / `std::fs::read_dir` (build-dir walking), the milestone-102/103 cmake reader's existing parsed-declaration output (`PackageDbEntry` instances tagged with `mikebom:source-mechanism = cmake-fetchcontent-{git,url}`), and the milestone-099/108 fingerprint matcher's existing `SymbolFingerprintMatch` records. The milestone-105 dedup pipeline (`SourceMechanism` enum + `mikebom:also-detected-via` collision handling) merges the cmake source-tier component with the post-attribution binary-tier component into ONE final component via shared PURL.
-- 108-fingerprint-corpus: Added Rust stable (workspace toolchain inherited from milestones 001–107; no nightly required for this user-space-only work). + Existing only — no new Cargo additions. `reqwest = "0.12"` (workspace; `rustls-tls` + `blocking` features already enabled; used for the corpus tarball fetch), `tar = "0.4"` (workspace; reused from milestone-002 layer extraction), `flate2` (workspace; gzip), `serde`/`serde_json` (corpus record (de)serialization), `sha2` + `data-encoding` (cache directory key validation), `tracing`, `anyhow`, `thiserror`, `clap` (the new flags via derive). Build-time embed of the corpus SHA uses `env!()` driven by a `build.rs`-set env var sourced from a per-crate `Cargo.toml` `[package.metadata.fingerprints]` entry — no new build dependencies.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/binding/alias.rs
+++ b/mikebom-cli/src/binding/alias.rs
@@ -1,0 +1,378 @@
+//! Operator-supplied PURL alias for cross-tier binding (milestone 111).
+//!
+//! Declares the `PurlAlias` newtype, the `AliasMap` container, the
+//! `AliasError` enum, and the clap `value_parser` for the
+//! `--pkg-alias LHS=RHS` CLI flag.
+//!
+//! Per `specs/111-pkg-alias-binding/data-model.md` and
+//! `specs/111-pkg-alias-binding/contracts/cli-flags.md`. Each alias
+//! pair is canonicalized at construction (both sides through
+//! `Purl::new`); equality and lookup are on the canonical form.
+//!
+//! The `AliasMap` is a `Vec`-backed insertion-ordered container:
+//! deterministic for SBOM emission and cheap to scan at the
+//! single-digit-N scale operators actually use (Constitution Principle
+//! VI — keep the dependency surface minimal; no new `HashMap` /
+//! `BTreeMap` machinery needed when linear search wins on N < 10).
+
+use mikebom_common::types::purl::{Purl, PurlError};
+
+/// A single `(LHS, RHS)` PURL alias declared by the operator.
+///
+/// LHS is the image-tier component PURL the binder will look up;
+/// RHS is the source-tier canonical PURL that LHS should be treated
+/// as for cross-tier binding match purposes. Both sides are
+/// canonicalized via [`Purl::new`].
+///
+/// Invariants enforced by [`PurlAlias::try_new`]:
+/// - Both `lhs` and `rhs` parse as valid PURLs.
+/// - `lhs != rhs` (operator-error sentinel — aliases must rewrite).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PurlAlias {
+    lhs: Purl,
+    rhs: Purl,
+}
+
+impl PurlAlias {
+    /// Construct from raw `&str` LHS and RHS. Both sides are run
+    /// through [`Purl::new`] for canonicalization. Returns the
+    /// appropriate [`AliasError`] variant on any failure.
+    pub fn try_new(lhs_raw: &str, rhs_raw: &str) -> Result<Self, AliasError> {
+        let lhs = Purl::new(lhs_raw).map_err(|source| AliasError::MalformedLhs {
+            lhs: lhs_raw.to_string(),
+            source,
+        })?;
+        let rhs = Purl::new(rhs_raw).map_err(|source| AliasError::MalformedRhs {
+            rhs: rhs_raw.to_string(),
+            source,
+        })?;
+        if lhs == rhs {
+            return Err(AliasError::LhsEqualsRhs(Box::new(lhs)));
+        }
+        Ok(Self { lhs, rhs })
+    }
+
+    /// LHS PURL (canonical form). The PURL the operator declared as
+    /// the image-tier component identifier.
+    pub fn lhs(&self) -> &Purl {
+        &self.lhs
+    }
+
+    /// RHS PURL (canonical form). The source-tier counterpart the
+    /// binder matches against.
+    pub fn rhs(&self) -> &Purl {
+        &self.rhs
+    }
+}
+
+/// Payload for the [`AliasError::ConflictingRhs`] variant. Boxed at
+/// the variant level so the enum's largest variant doesn't dominate
+/// the size of every `Result<_, AliasError>` (`clippy::result_large_err`).
+#[derive(Debug)]
+pub struct ConflictingRhsPayload {
+    pub lhs: Purl,
+    pub existing_rhs: Purl,
+    pub new_rhs: Purl,
+}
+
+impl core::fmt::Display for ConflictingRhsPayload {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "LHS '{}' declared twice with conflicting RHS values: \
+             '{}' and '{}'",
+            self.lhs, self.existing_rhs, self.new_rhs
+        )
+    }
+}
+
+/// Errors emitted by the alias subsystem. Each variant's `Display`
+/// message satisfies the SC-003 single-line-actionable contract
+/// (names both the misconfiguration and the corrective next step).
+#[derive(Debug, thiserror::Error)]
+pub enum AliasError {
+    #[error(
+        "--pkg-alias value '{raw}' is missing the '=' separator; \
+         expected format: 'LHS_PURL=RHS_PURL'"
+    )]
+    MissingSeparator { raw: String },
+
+    #[error("--pkg-alias LHS PURL '{lhs}' failed to parse: {source}")]
+    MalformedLhs {
+        lhs: String,
+        #[source]
+        source: PurlError,
+    },
+
+    #[error("--pkg-alias RHS PURL '{rhs}' failed to parse: {source}")]
+    MalformedRhs {
+        rhs: String,
+        #[source]
+        source: PurlError,
+    },
+
+    /// Boxed so the variant's three `Purl` fields don't bloat the
+    /// `Result<_, AliasError>` size used pervasively in the binding
+    /// path (`clippy::result_large_err`).
+    #[error(
+        "--pkg-alias LHS '{0}' identical to RHS; aliases must specify \
+         distinct PURLs (did you mean to declare a different RHS?)"
+    )]
+    LhsEqualsRhs(Box<Purl>),
+
+    /// Boxed payload for the same `result_large_err` reason.
+    #[error(
+        "--pkg-alias {0} (only one mapping per LHS is permitted; \
+         resolve the conflict and re-run)"
+    )]
+    ConflictingRhs(Box<ConflictingRhsPayload>),
+}
+
+/// Insertion-ordered container of validated aliases for one scan.
+///
+/// Backed by `Vec<PurlAlias>` for determinism in SBOM emission order
+/// and to avoid pulling in `BTreeMap`/`HashMap` machinery for the
+/// single-digit-N scale operators actually use. `get` is linear-scan;
+/// at N < 10 the constant factor of hash/tree overhead exceeds the
+/// linear cost.
+#[derive(Debug, Clone, Default)]
+pub struct AliasMap {
+    entries: Vec<PurlAlias>,
+}
+
+impl AliasMap {
+    /// Construct an empty alias map.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert an alias. Same-LHS-same-RHS is idempotent. Same-LHS-
+    /// different-RHS returns [`AliasError::ConflictingRhs`].
+    pub fn insert(&mut self, alias: PurlAlias) -> Result<(), AliasError> {
+        for existing in &self.entries {
+            if existing.lhs == alias.lhs {
+                if existing.rhs == alias.rhs {
+                    // Idempotent: same alias declared twice is fine.
+                    return Ok(());
+                }
+                return Err(AliasError::ConflictingRhs(Box::new(
+                    ConflictingRhsPayload {
+                        lhs: alias.lhs,
+                        existing_rhs: existing.rhs.clone(),
+                        new_rhs: alias.rhs,
+                    },
+                )));
+            }
+        }
+        self.entries.push(alias);
+        Ok(())
+    }
+
+    /// Look up the RHS for a given LHS PURL. Returns `None` when no
+    /// alias was declared for `lhs`.
+    pub fn get(&self, lhs: &Purl) -> Option<&Purl> {
+        self.entries
+            .iter()
+            .find(|a| &a.lhs == lhs)
+            .map(|a| &a.rhs)
+    }
+
+    /// True when no aliases have been declared.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Number of declared aliases.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Iterate over the declared aliases in insertion order.
+    pub fn iter(&self) -> impl Iterator<Item = &PurlAlias> {
+        self.entries.iter()
+    }
+}
+
+/// Clap `value_parser` for the `--pkg-alias LHS=RHS` flag.
+///
+/// Splits the raw value on the FIRST `=` (PURLs may contain qualifier
+/// keys with `=`-shaped suffixes, but those live AFTER the `?`
+/// segment; a top-level PURL never starts with `?` so the split on
+/// first `=` is unambiguous when the LHS is itself a well-formed
+/// PURL — `Purl::new` will reject anything malformed).
+///
+/// Returns `Result<PurlAlias, String>` per clap's parser-error
+/// contract (clap calls `.to_string()` on the error type). Maps
+/// `AliasError` variants verbatim via `.to_string()`.
+///
+/// NOTE: `ConflictingRhs` is NOT raised here — conflict detection
+/// happens at [`AliasMap::insert`] time, after all CLI + env-var
+/// values have been collected.
+pub fn parse_pkg_alias(raw: &str) -> Result<PurlAlias, String> {
+    let trimmed = raw.trim();
+    let (lhs_raw, rhs_raw) = trimmed.split_once('=').ok_or_else(|| {
+        AliasError::MissingSeparator {
+            raw: trimmed.to_string(),
+        }
+        .to_string()
+    })?;
+    PurlAlias::try_new(lhs_raw, rhs_raw).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    const LHS_GENERIC: &str = "pkg:generic/baz";
+    const RHS_CARGO: &str = "pkg:cargo/baz@1.0.0";
+    const RHS_CARGO_ALT: &str = "pkg:cargo/baz@1.1.0";
+
+    // ─────────────────────────────────────────────────────────────
+    // PurlAlias::try_new
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn try_new_succeeds_on_distinct_valid_purls() {
+        let a = PurlAlias::try_new(LHS_GENERIC, RHS_CARGO).unwrap();
+        assert_eq!(a.lhs().as_str(), LHS_GENERIC);
+        assert_eq!(a.rhs().as_str(), RHS_CARGO);
+    }
+
+    #[test]
+    fn try_new_rejects_malformed_lhs() {
+        let err = PurlAlias::try_new("not-a-purl", RHS_CARGO).unwrap_err();
+        assert!(
+            matches!(err, AliasError::MalformedLhs { .. }),
+            "expected MalformedLhs, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn try_new_rejects_malformed_rhs() {
+        let err = PurlAlias::try_new(LHS_GENERIC, "@@nope").unwrap_err();
+        assert!(matches!(err, AliasError::MalformedRhs { .. }));
+    }
+
+    #[test]
+    fn try_new_rejects_lhs_equals_rhs() {
+        let err = PurlAlias::try_new(RHS_CARGO, RHS_CARGO).unwrap_err();
+        assert!(matches!(err, AliasError::LhsEqualsRhs { .. }));
+    }
+
+    #[test]
+    fn try_new_accepts_non_generic_lhs() {
+        // C2 remediation per /speckit-analyze: the parser must accept
+        // ANY PURL scheme on the LHS, not just `pkg:generic/*`.
+        let a =
+            PurlAlias::try_new("pkg:deb/debian/foo@1.0", "pkg:github/foo/foo@1.0").unwrap();
+        assert_eq!(a.lhs().ecosystem(), "deb");
+        assert_eq!(a.rhs().ecosystem(), "github");
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // AliasMap insertion + lookup
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn insert_into_empty_map_succeeds() {
+        let mut map = AliasMap::new();
+        let alias = PurlAlias::try_new(LHS_GENERIC, RHS_CARGO).unwrap();
+        map.insert(alias).unwrap();
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn insert_same_lhs_same_rhs_is_idempotent() {
+        let mut map = AliasMap::new();
+        let alias1 = PurlAlias::try_new(LHS_GENERIC, RHS_CARGO).unwrap();
+        let alias2 = PurlAlias::try_new(LHS_GENERIC, RHS_CARGO).unwrap();
+        map.insert(alias1).unwrap();
+        map.insert(alias2).unwrap();
+        assert_eq!(map.len(), 1, "idempotent insert must not duplicate");
+    }
+
+    #[test]
+    fn insert_same_lhs_different_rhs_rejected() {
+        let mut map = AliasMap::new();
+        let alias1 = PurlAlias::try_new(LHS_GENERIC, RHS_CARGO).unwrap();
+        let alias2 = PurlAlias::try_new(LHS_GENERIC, RHS_CARGO_ALT).unwrap();
+        map.insert(alias1).unwrap();
+        let err = map.insert(alias2).unwrap_err();
+        assert!(matches!(err, AliasError::ConflictingRhs { .. }));
+    }
+
+    #[test]
+    fn insert_same_rhs_different_lhs_accepted() {
+        // U1 invariant per /speckit-analyze: multiple LHS aliases
+        // targeting the same RHS are valid (workspace projects emit
+        // distinct binaries from one source crate).
+        let mut map = AliasMap::new();
+        map.insert(PurlAlias::try_new("pkg:generic/baz-cli", RHS_CARGO).unwrap())
+            .unwrap();
+        map.insert(PurlAlias::try_new("pkg:generic/baz-daemon", RHS_CARGO).unwrap())
+            .unwrap();
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn get_returns_rhs_for_known_lhs() {
+        let mut map = AliasMap::new();
+        let alias = PurlAlias::try_new(LHS_GENERIC, RHS_CARGO).unwrap();
+        map.insert(alias).unwrap();
+        let lhs_purl = Purl::new(LHS_GENERIC).unwrap();
+        assert_eq!(map.get(&lhs_purl).unwrap().as_str(), RHS_CARGO);
+    }
+
+    #[test]
+    fn get_returns_none_for_unknown_lhs() {
+        let map = AliasMap::new();
+        let lhs_purl = Purl::new(LHS_GENERIC).unwrap();
+        assert!(map.get(&lhs_purl).is_none());
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // parse_pkg_alias (CLI value_parser)
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_succeeds_on_well_formed_input() {
+        let alias = parse_pkg_alias(&format!("{LHS_GENERIC}={RHS_CARGO}")).unwrap();
+        assert_eq!(alias.lhs().as_str(), LHS_GENERIC);
+        assert_eq!(alias.rhs().as_str(), RHS_CARGO);
+    }
+
+    #[test]
+    fn parse_trims_whitespace() {
+        let alias =
+            parse_pkg_alias(&format!("   {LHS_GENERIC}={RHS_CARGO}   ")).unwrap();
+        assert_eq!(alias.lhs().as_str(), LHS_GENERIC);
+    }
+
+    #[test]
+    fn parse_rejects_missing_separator() {
+        let err = parse_pkg_alias(LHS_GENERIC).unwrap_err();
+        assert!(
+            err.contains("missing the '=' separator"),
+            "error message should name the missing separator; got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_malformed_lhs_with_named_error() {
+        let err = parse_pkg_alias(&format!("not-a-purl={RHS_CARGO}")).unwrap_err();
+        assert!(
+            err.contains("LHS PURL 'not-a-purl' failed to parse"),
+            "error should name the LHS; got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_malformed_rhs_with_named_error() {
+        let err = parse_pkg_alias(&format!("{LHS_GENERIC}=@@nope")).unwrap_err();
+        assert!(
+            err.contains("RHS PURL '@@nope' failed to parse"),
+            "error should name the RHS; got: {err}"
+        );
+    }
+}

--- a/mikebom-cli/src/binding/annotation.rs
+++ b/mikebom-cli/src/binding/annotation.rs
@@ -96,6 +96,8 @@ mod tests {
             strength: BindingStrength::Verified,
             reason: None,
             algo: "v1".to_string(),
+            alias_from: None,
+            alias_to: None,
         }
     }
 

--- a/mikebom-cli/src/binding/mod.rs
+++ b/mikebom-cli/src/binding/mod.rs
@@ -24,12 +24,15 @@
 //! or enum. Production code uses `anyhow::Result` / `BindingError`;
 //! test code uses `#[cfg_attr(test, allow(clippy::unwrap_used))]`.
 
+pub mod alias;
 pub mod annotation;
 pub mod hash;
 pub mod identifiers;
 pub mod source_inputs;
 pub mod user_metadata;
 pub mod verify;
+
+pub use alias::{parse_pkg_alias, AliasError, AliasMap, PurlAlias};
 
 // ---------------------------------------------------------------------
 // Errors
@@ -194,9 +197,23 @@ pub struct SourceDocumentBinding {
     /// Optional for `Verified` / `Weak`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
-    /// Algorithm version. Always `"v1"` for milestone 072.
+    /// Algorithm version. Always `"v1"` for milestone 072. Milestone
+    /// 111's additive `alias_from`/`alias_to` fields do NOT bump this
+    /// version — they are metadata, not algorithm changes
+    /// (specs/111-pkg-alias-binding/research.md §2).
     #[serde(default = "default_algo_v1")]
     pub algo: String,
+    /// Milestone 111 — when this binding result was reached via a
+    /// `--pkg-alias` declaration, the LHS PURL the operator declared.
+    /// `None` otherwise. MUST be `Some` iff `alias_to` is `Some`
+    /// (paired-presence invariant).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub alias_from: Option<mikebom_common::types::purl::Purl>,
+    /// Milestone 111 — pair of `alias_from`. When `Some`, this is the
+    /// RHS PURL the binder matched against in the bind-source SBOM.
+    /// Paired-presence invariant with `alias_from`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub alias_to: Option<mikebom_common::types::purl::Purl>,
 }
 
 fn default_algo_v1() -> String {
@@ -214,6 +231,8 @@ impl SourceDocumentBinding {
             strength: BindingStrength::Unknown,
             reason: Some(reason.into()),
             algo: default_algo_v1(),
+            alias_from: None,
+            alias_to: None,
         }
     }
 }
@@ -362,5 +381,104 @@ mod tests {
             VexPropagationMode::default(),
             VexPropagationMode::Caveated
         );
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Milestone 111 — wire-compatibility tests for the extended
+    // SourceDocumentBinding envelope (alias_from / alias_to additive
+    // fields). Per specs/111-pkg-alias-binding/research.md §2.
+    // ──────────────────────────────────────────────────────────────
+
+    fn fixture_no_alias() -> SourceDocumentBinding {
+        SourceDocumentBinding {
+            source_doc_id: SourceDocumentId {
+                sha256: "e".repeat(64),
+                iri: None,
+            },
+            hash: Some(BindingHash::from_hex("a".repeat(64)).unwrap()),
+            strength: BindingStrength::Verified,
+            reason: None,
+            algo: "v1".to_string(),
+            alias_from: None,
+            alias_to: None,
+        }
+    }
+
+    fn fixture_with_alias() -> SourceDocumentBinding {
+        use mikebom_common::types::purl::Purl;
+        SourceDocumentBinding {
+            source_doc_id: SourceDocumentId {
+                sha256: "e".repeat(64),
+                iri: None,
+            },
+            hash: Some(BindingHash::from_hex("a".repeat(64)).unwrap()),
+            strength: BindingStrength::Verified,
+            reason: None,
+            algo: "v1".to_string(),
+            alias_from: Some(Purl::new("pkg:generic/baz").unwrap()),
+            alias_to: Some(Purl::new("pkg:cargo/baz@1.0.0").unwrap()),
+        }
+    }
+
+    #[test]
+    fn envelope_without_alias_omits_alias_fields_in_serialization() {
+        // SC-004 byte-identity guarantee: when no alias is present,
+        // the serialized form MUST NOT include alias_from / alias_to
+        // keys. Pre-milestone-111 SBOM consumers see the same wire
+        // shape they always have.
+        let b = fixture_no_alias();
+        let s = serde_json::to_string(&b).unwrap();
+        assert!(
+            !s.contains("alias_from"),
+            "no-alias envelope must NOT emit alias_from; got {s}"
+        );
+        assert!(
+            !s.contains("alias_to"),
+            "no-alias envelope must NOT emit alias_to; got {s}"
+        );
+    }
+
+    #[test]
+    fn envelope_with_alias_includes_both_fields_in_serialization() {
+        let b = fixture_with_alias();
+        let s = serde_json::to_string(&b).unwrap();
+        assert!(s.contains("\"alias_from\":\"pkg:generic/baz\""));
+        assert!(s.contains("\"alias_to\":\"pkg:cargo/baz@1.0.0\""));
+    }
+
+    #[test]
+    fn envelope_round_trips_with_alias() {
+        let b = fixture_with_alias();
+        let s = serde_json::to_string(&b).unwrap();
+        let parsed: SourceDocumentBinding = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed, b, "round-trip MUST preserve alias_from/alias_to");
+    }
+
+    #[test]
+    fn envelope_round_trips_without_alias() {
+        let b = fixture_no_alias();
+        let s = serde_json::to_string(&b).unwrap();
+        let parsed: SourceDocumentBinding = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed, b);
+        assert!(parsed.alias_from.is_none());
+        assert!(parsed.alias_to.is_none());
+    }
+
+    #[test]
+    fn envelope_deserializes_pre_feature_shape_with_no_alias_fields() {
+        // Wire-compat: pre-milestone-111 SBOMs (without alias_from /
+        // alias_to keys) MUST deserialize successfully into the new
+        // struct shape, with both fields defaulting to None via
+        // #[serde(default)].
+        let pre_feature_json = format!(
+            r#"{{"source_doc_id":{{"sha256":"{}"}},"hash":"{}","strength":"verified","algo":"v1"}}"#,
+            "e".repeat(64),
+            "a".repeat(64)
+        );
+        let parsed: SourceDocumentBinding =
+            serde_json::from_str(&pre_feature_json).unwrap();
+        assert!(parsed.alias_from.is_none());
+        assert!(parsed.alias_to.is_none());
+        assert_eq!(parsed.strength, BindingStrength::Verified);
     }
 }

--- a/mikebom-cli/src/binding/verify.rs
+++ b/mikebom-cli/src/binding/verify.rs
@@ -531,6 +531,10 @@ impl SourceSbomContext {
                 strength: b.strength,
                 reason: b.reason.clone(),
                 algo: b.algo.clone(),
+                // Source-tier bindings never carry milestone-111
+                // alias context; aliases are image-tier-only.
+                alias_from: None,
+                alias_to: None,
             },
             None => SourceDocumentBinding::unknown(
                 self.source_doc_id.clone(),
@@ -586,6 +590,8 @@ mod tests {
             strength: BindingStrength::Verified,
             reason: None,
             algo: "v1".to_string(),
+            alias_from: None,
+            alias_to: None,
         }
     }
 

--- a/mikebom-cli/src/sbom/mutator.rs
+++ b/mikebom-cli/src/sbom/mutator.rs
@@ -846,6 +846,8 @@ mod tests {
             strength,
             reason: reason.map(String::from),
             algo: "v1".to_string(),
+            alias_from: None,
+            alias_to: None,
         }
     }
 

--- a/specs/111-pkg-alias-binding/checklists/requirements.md
+++ b/specs/111-pkg-alias-binding/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Operator-supplied PURL alias for cross-tier binding
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Spec implements Option A of issue #225 only; Options B and C are explicitly deferred / off-table per the issue's recommendation.
+- No [NEEDS CLARIFICATION] markers needed — design ambiguities (wildcard support, scope-to-binary-path, env-var format) all resolved by deferring to v2 or by adopting straightforward defaults that match milestone-072 and milestone-110 conventions.
+- The new failure-reason vocabulary (`alias-target-not-found-in-bind-target`) extends the existing milestone-072 reason enum without breaking schema; assumes the reason field is already operator-facing-extensible (confirmed by trace_binding_cmd.rs:439-515 inspection during spec authoring).
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/111-pkg-alias-binding/contracts/binding-envelope-v1.1.md
+++ b/specs/111-pkg-alias-binding/contracts/binding-envelope-v1.1.md
@@ -1,0 +1,90 @@
+# Binding Envelope Schema (extended for milestone 111)
+
+**Feature**: 111-pkg-alias-binding
+**Base envelope**: milestone-072 `SourceDocumentBinding`
+**Change kind**: pure additive (two optional fields). `algo` field unchanged (`"v1"`).
+
+## Schema (JSON)
+
+```json
+{
+  "source_doc_id": { "...": "milestone-072 SourceDocumentId" },
+  "hash": "...",
+  "strength": "verified" | "weak" | "unknown",
+  "reason": "string (when strength=unknown)",
+  "algo": "v1",
+
+  "alias_from": "pkg:generic/baz",
+  "alias_to": "pkg:cargo/baz@1.0.0"
+}
+```
+
+| Field | Type | Required | Milestone | Notes |
+|---|---|---|---|---|
+| `source_doc_id` | object | yes | 072 | Pointer to source-tier SBOM document |
+| `hash` | string | no | 072 | Per-component layered hash; `None` when `strength == unknown` |
+| `strength` | enum | yes | 072 | `verified` / `weak` / `unknown`. **No new variants in milestone 111** (per /speckit-clarify Q3) |
+| `reason` | string | no | 072 | Required when `strength == unknown`. New value `"alias-target-not-found-in-bind-target"` (milestone 111) |
+| `algo` | string | yes | 072 | Always `"v1"`. **Not bumped for milestone 111** (additive metadata, not algorithm change) |
+| `alias_from` | string (PURL) | no | **111** | LHS PURL operator declared. Paired with `alias_to`. |
+| `alias_to` | string (PURL) | no | **111** | RHS PURL binder matched against. Paired with `alias_from`. |
+
+## Invariants
+
+1. `alias_from.is_some() == alias_to.is_some()` — paired presence.
+2. When `alias_from` is present, `strength != "unknown"` OR `reason == "alias-target-not-found-in-bind-target"`. (An alias was applied → either it succeeded or it failed for the alias-specific reason; other unknown reasons should not coexist with `alias_from`.)
+3. PURL values are canonical-form (lowercase scheme, sorted qualifiers, percent-encoding normalized).
+4. Both fields are absent in the wire form (via `skip_serializing_if = "Option::is_none"`) when no alias was applied.
+
+## Wire compatibility
+
+**Pre-feature emit → pre-feature consume**: byte-identical to pre-feature baseline. No alias fields present. ✓
+
+**Post-feature emit (no alias) → pre-feature consume**: byte-identical to pre-feature baseline (alias fields omitted via `skip_serializing_if`). ✓
+
+**Post-feature emit (with alias) → pre-feature consume**: pre-feature deserializer ignores unknown `alias_from` / `alias_to` fields by serde-default behavior. Existing binding result interpreted as verified/weak as usual; the pre-feature consumer does NOT surface that an alias was applied (no `applied_alias` sibling in their output). ✓
+
+**Post-feature emit → post-feature consume**: full round-trip; `applied_alias` sibling appears in verify-binding output. ✓
+
+## Format-parity emission
+
+The envelope serializes identically (modulo JSON whitespace + wrapper-property name) into all three target formats per the existing milestone-072 + milestone-071 parity infrastructure:
+
+| Format | Carrier |
+|---|---|
+| CDX 1.6 | `components[*].properties[]` entry with `name = "mikebom:binding-result-v1"` and `value = <JSON string of envelope>` |
+| SPDX 2.3 | `Package.annotations[].comment` wrapped in the existing `MikebomAnnotationCommentV1` envelope; `annotationType = "OTHER"`, `annotator = "Tool: mikebom-X.Y.Z"` |
+| SPDX 3.0.1 | `Annotation.statement` carrying the same `MikebomAnnotationCommentV1` envelope shape, attached via `Annotation.subject` to the affected Element |
+
+No new C-rows in `docs/reference/sbom-format-mapping.md`. The existing C56 (cross-tier binding annotation) row is amended with a note: "Envelope MAY additionally carry `alias_from` + `alias_to` fields when an operator-supplied `--pkg-alias` was applied (milestone 111)."
+
+## Validation contract
+
+Mikebom's existing milestone-072 envelope-validation logic (round-trip check, hash-shape check, strength-vs-reason consistency) is extended with:
+
+- **Paired presence**: `alias_from.is_some() XOR alias_to.is_some()` → reject envelope as malformed (defense-in-depth — this should never happen for envelopes mikebom emits, but defends against corrupted input).
+- **Canonical-form check on read**: a parsed `alias_from` / `alias_to` value MUST round-trip through `Purl::canonical()` unchanged; otherwise the envelope is rejected. Prevents abuse where a downstream tool injects a non-canonical PURL hoping mikebom will treat it as canonical.
+- **Same-PURL-on-both-sides check on read**: `alias_from == alias_to` → reject (matches `AliasError::LhsEqualsRhs` at CLI parse time).
+
+## Verify-binding output schema (sibling field)
+
+When verify-binding / trace-binding emits its per-component JSON result, an aliased binding gains a sibling field:
+
+```json
+{
+  "purl": "pkg:generic/baz",
+  "binding": {
+    "strength": "verified",
+    "reason": null,
+    "hash": "...",
+    "source_doc_id": "..."
+  },
+  "applied_alias": "pkg:generic/baz → pkg:cargo/baz@1.0.0"
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `applied_alias` | string | no | Present when the envelope's `alias_from` and `alias_to` are populated. Format: `"<LHS> → <RHS>"` (UTF-8 `→` U+2192) |
+
+`applied_alias` is sibling to the existing `binding` object, NOT nested inside it. This preserves the existing `binding` schema for pre-feature consumers and gives downstream JSON-querying tools an obvious `jq '.[] | select(.applied_alias != null)'` filter idiom.

--- a/specs/111-pkg-alias-binding/contracts/cli-flags.md
+++ b/specs/111-pkg-alias-binding/contracts/cli-flags.md
@@ -1,0 +1,78 @@
+# CLI Contract: `--pkg-alias`
+
+**Feature**: 111-pkg-alias-binding
+
+## Flag definition
+
+```
+--pkg-alias <LHS=RHS>
+    Declare that the binary-tier PURL `LHS` should be treated as the
+    source-tier PURL `RHS` when computing cross-tier binding (milestone
+    072). Both sides MUST be canonical-form PURLs. Repeatable; multiple
+    aliases compose. Requires `--bind-to-source` to have effect;
+    supplied otherwise, the flag emits a warning and the alias is
+    discarded from the emitted SBOM.
+
+    Also settable via `MIKEBOM_PKG_ALIAS` (comma-separated entries).
+
+    See `specs/111-pkg-alias-binding/` for full semantics.
+```
+
+## Syntax
+
+| Element | Rule |
+|---|---|
+| Outer separator | `=` (exactly one) |
+| LHS | Canonical-form PURL string |
+| RHS | Canonical-form PURL string |
+| LHS == RHS | Rejected (`AliasError::LhsEqualsRhs`) |
+| Repeated flag | Multiple `--pkg-alias` invocations are unioned into one `AliasMap` |
+| Conflicting RHS for same LHS | Rejected (`AliasError::ConflictingRhs`) |
+| Same RHS for different LHSes | Accepted |
+
+## Environment variable
+
+```
+MIKEBOM_PKG_ALIAS=pkg:generic/baz=pkg:cargo/baz@1.0.0,pkg:generic/qux=pkg:cargo/qux@2.0.0
+```
+
+| Element | Rule |
+|---|---|
+| Entry separator | `,` |
+| Per-entry shape | Same as `--pkg-alias` value |
+| Whitespace around `,` | Trimmed |
+| Empty entries (`,,`) | Skipped silently |
+| Conflict between env-var and CLI flag | Treated as a single composed alias-list; if the union contains a conflict, fail at parse time (FR-008) |
+
+## Error messages (FR-008, FR-009 — SC-003 single-line-actionable contract)
+
+| Trigger | Message |
+|---|---|
+| Missing `=` | `error: --pkg-alias value 'pkg:generic/baz' is missing the '=' separator; expected format: 'LHS_PURL=RHS_PURL'` |
+| Malformed LHS | `error: --pkg-alias LHS PURL 'pkg:bad@@thing' failed to parse: <PurlError details>` |
+| Malformed RHS | `error: --pkg-alias RHS PURL 'pkg:cargo/...' failed to parse: <PurlError details>` |
+| LHS == RHS | `error: --pkg-alias LHS 'pkg:cargo/baz@1.0.0' identical to RHS; aliases must specify distinct PURLs (did you mean to declare a different RHS?)` |
+| Conflicting RHS | `error: --pkg-alias LHS 'pkg:generic/baz' declared twice with conflicting RHS values: 'pkg:cargo/baz@1.0.0' and 'pkg:cargo/baz@1.1.0' (only one mapping per LHS is permitted; resolve the conflict and re-run)` |
+
+All errors exit with non-zero status before any scan I/O.
+
+## Warning messages
+
+| Trigger | Message (warn-level) |
+|---|---|
+| `--pkg-alias` supplied without `--bind-to-source` (FR-010) | `WARN: --pkg-alias declared (N entries) but --bind-to-source was not supplied; aliases have no effect on this scan and will not appear in the emitted SBOM. Add --bind-to-source <SOURCE_SBOM> to enable cross-tier binding.` |
+| Alias LHS unused (no scan-output component matched) (FR-011) | `INFO: --pkg-alias LHS 'pkg:generic/qux' did not match any scan-output component; no alias applied for this entry.` (Info, not warn, because operator typos are common and an info log is enough signal.) |
+
+## Interaction with other flags
+
+| Flag | Interaction |
+|---|---|
+| `--bind-to-source` | Required for `--pkg-alias` to have effect (FR-010) |
+| `--component-id` (milestone 073) | Independent; both may be supplied in the same invocation. `--component-id` adds identifier annotations; `--pkg-alias` rewrites binding-match input. No mutual exclusion enforced. |
+| `--fingerprints-corpus` (milestone 108) | Independent. Aliases apply to any scan-output component regardless of which reader produced it. |
+
+## Versioning + back-compat
+
+- The flag is purely additive; no existing flag's semantics change.
+- Pre-feature scans (no `--pkg-alias` supplied) produce byte-identical SBOMs to pre-feature baselines (SC-004).
+- Pre-feature consumers reading an alias-bearing SBOM see the extended envelope with two extra fields (`alias_from`, `alias_to`); serde-default ignore-unknown-fields means they deserialize without error and report the binding result as if it were a non-aliased verified/weak binding (`applied_alias` sibling absent in their output).

--- a/specs/111-pkg-alias-binding/data-model.md
+++ b/specs/111-pkg-alias-binding/data-model.md
@@ -1,0 +1,182 @@
+# Data Model: Operator-supplied PURL alias for cross-tier binding
+
+**Feature**: 111-pkg-alias-binding
+**Date**: 2026-06-09
+
+## Types
+
+### `PurlAlias` (new — `mikebom-cli/src/binding/alias.rs`)
+
+Newtype carrying a single `(LHS, RHS)` PURL pair. Constructed only via `parse_flag_value` or `from_env_entry`, both of which run both sides through `Purl::canonical()`.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PurlAlias {
+    pub lhs: Purl,   // image-tier component PURL
+    pub rhs: Purl,   // source-tier ecosystem PURL
+}
+```
+
+**Invariants**:
+- `lhs != rhs` (constructor enforces; same-on-both-sides is operator error).
+- Both fields are canonical-form PURLs (constructor runs `Purl::canonical()`).
+
+**Equality**: derived. Two aliases are equal iff both PURLs match exactly.
+
+---
+
+### `AliasMap` (new — `mikebom-cli/src/binding/alias.rs`)
+
+Container of validated aliases for one scan invocation. Lookups by LHS PURL are O(log N) via `BTreeMap` (deterministic iteration order for SBOM emission stability; N is typically < 10 so the constant matters more than the asymptote).
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub(crate) struct AliasMap {
+    by_lhs: std::collections::BTreeMap<Purl, Purl>,
+}
+
+impl AliasMap {
+    pub fn insert(&mut self, alias: PurlAlias) -> Result<(), AliasError> { ... }
+    pub fn get(&self, lhs: &Purl) -> Option<&Purl> { ... }
+    pub fn is_empty(&self) -> bool { ... }
+    pub fn iter(&self) -> impl Iterator<Item = (&Purl, &Purl)> { ... }
+}
+```
+
+**Invariants**:
+- `insert` rejects same-LHS-different-RHS pairs via `AliasError::ConflictingRhs` (FR-008).
+- Same-LHS-same-RHS insert is idempotent (no error).
+
+---
+
+### `AliasError` (new — `mikebom-cli/src/binding/alias.rs`)
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum AliasError {
+    #[error("malformed --pkg-alias value '{raw}': missing '=' separator")]
+    MissingSeparator { raw: String },
+    #[error("malformed --pkg-alias LHS PURL '{lhs}': {source}")]
+    MalformedLhs { lhs: String, source: PurlError },
+    #[error("malformed --pkg-alias RHS PURL '{rhs}': {source}")]
+    MalformedRhs { rhs: String, source: PurlError },
+    #[error("--pkg-alias LHS '{lhs}' declared twice with conflicting RHS values: '{existing_rhs}' and '{new_rhs}'")]
+    ConflictingRhs { lhs: Purl, existing_rhs: Purl, new_rhs: Purl },
+    #[error("--pkg-alias LHS '{lhs}' identical to RHS; aliases must specify distinct PURLs")]
+    LhsEqualsRhs { lhs: Purl },
+}
+```
+
+Maps cleanly to clap's `value_parser` error stringification (clap calls `.to_string()` on the error). Each variant's Display message satisfies the SC-003 single-line-actionable contract.
+
+---
+
+### `SourceDocumentBinding` (MODIFY — `mikebom-cli/src/binding/mod.rs:185`)
+
+Additive: two new optional fields. Existing fields unchanged.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SourceDocumentBinding {
+    pub source_doc_id: SourceDocumentId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hash: Option<BindingHash>,
+    pub strength: BindingStrength,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(default = "default_algo_v1")]
+    pub algo: String,
+
+    // NEW (milestone 111):
+    /// When this binding result was reached via a `--pkg-alias` declaration,
+    /// the LHS PURL the operator declared. None otherwise. MUST be `Some`
+    /// iff `alias_to` is `Some` (constructor enforces).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub alias_from: Option<Purl>,
+    /// Pair of `alias_from`. When `Some`, this is the RHS PURL the binder
+    /// matched against in the bind-source SBOM.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub alias_to: Option<Purl>,
+}
+```
+
+**Invariants**:
+- `alias_from.is_some() == alias_to.is_some()` (paired presence; never one without the other).
+- `algo` remains `"v1"` — this is an additive metadata extension, not an algorithm change (research.md §2).
+
+**Wire compatibility**: pre-feature consumers' deserialization sees two extra fields when present; serde's default ignore-unknown-fields behavior accepts the envelope. Pre-feature SBOMs (without the new fields) deserialize into the new struct with both fields `None` via `#[serde(default)]`. Round-trip byte-identity for no-alias scans is preserved by `skip_serializing_if`.
+
+---
+
+### `AliasFailureReason` (extension — string constant)
+
+New string value added to the enumerated `unknown { reason }` vocabulary:
+
+| Existing reason (milestone 072) | New reason (milestone 111) |
+|---|---|
+| `"source-not-found-in-bind-target"` | `"alias-target-not-found-in-bind-target"` |
+| `"no-evidence"` | (unchanged) |
+| `"base-layer-system-package"` | (unchanged) |
+| ... | (unchanged) |
+
+The new reason fires when an alias was declared, the LHS matched a scan-output component, but the RHS was NOT found in the bind-source SBOM. Distinguishes operator-misconfiguration (alias target missing) from genuine no-source (FR-007).
+
+---
+
+## Relationships
+
+```
+   CLI flag --pkg-alias LHS=RHS
+              │
+              ▼
+   value_parser::parse_pkg_alias()
+              │  Result<PurlAlias, AliasError>
+              ▼
+   AliasMap::insert()
+              │  Result<(), AliasError>
+              ▼
+   AliasMap held by ScanContext for the scan duration
+              │
+              ▼
+   binding::BindingComputer::compute(component_purl)
+   │   1. canonical_lhs = component_purl.canonical()
+   │   2. rhs = alias_map.get(canonical_lhs)
+   │   3. if rhs.is_some():
+   │        match_in_source(rhs)  → SourceDocumentBinding {
+   │                                    ..., alias_from: lhs, alias_to: rhs
+   │                                }
+   │      else:
+   │        match_in_source(canonical_lhs)  → SourceDocumentBinding {
+   │                                              ..., alias_from: None, alias_to: None
+   │                                          }
+              │
+              ▼
+   Envelope serialized into CDX/SPDX 2.3/SPDX 3 emission via parity extractors
+              │
+              ▼  (later, on verify-binding / trace-binding)
+              │
+   verify::ComponentBinding::binding_for_purl()
+   │   Reads alias_from/to back from envelope; emits applied_alias sibling
+   │   in output JSON when present.
+```
+
+## Lifecycle
+
+Per-scan:
+1. Operator passes `--pkg-alias` flags and/or sets `MIKEBOM_PKG_ALIAS`.
+2. `scan_cmd::execute` parses both sources into an `AliasMap`. Conflicts and malformed PURLs fail here.
+3. `AliasMap` is held by the scan context; consulted once per binary-tier component when `--bind-to-source` is active.
+4. Aliased components get the extended envelope with `alias_from` / `alias_to` populated.
+5. Unused aliases (LHS that matched no component) get an info-level log.
+6. SBOM is emitted; alias state is now baked into the document.
+
+Per-verify (later, no operator state):
+1. `verify-binding` / `trace-binding` parses the envelope.
+2. Encounters populated `alias_from` / `alias_to` → emits `applied_alias` sibling in output.
+3. Reproduces binding strength using only what the envelope records — no CLI re-supply required (FR-006).
+
+## Non-goals
+
+- Persisting the `AliasMap` outside the SBOM (no config file, no state file).
+- Wildcards, regex, name-only fuzz matching.
+- Reverse-direction (RHS → LHS) alias application.

--- a/specs/111-pkg-alias-binding/plan.md
+++ b/specs/111-pkg-alias-binding/plan.md
@@ -1,0 +1,133 @@
+# Implementation Plan: Operator-supplied PURL alias for cross-tier binding
+
+**Branch**: `111-pkg-alias-binding` | **Date**: 2026-06-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/111-pkg-alias-binding/spec.md`
+
+## Summary
+
+A new repeatable CLI flag `--pkg-alias LHS=RHS` (plus `MIKEBOM_PKG_ALIAS` env-var equivalent) on `mikebom sbom scan` declares that the binary-tier PURL `LHS` should be treated as the source-tier PURL `RHS` when computing the milestone-072 cross-tier binding. Aliased components reach `Verified` / `Weak` strength instead of `Unknown { reason: "source-not-found-in-bind-target" }`. The alias is persisted by extending the existing milestone-072 `SourceDocumentBinding` envelope with two optional fields (`alias_from`, `alias_to`) so `verify-binding` and `trace-binding` reproduce the same result without re-supplying the flag. Output also gains a sibling `applied_alias: "<LHS> → <RHS>"` field for at-a-glance auditor visibility. The `BindingStrength` enum is unchanged.
+
+Technical approach: PURL match is strict equality on canonical form (clarification Q1); persistence via additive `Option<Purl>` fields on `SourceDocumentBinding` with `#[serde(default, skip_serializing_if)]` so the envelope wire format remains backward-compatible (clarification Q2); verify-binding output extension via a sibling `Option<String>` field rather than a new strength variant (clarification Q3).
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–110; no nightly required for this user-space-only feature).
+**Primary Dependencies**: Existing only — `clap` (the new flag via `ArgAction::Append` derive), `serde`/`serde_json` (additive envelope round-trip), `Purl` newtype from `mikebom-common` (milestone 005 — canonicalization + equality), milestone-072 `SourceDocumentBinding` (the envelope this extends), `tracing` (warn/info logs), `anyhow` (error propagation), `thiserror` (alias-parse error variants). **No new Cargo dependencies.**
+**Storage**: N/A — alias declarations are in-process per scan; persisted only inside the emitted SBOM via the extended envelope. No caches, no databases.
+**Testing**: `cargo test --workspace` (CI gate). Unit tests in `mikebom-cli/src/binding/`, `mikebom-cli/src/cli/scan_cmd.rs`. Integration tests in `mikebom-cli/tests/` reusing the existing milestone-072 + milestone-096 fixtures plus three new alias-specific scenarios.
+**Target Platform**: Linux / macOS / Windows host (matches the milestone-101 Windows smoke matrix). The feature is pure user-space; no OS-specific code paths.
+**Project Type**: CLI tool feature extension. No new crates.
+**Performance Goals**: O(N_aliases × N_components) per binding pass. With typical N_aliases ≤ 10 and N_components ≤ 10k, the additional cost is microsecond-scale per scan. SC-005 requires workspace-of-5 aliases without ergonomic penalty; performance not on the critical path.
+**Constraints**:
+- **SC-004 byte-identity**: scans without any `--pkg-alias` flag MUST produce output byte-identical to the pre-feature baseline. The additive `Option<Purl>` envelope fields with `skip_serializing_if` plus the regression test against the existing milestone-072 + milestone-096 goldens enforce this.
+- **Principle IV no-`.unwrap()`**: all alias parsing returns `Result<_, AliasError>`; the `Purl` constructor returns `Result<Purl, PurlError>` and the CLI `value_parser` propagates.
+- **Principle V standards-native audit**: confirmed in research.md §1 — CDX 1.6 and SPDX 2.3/3.0.1 have no native cross-tier SBOM-to-SBOM binding construct, so the milestone-072 envelope extension is the only viable carrier.
+**Scale/Scope**: ~3 PRs (research → implementation → polish). Estimated LOC: ~600 lines of production code + ~400 lines of tests.
+
+## Constitution Check
+
+*Gate evaluated against mikebom Constitution v1.4.0. Re-checked after Phase 1 design (see post-design re-check at the bottom).*
+
+| Principle | Applicability | Status | Notes |
+|---|---|---|---|
+| I. Pure Rust, Zero C | Yes | PASS | All new code in Rust; no C bindings, no new build-script logic. |
+| II. eBPF-Only Observation | N/A | PASS | This milestone touches post-discovery binding logic only. No dependency-discovery changes; the eBPF-trace authority over component existence is unaffected. |
+| III. Fail Closed | Yes | PASS | Malformed PURLs and conflicting alias declarations reject at CLI parse time with actionable errors (FR-008/009). Aliases without `--bind-to-source` produce a warning, not silent loss (FR-010). |
+| IV. Type-Driven Correctness | Yes | PASS | Alias parsing returns `Result<PurlAlias, AliasError>`; `PurlAlias` is a newtype around `(Purl, Purl)`; no `.unwrap()` in production code paths. The CLI `value_parser` propagates parse errors via `anyhow`. |
+| V. Specification Compliance | Yes | PASS WITH AUDIT | Standards-native audit cited: CDX 1.6 + SPDX 2.3/3.0.1 have no native cross-tier SBOM-to-SBOM binding construct (research.md §1). The existing milestone-072 `SourceDocumentBinding` envelope is the only viable carrier; extending it with two optional fields preserves the parity-bridging justification documented in `docs/reference/sbom-format-mapping.md` C56 (binding rows). No new top-level `mikebom:*` property is introduced; only the existing envelope grows two additive fields. The envelope's CDX/SPDX 2.3/SPDX 3 emission shape is unchanged. |
+| VI. Three-Crate Architecture | Yes | PASS | All changes confined to `mikebom-cli/`. No new crates. |
+| VII. Test Isolation | Yes | PASS | All tests run in unprivileged CI. No eBPF / root requirements. |
+| VIII. Completeness | N/A | PASS | No discovery surface changes. |
+| IX. Accuracy | Yes | PASS | Aliases improve binding-result accuracy by removing the systemic `Unknown` for flagship components. Aliases are operator-asserted; the existing milestone-072 layered-evidence rules still apply to the RHS-side match (verified-via-hash-evidence vs weak-via-purl-only). |
+| X. Transparency | Yes | PASS | The extended envelope's `alias_from` / `alias_to` fields explicitly surface that an alias was applied; the `applied_alias` sibling field in verify-binding output gives auditors at-a-glance visibility. |
+| XI. Enrichment | N/A | PASS | No external enrichment. |
+| XII. External Data Source Enrichment | N/A | PASS | No external data sources. |
+| Strict Boundary 1: No lockfile-based discovery | N/A | PASS |
+| Strict Boundary 2: No MITM proxy | N/A | PASS |
+| Strict Boundary 3: No C code | N/A | PASS |
+| Strict Boundary 4: No `.unwrap()` in production | Yes | PASS | Enforced by `clippy::unwrap_used` deny at `mikebom-cli` crate root. New code follows the existing pattern. |
+
+**Gate result**: All principles pass. No violations to track. Complexity Tracking section below is therefore empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/111-pkg-alias-binding/
+├── plan.md              # This file
+├── research.md          # Phase 0 — standards audit + design decisions
+├── data-model.md        # Phase 1 — type extensions
+├── quickstart.md        # Phase 1 — operator walkthrough
+├── contracts/           # Phase 1 — CLI + envelope schemas
+│   ├── cli-flags.md
+│   └── binding-envelope-v1.1.md
+├── checklists/
+│   └── requirements.md  # Already created by /speckit-specify
+├── spec.md              # Spec with embedded clarifications
+└── tasks.md             # Phase 2 (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/
+├── src/
+│   ├── binding/
+│   │   ├── mod.rs                  # MODIFY: add optional alias_from / alias_to fields to SourceDocumentBinding
+│   │   ├── verify.rs               # MODIFY: per-component binding builder honors recorded aliases
+│   │   └── alias.rs                # NEW: PurlAlias newtype + AliasMap + AliasError + parser
+│   ├── cli/
+│   │   ├── scan_cmd.rs             # MODIFY: --pkg-alias flag + env-var propagation + parser wiring
+│   │   ├── verify_binding_cmd.rs   # MODIFY: applied_alias sibling field in output JSON
+│   │   └── trace_binding_cmd.rs    # MODIFY: applied_alias sibling field in output JSON
+│   └── parity/extractors/
+│       ├── cdx.rs                  # MODIFY: extractor for the extended envelope (alias_from / alias_to)
+│       ├── spdx2.rs                # MODIFY: same — SPDX 2.3 path
+│       └── spdx3.rs                # MODIFY: same — SPDX 3 path
+├── tests/
+│   ├── pkg_alias_binding_us1.rs    # NEW: User Story 1 integration test (single primary binary)
+│   ├── pkg_alias_binding_us2.rs    # NEW: User Story 2 integration test (workspace with multiple binaries)
+│   ├── pkg_alias_binding_us3.rs    # NEW: User Story 3 integration test (verify-binding round-trip)
+│   └── fixtures/
+│       └── pkg_alias_binding/
+│           ├── source-baz.cdx.json    # NEW: source-tier fixture with pkg:cargo/baz@1.0.0
+│           ├── image-baz.cdx.json     # NEW: image-tier fixture pre-binding
+│           └── workspace-multi.cdx.json # NEW: two-binary workspace fixture
+docs/reference/
+└── sbom-format-mapping.md         # MODIFY: extend C56 (binding) row with alias_from/alias_to note
+```
+
+**Structure Decision**: Extension of an existing milestone feature, no architectural change. New `binding/alias.rs` submodule keeps the alias-specific types isolated from the broader binding logic. Three integration tests (one per user story) reuse existing milestone-072 + milestone-096 fixture patterns. Parity extractors gain the two new fields in the same envelope, no new C-rows.
+
+## Phase 0 — Research
+
+See [research.md](./research.md) for:
+- **§1 Standards-native audit (Principle V mandatory)**: confirms no CDX/SPDX-native cross-tier-binding construct; documents the existing milestone-072 parity-bridging justification this milestone extends.
+- **§2 Envelope wire-compatibility**: the additive `Option<Purl>` field approach with `#[serde(default, skip_serializing_if = "Option::is_none")]`. Decision NOT to bump the envelope's `algo` field from `v1` to `v2` — consumers ignore unknown fields by spec, and a forced version bump would break pre-feature SBOM consumers unnecessarily.
+- **§3 Match semantics**: confirms clarification Q1's strict-canonical-equality choice. `Purl::canonical()` from milestone 005 is the comparison primitive on both sides (alias LHS at CLI parse time, scan-output component PURL at binding-time).
+- **§4 Conflict resolution**: same-LHS-different-RHS rejected at CLI parse time per FR-008. Same-RHS-multiple-LHS allowed per Edge Cases.
+- **§5 CLI ergonomics survey**: reviewed existing `--component-id` (milestone 073) for the `LHS=RHS` flag-value-parse pattern; reuse via a shared parser helper.
+
+## Phase 1 — Design
+
+See:
+- [data-model.md](./data-model.md) — `PurlAlias`, `AliasMap`, extended `SourceDocumentBinding`, `AliasError` enum.
+- [contracts/cli-flags.md](./contracts/cli-flags.md) — `--pkg-alias` syntax, env-var aliasing, error-message contract.
+- [contracts/binding-envelope-v1.1.md](./contracts/binding-envelope-v1.1.md) — extended `SourceDocumentBinding` schema with `alias_from` / `alias_to` fields; CDX / SPDX 2.3 / SPDX 3 emission shapes.
+- [quickstart.md](./quickstart.md) — operator walkthrough of the issue #225 scenario.
+
+## Constitution Re-Check (Post-Design)
+
+Re-evaluated after Phase 1 artifacts written. All gates from the initial check remain green:
+
+- The envelope-extension approach (Phase 1 contracts) introduces no new top-level `mikebom:*` property; the standards-native audit (Phase 0 research.md §1) holds.
+- The `PurlAlias` newtype in data-model.md satisfies Principle IV's type-driven correctness mandate.
+- The CLI `value_parser` design in contracts/cli-flags.md fails closed on malformed input (Principle III).
+- No design choice introduces a new dependency, a new crate, or a privilege requirement.
+
+No constitution amendments required. No complexity-tracking entries needed.
+
+## Complexity Tracking
+
+*Empty — Constitution Check produced no violations.*

--- a/specs/111-pkg-alias-binding/quickstart.md
+++ b/specs/111-pkg-alias-binding/quickstart.md
@@ -1,0 +1,142 @@
+# Quickstart: Binding a primary binary to its source-tier PURL
+
+**Feature**: 111-pkg-alias-binding (Option A of issue #225)
+**Audience**: operators following the textbook source-to-image workflow whose flagship binary's binding currently lands in `Unknown`.
+
+## The problem (before this feature)
+
+You have a Rust app `baz` at `github.com/foo/bar`. You produce two SBOMs:
+
+```bash
+# 1. Source-tier SBOM (run against your checkout)
+mikebom sbom scan --path . --output baz-source.cdx.json
+# emits a component for the main module:
+#   "purl": "pkg:cargo/baz@1.0.0"
+
+# 2. Image-tier SBOM (run against the built container)
+mikebom sbom scan --image myregistry/myimage:tag \
+    --bind-to-source baz-source.cdx.json \
+    --output baz-image.cdx.json
+```
+
+You inspect the image SBOM and find your flagship `baz` component:
+
+```json
+{
+  "purl": "pkg:generic/baz",
+  "properties": [{
+    "name": "mikebom:binding-result-v1",
+    "value": "{\"strength\":\"unknown\",\"reason\":\"source-not-found-in-bind-target\",...}"
+  }]
+}
+```
+
+`pkg:generic/baz` (image-tier) ≠ `pkg:cargo/baz@1.0.0` (source-tier), so the binder couldn't find a match. The single most important component in the scan has `unknown` binding.
+
+## The fix (after this feature)
+
+Add one `--pkg-alias` flag to your image-tier scan:
+
+```bash
+mikebom sbom scan --image myregistry/myimage:tag \
+    --bind-to-source baz-source.cdx.json \
+    --pkg-alias "pkg:generic/baz=pkg:cargo/baz@1.0.0" \
+    --output baz-image.cdx.json
+```
+
+The same component now shows:
+
+```json
+{
+  "purl": "pkg:generic/baz",
+  "properties": [{
+    "name": "mikebom:binding-result-v1",
+    "value": "{\"strength\":\"verified\",\"hash\":\"...\",\"source_doc_id\":\"...\",\"alias_from\":\"pkg:generic/baz\",\"alias_to\":\"pkg:cargo/baz@1.0.0\",...}"
+  }]
+}
+```
+
+Verified. Auditors can later trace the alias:
+
+```bash
+mikebom verify-binding baz-image.cdx.json baz-source.cdx.json
+# prints:
+# {
+#   "purl": "pkg:generic/baz",
+#   "binding": { "strength": "verified", ... },
+#   "applied_alias": "pkg:generic/baz → pkg:cargo/baz@1.0.0"
+# }
+```
+
+No `--pkg-alias` flag needed at verify time — the alias is recorded in the SBOM.
+
+## Multiple binaries (workspace project)
+
+A Cargo workspace with two binaries:
+
+```bash
+mikebom sbom scan --image myregistry/myimage:tag \
+    --bind-to-source workspace-source.cdx.json \
+    --pkg-alias "pkg:generic/baz=pkg:cargo/baz@1.0.0" \
+    --pkg-alias "pkg:generic/baz-debug=pkg:cargo/baz-debug@1.0.0" \
+    --output workspace-image.cdx.json
+```
+
+Or via env var (CI-friendly):
+
+```bash
+export MIKEBOM_PKG_ALIAS="pkg:generic/baz=pkg:cargo/baz@1.0.0,pkg:generic/baz-debug=pkg:cargo/baz-debug@1.0.0"
+mikebom sbom scan --image myregistry/myimage:tag \
+    --bind-to-source workspace-source.cdx.json \
+    --output workspace-image.cdx.json
+```
+
+Both forms produce identical SBOMs.
+
+## What can go wrong
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `error: --pkg-alias value 'pkg:generic/baz' is missing the '=' separator` | Forgot the `=` | Reformat as `LHS=RHS` |
+| `error: --pkg-alias LHS PURL '...' failed to parse` | Malformed PURL | Validate via `purl-spec.org` or copy from the source SBOM |
+| `error: --pkg-alias LHS 'X' declared twice with conflicting RHS values` | Same LHS appears with two RHSes (e.g., env var + CLI flag disagree) | Pick one RHS and remove the other |
+| `WARN: --pkg-alias declared but --bind-to-source was not supplied` | Forgot `--bind-to-source` | Add the flag |
+| `INFO: --pkg-alias LHS '...' did not match any scan-output component` | Typo'd LHS, or the scan didn't emit the expected component | Run without alias first, find the actual LHS PURL, then fix the alias |
+| `binding.strength = unknown, reason = "alias-target-not-found-in-bind-target"` | The RHS PURL isn't in `--bind-to-source` | Check the source SBOM has the expected `pkg:cargo/...` (or `pkg:npm/...`, etc.) component |
+
+## What this feature does NOT do
+
+- Doesn't auto-detect the alias for you — Option B of issue #225 is a follow-on milestone.
+- Doesn't do wildcard / pattern matching — strict PURL canonical-form equality only.
+- Doesn't rewrite the component's emitted PURL — the LHS stays as the component's `purl` field; the RHS is referenced only via the envelope's `alias_to`.
+- Doesn't apply in reverse — operator-declared alias is uni-directional LHS → RHS.
+
+## Round-tripping through CI
+
+Typical pipeline:
+
+```yaml
+# CI step 1: source SBOM
+- run: mikebom sbom scan --path . --output baz-source.cdx.json
+
+# CI step 2: build image, no SBOM yet
+- run: docker build -t $IMAGE_TAG .
+
+# CI step 3: image SBOM with binding
+- run: |
+    mikebom sbom scan --image $IMAGE_TAG \
+        --bind-to-source baz-source.cdx.json \
+        --pkg-alias "pkg:generic/baz=$SOURCE_PURL" \
+        --output baz-image.cdx.json
+
+# CI step 4: verify (no alias re-supply needed)
+- run: mikebom verify-binding baz-image.cdx.json baz-source.cdx.json
+```
+
+The `$SOURCE_PURL` can be extracted from `baz-source.cdx.json` with `jq`:
+
+```bash
+SOURCE_PURL=$(jq -r '.metadata.component.purl' baz-source.cdx.json)
+```
+
+(For workspace projects with multiple binaries, this gets one alias declaration per binary — see the `MIKEBOM_PKG_ALIAS` env-var form above for the cleanest shape.)

--- a/specs/111-pkg-alias-binding/research.md
+++ b/specs/111-pkg-alias-binding/research.md
@@ -1,0 +1,112 @@
+# Research: Operator-supplied PURL alias for cross-tier binding
+
+**Feature**: 111-pkg-alias-binding
+**Date**: 2026-06-09
+**Status**: Complete
+
+Five research items, each resulting in a Decision + Rationale + Alternatives Considered block.
+
+---
+
+## §1 Standards-native audit (Principle V mandatory)
+
+**Question**: Do CycloneDX 1.6 or SPDX 2.3 / 3.0.1 provide a native construct for "this binary-tier component is cross-tier-bound to a source-tier component identified by a different PURL"? Per Constitution Principle V, every new `mikebom:*` property requires a documented audit of the target formats showing no native equivalent exists.
+
+**Decision**: No native construct exists in any of the three target formats. The existing milestone-072 `SourceDocumentBinding` envelope (carried as a `mikebom:binding-result-v1` property in CDX 1.6 and via the `MikebomAnnotationCommentV1` envelope in SPDX 2.3 + SPDX 3) is the established parity-bridging mechanism for cross-tier binding semantics. This milestone extends that envelope additively (two optional fields `alias_from` / `alias_to`); no new top-level property is introduced.
+
+**Rationale**:
+- **CDX 1.6 cross-doc reference**: `bom-link` URN format references EXTERNAL SBOM documents but doesn't describe a "this PURL was rewritten" relationship. `dependencies[]` describes dependency relationships WITHIN a single BOM. `components[].properties[]` is the catch-all key/value carrier — which is what milestone 072 already uses.
+- **CDX 1.6 `declarations.claims[]`**: an operator-asserted claim — could in principle carry "I claim component X corresponds to component Y" — but `declarations` is scoped to compliance attestations (BSI, EU CRA-style), not provenance rewrites. Using it would be a semantic stretch and would create a new emission surface area for marginal gain.
+- **SPDX 2.3**: `Relationships` graph supports many predicate types (`DESCRIBES`, `CONTAINS`, `DEPENDS_ON`, `VARIANT_OF`, `OTHER`) but none semantically express cross-tier binding. The closest, `VARIANT_OF`, describes a single-package variant relationship within one SBOM. Adding a `Relationship` between an image-tier Package and a source-tier Package across SBOM boundaries via `ExternalDocumentRef` is technically expressible but would require operators to author the relationship structure manually — exactly the verbose-CDX problem the tool-survey thread (issue #326 context) flagged as hostile.
+- **SPDX 3.0.1**: `ExternalMap` provides cross-document Element references with `verifiedUsing` integrity. Closer to fit-for-purpose than SPDX 2.3, but still not a "rewrite alias" semantic — it's a content-addressable reference. SPDX 3 also has no native "binding strength" enum, so the milestone-072 envelope already does the cross-format bridging work.
+- **Confirmation by absence in OSS practice**: a literature survey across the SBOM-author tooling ecosystem (cyclonedx-cli, syft, sbom-tool, GUAC, ClearlyDefined, in-toto, CMake-SBOM-Builder — full results in issue #326's three-thread research) surfaced zero tools that emit a "this PURL was rewritten for binding match" annotation in standards-native form. Every cross-tier-binding tool that exists today (mikebom milestone 072, in-toto VSA, GUAC's `HasSBOM`) uses tool-specific envelopes.
+
+The existing `docs/reference/sbom-format-mapping.md` C56 row already documents the milestone-072 envelope's parity-bridging justification. This milestone amends the C56 row with a note that the envelope can carry the additive alias fields; no new C-row is needed.
+
+**Alternatives considered**:
+- **New top-level CDX `properties[]` entry**: `mikebom:pkg-alias-from` + `mikebom:pkg-alias-to` as two separate properties on the affected component. Rejected per Principle V — the envelope's `SourceDocumentBinding` already covers cross-tier-binding-result semantics, so adding sibling properties would split a logically-single concept across two emission surfaces. Verify-binding would have to read from two places.
+- **CDX 1.6 `declarations.claims[]`**: a claim per affected component asserting the alias. Rejected — semantically wrong (claims are compliance attestations) and ergonomically heavier (operators rarely interact with the declarations surface).
+- **SPDX 2.3 `Relationship` with `relationshipType: OTHER` + comment**: would require manual cross-document reference setup. Rejected as too verbose for a binding-time concept and not parity-bridgeable to CDX without an additional envelope anyway.
+
+---
+
+## §2 Envelope wire-compatibility
+
+**Question**: When adding `alias_from` / `alias_to` fields to the existing `SourceDocumentBinding` struct, do we bump the envelope's `algo` field from `v1` to `v2`, or treat the additive change as pure backward-compatible extension?
+
+**Decision**: Pure additive extension — no `algo` bump. Use `#[serde(default, skip_serializing_if = "Option::is_none")]` on the two new `Option<Purl>` fields. When the operator does NOT supply `--pkg-alias`, the fields are `None` and serde omits them from emission, producing byte-identical output to the pre-feature baseline (satisfies SC-004 directly). When the operator DOES supply `--pkg-alias`, the fields serialize as additional keys inside the existing envelope; pre-feature consumers' serde-derived deserializers ignore unknown fields by default and parse the envelope successfully.
+
+**Rationale**:
+- The existing `SourceDocumentBinding` already uses `#[serde(default, skip_serializing_if = "Option::is_none")]` on its `hash` and `reason` fields (verified by reading `binding/mod.rs:189-196`). The two new fields follow the same pattern, so the wire shape is consistent.
+- The `algo` field's documented contract (`binding/mod.rs:197`: "Always `\"v1\"` for milestone 072") is a version tag for the LAYERED-HASH algorithm, not for the envelope's field set. This milestone does NOT change the hash algorithm; the only change is two metadata fields that don't participate in hash computation. Bumping `algo` would falsely signal an algorithm change.
+- Serde's standard behavior (ignore-unknown-fields on `#[derive(Deserialize)]` without `deny_unknown_fields`) makes the additive change safe for pre-feature consumers. The existing envelope struct does NOT carry `deny_unknown_fields` (verified by reading `binding/mod.rs:184`), so this safety property holds.
+- Byte-identity for the no-alias case is the load-bearing regression guard. The `skip_serializing_if` directive makes this property mechanical rather than convention-based.
+
+**Alternatives considered**:
+- **Bump to `algo: "v2"`**: would force every pre-feature SBOM consumer (including milestone-072 verify-binding) to either accept both versions or fail. Rejected — gratuitous churn.
+- **New envelope type `SourceDocumentBindingV2`**: would require a new property name (`mikebom:binding-result-v2`) and dual-emission compatibility. Rejected — over-engineering for an additive change.
+- **Embedded sub-struct**: `binding.alias: Option<AliasSpec> { from: Purl, to: Purl }` — slightly cleaner nesting but adds a serialization layer and a parity-extractor row for the sub-struct. Rejected — flat `alias_from` / `alias_to` is simpler and matches the existing flat envelope shape.
+
+---
+
+## §3 Match semantics (canonical equality)
+
+**Question**: When comparing the alias LHS PURL against scan-output component PURLs, what equality model is used?
+
+**Decision**: Strict equality on canonical PURL form. Both sides are run through `Purl::canonical()` (the milestone-005 normalization: lowercase scheme, lowercase host, sorted qualifiers, percent-encoding normalization) and string-compared. No partial / name-only / version-pattern matches. This decision was locked at /speckit-clarify Q1; this section captures the implementation primitive.
+
+**Rationale**:
+- `Purl` is already a newtype in `mikebom-common` (per Constitution Principle IV and milestone 005 — workspace contract). The newtype's `canonical()` method exists and is the comparison primitive used elsewhere in the codebase for PURL equality (e.g., in milestone-072's component matching at `binding/verify.rs:431+`).
+- Operators ARE in control of the input — they author the LHS knowing the scan-output PURL shape. The issue #225 problem statement specifically references `pkg:generic/baz` as the scan-output shape; operators declare exactly that. Future evolution (e.g., milestone 096 emitting versioned generic PURLs) requires operators to update their aliases — an explicit-cost change, not a silent breakage.
+- Strict equality is the lowest-surprise default. Pattern matching (name-only, wildcard) introduces collision risk: `pkg:generic/log` (Rust crate? Unix log? something else?) shouldn't silently bind to a randomly-named source-tier `log` component.
+
+**Alternatives considered**: 4 options surveyed at /speckit-clarify Q1 (strict / name-only / name+version / bare-form); strict equality chosen.
+
+---
+
+## §4 Conflict resolution (same-LHS-different-RHS rejected at parse time)
+
+**Question**: When the operator declares two `--pkg-alias` flags with the same LHS but different RHS values, how does mikebom respond?
+
+**Decision**: Reject at CLI parse time with an actionable error message naming both conflicting declarations. Mikebom exits with non-zero status before any scan work begins. No scan runs with partial or first-wins semantics.
+
+**Rationale**:
+- Fail-closed posture (Principle III) — silent precedence would silently distort binding results, exactly the failure mode milestone 072's `unknown { reason }` transparency was designed to avoid. Operator typos should surface as immediate failures, not as wrong-component bindings discovered hours later.
+- The CLI-parse-time check is cheap (linear in N_aliases, executed before any I/O). Implementation: collect aliases into a `HashMap<Purl, Purl>` keyed by LHS; on insert, check for an existing entry with a different RHS and emit the error.
+- Same-RHS-multiple-LHS is NOT rejected (per Edge Cases) — multiple image-tier PURLs may legitimately bind to one source-tier PURL (e.g., a single source crate produces two distinct binaries that the binary scanner names differently). This is operator intent, not error.
+
+**Alternatives considered**:
+- **First-declaration-wins with a warning**: rejected — silent override violates fail-closed.
+- **Last-declaration-wins**: same rejection rationale.
+- **Reject at binding-time instead of CLI-parse-time**: rejected — wastes scan work and surfaces the error later than necessary.
+
+---
+
+## §5 CLI ergonomics — reuse the milestone-073 `LHS=RHS` parser pattern
+
+**Question**: How is the `LHS=RHS` flag value parsed at the clap layer? Does a similar parser exist in the codebase already?
+
+**Decision**: Reuse the parser pattern from milestone-073's `--component-id KEY=VALUE` flag (located in `mikebom-cli/src/cli/scan_cmd.rs:398` per the issue #225 references). The pattern is: a clap `value_parser` function `parse_pkg_alias(raw: &str) -> Result<PurlAlias, String>` that splits on `=`, validates both sides as canonical `Purl`s via `Purl::parse_canonical()`, and returns the typed result. Errors map to clap's stderr surface with the offending input shown verbatim. The env-var form (`MIKEBOM_PKG_ALIAS`) uses `,` as entry separator (matching milestone-110's `MIKEBOM_FINGERPRINTS_SOURCES`) and re-uses the per-entry parser.
+
+**Rationale**:
+- Consistency with milestone-073 reduces operator cognitive load — two adjacent flags with similar shapes parse the same way.
+- Consistency with milestone-110 env-var format means operators who already configured `MIKEBOM_FINGERPRINTS_SOURCES` recognize the comma-separated shape.
+- Clap's `value_parser` integration means error messages render via clap's standard error path, which already includes the flag name and offending value.
+
+**Alternatives considered**:
+- **String-typed CLI field with later parsing**: rejected — defers error reporting and complicates the test surface.
+- **Custom clap `Args` derive with a sub-struct**: over-engineering for a two-string parse.
+- **JSON-encoded flag values**: hostile to operator hand-authoring; rejected.
+
+---
+
+## Summary
+
+Five research questions resolved; no [NEEDS CLARIFICATION] markers remain. The implementation is fully unblocked for Phase 1 design + Phase 2 task generation.
+
+Key decisions for downstream phases:
+1. Standards audit clears Principle V; envelope-extension approach is the only viable carrier.
+2. Wire-compatibility approach: pure additive, no `algo` bump.
+3. Match primitive: `Purl::canonical()` equality on both sides.
+4. Conflict policy: fail-closed at CLI parse time.
+5. Parser pattern: reuse milestone-073 `KEY=VALUE` shape + milestone-110 env-var conventions.

--- a/specs/111-pkg-alias-binding/spec.md
+++ b/specs/111-pkg-alias-binding/spec.md
@@ -1,0 +1,128 @@
+# Feature Specification: Operator-supplied PURL alias for cross-tier binding
+
+**Feature Branch**: `111-pkg-alias-binding`
+**Created**: 2026-06-08
+**Status**: Draft
+**Input**: User description: "Operator-supplied PURL alias to bind binary-tier pkg:generic components to source-tier ecosystem PURLs (Option A of issue #225). Extends milestone 072 cross-tier binding."
+
+## Clarifications
+
+### Session 2026-06-09
+
+- Q: How does the LHS PURL in `--pkg-alias` compare against scan-output component PURLs? → A: Strict equality on canonical PURL form (name + version + qualifiers + subpath, after canonicalization). No partial / pattern matches; no version-or-qualifier fuzzing.
+- Q: Where does the applied-alias record live in the emitted SBOM, and what shape does it take? → A: Extend the existing milestone-072 binding-result property envelope with optional `alias_from` / `alias_to` fields. One property entry per component; existing verify-binding parser learns the new fields without new envelope plumbing.
+- Q: When verify-binding reads an alias-bearing SBOM, how should its output surface that the binding was reached via an alias? → A: Output gains a sibling field `applied_alias: "<LHS> → <RHS>"` (single-string format) when alias was applied. `BindingStrength` enum unchanged (no breaking change); auditors get the mapping at a glance.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Bind a single primary binary to its source-tier ecosystem PURL (Priority: P1)
+
+An operator builds a Rust application `baz` from `github.com/foo/bar`. The source-tier SBOM (produced by scanning the Rust workspace) has the project's main module emit as `pkg:cargo/baz@1.0.0`. CI builds a container image containing the compiled `baz` binary, and the image-tier SBOM (produced by scanning the image) identifies the binary as `pkg:generic/baz`. When the operator runs `mikebom sbom scan --image ... --bind-to-source baz-source.cdx.json` to bind image to source, the flagship `baz` component fails to bind because `pkg:generic/baz` and `pkg:cargo/baz@1.0.0` are not equal PURLs. The operator needs to declare that these two PURLs refer to the same logical component so cross-tier binding succeeds for the component they care most about.
+
+**Why this priority**: This is the textbook source-to-image workflow that motivates issue #225. Until this case works, the binding feature is operator-hostile for the most-important component in every scan. P1 because no MVP exists without it.
+
+**Independent Test**: Author a small Rust project with one binary; produce a source-tier SBOM; build a containerized version; produce an image-tier SBOM with the alias declaration; verify the binding strength of the binary component is `verified` or `weak`, never `unknown` with reason `source-not-found-in-bind-target`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a source-tier SBOM containing a component with PURL `pkg:cargo/baz@1.0.0` and an image containing a binary that mikebom identifies as `pkg:generic/baz`, **When** the operator runs `mikebom sbom scan --image ... --bind-to-source baz-source.cdx.json --pkg-alias "pkg:generic/baz=pkg:cargo/baz@1.0.0"`, **Then** the emitted image-tier SBOM contains a component for the binary whose binding strength is `verified` (when hash-evidence matches) or `weak` (when hash-evidence is absent or partial), AND the reason field does not say `source-not-found-in-bind-target`.
+2. **Given** the same scan as above, **When** an operator inspects the emitted SBOM later, **Then** the alias declaration is recorded on the affected component as a machine-readable property so a downstream consumer or auditor can see that an alias was applied to produce the binding result.
+3. **Given** a scan with no `--bind-to-source` flag, **When** the operator supplies `--pkg-alias` anyway, **Then** mikebom emits a warning and proceeds without error (aliases are a binding-time concept; supplying them outside the binding workflow is harmless but should produce a clear operator signal that the flag had no effect).
+
+---
+
+### User Story 2 - Bind multiple primary binaries in a workspace project (Priority: P2)
+
+An operator has a Cargo workspace containing two binaries `baz` and `baz-debug`. The source-tier SBOM emits two main-module components: `pkg:cargo/baz@1.0.0` and `pkg:cargo/baz-debug@1.0.0`. The image contains both compiled binaries. The operator needs to declare aliases for both so neither flagship component lands in the `unknown` binding state.
+
+**Why this priority**: Workspace projects are common in Rust, Go, and monorepo setups; without N-alias support the feature only handles single-binary projects. P2 because P1 has the same UX shape — the additional surface is per-flag repetition, not new semantics.
+
+**Independent Test**: Same setup as User Story 1 but with two binaries; verify both components bind correctly after declaring two `--pkg-alias` flags.
+
+**Acceptance Scenarios**:
+
+1. **Given** two binaries in an image and two corresponding source-tier components, **When** the operator passes `--pkg-alias` twice (once per binary), **Then** both image-tier components bind to their respective source-tier targets with strength `verified` or `weak`.
+2. **Given** the same setup, **When** the operator instead supplies the aliases as one environment variable (comma-separated entries matching the per-flag syntax), **Then** mikebom honors the env-var form identically to the per-flag form for CI-pipeline ergonomics.
+
+---
+
+### User Story 3 - Verify-binding consumes alias-bearing SBOMs without re-supplying the alias (Priority: P2)
+
+After a scan stamps the SBOM with the applied alias, an auditor running `mikebom verify-binding image.cdx.json baz-source.cdx.json` (or `mikebom trace-binding ...`) needs to reproduce the same binding result without having access to the original `--pkg-alias` flag value. The alias was operator intent at scan time; verification must honor that intent based purely on what's recorded in the artifacts.
+
+**Why this priority**: Without persistence, the alias is operationally fragile — the scan succeeds but the SBOM doesn't survive a round-trip through verify-binding. Audit pipelines that re-verify SBOMs (without access to the original CLI invocation) lose the binding result. P2 because P1 unblocks the scan-time workflow; this completes the round-trip.
+
+**Independent Test**: Run a scan with `--pkg-alias`, save the resulting SBOM, then run `verify-binding` on the saved SBOM against the same source-tier SBOM, with no CLI alias supplied; verify the binding strength matches the scan-time result.
+
+**Acceptance Scenarios**:
+
+1. **Given** an image-tier SBOM produced with `--pkg-alias` in User Story 1, **When** the operator runs `mikebom verify-binding image.cdx.json baz-source.cdx.json`, **Then** the verification result for the aliased component reports the same strength (`verified` or `weak`) as the scan-time result, AND identifies the alias as the source of the match.
+2. **Given** the same SBOM but a different source-tier SBOM that does NOT contain the alias's target PURL, **When** the operator runs `verify-binding`, **Then** the result is `unknown` with a distinct reason indicating the alias target is missing from the bind source (separate from the existing `source-not-found-in-bind-target` reason).
+
+---
+
+### Edge Cases
+
+- **Alias LHS does not appear in the scan output**: Operator supplies `--pkg-alias "pkg:generic/qux=pkg:cargo/qux@1.0.0"` but no `pkg:generic/qux` component is produced by the scan. Mikebom emits an info-level log noting the unused alias and proceeds; the unused alias is not recorded in the emitted SBOM. This protects against operator typos silently distorting the binding result.
+- **Alias RHS not present in the bind-source SBOM**: Operator supplies an alias whose RHS PURL does not exist in `--bind-to-source`. Mikebom records the alias-application attempt on the affected component but reports binding strength `unknown` with reason `alias-target-not-found-in-bind-target` (distinct from the existing `source-not-found-in-bind-target` reason) so operators can debug their alias declaration separately from a missing-source-document state.
+- **Same RHS targeted by multiple LHS aliases**: Operator declares `--pkg-alias A=X --pkg-alias B=X`. Both LHS components bind to the same RHS source-tier component. Mikebom does not collapse the two image-tier components into one; each retains its own identity while both bind to the same source.
+- **Same LHS with multiple different RHS aliases**: Operator declares `--pkg-alias A=X --pkg-alias A=Y` (two RHSes for one LHS). Mikebom rejects the second alias declaration at flag-parse time with a clear error message; ambiguity is treated as operator error, not silent precedence.
+- **Malformed PURL on either side of the alias**: Operator passes a syntactically invalid PURL string in the alias. Mikebom rejects the alias at flag-parse time with a clear error citing the malformed input, before any scan work begins.
+- **Alias supplied without `--bind-to-source`**: As scenario 3 of User Story 1: a warning is emitted; the scan proceeds; the alias is not recorded in the SBOM (since it had no effect).
+- **Alias whose LHS is not in the generic PURL namespace**: The flag accepts any LHS PURL, not just `pkg:generic/*`. Operators with hand-crafted scenarios (e.g., wanting to alias `pkg:deb/debian/foo@1.0` to `pkg:github/foo/foo@1.0` for a different source-tier representation) can do so.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Mikebom MUST accept a repeatable CLI flag `--pkg-alias LHS=RHS` on the `sbom scan` subcommand, where both LHS and RHS are PURL strings in canonical form. Match against scan-output components is strict equality of the canonical PURL form (name + version + qualifiers + subpath, after canonicalization); no partial, name-only, or version-pattern matches are performed.
+- **FR-002**: Mikebom MUST accept an environment variable `MIKEBOM_PKG_ALIAS` containing one or more alias entries (entries separated by `,`) using the same `LHS=RHS` syntax as the CLI flag; the env-var form and the repeated-flag form MUST produce identical behavior.
+- **FR-003**: When `--bind-to-source` is in effect AND a configured alias's LHS PURL matches a component produced by the scan, the binder MUST treat the matched component as if its PURL were the alias's RHS for the purpose of locating a counterpart in the bind-source SBOM.
+- **FR-004**: When an alias is applied to a component, the binder MUST compute the binding strength (`verified`, `weak`, or `unknown`) using the same layered-evidence rules that apply to non-aliased components, with the RHS source-side evidence as input.
+- **FR-005**: Mikebom MUST record the applied alias on the affected component in the emitted SBOM by extending the existing milestone-072 binding-result property envelope (one property entry per component) with two optional fields: `alias_from` carrying the LHS PURL the operator declared, and `alias_to` carrying the RHS PURL the binder matched against. The two fields MUST appear together (both populated when an alias was applied; both absent otherwise) so consumers can rely on their presence as a single signal. The format-parity layer emits the extended envelope in CDX 1.6, SPDX 2.3, and SPDX 3.0.1 with semantically equivalent content.
+- **FR-006**: `verify-binding` and `trace-binding` subcommands MUST honor an alias recorded in the input SBOM and produce the same binding strength they would have produced at scan time, without requiring the original CLI alias to be re-supplied. When an alias was applied, the output MUST surface a sibling field `applied_alias: "<LHS> → <RHS>"` (single-string format) so auditors can recognize alias-driven results at a glance. The `BindingStrength` enum MUST NOT gain new variants for the aliased case — `verified`, `weak`, and `unknown` remain the only values.
+- **FR-007**: When an alias's RHS does not appear in the bind-source SBOM, the binder MUST report `unknown` strength with reason `alias-target-not-found-in-bind-target`, distinct from the existing `source-not-found-in-bind-target` reason.
+- **FR-008**: When the operator supplies the same LHS with two different RHSes, mikebom MUST reject the invocation at CLI-parse time with an actionable error message citing the conflicting declarations.
+- **FR-009**: When the operator supplies a malformed PURL on either side of an alias, mikebom MUST reject the invocation at CLI-parse time with an actionable error message citing the malformed input.
+- **FR-010**: When the operator supplies `--pkg-alias` without `--bind-to-source`, mikebom MUST emit a warning identifying that the alias has no effect and proceed with the scan; the unused alias MUST NOT appear in the emitted SBOM.
+- **FR-011**: When a configured alias's LHS PURL does not match any component produced by the scan, mikebom MUST log the unused alias at info level and MUST NOT record it on any component in the emitted SBOM.
+- **FR-012**: Existing milestone-072 binding behavior for components without a configured alias MUST be unchanged; component-level binding results without an applied alias MUST be byte-identical to pre-feature output, modulo the absence of the new alias-property entry.
+- **FR-013**: The extended binding-result envelope MUST capture both the original LHS (in `alias_from`) and the RHS (in `alias_to`) so consumers can reconstruct what was rewritten without ambiguity; downstream tooling MUST be able to identify "this binding result was reached via an alias" by inspecting the presence of these fields alone, without consulting any external alias declaration source.
+
+### Key Entities
+
+- **PURL Alias**: A pair of PURL strings (LHS, RHS) declared by the operator. LHS is the component identifier produced by the binary-tier scan; RHS is the canonical ecosystem-tier PURL that LHS should be treated as during binding match.
+- **Aliased Component**: A component in the emitted SBOM whose PURL is LHS, whose binding result was computed against the RHS source-tier component, and which carries a property recording the alias declaration that produced that binding.
+- **Binding Strength**: One of `verified`, `weak`, or `unknown`, computed per the existing milestone-072 layered-evidence rules. The alias affects which RHS source-tier component is matched; it does not change the strength calculation itself.
+- **Alias Failure Reason**: A string field accompanying an `unknown` binding result that identifies why binding failed. New value `alias-target-not-found-in-bind-target` is added for the case when an alias's RHS is not present in the bind-source SBOM; existing `source-not-found-in-bind-target` continues to fire for components without an applied alias.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator scanning their flagship source-to-image workflow (one primary binary, one source SBOM, one image SBOM) can move the binding strength of the primary binary component from `unknown` to `verified` or `weak` by adding exactly one `--pkg-alias` flag to their existing scan command. No other CLI surface or configuration change is required.
+- **SC-002**: An auditor re-running `verify-binding` on an alias-bearing SBOM produced by a prior scan reproduces the same binding strength for every aliased component without re-supplying the alias at the command line.
+- **SC-003**: When an operator misconfigures an alias (typo'd LHS, missing RHS in source, malformed PURL, conflicting declarations), mikebom produces an error or warning message that names both the misconfiguration and the corrective next step within a single output line, so the operator can fix the alias without consulting documentation.
+- **SC-004**: A scan that does not supply any `--pkg-alias` flag produces an emitted SBOM byte-identical to the pre-feature baseline for every component (no new properties, no semantic drift, no new annotations). Regression-free for the OSS default-no-extras path.
+- **SC-005**: A workspace project with five primary binaries can be fully aliased with five repeated `--pkg-alias` flags (or one env-var entry containing all five), without per-binary CLI ergonomics penalties (no required-config files, no per-binary subcommands, no separate scan invocations).
+- **SC-006**: Aliased components round-trip cleanly through the existing format-parity layer: the alias-applied property emits in CDX 1.6, SPDX 2.3, and SPDX 3.0.1 with semantically equivalent content, and the cross-format parity gate accepts the new property without invariant violations.
+
+## Assumptions
+
+- Operators authoring `--pkg-alias` declarations know the source-tier PURL ahead of time (they have access to the source SBOM during scan invocation or can predict the main-module PURL from their build system). Out-of-band PURL lookup tooling is not part of this milestone.
+- Aliases are scan-time configuration, not persisted state — operators re-supply the alias at every scan that needs it. Aliases ARE persisted in the emitted SBOM so that downstream consumers (verify-binding, trace-binding) can honor them without re-supply.
+- The set of `unknown` reasons defined by milestone 072 is open for extension; adding `alias-target-not-found-in-bind-target` does not require external schema coordination.
+- The format-parity layer (milestone 071) and the catalog-row infrastructure (existing) accept new component-level properties on the same terms as existing milestone-072 binding properties; no new parity infrastructure work is required.
+- Operators who supply both `--pkg-alias` and the milestone-073 `--component-id` flag are responsible for understanding their distinct purposes; the spec does not need to enforce mutual exclusion. The two flags serve adjacent but non-overlapping goals — `--component-id` adds external identifiers as annotations, `--pkg-alias` rewrites the binding-match input — and operators may use them together without conflict.
+- Aliases apply only at binding time. Out of scope: alias-driven rewriting of the component's emitted PURL itself (the LHS remains the emitted PURL; the RHS is referenced only via the alias-applied property). This preserves the milestone-104 binary-role-classification + milestone-096 binary-identity invariants that depend on the binary-tier PURL being computed from binary evidence alone.
+- This milestone implements Option A from issue #225 only. Option B (source-side `mikebom:produces-binaries` annotation enabling automatic aliasing) is a deferred follow-on milestone. Option C (name-only heuristic match) is explicitly off the table.
+
+## Out of Scope
+
+- Wildcard alias matching (LHS = `pkg:generic/*` etc.) — start with literal LHS matches.
+- Automatic aliasing via source-side annotations (issue #225 Option B).
+- Name-only heuristic matching (issue #225 Option C).
+- Aliasing across non-PURL identifiers (CPE, swid, gitoid, etc.) — PURL-to-PURL only.
+- A configuration file format for aliases (e.g., `mikebom-aliases.toml`). Aliases are supplied via flag or env var; a config-file format may follow if operator usage demonstrates demand.
+- Scoping an alias to a specific binary path within the image (e.g., apply only to `/usr/local/bin/baz`, not all `pkg:generic/baz`). Defer until operator usage shows demand.
+- Reverse-direction alias application (treating the RHS as a synonym for the LHS) — the issue's problem statement is uni-directional.

--- a/specs/111-pkg-alias-binding/tasks.md
+++ b/specs/111-pkg-alias-binding/tasks.md
@@ -1,0 +1,208 @@
+---
+description: "Task list for milestone 111 — Operator-supplied PURL alias for cross-tier binding"
+---
+
+# Tasks: Operator-supplied PURL alias for cross-tier binding (Option A of issue #225)
+
+**Input**: Design documents from `/Users/mlieberman/Projects/mikebom/specs/111-pkg-alias-binding/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Test tasks are INCLUDED because (a) the constitution's Pre-PR Verification section mandates `cargo +stable test --workspace` passing clean, (b) the spec's SC-004 byte-identity regression for no-alias scans is test-mandatory (a golden-comparison check is the only way to enforce it), and (c) the binding-correctness path is precision-critical per Principle IX (Accuracy) and warrants TDD discipline.
+
+**Organization**: Tasks are grouped by user story. Story implementation order is US1 → US2 → US3, matching spec priority (US1 P1; US2/US3 both P2 — US3 depends on US1's emission of aliased SBOMs).
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: User story label (US1–US3); omitted on Setup / Foundational / Polish phases
+- Every task names exact file paths
+
+## Path Conventions (per plan.md)
+
+- All implementation in `mikebom-cli/src/binding/`, `mikebom-cli/src/cli/`, `mikebom-cli/src/parity/extractors/`.
+- Integration tests in `mikebom-cli/tests/`.
+- Test fixtures in `mikebom-cli/tests/fixtures/pkg_alias_binding/`.
+- No new crates per Constitution Principle VI.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm clean branch baseline and create the per-feature test-fixture directory tree.
+
+- [X] T001 Run `./scripts/pre-pr.sh` on the clean `111-pkg-alias-binding` branch to verify the pre-PR gate is green BEFORE any code changes; record the baseline test count + clippy warning count (expected: zero warnings) for later regression checks.
+- [X] T002 [P] Create the test-fixture directory tree at `mikebom-cli/tests/fixtures/pkg_alias_binding/` with an empty `.gitkeep` so the tree exists for fixture-generating tasks downstream.
+
+**Checkpoint**: Branch baseline confirmed; fixture tree exists.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define the alias type system + extend the milestone-072 envelope. No user-story work can begin until these compile.
+
+**⚠️ CRITICAL**: All user-story tasks below depend on Phase 2 completing.
+
+### Type definitions (data-model.md → code)
+
+- [X] T003 Create `mikebom-cli/src/binding/alias.rs` (NEW file) with module skeleton: `#![cfg(test)] #[cfg_attr(test, allow(clippy::unwrap_used))]` test-mod fence, public type stubs for `PurlAlias`, `AliasMap`, `AliasError` (bodies empty `// TODO T004-T006`). (Establishes the file as the foundational substrate; T004–T006 fill it.) **Implementation note:** consolidated with T004-T006 — the file landed fully implemented in one pass.
+- [X] T004 [P] Implement `PurlAlias` newtype + constructor in `mikebom-cli/src/binding/alias.rs` per data-model.md. Constructor takes raw `&str` slices for LHS and RHS, runs both through `Purl::canonical()`, returns `Result<PurlAlias, AliasError>`. Rejects `LHS == RHS` with `AliasError::LhsEqualsRhs`. **Implementation note:** `Purl::canonical()` does not exist as a separate method — `Purl::new()` canonicalizes internally and the canonical form is accessed via `as_str()`. Used that pattern.
+- [X] T005 [P] Implement `AliasError` thiserror enum in `mikebom-cli/src/binding/alias.rs` per data-model.md (variants: `MissingSeparator`, `MalformedLhs`, `MalformedRhs`, `ConflictingRhs`, `LhsEqualsRhs`). Each variant's `Display` message satisfies SC-003's single-line-actionable contract per contracts/cli-flags.md. **Implementation note:** `ConflictingRhs` and `LhsEqualsRhs` variants are boxed (carry `Box<ConflictingRhsPayload>` and `Box<Purl>` respectively) to satisfy `clippy::result_large_err`.
+- [X] T006 Implement `AliasMap` (BTreeMap-backed) with `insert`, `get`, `iter`, `is_empty` in `mikebom-cli/src/binding/alias.rs`. `insert` rejects same-LHS-different-RHS with `AliasError::ConflictingRhs`; same-LHS-same-RHS is idempotent. **Depends on T004, T005.** (Foundational; not parallel because same file.) **Implementation note:** chose `Vec<PurlAlias>` over `BTreeMap` — `Purl` does not implement `Ord`, and for N<10 the linear-scan constant beats any tree/hash setup cost; insertion order gives deterministic SBOM emission.
+
+### Envelope extension (binding/mod.rs)
+
+- [X] T007 Extend `SourceDocumentBinding` in `mikebom-cli/src/binding/mod.rs` with two new optional fields `alias_from: Option<Purl>` and `alias_to: Option<Purl>`, both `#[serde(default, skip_serializing_if = "Option::is_none")]`. Per data-model.md + contracts/binding-envelope-v1.1.md. `algo` field STAYS `"v1"` — additive metadata, not algorithm change (research.md §2). Add a paired-presence invariant check in any constructor / mutator.
+
+### Module wiring
+
+- [X] T008 Update `mikebom-cli/src/binding/mod.rs` to declare `pub(crate) mod alias;` and re-export `PurlAlias`, `AliasMap`, `AliasError`. **Depends on T003–T006.**
+
+### Foundational tests
+
+- [X] T009 Add wire-compatibility unit test in `mikebom-cli/src/binding/mod.rs::tests` that round-trips a `SourceDocumentBinding` through `serde_json` BOTH with `alias_from`/`alias_to` both `None` (expecting byte-identity to pre-feature output — SC-004 prerequisite) AND with both `Some(purl)` (expecting both fields appear in the serialized JSON). **Depends on T007.** (Foundational because every user story depends on the envelope serializing correctly; unlabeled per format spec.)
+
+**Checkpoint**: `cargo +stable check --workspace` passes; envelope round-trip test green. No behavioral change yet; all user stories can build on this foundation.
+
+---
+
+## Phase 3: User Story 1 — Bind a single primary binary to its source-tier ecosystem PURL (Priority: P1) 🎯 MVP
+
+**Goal**: An operator scanning a single-binary Rust project image with `--pkg-alias "pkg:generic/baz=pkg:cargo/baz@1.0.0"` against a `--bind-to-source` source SBOM gets binding strength `verified` or `weak` for the aliased component, NOT `unknown { reason: "source-not-found-in-bind-target" }`. The applied alias is persisted in the emitted SBOM via the extended envelope.
+
+**Independent Test**: `cargo +stable test --workspace --test pkg_alias_binding_us1`. Loads pre-built fixture source SBOM + pre-built fixture image SBOM, invokes the binder with `--pkg-alias`, asserts the affected component's `SourceDocumentBinding.strength != Unknown` AND `alias_from/alias_to` are both populated with the operator-declared values.
+
+### Tests for User Story 1 (FAIL FIRST per TDD)
+
+- [ ] T010 [P] [US1] Build US1 fixture source SBOM at `mikebom-cli/tests/fixtures/pkg_alias_binding/source-baz.cdx.json`. Hand-author a minimal CDX 1.6 document containing a single component with PURL `pkg:cargo/baz@1.0.0` and a pre-computed milestone-072 `binding-result-v1` envelope property. Validate via `jq` that the JSON parses.
+- [ ] T011 [P] [US1] Build US1 fixture image SBOM at `mikebom-cli/tests/fixtures/pkg_alias_binding/image-baz.cdx.json`. Hand-author a minimal CDX 1.6 document containing a single component with PURL `pkg:generic/baz` (no version) and the milestone-072 binding-result envelope showing `strength: unknown, reason: "source-not-found-in-bind-target"`. This is the PRE-feature baseline used both as the byte-identity golden AND as the binder input.
+- [ ] T012 [P] [US1] Add `pkg_alias_binding_us1.rs` integration test in `mikebom-cli/tests/` that exercises the binder programmatically via `env!("CARGO_BIN_EXE_mikebom")` with `--bind-to-source <source-fixture>` + `--pkg-alias` and asserts (a) emitted component carries `alias_from = "pkg:generic/baz"` + `alias_to = "pkg:cargo/baz@1.0.0"`, (b) `strength != "unknown"`, (c) reason is NOT `source-not-found-in-bind-target`. Test should FAIL initially because the CLI flag + binder integration doesn't exist yet.
+
+### Implementation for User Story 1
+
+- [ ] T013 [P] [US1] Implement `parse_pkg_alias` clap `value_parser` function in `mikebom-cli/src/binding/alias.rs` (per research.md §5). Returns `Result<PurlAlias, String>` where the error is `AliasError::to_string()` (clap calls `.to_string()` on parser errors). Handles `MissingSeparator`, `MalformedLhs`, `MalformedRhs`, `LhsEqualsRhs` — but NOT `ConflictingRhs` (that's an AliasMap-insert-time check, not parse-time).
+- [ ] T014 [US1] Add `--pkg-alias` CLI flag declaration on `ScanArgs` in `mikebom-cli/src/cli/scan_cmd.rs` per contracts/cli-flags.md: `#[arg(long = "pkg-alias", value_name = "LHS=RHS", value_parser = binding::alias::parse_pkg_alias, action = clap::ArgAction::Append)] pub pkg_alias: Vec<PurlAlias>`. Add a default value `vec![]` entry in the `ScanArgsForTest`-helper at scan_cmd.rs:~2622 (the `enrich_args` helper) so existing tests still construct. **Depends on T013** — the clap derive references `binding::alias::parse_pkg_alias`, which T013 declares.
+- [ ] T015 [US1] In `mikebom-cli/src/cli/scan_cmd.rs::execute`, accumulate the parsed `Vec<PurlAlias>` into an `AliasMap` (handling `AliasError::ConflictingRhs` via `anyhow::bail!`), then thread the `AliasMap` into the existing milestone-072 binding-construction path. Locate the call to `binding::verify::*` or the `--bind-to-source` flow (around `scan_cmd.rs:1838`) and pass the map as a new function parameter. **Depends on T014.**
+- [ ] T016 [US1] Extend the per-component binding-compute call site in `mikebom-cli/src/binding/verify.rs::ComponentBinding::binding_for_purl` (or equivalent at `binding/verify.rs:520`) to accept the `AliasMap` and consult it: when the LHS PURL matches a configured alias, perform the source-side lookup against the RHS; populate `SourceDocumentBinding.alias_from = Some(lhs_canonical)` + `alias_to = Some(rhs)` regardless of strength outcome (so the alias declaration is visible even when the RHS isn't found). **Depends on T007, T015.**
+- [ ] T017 [US1] Add the new `unknown` reason value `"alias-target-not-found-in-bind-target"` to the binding-build logic in `mikebom-cli/src/binding/verify.rs`: when an alias was applied (`alias_from.is_some()`) AND the RHS PURL was not found in `--bind-to-source`, emit `strength = Unknown` with this reason instead of the existing `source-not-found-in-bind-target`. **Depends on T016.**
+- [ ] T018 [US1] Emit the FR-010 warning in `mikebom-cli/src/cli/scan_cmd.rs::execute` when `args.pkg_alias` is non-empty AND `args.bind_to_source` is `None`: `tracing::warn!(count = ..., "--pkg-alias declared but --bind-to-source was not supplied; aliases have no effect ...")` per contracts/cli-flags.md. The AliasMap is dropped silently in this case (no alias persisted in the SBOM per FR-010).
+- [ ] T019 [US1] Emit the FR-011 info log for unused aliases: track which LHS PURLs the binder actually matched against during the per-component loop; after the loop, log unmatched LHSes at info level per contracts/cli-flags.md. **Depends on T016.**
+- [ ] T020 [P] [US1] Add unit tests for `parse_pkg_alias`, `AliasMap::insert` conflict detection, and `PurlAlias::canonical()` round-trip in `mikebom-cli/src/binding/alias.rs::tests`. Cover the 5 `AliasError` variants and the idempotent same-LHS-same-RHS insert. **Include one explicit non-`pkg:generic` LHS case** (e.g., `pkg:deb/debian/foo@1.0=pkg:github/foo/foo@1.0`) to assert spec.md's edge case "alias whose LHS is not in the generic PURL namespace" — the parser MUST accept any PURL scheme, not just `pkg:generic/*`.
+- [ ] T021 [US1] Run `cargo +stable test --workspace --test pkg_alias_binding_us1`; the test from T012 should now PASS. If it doesn't, diff the emitted envelope against the expected shape — likely candidates are missing `Purl::canonical()` on input or the alias not being threaded through to the binding-compute call site.
+- [ ] T022 [US1] Add a byte-identity regression test in `mikebom-cli/tests/pkg_alias_binding_us1.rs` (SC-004): invoke the binder against the same fixtures with NO `--pkg-alias` flag and assert the emitted SBOM is byte-identical (post-canonicalization) to the pre-feature golden at `mikebom-cli/tests/fixtures/pkg_alias_binding/image-baz.cdx.json`.
+- [ ] T023 [US1] Run the full `./scripts/pre-pr.sh` and confirm zero new clippy warnings + all existing tests still pass + the new US1 tests pass.
+
+**Checkpoint**: US1 acceptance scenarios 1, 2, 3 pass. SC-001 (one-flag move from Unknown to Verified/Weak) and SC-004 (byte-identity for no-alias path) are verifiable. MVP shippable here as a standalone PR if desired.
+
+---
+
+## Phase 4: User Story 2 — Bind multiple primary binaries in a workspace project (Priority: P2)
+
+**Goal**: An operator with two primary binaries in a Cargo workspace can declare two `--pkg-alias` flags (or one `MIKEBOM_PKG_ALIAS` env var with comma-separated entries) and both components bind correctly. Env-var and repeated-flag forms produce identical SBOMs.
+
+**Independent Test**: `cargo +stable test --workspace --test pkg_alias_binding_us2`. Loads a two-binary fixture; runs the binder twice — once with two repeated `--pkg-alias` flags, once with the env-var form — asserts both runs produce identical aliased bindings on both components.
+
+### Tests for User Story 2 (FAIL FIRST)
+
+- [ ] T024 [P] [US2] Build US2 workspace fixtures at `mikebom-cli/tests/fixtures/pkg_alias_binding/`:
+  - `workspace-multi.cdx.json` — source-tier with two components `pkg:cargo/baz@1.0.0` + `pkg:cargo/baz-debug@1.0.0` AND a sibling image-tier `image-multi.cdx.json` with two `pkg:generic/baz` + `pkg:generic/baz-debug` components (the basic two-binary case);
+  - `workspace-five.cdx.json` + `image-five.cdx.json` — five-binary source-tier and image-tier pair (`pkg:cargo/baz@1.0.0` through `pkg:cargo/baz5@1.0.0` / `pkg:generic/baz` through `pkg:generic/baz5`) for the SC-005 literal-threshold assertion;
+  - `image-multi-same-rhs.cdx.json` — same-source-different-image fixture with two distinct image-tier components (`pkg:generic/baz-cli` and `pkg:generic/baz-daemon`) both intended to alias to the SAME source-tier `pkg:cargo/baz@1.0.0`, for the U1 non-collapse assertion in T025.
+- [ ] T025 [US2] Add `pkg_alias_binding_us2.rs` integration test in `mikebom-cli/tests/` covering: (a) two repeated `--pkg-alias` flags against the two-binary fixture, both components bind; (b) one `MIKEBOM_PKG_ALIAS=entry1,entry2` env var, identical result to (a); (c) cross-check identity of emitted SBOM bytes between (a) and (b) so future operators trust the two surfaces are interchangeable; (d) **SC-005 literal-threshold assertion** — five aliases via a single `MIKEBOM_PKG_ALIAS` env var against `image-five.cdx.json`, all five components bind with `alias_from`/`alias_to` populated, scan invocation exits with status 0 and no per-binary CLI ergonomics penalties (no required-config files, no separate scan invocations, no `--pkg-alias-file` deferred-feature dependency); (e) **U1 non-collapse assertion** — two distinct LHS aliases targeting the SAME RHS against `image-multi-same-rhs.cdx.json`, both LHS image-tier components retain their distinct identities in the emitted SBOM (verified by asserting both `pkg:generic/baz-cli` and `pkg:generic/baz-daemon` appear as separate `components[]` entries, each with its own `alias_from`/`alias_to` populated to the shared RHS). Test should FAIL because the env-var-parse path doesn't exist yet.
+
+### Implementation for User Story 2
+
+- [ ] T026 [US2] Implement `MIKEBOM_PKG_ALIAS` env-var parsing in `mikebom-cli/src/cli/scan_cmd.rs`: read the env var via `std::env::var("MIKEBOM_PKG_ALIAS")`, split on `,`, trim whitespace per entry, run each entry through `binding::alias::parse_pkg_alias`, append to the CLI-derived `Vec<PurlAlias>`. Per contracts/cli-flags.md. Empty entries (`,,`) silently skipped. Same `ConflictingRhs` detection applies across the union.
+- [ ] T027 [US2] Run `cargo +stable test --workspace --test pkg_alias_binding_us2`; iterate until all three scenarios PASS. Debug the env-var path by adding `tracing::debug!` on the parsed entries during dev.
+- [ ] T028 [US2] Re-run `./scripts/pre-pr.sh` to confirm no regression in US1 (single-binary path) caused by US2's env-var addition.
+
+**Checkpoint**: US2 acceptance scenarios 1 and 2 pass. SC-005 (workspace-of-5 aliases without ergonomic penalty) is verified DIRECTLY at N=5 by T025 scenario (d); operator-of-N for arbitrary larger N extrapolates from the linear composition. U1 non-collapse invariant (same RHS aliased by multiple LHSes retains distinct image-tier identities) verified by T025 scenario (e).
+
+---
+
+## Phase 5: User Story 3 — Verify-binding consumes alias-bearing SBOMs without re-supplying the alias (Priority: P2)
+
+**Goal**: After a scan persists an alias-bearing SBOM, an auditor running `mikebom verify-binding image.cdx.json source.cdx.json` (no CLI alias supplied) reproduces the same binding strength AND surfaces the alias via a new `applied_alias: "<LHS> → <RHS>"` sibling field in the output. Same applies to `trace-binding`.
+
+**Independent Test**: `cargo +stable test --workspace --test pkg_alias_binding_us3`. Reuses the US1 emitted SBOM as input. Runs `verify-binding` programmatically; asserts the output JSON contains `applied_alias = "pkg:generic/baz → pkg:cargo/baz@1.0.0"` AND `binding.strength` matches the original scan-time result.
+
+### Tests for User Story 3 (FAIL FIRST)
+
+- [ ] T029 [US3] Add `pkg_alias_binding_us3.rs` integration test in `mikebom-cli/tests/` covering: (a) round-trip — alias-bearing SBOM produced by the US1 binder, run through verify-binding, asserts `applied_alias` sibling field present + binding strength matches; (b) RHS-missing scenario — same image SBOM run against a different source SBOM whose component list does NOT include the aliased RHS, asserts `binding.strength = "unknown"` AND `binding.reason = "alias-target-not-found-in-bind-target"`. Test should FAIL because the `applied_alias` output field doesn't exist yet.
+
+### Implementation for User Story 3
+
+- [ ] T030 [P] [US3] Add `applied_alias: Option<String>` field to the per-component verify-binding output struct in `mikebom-cli/src/cli/verify_binding_cmd.rs`. Populated as `format!("{} → {}", alias_from, alias_to)` (UTF-8 `→` U+2192 per contracts/binding-envelope-v1.1.md) when the envelope's `alias_from` and `alias_to` are both `Some`. `None` otherwise; `#[serde(skip_serializing_if = "Option::is_none")]` so non-aliased outputs stay byte-identical to pre-feature.
+- [ ] T031 [P] [US3] Add the same `applied_alias` field to the trace-binding output struct in `mikebom-cli/src/cli/trace_binding_cmd.rs` (it's a separate command but emits a related per-component object). Mirror the population logic from T030.
+- [ ] T032 [US3] Update the binding-builder in `mikebom-cli/src/binding/verify.rs::ComponentBinding::binding_for_purl` (line ~520) to honor a recorded alias when reading an alias-bearing input SBOM: when the input envelope has `alias_from` + `alias_to`, perform the source-side lookup against `alias_to` instead of the component's own PURL. This is the verify-time analog of T016's scan-time logic.
+- [ ] T033 [US3] Add the FR-007 `alias-target-not-found-in-bind-target` reason to the verify-binding path as well: when the input envelope had an alias but the RHS isn't in the supplied source SBOM at verify time, emit `strength = Unknown` with this reason (distinct from `source-not-found-in-bind-target`).
+- [ ] T034 [US3] Run `cargo +stable test --workspace --test pkg_alias_binding_us3`; iterate until both scenarios PASS.
+- [ ] T035 [US3] Re-run `./scripts/pre-pr.sh` to confirm no regression in US1 (scan-time path) or US2 (multi-binary path).
+
+**Checkpoint**: US3 acceptance scenarios 1 and 2 pass. SC-002 (verify-binding reproduces scan-time strength without CLI re-supply) is verifiable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Format-parity coverage, docs, CHANGELOG, full pre-PR gate.
+
+- [ ] T036 [P] Update CDX parity extractor at `mikebom-cli/src/parity/extractors/cdx.rs` to surface `alias_from` / `alias_to` from the existing binding-result envelope into the parity-comparator's normalized form. The C56 row's parity check must continue to pass when both fields are present (round-trip CDX ↔ SPDX 2.3 ↔ SPDX 3 must preserve the alias context).
+- [ ] T037 [P] Update SPDX 2.3 parity extractor at `mikebom-cli/src/parity/extractors/spdx2.rs` with the same envelope-field extraction. The `MikebomAnnotationCommentV1` wrapper already carries the JSON-encoded envelope; the extractor just needs to surface the two new fields.
+- [ ] T038 [P] Update SPDX 3 parity extractor at `mikebom-cli/src/parity/extractors/spdx3.rs` with the same. The `Annotation.statement` envelope carries the same shape as SPDX 2.3.
+- [ ] T039 [P] Add a cross-format parity round-trip test in `mikebom-cli/tests/` (extend an existing parity test rather than adding a new file): emit the same aliased component in CDX 1.6 + SPDX 2.3 + SPDX 3, run the existing parity comparator, assert zero invariant violations. Verifies SC-006.
+- [ ] T040 [P] Update `docs/reference/sbom-format-mapping.md` C56 row with a note: "Envelope MAY additionally carry `alias_from` + `alias_to` fields when an operator-supplied `--pkg-alias` was applied (milestone 111). Both fields are paired-presence (both populated or both absent)." No new C-row.
+- [ ] T041 [P] Add a CHANGELOG entry under `CHANGELOG.md`'s `## [Unreleased]` section: "Operator-supplied PURL alias for cross-tier binding (milestone 111, Option A of #225). New `--pkg-alias LHS=RHS` flag on `mikebom sbom scan` (and `MIKEBOM_PKG_ALIAS` env var) lets operators declare that a binary-tier PURL should be treated as a source-tier PURL during `--bind-to-source` binding. Aliased components reach `Verified`/`Weak` strength instead of `Unknown`. Verify-binding output gains an `applied_alias: \"<LHS> → <RHS>\"` sibling field. See `specs/111-pkg-alias-binding/spec.md`."
+- [ ] T042 Run the full `cargo +stable test --workspace` one more time + manually exercise the quickstart.md scenarios 1–3 against the test fixtures to confirm operator-facing UX matches the documented contract.
+- [ ] T043 Final pre-PR pass: `./scripts/pre-pr.sh` MUST exit zero. Inspect every clippy line in the output even at zero-warning state — sometimes new code triggers nit-level lints that warrant a `#[allow(...)]` with a comment.
+
+---
+
+## Dependencies
+
+Sequential dependencies (each phase blocks the next):
+
+```text
+Phase 1 (Setup) ──▶ Phase 2 (Foundational) ──▶ Phase 3 (US1 MVP)
+                                              │
+                                              └─▶ Phase 4 (US2) ─┐
+                                                                 ├─▶ Phase 6 (Polish)
+                                              └─▶ Phase 5 (US3) ─┘
+```
+
+US3 depends on US1 (verify-binding needs aliased SBOMs to verify; US1 produces them). US2 is mostly orthogonal to US3 (env-var parsing is independent of verify-binding output). Phases 4 and 5 may proceed in parallel after Phase 3 completes.
+
+Parallel opportunities:
+- Within Phase 2: T004, T005 are independent type definitions in the same file (parallel-conceptual; serialize the actual edits if same-file conflict matters).
+- Within Phase 3: T010, T011, T013, T014, T020 parallelize across distinct files. T015–T019 are sequential due to file overlap in `cli/scan_cmd.rs` + `binding/verify.rs`. T012 (integration test scaffold) parallelizes with the implementation tasks but should be written FIRST (TDD discipline).
+- Within Phase 5: T030 and T031 parallelize (different files: `verify_binding_cmd.rs` vs `trace_binding_cmd.rs`).
+- Within Phase 6: T036–T041 are all parallel (different files).
+
+## Implementation Strategy
+
+**MVP scope** (most operator-visible value with minimum risk):
+
+The MVP is **US1 alone** (Phases 1, 2, 3). It delivers the textbook source-to-image binding workflow — exactly the issue #225 problem statement. Operators who only need the single-primary-binary case can ship MVP scope first.
+
+US2 (env-var + multi-flag) is a separable second PR — the underlying machinery is identical; only the input-parsing surface grows.
+
+US3 (verify-binding output) is a separable third PR — the persistence is already done in US1; US3 just makes the existing data operator-visible at verify time.
+
+**Suggested commit cadence** (each commit independently passes pre-PR gate):
+
+1. Phase 1 + Phase 2 (foundational types, envelope extension, no behavioral change) — 1 PR.
+2. Phase 3 (US1 MVP) — 1 PR. CI gate green; SC-001 + SC-004 verified.
+3. Phase 4 (US2 env-var + multi-flag) — 1 PR. Quick wrap on the input surface.
+4. Phase 5 (US3 verify-binding output) — 1 PR.
+5. Phase 6 (parity-extractors + docs + CHANGELOG) — 1 PR.
+
+Five PRs is the conservative max. Phases 4 + 5 could combine into one PR if review bandwidth is tight; Phase 6 could combine with whichever phase ships last. Three PRs is the floor (foundation + MVP+US1, US2+US3 combined, polish).
+
+## Format validation
+
+All tasks conform to the `- [ ] TaskID [P?] [Story?] Description with file path` format per the speckit-tasks rules:
+- 43 total tasks (T001–T043).
+- 14 of those are `[P]` marked (T014's `[P]` removed during /speckit-analyze remediation O1 — it depends on T013's parser signature).
+- 25 carry a `[Story]` label (US1: 14, US2: 5, US3: 6); the remaining 18 are Setup / Foundational / Polish with no story label per the format spec.
+- Every task names exact file paths or scripts.
+- Post-analyze remediations applied: C1 (T024+T025 extended to N=5 fixture + assertion), C2 (T020 extended with non-`pkg:generic` LHS case), O1 (T014 `[P]` removed + T013 dependency noted), U1 (T024+T025 extended with multi-LHS-same-RHS non-collapse fixture + assertion).


### PR DESCRIPTION
## Summary

Milestone 111 PR 1 of 4 — foundational types + envelope extension for operator-supplied PURL aliases on cross-tier binding (issue #225 Option A). Zero behavior change at the CLI / scan path; PR 2 wires US1 (the single-binary alias case that motivates the milestone).

## What lands

- **`mikebom-cli/src/binding/alias.rs`** (new, ~280 lines): \`PurlAlias\` newtype, \`AliasMap\` Vec-backed container with linear-scan \`get\` and conflict-detecting \`insert\`, \`AliasError\` thiserror enum, \`parse_pkg_alias\` clap value_parser. 16 unit tests covering: parser separator/PURL malformedness, LHS-equals-RHS rejection, non-\`pkg:generic\` LHS acceptance (the analyze-pass C2 remediation), insert idempotency, same-LHS-different-RHS conflict, same-RHS-different-LHS acceptance (the U1 remediation).
- **\`mikebom-cli/src/binding/mod.rs\`**: \`SourceDocumentBinding\` gains \`alias_from: Option<Purl>\` and \`alias_to: Option<Purl>\` fields with \`#[serde(default, skip_serializing_if = \"Option::is_none\")]\`. \`algo\` stays \`\"v1\"\` — these are additive metadata, not algorithm changes. 5 wire-compat tests (emit-without-alias-omits-fields, emit-with-alias-includes-fields, round-trip-with-alias, round-trip-without-alias, pre-feature-shape-deserializes).
- **Four existing call sites updated** (\`sbom/mutator.rs\`, \`binding/annotation.rs\`, \`binding/verify.rs\` production + test) to include the two new fields as \`None\`.
- **\`specs/111-pkg-alias-binding/\`**: full spec / plan / research / data-model / contracts / quickstart / tasks set. Includes /speckit-clarify session resolving three design questions (strict canonical PURL equality, envelope extension over flat property, applied_alias sibling field) and /speckit-analyze remediations for four LOW/MEDIUM findings.

## Wire compatibility

- **No-alias scans → pre-feature consumers**: byte-identical to pre-feature output (\`skip_serializing_if\` omits the new fields when None). SC-004 byte-identity prerequisite satisfied at this layer.
- **Alias-bearing scans → pre-feature consumers**: pre-feature consumers see two extra fields; serde's default ignore-unknown-fields behavior accepts the envelope; binding result interpreted as non-aliased verified/weak as usual.
- **Either direction → post-feature consumers**: full round-trip; \`alias_from\`/\`alias_to\` round-trip cleanly.

## Constitution alignment

- **Principle V** (standards-native audit, mandatory v1.4.0 clause): no new top-level \`mikebom:*\` property — the existing milestone-072 envelope is extended with two additive fields. The audit (research.md §1) confirms CDX 1.6 + SPDX 2.3 + SPDX 3.0.1 have no native cross-tier-binding construct; extending the existing parity-bridging envelope is the only viable carrier. C56 row update in \`docs/reference/sbom-format-mapping.md\` deferred to PR 4 polish.
- **Principle IV**: \`PurlAlias::try_new\` returns \`Result<_, AliasError>\`; no \`.unwrap()\` in production code. The \`ConflictingRhs\` and \`LhsEqualsRhs\` variants are boxed to satisfy \`clippy::result_large_err\`.

## Test plan

- [x] \`cargo +stable clippy --workspace --all-targets\` — zero warnings
- [x] \`cargo +stable test --workspace\` — full workspace green; no existing test regressed
- [x] 16 new \`binding::alias::tests::\` unit tests pass
- [x] 5 new \`binding::tests::\` envelope wire-compat tests pass

## Next PR

PR 2: CLI flag wiring + per-component binding-compute integration + US1 integration test (Phase 3 of the milestone-111 task plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)