### PR TITLE
ci: bump actions/checkout from 6.0.2 to 6.0.3 (closes #319)

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -37,7 +37,7 @@ jobs:
     if: "${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'release: bump workspace to v') }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     name: Lint + test (linux-x86_64)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Don't write the auto-provisioned GITHUB_TOKEN into the
           # checked-out repo's `.git/config`. The CI flow doesn't push
@@ -264,7 +264,7 @@ jobs:
     name: Lint + test (macos-latest)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false  # see lint-and-test job for rationale
 
@@ -331,7 +331,7 @@ jobs:
     name: Lint + test (windows-latest)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false  # see lint-and-test job for rationale
 
@@ -419,7 +419,7 @@ jobs:
     name: Lint + test (linux-x86_64, --features ebpf-tracing)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false  # see lint-and-test job for rationale
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -37,7 +37,7 @@ jobs:
         runner: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-25)

--- a/.github/workflows/realistic-projects.yml
+++ b/.github/workflows/realistic-projects.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false  # see ci.yml for rationale
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     name: Build eBPF object
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ env.TAG_NAME }}
 
@@ -111,7 +111,7 @@ jobs:
     env:
       TARGET: x86_64-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ env.TAG_NAME }}
 
@@ -222,7 +222,7 @@ jobs:
     env:
       TARGET: aarch64-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ env.TAG_NAME }}
 
@@ -314,7 +314,7 @@ jobs:
     env:
       TARGET: aarch64-apple-darwin
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ env.TAG_NAME }}
 
@@ -384,7 +384,7 @@ jobs:
     env:
       TARGET: x86_64-pc-windows-msvc
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ env.TAG_NAME }}
 
@@ -462,7 +462,7 @@ jobs:
       packages: write
       id-token: write # Required for cosign keyless OIDC token exchange.
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ env.TAG_NAME }}
           # Kusari Inspector requirement: prevent token-in-.git/config


### PR DESCRIPTION
## Summary

Bulk SHA-bump across all 5 workflow files (13 total references): `ci.yml`, `release.yml`, `perf.yml`, `realistic-projects.yml`, `auto-tag-release.yml`.

Supersedes dependabot's #319 — which can only update workflow files that haven't changed since the dependabot branch was opened. After #338 (auto-tag worker + workflow_dispatch escape hatch) reshuffled `release.yml` and added `auto-tag-release.yml`, dependabot's rebased branch ended up touching only the new file (1 of 13). This PR catches the remaining 12.

## Verification

- All 5 workflow YAMLs parse cleanly via `js-yaml`.
- SHA-pinned to `df4cb1c069e1874edd31b4311f1884172cec0e10` per project convention (matches the SHA dependabot proposed in #319).

## Test plan

CI on this PR will exercise every workflow that fires on PR.

Closes #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)