### PR TITLE
fix(golang): skip testdata/ and _-prefixed dirs per Go tool convention

### DIFF
--- a/mikebom-cli/src/scan_fs/package_db/go_binary.rs
+++ b/mikebom-cli/src/scan_fs/package_db/go_binary.rs
@@ -654,12 +654,16 @@ fn should_skip_binary_descent(path: &Path) -> bool {
     let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
         return true;
     };
-    if name.starts_with('.') {
+    // Mirror the Go source walker's skip rules (`go help packages`:
+    // dot- and underscore-prefixed dirs and the literal `testdata`
+    // are reserved/ignored by the go tool). Binaries living under
+    // those dirs are fixture artifacts, not runtime artifacts.
+    if name.starts_with('.') || name.starts_with('_') {
         return true;
     }
     if matches!(
         name,
-        "vendor" | "node_modules" | "target" | "__pycache__" | "proc" | "sys"
+        "vendor" | "node_modules" | "target" | "__pycache__" | "proc" | "sys" | "testdata"
     ) {
         return true;
     }

--- a/mikebom-cli/src/scan_fs/package_db/golang/legacy.rs
+++ b/mikebom-cli/src/scan_fs/package_db/golang/legacy.rs
@@ -2035,12 +2035,16 @@ fn should_skip_descent(path: &std::path::Path) -> bool {
     let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
         return true;
     };
-    if name.starts_with('.') {
+    // Per `go help packages`: "Directory and file names that begin
+    // with '.' or '_' are ignored by the go tool, as are directories
+    // named 'testdata'." We mirror the same three rules so mikebom's
+    // workspace discovery sees exactly what `go list ./...` would.
+    if name.starts_with('.') || name.starts_with('_') {
         return true;
     }
     if matches!(
         name,
-        "vendor" | "node_modules" | "target" | "dist" | "build" | "__pycache__"
+        "vendor" | "node_modules" | "target" | "dist" | "build" | "__pycache__" | "testdata"
     ) {
         return true;
     }
@@ -2955,6 +2959,55 @@ tool (
         assert!(
             entries.is_empty(),
             "walker must skip /workspace/go/pkg/mod cache tree: {entries:?}",
+        );
+    }
+
+    #[test]
+    fn walker_skips_testdata_subtree() {
+        // Per `go help packages`: directories named `testdata` are
+        // ignored by the Go tool. A `go.mod` under `testdata/` is a
+        // fixture for testing SBOM/build tooling, not a real workspace
+        // — it would silently invert dependency edges in the emitted
+        // SBOM (parent looks like it depends on the fixture). Match
+        // Go's own behavior and skip the subtree.
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("app");
+        write_go_project(&real, "example.com/app", &[("github.com/real/dep", "v1.0.0")]);
+        let fixture = real.join("pkg/sbomgen/testdata/gofixture");
+        write_go_project(
+            &fixture,
+            "example.com/fixture",
+            &[("example.com/app", "v0.0.0-fake")],
+        );
+        let (entries, _) = read(dir.path(), false);
+        assert!(
+            entries.iter().any(|e| e.name == "example.com/app"),
+            "real workspace must still emit: {entries:?}",
+        );
+        assert!(
+            !entries.iter().any(|e| e.name == "example.com/fixture"),
+            "testdata/ go.mod must NOT become a main-module: {entries:?}",
+        );
+    }
+
+    #[test]
+    fn walker_skips_underscore_prefixed_subtree() {
+        // Per `go help packages`: directories whose name starts with
+        // `_` are ignored by the Go tool. Common patterns: `_fork/`,
+        // `_archive/`, `_examples/`. Match Go and skip.
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("app");
+        write_go_project(&real, "example.com/app", &[("github.com/real/dep", "v1.0.0")]);
+        let archived = real.join("_archive/oldproject");
+        write_go_project(&archived, "example.com/archived", &[]);
+        let (entries, _) = read(dir.path(), false);
+        assert!(
+            entries.iter().any(|e| e.name == "example.com/app"),
+            "real workspace must still emit: {entries:?}",
+        );
+        assert!(
+            !entries.iter().any(|e| e.name == "example.com/archived"),
+            "_-prefixed dir go.mod must NOT become a main-module: {entries:?}",
         );
     }
 


### PR DESCRIPTION
## Summary

Per [`go help packages`](https://pkg.go.dev/cmd/go#hdr-Package_lists_and_patterns):

> Directory and file names that begin with '.' or '_' are ignored by the go tool, as are directories named 'testdata'.

mikebom's Go walkers only honored the dot-prefix rule. This PR adds the other two so `mikebom scan` sees exactly what `go list ./...` would.

## Symptom

Reported by an SBOM consumer: a kusari-cli scan emitted the chain `kusaridev/iac/app-code/apigatewayv2/gh-pr-analysis-worker → iac-test-fixture-sbomgen → kusaridev/iac/app-code/apigatewayv2/gh-pr-analysis-worker` — a fixture in the middle of what should have been a direct self-edge.

Root cause: a Go test fixture at `pkg/sbomgen/testdata/gofixture/go.mod` whose go.mod `require`d the parent module (a typical pattern for repos that test SBOM-generation tooling against themselves). mikebom walked into `testdata/`, treated the fixture as a real main-module, and recorded the synthetic require edge. The fixture component also carried `mikebom:orphan-reason: flat-attached-fallback` because mikebom couldn't place it in any real hierarchy — second tell.

## Changes

- `mikebom-cli/src/scan_fs/package_db/golang/legacy.rs:should_skip_descent` — add `testdata` to the `matches!`, add `name.starts_with('_')` alongside `name.starts_with('.')`
- `mikebom-cli/src/scan_fs/package_db/go_binary.rs:should_skip_binary_descent` — same two additions for parity with the source walker
- Two regression tests in `golang/legacy.rs`: `walker_skips_testdata_subtree` (the reported scenario) and `walker_skips_underscore_prefixed_subtree` (e.g. `_archive/`, `_fork/`)

## Why this is safe

Mirroring Go's own documented behavior exactly. No Go user could have a `go.mod` under `testdata/` or `_archive/` that real Go tooling would see — `go list ./...`, `go build ./...`, `go test ./...` all skip those subtrees. mikebom matching that behavior is parity restoration, not new policy.

## Related

#334 tracks the generic `--exclude-path` flag for the same shape of bug in non-Go ecosystems (cargo / maven / gem / pip / npm / gradle / nuget / yocto), where there's no documented language convention to lean on — those need opt-in user-supplied exclusion paths.

## Test plan

- [x] `MIKEBOM_SKIP_DOCKER_INTEGRATION=1 ./scripts/pre-pr.sh` — clippy `--workspace --all-targets` + full workspace tests, both clean
- [x] Two new regression tests pass; existing 4 walker_skip_* tests unchanged
- [ ] Re-scan the reporter's image after merge to confirm the chain collapses to the expected direct edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)