### PR TITLE
perf(scan): drop build intermediates before reading them

### DIFF
--- a/mikebom-cli/src/scan_fs/binary/jdk_collapse.rs
+++ b/mikebom-cli/src/scan_fs/binary/jdk_collapse.rs
@@ -50,6 +50,12 @@ pub struct JdkCollapser {
 }
 
 impl JdkCollapser {
+    /// Side-effect-free twin of [`Self::try_collapse`] — see the
+    /// python collapser's `would_collapse` for the rationale.
+    pub fn would_collapse(&self, path: &Path, rootfs: &Path) -> bool {
+        detect_jdk_version(path, rootfs).is_some()
+    }
+
     /// Attempt to classify `path` as a JDK/JRE binary. Returns `true`
     /// if the collapser claimed it (caller should skip file-level +
     /// linkage emission for it).

--- a/mikebom-cli/src/scan_fs/binary/mod.rs
+++ b/mikebom-cli/src/scan_fs/binary/mod.rs
@@ -201,24 +201,70 @@ pub fn read(
     };
 
     for path in discover_binaries(rootfs) {
+        // Size bounds via metadata BEFORE the full-file read. A
+        // multi-GB file that exceeds MAX_BINARY_SIZE_BYTES used to be
+        // slurped into memory in its entirety just to be rejected by
+        // the bounds check below.
+        let file_len = match std::fs::metadata(&path) {
+            Ok(m) => m.len(),
+            Err(_) => {
+                if walker_debug {
+                    eprintln!("WALKER {}: DROPPED reason=read-error", path.display());
+                }
+                continue;
+            }
+        };
+        if !(elf::MIN_BINARY_SIZE_BYTES..=elf::MAX_BINARY_SIZE_BYTES).contains(&file_len) {
+            if walker_debug {
+                eprintln!(
+                    "WALKER {}: DROPPED reason=size-out-of-bounds bytes={}",
+                    path.display(),
+                    file_len
+                );
+            }
+            continue;
+        }
+
+        // Early build-intermediate gate. `.o` / `.a` files used to be
+        // fully read AND fully introspected by `scan_binary` before
+        // the post-scan build-intermediate check threw the result
+        // away — on a Rust `target/` directory that meant reading +
+        // parsing hundreds of thousands of Mach-O objects (tens of
+        // GB) for nothing.
+        //
+        // Drop them here, BEFORE the read, with one carve-out: paths
+        // that could route into a cpython/openjdk umbrella fall
+        // through to the unchanged full pipeline, so collapse side
+        // effects keep firing only after a successful binary parse
+        // (exactly the pre-gate ordering). Every other `.o`/`.a`
+        // outcome in the old pipeline — parse failure, format
+        // mismatch, claimed path, rpm-dir heuristic, the
+        // build-intermediate drop itself — ended in a side-effect-free
+        // skip, so dropping unconditionally is observably identical.
+        let is_o_or_a_extension = matches!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("o") | Some("a")
+        );
+        if is_o_or_a_extension
+            && !python_collapser.would_collapse(&path, rootfs)
+            && !jdk_collapser.would_collapse(&path, rootfs)
+        {
+            if walker_debug {
+                eprintln!(
+                    "WALKER {}: DROPPED reason=build-intermediate ext={:?}",
+                    path.display(),
+                    path.extension().and_then(|e| e.to_str())
+                );
+            }
+            continue;
+        }
+
         let Ok(bytes) = std::fs::read(&path) else {
             if walker_debug {
                 eprintln!("WALKER {}: DROPPED reason=read-error", path.display());
             }
             continue;
         };
-        if bytes.len() < elf::MIN_BINARY_SIZE_BYTES as usize
-            || bytes.len() > elf::MAX_BINARY_SIZE_BYTES as usize
-        {
-            if walker_debug {
-                eprintln!(
-                    "WALKER {}: DROPPED reason=size-out-of-bounds bytes={}",
-                    path.display(),
-                    bytes.len()
-                );
-            }
-            continue;
-        }
         let Some(scan) = scan_binary(&path, &bytes) else {
             if walker_debug {
                 eprintln!(
@@ -707,6 +753,80 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("script.sh"), b"#!/bin/sh\necho hi").unwrap();
         std::fs::write(dir.path().join("data.txt"), b"hello world").unwrap();
+        assert!(read(
+            dir.path(),
+            &Default::default(),
+            #[cfg(unix)]
+            &Default::default()
+        )
+        .is_empty());
+    }
+
+    /// Minimal parseable ELF64 little-endian header (no program/
+    /// section headers), padded past MIN_BINARY_SIZE_BYTES.
+    fn minimal_elf64_bytes(total_len: usize) -> Vec<u8> {
+        let mut b = vec![0u8; total_len.max(64)];
+        b[..4].copy_from_slice(&[0x7F, b'E', b'L', b'F']);
+        b[4] = 2; // ELFCLASS64
+        b[5] = 1; // little-endian
+        b[6] = 1; // EV_CURRENT
+        b[16] = 2; // e_type = ET_EXEC
+        b[18] = 0x3E; // e_machine = EM_X86_64
+        b[20] = 1; // e_version
+        b[52] = 64; // e_ehsize
+        b
+    }
+
+    /// Build intermediates (`.o` / `.a`) are dropped by the early gate
+    /// before the full-file read — they must never surface as
+    /// components, regardless of carrying a valid binary magic.
+    #[test]
+    fn object_files_are_dropped_as_build_intermediates() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("foo.o"), minimal_elf64_bytes(2048)).unwrap();
+        std::fs::write(dir.path().join("libbar.a"), minimal_elf64_bytes(2048)).unwrap();
+        assert!(read(
+            dir.path(),
+            &Default::default(),
+            #[cfg(unix)]
+            &Default::default()
+        )
+        .is_empty());
+    }
+
+    /// A `.o` under a `Python-<X.Y.Z>/` source tree still routes into
+    /// the cpython umbrella — the early build-intermediate gate must
+    /// not starve the python collapser (regression guard for the
+    /// fall-through carve-out).
+    #[test]
+    fn python_source_tree_object_file_still_collapses() {
+        let dir = tempfile::tempdir().unwrap();
+        let tree = dir.path().join("Python-3.11.4/Modules");
+        std::fs::create_dir_all(&tree).unwrap();
+        std::fs::write(tree.join("foo.o"), minimal_elf64_bytes(2048)).unwrap();
+        let entries = read(
+            dir.path(),
+            &Default::default(),
+            #[cfg(unix)]
+            &Default::default(),
+        );
+        assert_eq!(entries.len(), 1, "expected exactly the cpython umbrella");
+        assert!(
+            entries[0].purl.as_str().contains("cpython@3.11"),
+            "got {}",
+            entries[0].purl.as_str()
+        );
+    }
+
+    /// Files beyond MAX_BINARY_SIZE_BYTES are rejected via metadata
+    /// before any read (the sparse file here would be 500MB+ of
+    /// zeroes if it were slurped).
+    #[test]
+    fn oversized_file_is_skipped_via_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("huge");
+        let f = std::fs::File::create(&path).unwrap();
+        f.set_len(elf::MAX_BINARY_SIZE_BYTES + 1).unwrap();
         assert!(read(
             dir.path(),
             &Default::default(),

--- a/mikebom-cli/src/scan_fs/binary/python_collapse.rs
+++ b/mikebom-cli/src/scan_fs/binary/python_collapse.rs
@@ -40,6 +40,24 @@ pub struct PythonStdlibCollapser {
 }
 
 impl PythonStdlibCollapser {
+    /// Side-effect-free twin of [`Self::try_collapse`]: would this
+    /// path route into a cpython umbrella? Used by the walker's early
+    /// build-intermediate gate to decide whether a `.o`/`.a` file
+    /// needs the full read+parse pipeline (so collapse side effects
+    /// keep firing only after a successful binary parse, exactly as
+    /// before the gate existed).
+    pub fn would_collapse(&self, path: &Path, rootfs: &Path) -> bool {
+        if detect_python_version(path, rootfs).is_some() {
+            return true;
+        }
+        if let Ok(canonical) = std::fs::canonicalize(path) {
+            if canonical != path && detect_python_version(&canonical, rootfs).is_some() {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Attempt to classify `path` as a CPython stdlib binary. Returns
     /// `true` if the path was claimed by the collapser — the caller
     /// should then skip emitting a file-level component for it.

--- a/mikebom-cli/src/scan_fs/package_db/go_binary.rs
+++ b/mikebom-cli/src/scan_fs/package_db/go_binary.rs
@@ -131,6 +131,9 @@ pub enum GoBinaryError {
 pub enum DetectResult {
     Found { buildinfo_offset: usize },
     NotGoBinary,
+    // Only the path-based `detect_is_go` wrapper (test-only since the
+    // production path moved to `detect_is_go_bytes`) constructs this.
+    #[cfg_attr(not(test), allow(dead_code))]
     AmbiguousError,
 }
 
@@ -138,6 +141,7 @@ pub enum DetectResult {
 /// lookup (fast, precise), then falls back to a memmem scan for the
 /// magic bytes (handles stripped binaries where the section name is
 /// gone). Size-bounded by [`MAX_BINARY_SIZE_BYTES`].
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn detect_is_go(path: &Path) -> DetectResult {
     let Ok(meta) = std::fs::metadata(path) else {
         return DetectResult::AmbiguousError;
@@ -149,9 +153,15 @@ pub fn detect_is_go(path: &Path) -> DetectResult {
     let Ok(bytes) = std::fs::read(path) else {
         return DetectResult::AmbiguousError;
     };
+    detect_is_go_bytes(&bytes)
+}
 
+/// Bytes-based core of [`detect_is_go`]. Lets callers that already
+/// hold the file contents (e.g. [`read_binary`]) avoid a second full
+/// read of the same file from disk.
+pub fn detect_is_go_bytes(bytes: &[u8]) -> DetectResult {
     // Tier 1: named-section lookup via `object`.
-    if let Some(offset) = find_buildinfo_section(&bytes) {
+    if let Some(offset) = find_buildinfo_section(bytes) {
         return DetectResult::Found {
             buildinfo_offset: offset,
         };
@@ -160,7 +170,7 @@ pub fn detect_is_go(path: &Path) -> DetectResult {
     // Tier 2: memmem scan for the magic prefix. Handles stripped
     // binaries (section header gone) and anything the object crate
     // can't classify.
-    if let Some(offset) = memmem(&bytes, BUILDINFO_MAGIC) {
+    if let Some(offset) = memmem(bytes, BUILDINFO_MAGIC) {
         return DetectResult::Found {
             buildinfo_offset: offset,
         };
@@ -441,7 +451,11 @@ pub fn read_binary(path: &Path) -> (BuildInfoStatus, Option<GoBinaryInfo>) {
         Ok(b) => b,
         Err(_) => return (BuildInfoStatus::NotGoBinary, None),
     };
-    let offset = match detect_is_go(path) {
+    // Detection runs over the buffer we already read — calling the
+    // path-based `detect_is_go` here would read the whole file from
+    // disk a second time, which dominated scan wall-time on large
+    // build trees.
+    let offset = match detect_is_go_bytes(&bytes) {
         DetectResult::Found { buildinfo_offset } => buildinfo_offset,
         DetectResult::NotGoBinary => return (BuildInfoStatus::NotGoBinary, None),
         DetectResult::AmbiguousError => return (BuildInfoStatus::Missing, None),
@@ -572,6 +586,17 @@ fn walk_for_binaries(
             continue;
         }
         if !meta.is_file() || meta.len() < MIN_BINARY_SIZE_BYTES {
+            continue;
+        }
+        // Go binaries never carry compiler/linker intermediate
+        // extensions. Skipping them here avoids full-file probe reads
+        // across e.g. a Rust `target/` tree, where hundreds of
+        // thousands of `.o`/`.rlib` files otherwise dominate scan
+        // wall-time.
+        if matches!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("o") | Some("a") | Some("rlib") | Some("rmeta")
+        ) {
             continue;
         }
 
@@ -1096,6 +1121,33 @@ mod tests {
         assert!(entries.iter().any(|e| e.name == "example.com/app"));
         assert!(entries.iter().any(|e| e.name == "gh/x/y"));
         assert!(entries.iter().all(|e| e.source_type.as_deref() != Some("go-buildinfo-missing")));
+    }
+
+    #[test]
+    fn build_intermediate_extensions_are_not_probed() {
+        // A file whose bytes look exactly like a Go binary but whose
+        // extension marks it as a compiler/linker intermediate must be
+        // skipped by the walker — Go binaries never ship as
+        // .o/.a/.rlib/.rmeta, and probing them dominated scan time on
+        // large build trees.
+        let dir = tempfile::tempdir().unwrap();
+        let mut bin = vec![0u8; 4096];
+        bin.extend_from_slice(&build_inline_buildinfo(
+            "path\texample.com/fake\nmod\texample.com/fake\tv0.0.0\t\n",
+            "",
+        ));
+        for name in ["fake.o", "fake.a", "fake.rlib", "fake.rmeta"] {
+            std::fs::write(dir.path().join(name), &bin).unwrap();
+        }
+
+        let (entries, _) = read(
+            dir.path(),
+            false,
+            &std::collections::HashSet::new(),
+            #[cfg(unix)]
+            &std::collections::HashSet::new(),
+        );
+        assert!(entries.is_empty(), "intermediates must not emit entries: {entries:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Scanning a Rust `target/debug` tree (55 GB / 531,070 files / 483,568 `.o` files totaling 48 GB) took **4m15s** — nearly all of it spent fully reading files whose results were guaranteed to be discarded. Two independent hotspots:

1. **Binary walker** (`scan_fs/binary/mod.rs`): every `.o`/`.a` file was fully read AND fully introspected by `scan_binary` (object parse, imports, symbols, Mach-O metadata) before the *post-scan* build-intermediate check threw the result away. Fixed by gating `.o`/`.a` **before** the read. One carve-out keeps parity exact: paths that could route into a cpython/openjdk umbrella (checked via new side-effect-free `would_collapse` twins on both collapsers) fall through to the unchanged full pipeline, so collapse side effects still fire only after a successful binary parse — exactly the pre-gate ordering. Every other `.o`/`.a` outcome in the old pipeline ended in a side-effect-free skip, so the early drop is observably identical. The size-bounds check also moved to `fs::metadata` so >500 MB files are rejected without being slurped into memory.

2. **Go binary reader** (`scan_fs/package_db/go_binary.rs`): its walker probed **every** file ≥ 1 KB with **two** full reads each (`read_binary`'s own `fs::read` plus `detect_is_go`'s second one) followed by a naive memmem over the whole buffer — ~110 GB of redundant I/O on this tree. Fixed by (a) running detection on the already-read buffer (`detect_is_go_bytes`), and (b) skipping compiler/linker intermediate extensions (`.o`/`.a`/`.rlib`/`.rmeta`) outright, since Go binaries never ship with these.

## Benchmark (release build, same 55 GB `target/debug` tree)

| Build | Wall time | Components |
|---|---|---|
| baseline (`main`) | 4m15s | 1990 |
| binary-walker fix only | 3m41s | 1990 |
| both fixes (this PR) | **2m17s** | **1639** |

## Component diff: −351, all false positives

The 351 removed components are **all** `pkg:generic/*.rcgu.o`-style diagnostic entries: mikebom's own compiled object files embed the Go `BUILDINFO_MAGIC` test constants, so the go probe's tier-2 memmem "found" buildinfo in them, decode failed, and a meaningless `pkg:generic/<basename>.o` diagnostic was emitted per file. Zero legitimate components changed (verified by set-diff of PURLs; nothing added, nothing non-`.o` removed). The 33 byte-identity golden tests pass unchanged.

## Tests

- `object_files_are_dropped_as_build_intermediates` — `.o`/`.a` never surface even with valid ELF magic
- `python_source_tree_object_file_still_collapses` — regression guard for the umbrella carve-out
- `oversized_file_is_skipped_via_metadata` — sparse 500 MB+1 file rejected without read
- `build_intermediate_extensions_are_not_probed` — go-walker skip, using a byte-identical synthetic Go binary renamed to `.o`/`.a`/`.rlib`/`.rmeta`

## Test plan

- [x] `./scripts/pre-pr.sh` clean (clippy `--all-targets` zero errors + full workspace tests)
- [x] Release-build benchmark on a 55 GB Rust target dir: 4m15s → 2m17s, component diff verified FP-only

Remaining known cost on pathological build trees: the go probe still reads non-intermediate files like rustc incremental `query-cache.bin` (180 of which also embed the magic constants). Deeper gating (binary-magic prefilter) would break the reader's documented headerless-fixture contract, so it's left for a follow-on — a "rust target dir" pathological fixture for the #328 benchmark suite would catch regressions here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)