### PR TITLE
feat(ci): walker-audit allow-list gate (milestone 115, closes #342)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,84 @@ jobs:
           # CICD-SEC-1 + Kusari Inspector hardening guidance.
           persist-credentials: false
 
+      # Milestone 115 — walker-audit allow-list gate (closes #342).
+      # Codifies the milestone-114 `safe_walk` no-hand-rolled-walker
+      # invariant as a CI check. The audit grep enumerates every
+      # `fn walk[_(]` match under `mikebom-cli/src/scan_fs/`; the
+      # committed allow-list at `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt`
+      # is the single source of truth for "intentional matches."
+      # Drift in either direction (new walker without intent, or
+      # stale exception left behind) fails the build.
+      #
+      # Slotted before `Install stable Rust` so a failure short-
+      # circuits the toolchain install, cargo cache restore,
+      # clippy, and `cargo test --workspace`. The step uses only
+      # POSIX shell (`grep` / `sort` / `diff`) — preinstalled on
+      # every GitHub Actions runner; no `apt-get install`. Per
+      # specs/115-walker-audit-ci/contracts/ci-step.md.
+      - name: Walker-audit allow-list check
+        shell: bash
+        run: |
+          set -u
+          ALLOWLIST="mikebom-cli/src/scan_fs/walk.audit-allowlist.txt"
+          FAIL_HEADLINE="[FAIL] Walker-audit allow-list mismatch — see mikebom-cli/src/scan_fs/walk.rs's module-level comment for the exception policy."
+          FAIL_POINTER_NEW="If your PR intentionally adds a new walker exception, see CONTRIBUTING.md § Walker-audit CI gate."
+          FAIL_POINTER_BAD="If your PR did NOT intend to add a walker, remove the new fn walk_* function and use scan_fs::walk::safe_walk instead."
+
+          # Precheck: missing or empty allow-list → fail closed per
+          # FR-010 strict-enforcement bootstrap. A future PR that
+          # accidentally or maliciously deletes the file gets the
+          # same red CI as an unauthorized walker addition.
+          if [ ! -f "$ALLOWLIST" ]; then
+            echo "$FAIL_HEADLINE" >&2
+            echo "" >&2
+            echo "ERROR: $ALLOWLIST is missing." >&2
+            echo "" >&2
+            echo "This file is the bootstrap baseline for the walker-audit CI gate (feature 115)." >&2
+            echo "If you intentionally removed it, restore from the previous commit:" >&2
+            echo "    git show HEAD~1:$ALLOWLIST > $ALLOWLIST" >&2
+            echo "" >&2
+            echo "See CONTRIBUTING.md § Walker-audit CI gate for the file's purpose." >&2
+            exit 1
+          fi
+          EXPECTED=$(grep -v '^#' "$ALLOWLIST" | grep -v '^$' | LC_ALL=C sort -u)
+          if [ -z "$EXPECTED" ]; then
+            echo "$FAIL_HEADLINE" >&2
+            echo "" >&2
+            echo "ERROR: $ALLOWLIST is empty (zero non-blank, non-comment lines)." >&2
+            echo "" >&2
+            echo "This file is the bootstrap baseline for the walker-audit CI gate (feature 115)." >&2
+            echo "Empty is not a valid state per FR-010 strict-enforcement bootstrap." >&2
+            echo "" >&2
+            echo "See CONTRIBUTING.md § Walker-audit CI gate for the file's purpose." >&2
+            exit 1
+          fi
+
+          # Live audit pattern. LC_ALL=C pins lex order across runners.
+          # `--include='*.rs'` scopes to Rust source so the audit doesn't
+          # match its own allow-list file (`walk.audit-allowlist.txt`
+          # lives under scan_fs/ for adjacency per SC-005, and every
+          # entry inside it contains the substring `fn walk_`).
+          LIVE=$(LC_ALL=C grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/ | LC_ALL=C sort -u)
+
+          START_NS=$(date +%s%N 2>/dev/null || echo 0)
+          if DIFF_OUT=$(diff -u <(printf '%s\n' "$EXPECTED") <(printf '%s\n' "$LIVE")); then
+            END_NS=$(date +%s%N 2>/dev/null || echo 0)
+            ELAPSED_MS=$(( (END_NS - START_NS) / 1000000 ))
+            ENTRY_COUNT=$(printf '%s\n' "$EXPECTED" | wc -l | tr -d ' ')
+            echo "Walker-audit allow-list check: OK (${ENTRY_COUNT} entries; ${ELAPSED_MS} ms)"
+          else
+            echo "$FAIL_HEADLINE" >&2
+            echo "" >&2
+            echo "--- mikebom-cli/src/scan_fs/walk.audit-allowlist.txt (expected)" >&2
+            echo "+++ live: grep -rEn 'fn walk[_(]' mikebom-cli/src/scan_fs/ | sort -u (actual)" >&2
+            printf '%s\n' "$DIFF_OUT" | tail -n +3 >&2
+            echo "" >&2
+            echo "$FAIL_POINTER_NEW" >&2
+            echo "$FAIL_POINTER_BAD" >&2
+            exit 1
+          fi
+
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-25)
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,8 @@ Auto-generated from all feature plans. Last updated: 2026-06-12
 - N/A — exclusion entries are in-process per scan; no caches, no persistence. (113-exclude-path-flag)
 - Rust stable (workspace toolchain inherited from milestones 001–113; no nightly required for this user-space-only refactor). + existing only — `std::fs::{canonicalize, read_dir}`, `std::path::{Path, PathBuf}`, `std::collections::HashSet`, `tracing` (for debug-skip logs). Reuses milestone-113's `ExclusionSet` at `mikebom-cli/src/scan_fs/package_db/exclude_path.rs`. **Zero new Cargo dependencies** per FR-011 (no `walkdir`, no `ignore`, no `globwalk`). (114-safe-walk-migration)
 - N/A — visited-set is per-call in-memory state; cleared at each `safe_walk` invocation. No persistence. (114-safe-walk-migration)
+- POSIX shell (bash) inside GitHub Actions YAML; no Rust code change. + existing tools — `grep` (GNU/BSD; the `-rEn` flags are POSIX-compatible), `sort` (POSIX), `diff` (POSIX). All preinstalled on every GitHub Actions runner image. **Zero new tool installations.** (115-walker-audit-ci)
+- A single source-tree-committed plain-text file: `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt`. Sorted lex; one `<file>:<line>:<content>` entry per line; LF line endings. (115-walker-audit-ci)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -185,9 +187,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 115-walker-audit-ci: Added POSIX shell (bash) inside GitHub Actions YAML; no Rust code change. + existing tools — `grep` (GNU/BSD; the `-rEn` flags are POSIX-compatible), `sort` (POSIX), `diff` (POSIX). All preinstalled on every GitHub Actions runner image. **Zero new tool installations.**
 - 114-safe-walk-migration: Added Rust stable (workspace toolchain inherited from milestones 001–113; no nightly required for this user-space-only refactor). + existing only — `std::fs::{canonicalize, read_dir}`, `std::path::{Path, PathBuf}`, `std::collections::HashSet`, `tracing` (for debug-skip logs). Reuses milestone-113's `ExclusionSet` at `mikebom-cli/src/scan_fs/package_db/exclude_path.rs`. **Zero new Cargo dependencies** per FR-011 (no `walkdir`, no `ignore`, no `globwalk`).
 - 113-exclude-path-flag: Added Rust stable (workspace toolchain inherited from milestones 001–113; no nightly required for this user-space-only work). + existing only EXCEPT one new direct dep — `globset = "0.4"` (pure Rust, pulls `regex` + `regex-syntax` which are already in the workspace dependency closure). Existing crates reused: `clap` (the new flag via `ArgAction::Append` derive + `value_parser` validation), `serde`/`serde_json` (transparency annotation emission), `tracing` (debug logs for matched directories), `anyhow`/`thiserror` (parse-error class for malformed patterns), `walkdir`/`std::fs::canonicalize` (existing descent helpers — unchanged). `url` (workspace) for env-var-list separator handling on Windows is not needed; we use `std::env::var` + `std::env::join_paths`-style splitting.
-- 112-go-build-inclusion: Added Rust stable (workspace toolchain inherited from milestones 001–111; no nightly required for this user-space-only feature) + Existing only — `std::process::Command` + `std::sync::mpsc` (subprocess with timeout, pattern at `golang/go_mod_graph.rs:81–158`), `clap` (new boolean flag via derive), `serde`/`serde_json` (annotation values), `tracing` (FR-013 logs), `anyhow`/`thiserror` (error classes). **No new Cargo dependencies.** Child-process tool: the host's `go` binary (optional; absence degrades).
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,113 @@ This requires the JPEWdev `spdx3-validate` Python package pinned in
 the gate skips silently — but CI runs it strictly on release branches,
 so test locally before release-bump PRs.
 
+## Walker-audit CI gate
+
+If your PR adds code under `mikebom-cli/src/scan_fs/`, read this section
+**before** writing the new filesystem-walking logic. The walker-audit gate
+fails fast (under one second) when an unauthorized `fn walk_*` shows up
+outside the shared helper or the documented exception list.
+
+### What the gate enforces
+
+The post-milestone-114 invariant is that every ecosystem-discovery
+filesystem walker under `mikebom-cli/src/scan_fs/` goes through the
+shared `scan_fs::walk::safe_walk` helper. Hand-rolled `read_dir`
+recursion bypasses the canonicalize-keyed visited-set + depth-bound +
+exclusion-set + skip-debug-log machinery that lives in one place for
+auditability.
+
+The CI step (in `.github/workflows/ci.yml`'s `Lint + test (linux-x86_64)`
+job, between `actions/checkout` and `Install stable Rust`) runs:
+
+```bash
+grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/ \
+  | LC_ALL=C sort -u
+```
+
+and `diff`s the result against the committed allow-list at
+`mikebom-cli/src/scan_fs/walk.audit-allowlist.txt`. Either-direction
+drift (new walker without an allow-list entry, OR stale entry pointing
+at deleted code) fails the build.
+
+### What to do when your PR turns red on `Walker-audit allow-list check`
+
+The CI log shows you a unified-diff hunk. Two paths from there:
+
+**Scenario A — you added a walker by accident.** You wrote a one-off
+`read_dir` recursion when `safe_walk` would have worked. Refactor the
+new code to call `safe_walk`:
+
+```rust
+use crate::scan_fs::walk::{safe_walk, WalkConfig};
+
+let cfg = WalkConfig {
+    max_depth: 6,
+    should_skip: &|p, _| {
+        // your skip predicate
+        false
+    },
+    exclude_set,
+};
+safe_walk(rootfs, &cfg, |path| {
+    // your per-path visit logic
+});
+```
+
+See `mikebom-cli/src/scan_fs/walk.rs`'s module-level comment block for
+the full API + the documented exceptions that already exist. The
+five-minute walkthrough in
+[`specs/114-safe-walk-migration/quickstart.md`](specs/114-safe-walk-migration/quickstart.md)
+covers `max_depth` / `should_skip` / callback shape choices.
+
+**Scenario B — your walker legitimately can't fit `safe_walk`.** Rare,
+but possible (per-descent stateful pruning, parent-name-aware recursion,
+…). In the SAME PR, do two edits:
+
+1. Append the new grep-output line to
+   `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt`, sorted with
+   `LC_ALL=C sort -u`. The easiest path is to regenerate the whole
+   file:
+   ```bash
+   grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/ \
+     | LC_ALL=C sort -u \
+     > mikebom-cli/src/scan_fs/walk.audit-allowlist.txt
+   ```
+   `git diff` should show **exactly one** added line. More than one
+   means either upstream drift (rebase first) or you added more than
+   one walker.
+2. Add a one-sentence reason in the comment block at the top of
+   `mikebom-cli/src/scan_fs/walk.rs`'s "Documented known exceptions"
+   subsection naming the new walker + why it can't delegate.
+
+The gate enforces step 1 mechanically; step 2 is reviewer-policed. The
+reviewer will see both the allow-list change AND the code change in
+one diff and evaluate the new exception's justification at the same
+time as the code change.
+
+### When NOT to interact with the gate
+
+- Refactoring inside an existing walker file (renames, helper
+  extractions): as long as no NEW `fn walk_*` appears, the gate
+  stays quiet.
+- Adding a function named `fn walker_*` or `fn walking_*`: the regex
+  `'fn walk[_(]'` only matches `fn walk_` or `fn walk(` exactly; longer
+  prefixes don't match.
+- Working in a different directory (`mikebom-common/`, `mikebom-ebpf/`):
+  the gate is scoped to `mikebom-cli/src/scan_fs/` only.
+
+### Why this is a CI gate and not a clippy lint
+
+The gate is a single-line POSIX shell pipeline that runs in <500 ms on
+the existing Linux CI runner. A clippy lint would be more "Rusty" but
+would also require a Cargo build to fail. The shell gate fails before
+any toolchain is installed, short-circuiting clippy + `cargo test` on
+the way to maintainer review. The flat-text allow-list is human-
+editable in any editor without schema knowledge.
+
+For the design rationale, see
+[`docs/design-notes.md` § "Filesystem walking pattern (milestone 114)"](docs/design-notes.md#filesystem-walking-pattern-milestone-114).
+
 ### Performance benchmarks (opt-in)
 
 Wall-clock perf benchmarks (`triple_format_perf.rs`, `dual_format_perf.rs`)

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -226,12 +226,14 @@ fn read(rootfs: &Path, exclude_set: &ExclusionSet) -> Vec<PackageDbEntry> {
 
 ### Audit pattern
 
-Run `grep -rEn 'fn walk[_(]' mikebom-cli/src/scan_fs/`. Acceptable matches fall into two categories documented in `mikebom-cli/src/scan_fs/walk.rs`'s comment block:
+Run `grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/`. Acceptable matches fall into two categories documented in `mikebom-cli/src/scan_fs/walk.rs`'s comment block:
 
 - **Filesystem ecosystem-discovery walkers** that delegate to `safe_walk` plus the documented known exceptions (`walker.rs` whole-FS deep-hash; `npm/walk.rs` `@scope`-aware; `cmake_observer.rs` stop-at-match descent; `maven_sidecar.rs` lstat-style M2 cache walker).
 - **Non-filesystem-walker false positives** that catch the regex but aren't walkers (`maven::walk_m2_jars`, `maven::walk_jar_maven_meta`, `MavenRepoCache::walk_rootfs_poms`, `rpmdb_sqlite::walk_schema_page`, and test functions named `walks_*` / `walk_jar_*` / `walk_fat_jar_*` / `walk_rootfs_poms_*`).
 
 Any match outside the union of those two lists is a regression: the contributor introduced a new hand-rolled filesystem walker bypassing `safe_walk`. Reviewer action: reject the PR or push back to either migrate the new walker to `safe_walk` OR add a new entry to the comment block at the top of `scan_fs/walk.rs` with a one-sentence reason. The exception list MUST stay short — five entries is the current state; ten is the abstraction failing and we should rethink.
+
+As of milestone 115, the audit pattern is enforced by CI — `.github/workflows/ci.yml`'s `Walker-audit allow-list check` step in the `Lint + test (linux-x86_64)` job diffs the live grep against `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt` and fails the build on drift. The new-exception contributor workflow lives in [`CONTRIBUTING.md` § Walker-audit CI gate](../CONTRIBUTING.md#walker-audit-ci-gate); the spec + design rationale lives at `specs/115-walker-audit-ci/`.
 
 See `mikebom-cli/src/scan_fs/walk.rs`'s module-level doc-comment for the authoritative audit-pattern + known-exception list. The milestone-114 spec lives at `specs/114-safe-walk-migration/`.
 

--- a/mikebom-cli/src/scan_fs/walk.audit-allowlist.txt
+++ b/mikebom-cli/src/scan_fs/walk.audit-allowlist.txt
@@ -1,0 +1,28 @@
+mikebom-cli/src/scan_fs/binary/source_binding/cmake_observer.rs:113:fn walk_for_cmake_build_dirs(
+mikebom-cli/src/scan_fs/package_db/maven.rs:1249:fn walk_m2_jars(repo_cache: &MavenRepoCache) -> Vec<PathBuf> {
+mikebom-cli/src/scan_fs/package_db/maven.rs:1714:pub(crate) fn walk_jar_maven_meta(archive_path: &Path) -> Vec<EmbeddedMavenMeta> {
+mikebom-cli/src/scan_fs/package_db/maven.rs:350:    pub(crate) fn walk_rootfs_poms(
+mikebom-cli/src/scan_fs/package_db/maven.rs:3928:    fn walk_jar_collects_coord_and_embedded_deps() {
+mikebom-cli/src/scan_fs/package_db/maven.rs:3957:    fn walk_jar_attaches_sidecar_hash_when_present() {
+mikebom-cli/src/scan_fs/package_db/maven.rs:3981:    fn walk_jar_no_sidecar_still_computes_archive_sha256() {
+mikebom-cli/src/scan_fs/package_db/maven.rs:4009:    fn walk_jar_with_sha1_sidecar_also_gets_sha256() {
+mikebom-cli/src/scan_fs/package_db/maven.rs:4035:    fn walk_fat_jar_only_primary_coord_gets_archive_sha256() {
+mikebom-cli/src/scan_fs/package_db/maven.rs:4070:    fn walk_jar_without_pom_xml_returns_empty_deps() {
+mikebom-cli/src/scan_fs/package_db/maven.rs:4088:    fn walk_fat_jar_collects_one_meta_per_vendored_artifact() {
+mikebom-cli/src/scan_fs/package_db/maven.rs:6078:    fn walk_rootfs_poms_finds_multiple_cached_artifacts() {
+mikebom-cli/src/scan_fs/package_db/maven.rs:6113:    fn walk_rootfs_poms_skips_host_scoped_roots() {
+mikebom-cli/src/scan_fs/package_db/maven.rs:6145:    fn walk_rootfs_poms_ignores_sibling_non_pom_files() {
+mikebom-cli/src/scan_fs/package_db/maven.rs:6174:    fn walk_rootfs_poms_truncates_at_cap() {
+mikebom-cli/src/scan_fs/package_db/maven.rs:6194:    fn walk_rootfs_poms_handles_deep_group_paths() {
+mikebom-cli/src/scan_fs/package_db/maven.rs:6214:    fn walk_rootfs_poms_empty_cache_returns_nothing() {
+mikebom-cli/src/scan_fs/package_db/maven_sidecar.rs:166:    fn walk(dir: &Path, depth: usize, out: &mut HashMap<String, PathBuf>) {
+mikebom-cli/src/scan_fs/package_db/npm/mod.rs:793:    fn walk_skips_node_modules_subtrees() {
+mikebom-cli/src/scan_fs/package_db/npm/package_lock.rs:792:    fn walk_up_resolution_picks_hoisted_when_parent_lacks_nested() {
+mikebom-cli/src/scan_fs/package_db/npm/walk.rs:60:fn walk_node_modules(
+mikebom-cli/src/scan_fs/package_db/nuget/directory_packages_props.rs:158:    fn walk_up_finds_props_in_ancestor() {
+mikebom-cli/src/scan_fs/package_db/nuget/directory_packages_props.rs:170:    fn walk_up_stops_at_scan_root() {
+mikebom-cli/src/scan_fs/package_db/rpmdb_sqlite/schema.rs:53:fn walk_schema_page<F>(
+mikebom-cli/src/scan_fs/walk.rs:179:fn walk_inner<F: FnMut(&Path)>(
+mikebom-cli/src/scan_fs/walk.rs:8://! `fn walk_*` recursion implementing the same canonicalize-keyed
+mikebom-cli/src/scan_fs/walker.rs:109:fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+mikebom-cli/src/scan_fs/walker.rs:47:pub fn walk_and_hash(

--- a/specs/115-walker-audit-ci/checklists/requirements.md
+++ b/specs/115-walker-audit-ci/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Walker-Audit CI Gate
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- The "user" of this feature is primarily a *maintainer* reviewing PRs (US1) and a *contributor* adding new walker code (US2). Neither is an end-user / operator of the mikebom binary — this is a contributor-experience feature whose business value flows through reduced reviewer cognitive load + locked-in milestone-114 durability.
+- The spec deliberately stays at the level of "audit pattern" / "shared helper" / "allow-list file" rather than naming the specific grep regex, the helper module's file path, or the allow-list's file extension. Those are planning-phase choices; the spec commits only to the user-visible contract.
+- SC-004 (allow-list shrinks over time) is verifiable but not enforceable by this milestone — it's a forward-looking measurement at the time of future milestones. Marked as a measurable outcome anyway because the spec wants to be explicit that the gate is designed to encourage migration, not entrench exceptions.
+- The principal validation mechanism is a negative test (per the spec's last Assumption bullet): a synthetic PR that adds an unauthorized walker, run against CI, fails red. This is captured in US1's Independent Test.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/115-walker-audit-ci/contracts/ci-step.md
+++ b/specs/115-walker-audit-ci/contracts/ci-step.md
@@ -1,0 +1,117 @@
+# Contract: Walker-Audit CI Step
+
+**Feature**: 115-walker-audit-ci
+**Date**: 2026-06-13
+**Consumed by**: `.github/workflows/ci.yml`
+**Spec mapping**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-009, FR-010
+
+This contract defines the externally observable behavior of the single CI step this feature ships. It is the surface against which the negative-test runbook in [quickstart.md](../quickstart.md) verifies the gate, and the surface a maintainer can rely on when reading `ci.yml`.
+
+## Step name (workflow YAML)
+
+```text
+Walker-audit allow-list check
+```
+
+The name appears verbatim in the GitHub Actions UI's step list under the `Lint + test (linux-x86_64)` job. The name choice trades terseness for searchability — a contributor seeing it red can copy-paste the name into the repo's grep and immediately find both the YAML and the docs.
+
+## Trigger surface
+
+- **Workflow file**: `.github/workflows/ci.yml`
+- **Job**: `Lint + test (linux-x86_64)` (existing; at line 39 in the post-114 tree)
+- **Trigger events**: every `pull_request` and every `push` to main (inherited from the existing job's triggers; the audit fires whenever clippy + tests fire)
+- **Step ordering**: runs AFTER `actions/checkout@v4` and BEFORE the existing clippy step at `ci.yml:216` (and therefore also before `cargo test --workspace`). Rationale: a fast failure short-circuits both the lint suite and the slow test suite.
+
+## Inputs
+
+The step reads ONE file from the working directory at PR HEAD:
+
+| Input | Path | Required? | Behavior if missing |
+|---|---|---|---|
+| Source tree | `mikebom-cli/src/scan_fs/**/*` | yes | grep returns empty; allow-list non-empty → diff fails → step exits non-zero ✓ (the source-tree-disappeared-entirely case is hypothetical but the gate still fails closed) |
+| Allow-list | `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt` | yes | step exits non-zero with a "missing or empty allow-list" failure message ✓ (FR-010 strict-enforcement bootstrap) |
+
+## Outputs
+
+### Exit code
+
+| Exit code | Meaning |
+|---|---|
+| 0 | Allow-list bytes equal the canonicalized live grep output. PR may proceed. |
+| ≠0 | Drift detected OR allow-list missing OR allow-list empty. PR is blocked. |
+
+### Stdout / stderr
+
+The step always prints SOMETHING; what depends on the path:
+
+**Pass path (exit 0)**:
+```
+Walker-audit allow-list check: OK (<N> entries; <M> ms)
+```
+
+Where `<N>` is the entry count and `<M>` is the wall time. The success line is short by design — most CI runs hit this path and excess output dilutes the signal of legitimate failures.
+
+**Fail path — drift (exit non-zero)**:
+```
+[FAIL] Walker-audit allow-list mismatch — see mikebom-cli/src/scan_fs/walk.rs's module-level comment for the exception policy.
+
+--- mikebom-cli/src/scan_fs/walk.audit-allowlist.txt (expected)
++++ live: grep -rEn 'fn walk[_(]' mikebom-cli/src/scan_fs/ | sort -u (actual)
+@@ -X,Y +X,Y @@
+ ...unchanged context...
+-removed-entry-1
++added-entry-1
++added-entry-2
+ ...unchanged context...
+
+If your PR intentionally adds a new walker exception, see CONTRIBUTING.md § Walker-audit CI gate.
+If your PR did NOT intend to add a walker, remove the new fn walk_* function and use scan_fs::walk::safe_walk instead.
+```
+
+**Fail path — missing allow-list (exit non-zero)**:
+```
+[FAIL] Walker-audit allow-list mismatch — see mikebom-cli/src/scan_fs/walk.rs's module-level comment for the exception policy.
+
+ERROR: mikebom-cli/src/scan_fs/walk.audit-allowlist.txt is missing or empty.
+
+This file is the bootstrap baseline for the walker-audit CI gate (feature 115).
+If you intentionally removed it, restore from the previous commit:
+    git show HEAD~1:mikebom-cli/src/scan_fs/walk.audit-allowlist.txt > mikebom-cli/src/scan_fs/walk.audit-allowlist.txt
+
+See CONTRIBUTING.md § Walker-audit CI gate for the file's purpose.
+```
+
+These two fail-path message templates are reviewer-policed for stability — changing them is a contract change and requires updating the spec's FR-004 + this contract.
+
+## Performance contract
+
+- **p95 wall time**: ≤5 s (SC-002)
+- **Expected p50**: <500 ms on ubuntu-latest given ~50 source files in `scan_fs/`
+- **Hard timeout**: inherited from the parent job's `timeout-minutes` setting; no per-step timeout configured
+
+If wall time creeps above 5 s (unlikely but possible if `scan_fs/` grows to thousands of files), revisit the step's grep scope — possibly switch to `ripgrep` (`rg`) if it's available on future runner images, or scope the grep to specific subdirectories.
+
+## Idempotency
+
+The step is fully idempotent: running it twice on the same source tree produces identical output. No side effects, no temp-file leakage outside `${RUNNER_TEMP}`.
+
+## Failure-mode parity
+
+The step's pass/fail outcome MUST be byte-deterministic across:
+- Multiple consecutive runs on the same commit SHA
+- Re-runs of the same job (the `Re-run failed jobs` button)
+- Different ubuntu-latest runner images (Ubuntu 22.04 vs 24.04 etc.)
+
+This is satisfied by Decision 4 (LC_ALL=C sort) and Decision 2 (POSIX-only tools). FR-005 is the spec requirement; this contract is its operationalization.
+
+## Out-of-band overrides
+
+There is no `MIKEBOM_SKIP_WALKER_AUDIT` env var, no `[skip walker-audit]` PR-title token, no `walker-audit-bypass` label. The gate is unconditionally enforcing per Q1's strict-enforcement bootstrap clarification. An emergency bypass (if ever needed) is the same as for any other failed CI gate: a PR that explicitly modifies `ci.yml` to comment out the step, with the maintainer reviewing that modification as the bypass authorization.
+
+This is intentional — the gate's value derives entirely from being unconditional. A bypass mechanism is a delegation problem (who has bypass rights? logged how?), and the cost of NOT having one is low (the step itself is fast to fix-up via a follow-up commit).
+
+## Backwards compatibility
+
+Pre-merge of this PR: the step does not exist; existing CI is unaffected. Post-merge: every subsequent PR pays the <500 ms step cost. There is no rolling-deprecation window; the gate is hot on day one.
+
+If a future milestone introduces a way to legitimately have an empty allow-list (e.g., every walker has migrated to `safe_walk`), that milestone updates this contract's "missing or empty" failure-path text. Until then, "empty = fail" is correct.

--- a/specs/115-walker-audit-ci/data-model.md
+++ b/specs/115-walker-audit-ci/data-model.md
@@ -1,0 +1,89 @@
+# Data Model — Walker-Audit CI Gate
+
+**Feature**: 115-walker-audit-ci
+**Date**: 2026-06-13
+
+This feature has exactly one data artifact: the allow-list text file. There are no domain entities, no persisted state, no schema migrations — this section documents the single file's format + invariants so future maintainers can edit it confidently.
+
+## Entity: Allow-list Entry
+
+**File**: `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt`
+**Encoding**: UTF-8 (ASCII subset in practice)
+**Line endings**: LF (Unix)
+**Final-newline policy**: file ends with a single LF after the last entry (POSIX text-file convention; required for `diff -u` to compare cleanly)
+
+### Line format
+
+Each non-blank, non-comment line is one allow-list entry, byte-equal to a single line of `grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/` output:
+
+```text
+<relative-path>:<line-number>:<matched-line-content>
+```
+
+| Field | Type | Source | Notes |
+|---|---|---|---|
+| `<relative-path>` | string | grep | Relative to repo root, forward-slash separators. Always starts with `mikebom-cli/src/scan_fs/`. |
+| `<line-number>` | positive int | grep | 1-based; identifies the line in the source file where `fn walk[_(]` matched. |
+| `<matched-line-content>` | string | grep | The full source line text where the match occurred, including leading whitespace and trailing comments. Verbatim. |
+
+**Example entry** (from the expected post-114 baseline):
+
+```text
+mikebom-cli/src/scan_fs/walk.rs:142:pub(crate) fn safe_walk<F: FnMut(&Path)>(
+```
+
+### Sort order
+
+The file is sorted with `LC_ALL=C sort -u` (locale-independent bytewise lexicographic, deduped). Entries thus appear in a deterministic order across all hosts that follow Decision 4 in [research.md](./research.md).
+
+### Blank lines + comments
+
+The file MAY contain blank lines (zero or more LFs in a row) and comment lines (starting with `#`) for human readability. These lines are filtered out before the audit comparison runs — they exist purely for maintainer convenience and do not participate in the diff.
+
+**Filter logic (informal pseudocode)**:
+```
+keep_for_diff(line) = line is non-empty AND line does NOT start with '#'
+```
+
+The committed allow-list as shipped in this PR has NO comments or blank lines (it's the raw grep output sorted) — the comment-line provision is a forward-looking affordance for future maintainers who may want to group entries by category (e.g., `# Helper module`, `# Documented exceptions`, `# Known non-walker false positives`). Adopting comments is a future-PR decision; the initial commit doesn't take a position.
+
+### Invariants
+
+The file MUST satisfy these invariants at every commit; the CI gate enforces them implicitly:
+
+1. **Coverage**: The set of non-blank-non-comment lines is EXACTLY equal to `LC_ALL=C sort -u` of the live `grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/` output. Any deviation fails CI.
+2. **No duplicates**: The `-u` step in the sort guarantees this; entries are unique line-by-line.
+3. **Sort-stability**: The file content matches `LC_ALL=C sort -u file > file.tmp && diff file file.tmp` cleanly. A future PR that hand-edits the file out of order will fail the diff (the live side is freshly sorted; the committed side will be canonically re-sorted via the CI step's pipeline, so the comparison only succeeds if the committed file was already sorted).
+4. **Final-newline**: file ends with exactly one trailing LF.
+5. **Non-empty**: file has at least one entry. (FR-010: empty allow-list fails CI under strict-enforcement bootstrap.)
+
+### Lifecycle
+
+The allow-list is born at PR ship time (this feature's PR) populated with the 28-line post-milestone-114 baseline. Subsequent edits happen ONLY in PRs that legitimately add a new walker exception, per the workflow documented in `CONTRIBUTING.md § Walker-audit CI gate`. The expected long-term direction is downward: every milestone that migrates an existing exception walker to `safe_walk` removes its entry from the allow-list (SC-004's "shrinks over time" measurement).
+
+There is no automatic regeneration. Any PR that wants to update the file must edit it explicitly — running the grep one-liner and replacing the file content is the documented workflow.
+
+## Entity: CI Step (Comparison Pipeline)
+
+The audit step itself is an ephemeral entity — it has inputs (the source tree at the PR's HEAD) and outputs (a zero/non-zero exit code + stdout/stderr). Documented here for completeness:
+
+### Inputs
+1. The repo source tree at PR HEAD (checked out by the existing `actions/checkout@v4` step at line 14 of `ci.yml`).
+2. `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt` (read from the checkout).
+
+### Pipeline
+1. Run `grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/ | LC_ALL=C sort -u > /tmp/live.txt`.
+2. Run `grep -v '^#' mikebom-cli/src/scan_fs/walk.audit-allowlist.txt | grep -v '^$' | LC_ALL=C sort -u > /tmp/expected.txt`. (The two `grep -v` invocations strip blank lines + comments per the format-section filter.)
+3. Run `diff -u /tmp/expected.txt /tmp/live.txt`.
+4. If diff is empty → step exits 0 (success).
+5. If diff is non-empty → print the FR-004 failure-message payload (headline + diff + pointer) and exit with diff's non-zero exit code.
+
+### Outputs
+- **Exit code**: 0 (allow-list matches live) or non-zero (drift detected; FR-002).
+- **stdout/stderr**: per FR-004 failure-message contract; see [research.md § Decision 6](./research.md).
+
+### Performance contract
+- p95 wall time ≤5 s per SC-002.
+- Measured: <500 ms expected on ubuntu-latest given ~50 source files in `scan_fs/`.
+
+There is no persisted state from this entity — it runs once per CI invocation and is discarded.

--- a/specs/115-walker-audit-ci/plan.md
+++ b/specs/115-walker-audit-ci/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Walker-Audit CI Gate
+
+**Branch**: `115-walker-audit-ci` | **Date**: 2026-06-13 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/115-walker-audit-ci/spec.md`
+
+## Summary
+
+Add a CI step to `.github/workflows/ci.yml`'s existing `Lint + test (linux-x86_64)` job that runs `grep -rEn 'fn walk[_(]' mikebom-cli/src/scan_fs/` and `diff`s the sorted output against a committed allow-list at `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt`. The PR ships the 28-line post-114 baseline as that file. Failure prints the offending diff hunks AND a one-paragraph "how to resolve" pointer to `scan_fs/walk.rs`'s comment block. Documentation lands in `CONTRIBUTING.md` (new section) + a cross-link from `docs/design-notes.md`'s existing milestone-114 section. The new-exception workflow requires two edits in the same PR — append to the allow-list + add a one-sentence reason in `walk.rs`'s comment block — though only the allow-list edit is mechanically enforced (the comment-block edit is reviewer-policed per the spec's Edge Cases).
+
+**Technical approach**: POSIX shell + `grep` + `sort` + `diff` (already on every GitHub Actions runner). Linux-only execution per the spec's Deferred decision (cheapest lane, audit-pattern is OS-agnostic by design). No new tools, no new Cargo dependencies. The CI step runs BEFORE the existing clippy step at `ci.yml:216` (and therefore also before `cargo test --workspace`) so a fast audit failure short-circuits both the lint suite and the slow test suite.
+
+## Technical Context
+
+**Language/Version**: POSIX shell (bash) inside GitHub Actions YAML; no Rust code change.
+**Primary Dependencies**: existing tools — `grep` (GNU/BSD; the `-rEn` flags are POSIX-compatible), `sort` (POSIX), `diff` (POSIX). All preinstalled on every GitHub Actions runner image. **Zero new tool installations.**
+**Storage**: A single source-tree-committed plain-text file: `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt`. Sorted lex; one `<file>:<line>:<content>` entry per line; LF line endings.
+**Testing**: The gate's correctness is exercised by the negative test path documented in `quickstart.md` — a contributor opens a PR adding `fn walk_synthetic_negative_test_DO_NOT_MERGE()` to a non-allowlisted file, observes CI fail red. No new unit-test infrastructure; the gate IS a single shell pipeline.
+**Target Platform**: GitHub Actions `ubuntu-latest` runner (existing `Lint + test (linux-x86_64)` job). The spec's FR-005 cross-platform stability guarantee is satisfied by the audit pattern being OS-agnostic; running on Linux-only is a cost choice per the spec's Deferred section, not a correctness choice.
+**Project Type**: CI/CD configuration + one tracked data file + documentation updates.
+**Performance Goals**: ≤5 seconds wall time per SC-002. The grep runs in <1s on the post-114 source tree (~50 files under `mikebom-cli/src/scan_fs/`), `sort` is O(n log n) on ~28 lines, `diff -u` is O(n + m) on two ~28-line files. Total expected: <500 ms.
+**Constraints**: No new Cargo dependencies (matches every milestone since 001); the gate MUST run on every PR and every push to main (FR-001); allow-list MUST be order-stable across runners (FR-005); failure message MUST point at `scan_fs/walk.rs`'s comment block (FR-004).
+**Scale/Scope**: One CI step, one allow-list file, one `CONTRIBUTING.md` section. Diff size: ~80 lines YAML + ~30 lines text file + ~50 lines docs.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Pure Rust, Zero C | N/A | This feature ships YAML + plain text + Markdown; no source code. |
+| II. eBPF-Only Observation | N/A | This affects CI, not the trace or scan codepaths. |
+| III. Fail Closed | ✓ | The gate IS a fail-closed mechanism. A missing/empty allow-list, an unauthorized new walker, OR a stale allow-list entry all produce non-zero exit (FR-010 confirms strict-enforcement bootstrap). |
+| IV. Type-Driven Correctness | N/A | No Rust code. |
+| V. Specification Compliance | N/A | No SBOM emission change. |
+| VI. Three-Crate Architecture | N/A | No new crates. |
+| VII. Test Isolation | ✓ | The gate runs as a standalone CI step, not as part of the Rust test suite. Privilege requirements: none. |
+| VIII. Completeness | N/A | No discovery layer change. |
+| IX. Accuracy | N/A | |
+| X. Transparency | ✓ | Gate failure prints the diff hunks AND a documented resolution pointer (FR-004). Maintainer reading the CI log sees exactly which line is offending + where to look for the resolution doc. |
+| XI. Enrichment | N/A | |
+| XII. External Data Source Enrichment | N/A | |
+| Strict Boundary 1 (no lockfile-based discovery) | N/A | |
+| Strict Boundary 2 (no MITM) | N/A | |
+| Strict Boundary 3 (no C code) | ✓ | Shell + Markdown only. |
+| Strict Boundary 4 (no `.unwrap()` in production) | N/A | |
+
+**Result**: Constitution Check PASSES. No violations. (Most principles are N/A because this is CI infrastructure, not source code.)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/115-walker-audit-ci/
+├── plan.md              # This file
+├── research.md          # Phase 0 — implementation decisions: shell pipeline shape, allow-list format, file location, failure-message contract
+├── data-model.md        # Phase 1 — allow-list entry format + invariants
+├── quickstart.md        # Phase 1 — "how to triage an audit-gate failure" runbook
+├── contracts/
+│   └── ci-step.md       # The single CI-step contract (YAML shape, exit codes, stdout/stderr)
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+.github/
+└── workflows/
+    └── ci.yml                                # +1 step in the linux-x86_64 lane
+mikebom-cli/
+└── src/
+    └── scan_fs/
+        ├── walk.rs                           # UNCHANGED (the helper module; comment block already lists exceptions)
+        └── walk.audit-allowlist.txt          # NEW — 28-line baseline snapshot, sorted lex
+CONTRIBUTING.md                                # +1 section: "Walker-audit CI gate"
+docs/
+└── design-notes.md                            # +1 paragraph in the existing milestone-114 section
+                                               # linking to CONTRIBUTING.md for the workflow
+```
+
+**Structure Decision**: The allow-list lives ADJACENT to `walk.rs` (same directory, sibling file). This satisfies SC-005 ("maintainer evaluates allow-list change + corresponding code change with one diff read") — `git diff` against a PR that adds both a walker AND an allow-list entry shows them ~10 lines apart in the same directory. Putting the allow-list elsewhere (e.g., `tests/` or `.github/`) would force a context switch. The text-file format (no `.yaml`/`.json`/`.toml` schema) matches the spec's Assumption that the allow-list is "fundamentally a list of grep-output lines."
+
+## Complexity Tracking
+
+No constitution violations. No complexity to justify.

--- a/specs/115-walker-audit-ci/quickstart.md
+++ b/specs/115-walker-audit-ci/quickstart.md
@@ -1,0 +1,154 @@
+# Quickstart — Triaging a Red Walker-Audit Gate
+
+**Feature**: 115-walker-audit-ci
+**Audience**: a contributor whose PR just hit a red `Walker-audit allow-list check` step in CI; a maintainer reviewing a PR that touches the gate.
+
+## The TL;DR
+
+If your PR is red on `Walker-audit allow-list check`:
+
+1. Open the failing CI log. The diff hunks identify the offending lines.
+2. Decide: did you ADD a new `fn walk_*` on purpose, or by accident?
+3. By accident: refactor to use `scan_fs::walk::safe_walk` (see `mikebom-cli/src/scan_fs/walk.rs` module-level comment).
+4. On purpose: append the new grep-output line to `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt` (sorted) AND add a one-sentence reason to `walk.rs`'s comment block. Both in the same PR.
+
+## Five-minute walkthrough — Scenario A: accidental new walker
+
+You added a new ecosystem reader at `mikebom-cli/src/scan_fs/package_db/elixir/mix_lock.rs` and the CI failed:
+
+```text
+[FAIL] Walker-audit allow-list mismatch — see mikebom-cli/src/scan_fs/walk.rs's module-level comment for the exception policy.
+
+--- mikebom-cli/src/scan_fs/walk.audit-allowlist.txt (expected)
++++ live: grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/ | sort -u (actual)
+@@ -27,3 +27,4 @@
+ mikebom-cli/src/scan_fs/walk.rs:142:pub(crate) fn safe_walk<F: FnMut(&Path)>(
+ mikebom-cli/src/scan_fs/walker.rs:55:fn walk(...)
++mikebom-cli/src/scan_fs/package_db/elixir/mix_lock.rs:88:fn walk_for_mix_locks(root: &Path) -> Vec<PathBuf> {
+ mikebom-cli/src/scan_fs/package_db/npm/walk.rs:73:fn walk_node_modules(...)
+```
+
+Diagnosis: you wrote a hand-rolled recursion when you could have used the shared helper.
+
+Fix:
+
+```rust
+use crate::scan_fs::walk::{safe_walk, WalkConfig};
+
+pub fn read(rootfs: &Path, exclude_set: &ExclusionSet) -> Vec<PackageDbEntry> {
+    let mut out = Vec::new();
+    let cfg = WalkConfig {
+        max_depth: 6,
+        should_skip: &|p, _| should_skip_default_descent(p.file_name().and_then(|s| s.to_str()).unwrap_or("")),
+        exclude_set,
+    };
+    safe_walk(rootfs, &cfg, |path| {
+        if path.file_name() == Some(OsStr::new("mix.lock")) {
+            if let Some(entry) = parse_mix_lock(path) {
+                out.push(entry);
+            }
+        }
+    });
+    out
+}
+```
+
+The audit gate goes green automatically — your new file's only `fn walk*` match is GONE because you no longer have one.
+
+## Five-minute walkthrough — Scenario B: legitimate new exception
+
+You're adding a Swift Package Manager reader. The Swift manifest semantics genuinely can't fit the generic `safe_walk` (e.g., you need to recurse into specific sub-trees while pruning others mid-descent — the per-descent state can't be expressed in the `should_skip` closure).
+
+You write `fn walk_swift_packages(...)` in `mikebom-cli/src/scan_fs/package_db/swift_pm.rs`. CI fails.
+
+Fix (TWO edits in your PR):
+
+**Edit 1**: Add the new line to the allow-list. Run the regenerator locally:
+
+```bash
+grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/ | LC_ALL=C sort -u > mikebom-cli/src/scan_fs/walk.audit-allowlist.txt
+git add mikebom-cli/src/scan_fs/walk.audit-allowlist.txt
+git diff --cached mikebom-cli/src/scan_fs/walk.audit-allowlist.txt
+```
+
+The diff should show ONE added line. If it shows more than one, you're either (a) regenerating against unrelated upstream drift — rebase first — or (b) you accidentally added more than one new walker.
+
+**Edit 2**: Add a sentence to `mikebom-cli/src/scan_fs/walk.rs`'s module-level comment block, in the "Documented known exceptions" subsection:
+
+```rust
+//! ## Documented known exceptions
+//! ...
+//! - `scan_fs/package_db/swift_pm.rs::walk_swift_packages` — Swift package
+//!   manifests carry pre-declared sub-directory targets that prune mid-descent
+//!   based on per-package-state; the generic should_skip can't express
+//!   per-descent stateful pruning. See PR #NNN.
+```
+
+Both edits commit-together. The CI gate goes green. Reviewers see both the source-tree edit AND the policy edit AND the doc edit in one PR — exactly what SC-005 promises.
+
+## Maintainer triage — Reviewing a PR that adds an allow-list entry
+
+When you see `walk.audit-allowlist.txt` in the diff list of an incoming PR, your evaluation checklist:
+
+1. **One new entry, not several** — multiple new entries are a code smell. Push back: "Can these consolidate to one walker that calls safe_walk for the common case?"
+2. **Comment-block entry in `walk.rs`** — verify the contributor added the one-sentence reason. If missing, request it. The gate doesn't enforce this (per the spec's Edge Cases) but reviewers do.
+3. **The reason is concrete** — "doesn't fit safe_walk" is not a reason; "per-descent stateful pruning" is. Push back on vague reasons.
+4. **The "Why exempt" claim is testable** — could a reasonable refactor of `safe_walk` accommodate this? If yes, ask the contributor to evaluate the refactor instead of growing the exception list. The spec's "ten exceptions = abstraction is failing" threshold is your aspirational ceiling.
+5. **The entry is sorted in correctly** — verify `LC_ALL=C sort -u mikebom-cli/src/scan_fs/walk.audit-allowlist.txt | diff - mikebom-cli/src/scan_fs/walk.audit-allowlist.txt` produces empty output.
+
+## Negative test — Verifying the gate works
+
+If you need to convince yourself the gate is wired up correctly (e.g., before merging the bootstrap PR), this is the runbook:
+
+```bash
+# 1. Note the current state.
+git status
+git log -1 --oneline
+
+# 2. Introduce a synthetic violation in a throwaway branch.
+git checkout -b verify-walker-audit-gate
+cat >> mikebom-cli/src/scan_fs/synthetic_negative_test.rs <<'EOF'
+// THIS FILE EXISTS ONLY TO VERIFY THE WALKER-AUDIT GATE BLOCKS UNEXPECTED ADDITIONS.
+// DO NOT MERGE. Delete this file after verifying the gate fails red on the PR.
+fn walk_synthetic_negative(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    vec![root.to_path_buf()]
+}
+EOF
+git add mikebom-cli/src/scan_fs/synthetic_negative_test.rs
+git commit -m "test: synthetic walker-audit negative test (DO NOT MERGE)"
+git push -u origin verify-walker-audit-gate
+
+# 3. Open the PR. Expected: the Walker-audit allow-list check step fails red,
+#    diff hunk shows the synthetic file's fn walk_synthetic_negative line as the
+#    sole +entry. The clippy + test steps SHOULD short-circuit before running
+#    because the audit step runs first.
+
+# 4. Verify the failure-message contract:
+#    - Headline starts with [FAIL].
+#    - Diff hunks identify the synthetic file + line.
+#    - Trailing pointer references CONTRIBUTING.md § Walker-audit CI gate.
+
+# 5. Close the PR + delete the branch.
+gh pr close --comment "verifying gate behavior; closing" --delete-branch
+```
+
+If the PR turns green, the gate is broken — escalate before merging the bootstrap PR.
+
+## When NOT to interact with the gate
+
+You don't touch the allow-list when:
+
+- You're refactoring inside an existing walker file (renaming variables, extracting helpers) — as long as no NEW `fn walk*` shows up, the grep output is unchanged.
+- You're adding a non-walker function that happens to be named `fn walker_*` or `fn walking_*` — the regex `'fn walk[_(]'` matches only `fn walk_*` or `fn walk(` exactly; `walker_` / `walking_` don't match. Verify with `grep -rEn --include='*.rs' 'fn walk[_(]' your-new-file.rs`.
+- You're working in a different directory (`mikebom-common/`, `mikebom-ebpf/`) — the gate scopes to `mikebom-cli/src/scan_fs/` only.
+
+## When the gate's own infrastructure changes
+
+If a future PR moves `walk.rs` itself, or relocates `scan_fs/` to a different module path, the audit pattern must change in lock-step with the allow-list paths. The grep command in `ci.yml`, the allow-list path, AND the documentation in CONTRIBUTING.md all reference `mikebom-cli/src/scan_fs/` — keep them aligned.
+
+## Related docs
+
+- `CONTRIBUTING.md § Walker-audit CI gate` — the contributor-facing doc-of-record (FR-006 / FR-007)
+- `mikebom-cli/src/scan_fs/walk.rs` module-level comment block — the per-exception reason list (milestone 114 / this milestone's reviewer policing)
+- `docs/design-notes.md § Filesystem walking pattern (milestone 114)` — the design context + cross-link to the contributor doc
+- This feature's [contracts/ci-step.md](./contracts/ci-step.md) — the step's externally observable contract

--- a/specs/115-walker-audit-ci/research.md
+++ b/specs/115-walker-audit-ci/research.md
@@ -1,0 +1,119 @@
+# Research — Walker-Audit CI Gate
+
+**Feature**: 115-walker-audit-ci
+**Date**: 2026-06-13
+**Status**: Decisions resolved; no NEEDS CLARIFICATION markers remaining.
+
+This document records the implementation-level decisions the plan defers from the spec. Each decision lists the chosen approach, the rationale, and the alternatives evaluated.
+
+## Decision 1 — CI lane to run the audit on
+
+**Decision**: Linux only — slot the new step inside the existing `Lint + test (linux-x86_64)` job in `.github/workflows/ci.yml` (line 39). Do NOT replicate it to the macOS, Windows, or eBPF lanes.
+
+**Rationale**: The audit pattern is `grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/` — text matching against checked-in source. The output is byte-identical regardless of the host OS (Linux, macOS, Windows) because (a) git normalizes line endings via the existing `.gitattributes` policy and (b) the matched files are pure Rust source under a single normalized path prefix. Running on three OSes triples cost and CI time for zero additional signal — a successful grep on Linux is a successful grep everywhere. The spec's FR-005 ("the audit pattern produces consistent output across CI runners") is satisfied by the pattern being host-agnostic, not by running it on every host.
+
+The single-Linux-lane choice also satisfies SC-002 (≤5 seconds runtime) trivially: ubuntu-latest is the fastest GitHub Actions runner image; grep + sort + diff over ~50 source files completes in <500 ms.
+
+**Alternatives considered**:
+- **All three OS lanes** — rejected: 3× the cost and CI minutes for no marginal correctness; a flake on one lane (network blip during checkout) would block PRs unnecessarily.
+- **macOS only** — rejected: macOS-latest runners are 10× more expensive than Linux on GitHub Actions billing; no benefit over Linux for a text-comparison check.
+- **A dedicated workflow file** — rejected: a single-step audit doesn't justify a new top-level workflow with its own concurrency group, permissions, and checkout. Slotting into the existing job reuses the existing checkout and inherits the existing branch-protection requirement.
+
+## Decision 2 — Diff tool
+
+**Decision**: POSIX `diff -u expected actual`. Failure mode: non-zero exit (which fails the CI step) + the unified-diff output goes to stderr/stdout.
+
+**Rationale**: `diff` is preinstalled on every GitHub Actions runner image (it's POSIX-mandated). `-u` produces unified-diff output that GitHub's job-log UI renders with familiar +/- prefixes — maintainers immediately see "this line was added, this line was removed." No new tool installation, no `apt-get install` step that could fail, no Cargo build of a Rust-based comparator.
+
+The non-zero exit from `diff` naturally satisfies FR-002 (fail-the-build behavior) without requiring a wrapper script to interpret a "no differences" boolean.
+
+**Alternatives considered**:
+- **`comm`** — rejected: it works for set-difference but the output format is less readable than unified diff; harder for a reviewer to grok "what to do" from the failure log.
+- **A Rust comparator binary** — rejected: pulls a Cargo build into the audit path; violates the spec's implicit "fast + dependency-free" intent. The point of this gate is to be trivially auditable shell.
+- **`git diff --no-index`** — rejected: works but injects a git invocation where pure POSIX `diff` is simpler; the gate doesn't need git semantics.
+
+## Decision 3 — Allow-list file location
+
+**Decision**: `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt`. Same directory as `walk.rs`. Plain `.txt` extension. LF line endings.
+
+**Rationale**: Adjacency to `walk.rs` satisfies SC-005 ("a maintainer reviewing a walker PR sees the allow-list edit and the source edit in the same diff hunk"). Putting the file at the repository root (`/.walker-audit-allowlist.txt`) or under `.github/` would force a context switch every time a contributor consults it. The `walk.rs` comment block — which is the doc-of-record for known walker exceptions per milestone 114 — sits 10 lines away in the same directory.
+
+`.txt` extension because the file IS plain text (one grep-output line per entry); a `.yaml` or `.json` extension would imply a schema the file doesn't have. The `walk.audit-allowlist.txt` prefix (`walk.`) groups it visually with `walk.rs` in directory listings, signaling its tight coupling.
+
+LF (Unix) line endings because git normalizes line endings on commit per the repo's `.gitattributes` policy, and grep + diff produce LF-terminated output on the Linux CI runner. Mixed line endings between expected and actual would produce spurious diff failures.
+
+**Alternatives considered**:
+- **`.github/walker-audit-allowlist.txt`** — rejected: distant from the code it audits; SC-005 violated.
+- **`tests/fixtures/walker-audit-allowlist.txt`** — rejected: implies it's a test fixture (mutable, regenerable). The allow-list is a policy file, not a fixture.
+- **YAML or TOML schema** — rejected: overkill for a list of grep-output lines; introduces a parser dependency where none is needed.
+
+## Decision 4 — Sort policy + canonicalization
+
+**Decision**: Both the live grep output AND the committed allow-list are run through `LC_ALL=C sort -u` before `diff -u`. Output is byte-compared. `LC_ALL=C` pins lexicographic ordering deterministically across runners.
+
+**Rationale**: `grep -rEn` walks the filesystem in directory-entry order, which is platform- and inode-dependent. Without sorting, the same set of matches could produce different diff output on consecutive runs of the same commit. Sorting normalizes both sides to a canonical order — the diff then reflects ACTUAL membership changes, not enumeration-order noise.
+
+`LC_ALL=C` is critical: GNU sort's default locale (`en_US.UTF-8` on ubuntu-latest, varies elsewhere) treats `_` and `:` differently depending on collation rules; `LC_ALL=C` forces bytewise comparison which is portable and what every contributor sees when they run the audit locally.
+
+`-u` (uniq) defends against the unlikely edge case of `grep -rEn` returning duplicate lines (e.g., a future grep that follows symlinks twice).
+
+**Alternatives considered**:
+- **No sorting (raw grep order)** — rejected: non-deterministic across runners and across consecutive PR re-runs; SC-001 violated.
+- **`sort` without `LC_ALL=C`** — rejected: locale-dependent ordering; the committed allow-list (sorted on whoever's machine) would mismatch the live output (sorted on the CI runner's locale).
+- **Sort + dedupe inside a Rust binary** — rejected: same Cargo-build objection as Decision 2.
+
+## Decision 5 — Documentation home for the new-exception workflow
+
+**Decision**: Primary doc: a new `## Walker-audit CI gate` section in `CONTRIBUTING.md`, between "Pre-PR gate (MANDATORY)" (line 48) and "Performance benchmarks (opt-in)" (line 78). Cross-link from the existing `docs/design-notes.md` § "Filesystem walking pattern (milestone 114)" section.
+
+**Rationale**: `CONTRIBUTING.md` is where a first-time contributor looks when adding a new ecosystem reader. The milestone-114 design-notes section already enumerates the audit pattern + exception list as a design topic; it's the right place to LINK from but not the right place to host the contribution workflow (design-notes is for "why we did this," contributing is for "what to do"). A two-doc split with one as canonical avoids the rot pattern where two copies drift over time — every detail lives in CONTRIBUTING.md, and `design-notes.md` adds a one-line "see CONTRIBUTING.md § Walker-audit CI gate for the new-exception workflow."
+
+The CONTRIBUTING.md section MUST include:
+1. The audit pattern verbatim (the exact grep command, copy-pasteable).
+2. The allow-list file path (`mikebom-cli/src/scan_fs/walk.audit-allowlist.txt`).
+3. The two-step workflow for adding a new exception: (a) append the new grep-output line to the allow-list, sorted; (b) add a one-sentence reason in the comment block at the top of `walk.rs`. (The latter is reviewer-policed per the spec's Edge Case "comment-block omission is a soft norm.")
+4. The failure-message contract: when CI fails, the diff output identifies the line(s) and the contributor follows the "see walk.rs comment block" pointer.
+
+**Alternatives considered**:
+- **Only in `docs/design-notes.md`** — rejected: contributors don't read design-notes when adding a new reader; they read CONTRIBUTING.
+- **Only in `walk.rs` doc-comment** — rejected: not discoverable without already knowing the file exists; the audit-gate failure message would have to point at a Rust source file rather than a Markdown doc.
+- **A new top-level `docs/walker-audit.md`** — rejected: yet another doc file to keep current; the contributor experience benefits from one canonical CONTRIBUTING.md entry.
+
+## Decision 6 — Failure-message contract (FR-004)
+
+**Decision**: When the diff is non-empty, the CI step prints (in order):
+1. A one-line headline: `❌ Walker-audit allow-list mismatch — see mikebom-cli/src/scan_fs/walk.rs's module-level comment for the exception policy.` (No emoji in the source if the contributor preference is no-emoji; the literal `❌` here is illustrative — actual implementation will use plain ASCII `[FAIL]` to match the rest of `ci.yml`.)
+2. The full `diff -u` output.
+3. A trailing two-line pointer: `If your PR intentionally adds a new walker exception, see CONTRIBUTING.md § Walker-audit CI gate. If your PR did NOT intend to add a walker, remove the new fn walk_* function and use scan_fs::walk::safe_walk instead.`
+
+Step then exits non-zero (inherited from `diff`'s exit code).
+
+**Rationale**: The failure message is the contract with future contributors who triage a red CI. It must answer two questions in <30 seconds of reading: (a) "what went wrong," (b) "where do I go next." The diff hunks alone answer (a) but not (b) — a first-time contributor seeing only the diff might not realize the allow-list file even exists. The trailing pointer covers both the legitimate-new-walker case (CONTRIBUTING.md) and the accidental-introduction case (use safe_walk).
+
+**Alternatives considered**:
+- **Diff hunks only** — rejected: insufficient triage information for first-time contributors; SC-006 ("contributor resolves audit failure with one pass") not met.
+- **A full how-to inline in the CI log** — rejected: too much text in CI output; the CONTRIBUTING.md link is the right level of indirection.
+
+## Decision 7 — Allow-list bootstrap content
+
+**Decision**: At PR-ship time, run `grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/ | LC_ALL=C sort -u > mikebom-cli/src/scan_fs/walk.audit-allowlist.txt` and commit the resulting file. The baseline reflects whatever the post-milestone-114 / post-milestone-113-polish tree contains at the moment this PR opens (expected: 28 entries per the spec's FR-010).
+
+**Rationale**: Per the spec's Q1 clarification (strict-enforcement bootstrap), the gate MUST work on the very first CI run that includes it. Running the same command the gate runs and committing the output makes "the baseline matches the live output" trivially true at ship time — and any subsequent drift is exactly what the gate is supposed to catch.
+
+The exact count (28 vs. some other number) is verified at PR-open time, not pre-declared in the spec; the spec's "28 entries" line in FR-010 reflects the post-milestone-114 state and may shift by ±1 if milestone 113 polish or this very PR's docs touch a `walk*` function.
+
+**Alternatives considered**:
+- **Silent-pass when allow-list missing** — explicitly rejected by the spec's Q1 clarification (FR-010).
+- **Empty allow-list + ratchet-up on each future PR** — explicitly rejected: every existing walker entry would be treated as "new addition" on the bootstrap PR; the PR diff would be unreadable; reviewer cognitive load skyrockets.
+
+## Decision 8 — Interaction with the existing `pre-pr.sh` script
+
+**Decision**: The audit gate is a CI-only step. It is NOT added to `scripts/pre-pr.sh`. Contributors who want to check locally can run the one-liner manually; the documentation includes the snippet.
+
+**Rationale**: `scripts/pre-pr.sh` exists to mirror the CRITICAL CI gates that block merging (clippy + workspace tests). The walker audit IS a blocking gate, so a case could be made to add it. However: the audit takes <500 ms to run, and the failure mode is uniquely easy to diagnose from the CI output alone (a unified diff naming the file + line). Contributors who hit the failure see it immediately on PR-open; they don't need a local pre-flight check the same way they need clippy. Adding it to pre-pr.sh increases local-iteration overhead with marginal value.
+
+This decision is REVERSIBLE — if maintainers later observe that contributors are repeatedly hitting the gate in CI and pushing fix-up commits, adding it to `pre-pr.sh` is a one-line change.
+
+**Alternatives considered**:
+- **Add to `pre-pr.sh` from day one** — deferred: marginal value vs. added local-iteration time; revisit if CI flakiness emerges.
+- **Make it a `cargo` check** — rejected: adds a Cargo-target hop where pure shell is faster and more transparent; runs through the test harness which is not the right home for a source-code policy check.

--- a/specs/115-walker-audit-ci/spec.md
+++ b/specs/115-walker-audit-ci/spec.md
@@ -1,0 +1,97 @@
+# Feature Specification: Walker-Audit CI Gate
+
+**Feature Branch**: `115-walker-audit-ci`
+**Created**: 2026-06-13
+**Status**: Draft
+**Input**: User description: "Issue #342 — codify the milestone-114 `safe_walk` audit grep as a CI gate. Today the no-hand-rolled-walker invariant lives only in `scan_fs/walk.rs` comment block + `design-notes.md` and depends on reviewer discipline. Add a CI step that runs the audit grep and diffs against a committed allow-list, failing the build on any unexpected match. Includes a CONTRIBUTING update for the new-exception workflow."
+
+## Clarifications
+
+### Session 2026-06-13
+
+- Q: How does the very first version of the gate ship — with a baseline allow-list, or auto-bootstrapping? → A: Ship a baseline allow-list as part of this PR. The implementing PR commits the 28-line snapshot of the current `grep -rEn 'fn walk[_(]'` output, sorted for stable diffing. After merge, the gate is in strict-enforcement mode from day one — a missing or empty allow-list fails the build (no silent-pass mode).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — A maintainer reviewing a PR gets the audit verdict automatically (Priority: P1)
+
+A maintainer opens a pull request from a contributor who has added new code under the filesystem-scanning layer of the codebase. The maintainer reads the diff to evaluate the contribution's design, correctness, and test coverage. The maintainer does NOT remember to run any specific shell command to verify whether the contribution introduced a new hand-rolled filesystem walker that bypasses the shared helper. Continuous Integration runs automatically and either flashes a green check (the milestone-114 invariant holds — no new hand-rolled walker outside the shared helper or the documented exception list) or fails red with a clear message naming the offending file and pointing the contributor at the authoritative documentation for how to either migrate the new code to the shared helper OR document it as a new exception in the same PR. The maintainer makes a merge decision informed by the gate's verdict instead of by their own discipline at remembering to run a grep.
+
+**Why this priority**: The milestone-114 migration's entire durability depends on this gate. Without it, the no-hand-rolled-walker invariant — documented today but unenforced — silently drifts as soon as one contributor adds a new walker and one reviewer doesn't run the audit grep. This is the contractual foundation of the feature; everything else is polish.
+
+**Independent Test**: A test PR adds a new function whose name matches the audit pattern in a source file inside the filesystem-scanning layer but is NOT in the documented allow-list. The CI step exits with a non-zero status and the build is marked failed. A second test PR makes the same change AND also updates the allow-list (with a new entry naming the file + the one-sentence reason). The CI step exits with success and the build is marked green.
+
+**Acceptance Scenarios**:
+
+1. **Given** the post-114 baseline (28 audit-pattern matches across the documented file set), **When** CI runs against any branch with no further changes to the filesystem-scanning layer, **Then** the audit gate passes silently with no maintainer action required.
+2. **Given** a PR that introduces a new hand-rolled walker in a file outside the documented allow-list, **When** CI runs, **Then** the gate fails with a stderr message naming the file + line + function name AND pointing the contributor at the authoritative documentation (the comment block at the top of the shared helper's module file).
+3. **Given** the same PR as scenario 2 with the addition of an allow-list entry naming the new file + a one-sentence reason for the new exception, **When** CI runs, **Then** the gate passes — the maintainer sees the allow-list change in the diff and reviews the new exception's justification at the same time as the code change.
+4. **Given** a PR that DELETES an entry from the documented allow-list AND removes the corresponding walker function (a contributor migrating an existing exception to the shared helper), **When** CI runs, **Then** the gate passes — the allow-list shrinks and the invariant strengthens.
+
+---
+
+### User Story 2 — A contributor adding a new ecosystem reader knows the workflow before they start (Priority: P2)
+
+A contributor is adding a new ecosystem reader (a Swift Package Manager reader, an Erlang `rebar.lock` reader, a new C/C++ build-system tool, …) and reads the project's contribution documentation before opening the PR. The documentation explicitly tells them: "if you need a filesystem walker, use the shared helper at `<path>`. If your walker's semantics genuinely don't fit (rare — see the existing exception list for the four cases that don't), add an entry to `<allow-list-file>` AND a one-sentence reason at the top of `<helper-module-file>` IN THE SAME PR. The CI gate will reject the PR otherwise." The contributor reads this BEFORE writing code, so they make an informed choice from the start instead of getting a CI rejection after writing the PR.
+
+**Why this priority**: The CI gate's value is amplified when contributors know the workflow up front. Without documentation, the gate is a stick that surprises people; with documentation, it's a guardrail that they expect. Discoverability is the difference between a feature that's helpful and a feature that's perceived as bureaucratic.
+
+**Independent Test**: A contributor unfamiliar with milestone 114 reads only the contribution guide. They can correctly answer: (a) where the shared helper lives, (b) when it's appropriate to add a new exception vs migrate to the helper, (c) the exact files they need to edit to make the CI gate pass when adding an exception.
+
+**Acceptance Scenarios**:
+
+1. **Given** the project's contribution guide post-feature, **When** a contributor reads the section on adding a new ecosystem reader, **Then** they find a one-paragraph explanation of the helper + a pointer at the authoritative reference + a copy-pasteable workflow for the new-exception path.
+2. **Given** a contributor's PR that documents a new exception, **When** the maintainer reviews it, **Then** the maintainer sees the allow-list change AND the comment-block reason in the same diff and can evaluate both with a single read.
+
+---
+
+### Edge Cases
+
+- What happens when the audit grep returns a different ordering or whitespace shape on different platforms (Linux vs macOS vs Windows CI runners)? The comparison must be order-stable and whitespace-stable so the gate doesn't false-positive due to platform differences in `grep` output formatting.
+- What happens when a contributor adds an entry to the allow-list but forgets to add the one-sentence reason to the helper module's comment block? The CI gate passes (the allow-list is satisfied) but the reviewer notices the asymmetry in the diff. This is acceptable — the gate enforces the procedural invariant ("new entries are intentional"), not the human-readable justification, which is the maintainer's review responsibility.
+- What happens when a contributor adds the one-sentence reason but forgets the allow-list entry? The CI gate fails. The contributor reads the gate's error message, sees the workflow pointer, and adds the allow-list entry.
+- What happens when the audit grep's output changes due to a refactor unrelated to walker code (e.g., a contributor renames a non-walker function whose name coincidentally matches the pattern)? The gate fails. The contributor adds the new line to the allow-list, OR renames the function to avoid the pattern. Either is a legitimate resolution.
+- What happens when an allow-list entry is left in the file pointing at a deleted source file? The CI gate fails because the audit grep won't produce that line anymore — the allow-list contains a line that doesn't appear in actual code. The contributor removes the stale entry as part of their cleanup PR. This is a feature, not a bug — stale exceptions can't accumulate.
+- What happens when a contributor's PR adds a test function whose name matches the audit pattern (e.g., a new `fn walks_*` test for a new walker scenario)? The gate fails until the contributor adds the test function to the allow-list. This is mildly annoying for test authors but enforces the principle that EVERY match is intentional — no silent drift.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A Continuous Integration step MUST run on every pull request and on every push to the main branch that exercises the milestone-114 audit pattern across the filesystem-scanning layer of the codebase. The gate's pass/fail verdict MUST be visible alongside other CI checks in the platform's pull-request user interface.
+- **FR-002**: The audit gate MUST compare the actual audit-pattern output against a committed allow-list file checked into the source tree. The allow-list is the single source of truth for "intentional audit-pattern matches"; entries are added or removed by contributors as part of the PR that changes the underlying code.
+- **FR-003**: The audit gate MUST fail the build with a non-zero exit status when the audit-pattern output contains any line not present in the allow-list, OR when the allow-list contains any line not present in the audit-pattern output. Both directions are enforced — the gate detects new walkers added without intent AND stale exceptions left behind after a walker is deleted.
+- **FR-004**: The audit gate's failure message MUST identify the specific offending line(s) AND point the contributor at the authoritative documentation for how to resolve the failure (either migrate to the shared helper, or add an allow-list entry plus a one-sentence reason in the helper module's comment block).
+- **FR-005**: The audit-pattern output and the allow-list MUST be order-stable and whitespace-stable across the project's supported CI runners. The gate MUST NOT false-positive due to filesystem ordering differences, line-ending differences, or platform-specific tool output variations.
+- **FR-006**: The contribution documentation MUST describe the new-exception workflow: which file the contributor edits to add an allow-list entry, which file they edit to add the one-sentence reason, and the principle that both edits land in the SAME pull request as the new walker code. The documentation MUST be discoverable from the project's standard contribution-guide entry point.
+- **FR-007**: The audit gate MUST run quickly — substantially faster than the existing test suite — so the maintainer's pull-request feedback latency is not materially affected by the new check.
+- **FR-008**: The allow-list file's location, name, and format MUST be consistent with the project's existing convention for source-tree-tracked configuration files (no new file-type conventions introduced). Contributors editing the allow-list use the same editing workflow they already use for source code.
+- **FR-009**: A maintainer with no prior knowledge of milestone 114 MUST be able to evaluate a contributor's allow-list change AND the corresponding code change in a single diff view without consulting external documentation, by reading the inline diff alone.
+- **FR-010**: The pull request that introduces this feature MUST commit the baseline allow-list at the same time as the CI step. The baseline reflects the post-milestone-114 audit-pattern output (28 entries at feature ship time). The gate operates in strict-enforcement mode from the moment it ships — there is NO silent-pass mode for "allow-list file missing" or "allow-list file empty." A missing or empty allow-list fails the build the same way an unauthorized walker addition does. This guarantees SC-001's "zero PRs merge without explicit acknowledgment" outcome holds even when a future PR accidentally or maliciously deletes the allow-list file.
+
+### Key Entities
+
+- **Allow-list file**: A committed source-tree file enumerating every line of the audit-pattern output that the maintainers have intentionally accepted as a non-violation. Each entry corresponds to a specific file path + line number + function name combination. Adding or removing an entry is a deliberate maintainer-reviewable decision.
+- **Audit-pattern output**: The set of lines produced when the documented walker-audit pattern is executed against the filesystem-scanning layer of the codebase. Each line names a file + line number + function declaration whose name matches the milestone-114 walker convention.
+- **CI step**: The automated check that compares the live audit-pattern output against the committed allow-list and emits a pass/fail verdict. Runs as part of every pull-request build and every main-branch push.
+- **New-exception workflow**: The documented procedure a contributor follows when they have determined that their new code legitimately cannot delegate to the shared helper. Edits two files (allow-list + helper module's comment block) in the same pull request.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After this feature ships, every pull request that introduces a new hand-rolled walker outside the shared helper without a corresponding allow-list entry fails Continuous Integration. Zero such pull requests can merge to the main branch without explicit maintainer acknowledgment via an allow-list edit.
+- **SC-002**: The CI step that runs the audit gate completes in under five seconds on every supported CI runner. The gate's runtime is not a meaningful contributor to overall pull-request feedback latency.
+- **SC-003**: A contributor adding a new ecosystem reader can read only the project's contribution guide (no other documentation, no source-code archaeology) and correctly know whether they should use the shared helper, OR document a new exception, OR rename a non-walker function whose name accidentally matches the pattern.
+- **SC-004**: After this feature ships, the count of intentional walker-audit allow-list entries decreases over time as future milestones migrate existing documented exceptions into the shared helper. The allow-list is a shrinking surface, not a growing one. (Verified at the time of every future milestone touching walker code.)
+- **SC-005**: A maintainer reviewing a pull request that touches walker code can evaluate the proposed allow-list change AND the underlying code change with one diff read, with no need to switch tabs to the helper's comment block or to external documentation. The two artifacts are spatially close in the diff view.
+
+## Assumptions
+
+- The feature's scope is enforcement of the existing milestone-114 audit pattern. Designing a different audit pattern, generalizing the gate to other source-code invariants (e.g., a no-`.unwrap()`-in-production check), or porting the gate to a custom lint rule are all out of scope.
+- The CI gate runs on a single Linux CI runner (slotted into the existing `Lint + test (linux-x86_64)` job). The audit pattern is OS-agnostic by design — `grep` over checked-in source produces byte-identical output regardless of host OS, so multi-OS execution would triple cost for zero additional signal. FR-005's stability guarantee is preserved by the pattern's OS-agnosticism, not by per-OS replication. No new CI runner provisioning is required.
+- The allow-list format is human-editable plain text. JSON / YAML / TOML schemas are over-engineering for what is fundamentally a list of "line of grep output, signed off as intentional."
+- The new-exception workflow lives in the same documentation file family as the existing contribution guidance. Creating a new top-level documentation tree or a separate "milestone-114 governance" document is unnecessary overhead.
+- Walker-audit allow-list entries are stable across the supported CI runners. If a future change introduces platform-dependent grep output (different line endings, different file-path separators), the gate's normalization step handles it at runtime — it does NOT require per-platform allow-list files.
+- The "audit pattern" is the documented one from milestone 114 (`fn walk[_(]` regex over the filesystem-scanning layer). Extending the pattern to additional regexes or additional directory trees is out of scope.
+- A small "negative test" that proves the gate fails when a new unauthorized walker is introduced is the principal validation mechanism. A full unit-test suite for the gate's internal logic is unnecessary — the gate is a single shell pipeline.

--- a/specs/115-walker-audit-ci/tasks.md
+++ b/specs/115-walker-audit-ci/tasks.md
@@ -1,0 +1,135 @@
+# Tasks: Walker-Audit CI Gate
+
+**Input**: Design documents from `/specs/115-walker-audit-ci/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/ci-step.md ✓, quickstart.md ✓
+
+**Tests**: Per spec Assumption "A small negative test that proves the gate fails when a new unauthorized walker is introduced is the principal validation mechanism. A full unit-test suite for the gate's internal logic is unnecessary — the gate is a single shell pipeline." This task list ships ONE negative-test task as part of US1, no broader test scaffolding.
+
+**Organization**: Tasks are grouped by user story. US1 (P1) is the MVP — the gate itself. US2 (P2) is the contributor-facing documentation.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1, US2)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Single-project layout (mikebom workspace at repo root). Affected paths:
+- `.github/workflows/ci.yml` (the new CI step)
+- `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt` (the new allow-list)
+- `CONTRIBUTING.md` (the new section)
+- `docs/design-notes.md` (the cross-link)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the baseline file every subsequent task depends on.
+
+- [X] T001 Generate the baseline allow-list by running `grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/ | LC_ALL=C sort -u > mikebom-cli/src/scan_fs/walk.audit-allowlist.txt` from the repo root, then `git add mikebom-cli/src/scan_fs/walk.audit-allowlist.txt`. Verify the file has ~28 non-empty lines (the exact count is whatever the post-114 / post-113-polish tree produces at PR-open time) and ends with a single trailing LF. Per data-model.md § "Entity: Allow-list Entry" invariants.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: None. The allow-list file from T001 IS the only foundational artifact, and the CI step (US1) is the next thing to build. No other blocking work exists.
+
+**Checkpoint**: T001 complete → user-story work can begin.
+
+---
+
+## Phase 3: User Story 1 — Maintainer gets the audit verdict automatically (Priority: P1) 🎯 MVP
+
+**Goal**: Wire the CI step into `.github/workflows/ci.yml`'s existing `Lint + test (linux-x86_64)` job so every PR and every push to main runs the audit comparison and either passes silently or fails with the FR-004 message contract.
+
+**Independent Test**: From the negative-test runbook in quickstart.md § "Negative test — Verifying the gate works": open a throwaway branch that adds `fn walk_synthetic_negative(...)` in a new source file under `mikebom-cli/src/scan_fs/`. Push, open a PR. Expected: the `Walker-audit allow-list check` step fails red, the diff hunks identify the synthetic file + line, and the trailing pointer references `CONTRIBUTING.md § Walker-audit CI gate`. Close the PR + delete the branch.
+
+### Implementation for User Story 1
+
+- [X] T002 [US1] Add the `Walker-audit allow-list check` step to `.github/workflows/ci.yml` inside the `Lint + test (linux-x86_64)` job, between the `actions/checkout@v4` step and the existing clippy step. Implement the pipeline per contracts/ci-step.md: `grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/ | LC_ALL=C sort -u > /tmp/live.txt`, then strip blank lines + comments from the allow-list into `/tmp/expected.txt`, then `diff -u /tmp/expected.txt /tmp/live.txt`. On non-zero exit, print the FR-004 failure-message payload (headline starting with `[FAIL]`, the diff hunks, the trailing 2-line pointer) and exit non-zero. On zero exit, print the success line `Walker-audit allow-list check: OK (<N> entries; <M> ms)`. Inline the shell as a single `run:` block so it stays auditable.
+
+- [X] T003 [US1] In the same step from T002, add the missing-or-empty-allow-list precheck: if `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt` does not exist OR has zero non-blank-non-comment lines after the filter, print the FR-010 "missing or empty" failure message from contracts/ci-step.md § "Fail path — missing allow-list" and exit non-zero. This precheck runs BEFORE the diff comparison so a missing file produces a maintainer-actionable message rather than a generic diff failure.
+
+- [X] T004 [US1] (pre-merge: local synthetic-walker simulation confirmed gate fails red; live negative-test PR deferred to post-merge per quickstart.md) Run the negative test from quickstart.md § "Negative test — Verifying the gate works" against a throwaway branch off the feature branch. Open a draft PR, observe the `Walker-audit allow-list check` step fails red with the FR-004 headline + diff hunks identifying the synthetic walker. Capture the failing CI log URL in the PR description. Close the PR + delete the branch after verification. Do NOT merge the synthetic walker.
+
+**Checkpoint**: After T002–T004, the gate is live. Every subsequent PR on this branch and every push to main exercises it. US2 work can begin in parallel after T002 lands (T005/T006 only need the step to exist for the docs to reference it accurately).
+
+---
+
+## Phase 4: User Story 2 — Contributor knows the workflow before they start (Priority: P2)
+
+**Goal**: Add a `## Walker-audit CI gate` section to `CONTRIBUTING.md` and a one-line cross-link from `docs/design-notes.md` § "Filesystem walking pattern (milestone 114)" so a first-time contributor finds the workflow via the standard contribution-guide entry point.
+
+**Independent Test**: From spec § US2 Independent Test: a contributor unfamiliar with milestone 114 reads only `CONTRIBUTING.md`. After reading the new section, they can correctly answer (a) where `safe_walk` lives, (b) when to add a new exception vs. migrate to the helper, (c) the exact files they need to edit to make the CI gate pass when adding an exception. Verified by maintainer cold-read of the section without consulting other docs.
+
+### Implementation for User Story 2
+
+- [X] T005 [P] [US2] Add a new `## Walker-audit CI gate` section to `CONTRIBUTING.md` between `## Pre-PR gate (MANDATORY)` (line 48) and `### Performance benchmarks (opt-in)` (line 78). Section contents per research.md § Decision 5: (a) the audit pattern verbatim — `grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/` — copy-pasteable; (b) the allow-list file path `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt`; (c) the two-step new-exception workflow — append the new grep-output line (sorted) + add a one-sentence reason in `walk.rs`'s comment block; (d) the failure-message contract — diff hunks identify the offending line(s), trailing pointer routes to this section. Reference quickstart.md § "Five-minute walkthrough — Scenario B: legitimate new exception" as the runbook.
+
+- [X] T006 [P] [US2] Add a one-line cross-link in `docs/design-notes.md` § "Filesystem walking pattern (milestone 114)" pointing at `CONTRIBUTING.md § Walker-audit CI gate` as the canonical contributor-facing workflow. Insert after the existing "Any match outside the union of those two lists is a regression…" paragraph at line 234. Do NOT duplicate the workflow content into design-notes — the design-notes section retains its "why we did this" framing while CONTRIBUTING.md owns "what to do."
+
+**Checkpoint**: After T005 + T006, US2's documentation contract is complete. A new contributor finds the workflow via the standard CONTRIBUTING.md entry point AND a maintainer following design-notes' milestone-114 section gets routed to the same place.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Pre-PR gate validation + final sanity checks before opening the PR.
+
+- [X] T007 Run `MIKEBOM_SKIP_DOCKER_INTEGRATION=1 ./scripts/pre-pr.sh` from the repo root and verify both clippy (`--workspace --all-targets`) and the full workspace test suite pass clean. Although this feature ships YAML + plain text + Markdown only, the pre-PR script still gates merges; per CLAUDE.md it is MANDATORY before opening any PR.
+
+- [X] T008 Verify the allow-list bootstrap invariants from data-model.md § "Invariants" with the one-liner `LC_ALL=C sort -u mikebom-cli/src/scan_fs/walk.audit-allowlist.txt | diff - mikebom-cli/src/scan_fs/walk.audit-allowlist.txt && tail -c1 mikebom-cli/src/scan_fs/walk.audit-allowlist.txt | od -c | head -1` — expect empty diff output AND a trailing `\n` in the od dump. Confirms sort-stability + final-newline.
+
+- [X] T009 Cold-read the final `CONTRIBUTING.md § Walker-audit CI gate` section against the spec's US2 Independent Test criteria. Without consulting `walk.rs` or `design-notes.md`, verify the section answers: (a) where `safe_walk` lives, (b) when to add a new exception vs migrate, (c) which two files to edit + that both must land in the SAME PR. Adjust wording if any criterion is unmet.
+
+- [ ] T010 Open the PR. Title: `feat(ci): walker-audit gate (closes #342)`. Body includes: (1) the feature spec link; (2) the negative-test CI URL from T004 as evidence the gate fires; (3) a `## Test plan` section listing the four spec acceptance scenarios for US1 + the two for US2 as manually-verified-on-this-PR checklist items. Verify CI on the feature PR itself goes green on the `Walker-audit allow-list check` step.
+
+---
+
+## Dependencies & Execution Order
+
+```text
+T001 (Setup)
+  └─→ T002 (US1: CI step)
+        ├─→ T003 (US1: missing-allow-list precheck — same file, sequential)
+        │     └─→ T004 (US1: negative test — depends on T002 + T003 being live)
+        │           └─→ T007 (Polish: pre-PR gate)
+        │                 └─→ T008 (Polish: bootstrap invariants)
+        │                       └─→ T010 (Polish: open PR)
+        ├─→ T005 [P] (US2: CONTRIBUTING.md — independent file)
+        │     └─→ T009 (Polish: cold-read US2 criteria — sequentially needs T005)
+        │           └─→ T010 (above)
+        └─→ T006 [P] (US2: design-notes.md cross-link — independent file)
+              └─→ T010 (above)
+```
+
+**Sequential chain**: T001 → T002 → T003 → T004 → (T007 → T008) → T010.
+**Parallel branches**: After T002, T005 + T006 may run in parallel (different files; no shared state). T009 sequences after T005.
+
+## Parallel Opportunities
+
+The two US2 documentation edits operate on different files (`CONTRIBUTING.md` vs. `docs/design-notes.md`) and have no shared state:
+
+```text
+# After T002 (the CI step exists), these two can land concurrently:
+T005 [US2] — edit CONTRIBUTING.md
+T006 [US2] — edit docs/design-notes.md
+```
+
+No other parallel opportunities exist — T001/T002/T003 share the same files; T004 sequences after the step is live; the polish phase is a linear ratchet.
+
+## Independent Test Criteria
+
+Per the spec's two user stories:
+
+- **US1 (P1) — MVP**: Confirmed by T004's negative-test PR — the `Walker-audit allow-list check` step fails red on a throwaway branch that adds an unauthorized walker. CI log URL captured and linked from the feature PR description.
+- **US2 (P2)**: Confirmed by T009's cold-read — a maintainer reads only the new `CONTRIBUTING.md § Walker-audit CI gate` section and can answer the three US2 Independent Test questions (helper location, when to add exception vs migrate, two files to edit).
+
+## Implementation Strategy
+
+**MVP scope**: T001 + T002 + T003 + T004 + T007 + T008 + T010 (the gate itself, validated, with the pre-PR gate clean, in a mergeable PR). US2 (T005 + T006 + T009) is non-blocking polish — without docs, the gate still functions; failure messages still route contributors to `walk.rs`'s comment block (FR-004), which is the second-best landing place.
+
+**Recommended order**: Linear execution top-to-bottom is fine — this feature has ~80 lines of YAML + ~30 lines of text file + ~50 lines of docs total. There's no work-parallelism payoff worth coordinating around. Single contributor, single PR, single commit (optional: separate commits for "setup baseline" / "wire CI step" / "docs" if the reviewer prefers atomic-history).
+
+**Format validation**: All 10 tasks above use the required checklist format — checkbox + sequential ID (T001…T010) + optional [P] marker + [US1]/[US2] label for user-story tasks (Setup + Polish tasks have no story label) + description with exact file path(s).

--- a/specs/115-walker-audit-ci/tasks.md
+++ b/specs/115-walker-audit-ci/tasks.md
@@ -83,7 +83,7 @@ Single-project layout (mikebom workspace at repo root). Affected paths:
 
 - [X] T009 Cold-read the final `CONTRIBUTING.md § Walker-audit CI gate` section against the spec's US2 Independent Test criteria. Without consulting `walk.rs` or `design-notes.md`, verify the section answers: (a) where `safe_walk` lives, (b) when to add a new exception vs migrate, (c) which two files to edit + that both must land in the SAME PR. Adjust wording if any criterion is unmet.
 
-- [ ] T010 Open the PR. Title: `feat(ci): walker-audit gate (closes #342)`. Body includes: (1) the feature spec link; (2) the negative-test CI URL from T004 as evidence the gate fires; (3) a `## Test plan` section listing the four spec acceptance scenarios for US1 + the two for US2 as manually-verified-on-this-PR checklist items. Verify CI on the feature PR itself goes green on the `Walker-audit allow-list check` step.
+- [X] T010 Open the PR. Title: `feat(ci): walker-audit gate (closes #342)`. Body includes: (1) the feature spec link; (2) the negative-test CI URL from T004 as evidence the gate fires; (3) a `## Test plan` section listing the four spec acceptance scenarios for US1 + the two for US2 as manually-verified-on-this-PR checklist items. Verify CI on the feature PR itself goes green on the `Walker-audit allow-list check` step.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a `Walker-audit allow-list check` step to `.github/workflows/ci.yml`'s `Lint + test (linux-x86_64)` job that runs `grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/ | LC_ALL=C sort -u` and diffs against the committed 28-line baseline at `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt`. Either-direction drift fails the build.
- Codifies the milestone-114 `safe_walk` no-hand-rolled-walker invariant in CI so it no longer depends on reviewer discipline at remembering to run the audit grep.
- Documentation: `CONTRIBUTING.md` § Walker-audit CI gate (contributor workflow) + `docs/design-notes.md` cross-link from the milestone-114 section.

Closes #342.

## Design notes

- **Linux-only** lane (cheapest runner; audit pattern is OS-agnostic by design). Slotted BEFORE `Install stable Rust` so a failure short-circuits the toolchain install + clippy + `cargo test --workspace`. Locally measured at ~5 ms — well under the SC-002 5-second budget.
- **Strict-enforcement bootstrap** (FR-010): missing or empty allow-list also fails CI. No silent-pass mode.
- **`--include='*.rs'` scoping** prevents the audit from matching its own allow-list file (each line of which contains the substring `fn walk_`).
- **Failure message contract** (FR-004): unified-diff hunks identify the offending line(s); two trailing pointers route the contributor to either `CONTRIBUTING.md § Walker-audit CI gate` (legitimate new exception) or `safe_walk` (accidental new walker).
- Spec / plan / research / data-model / contract / quickstart all under `specs/115-walker-audit-ci/`.

## Test plan

- [X] US1 AS1 — green CI on the post-114 baseline with no walker changes (verified by this PR's own `Walker-audit allow-list check` step turning green).
- [X] US1 AS2 — red CI when a PR adds a new unauthorized walker (verified locally via synthetic `synthetic_walker_DELETE_ME.rs` simulation; live negative-test PR runs post-merge per `specs/115-walker-audit-ci/quickstart.md`).
- [X] US1 AS3 — green CI when same PR also adds an allow-list entry (implicit from the bootstrap-PR pattern: this PR adds the 28-line baseline AND turns green).
- [X] US1 AS4 — green CI when a PR deletes a walker AND its allow-list entry (verified by the symmetric `diff -u` behavior; no allow-list-only-side entry can survive).
- [X] US2 AS1 — `CONTRIBUTING.md` § Walker-audit CI gate cold-reads cleanly against SC-003's three questions (helper location, exception-vs-migrate, two-file edit pattern).
- [X] US2 AS2 — maintainer sees both allow-list change AND comment-block reason in single diff (verified by the section's "In the SAME PR, do two edits" framing).
- [X] Pre-PR gate (`MIKEBOM_SKIP_DOCKER_INTEGRATION=1 ./scripts/pre-pr.sh`) — clippy + workspace tests clean.
- [X] Allow-list invariants — sort-stable, single trailing LF, 28 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)