### PR TITLE
feat(generate): --root-purl-type + --no-root-purl flags for root-component PURL control

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -550,6 +550,8 @@ Exactly one of `--path` or `--image` is required.
 | `--component-id <PURL=SCHEME:VALUE>` | string (repeatable) | (none) | Attach a user-defined identifier to a specific component. |
 | `--root-name <NAME>` | string | auto-derived | Override `metadata.component.name`. |
 | `--root-version <VERSION>` | string | auto-derived | Override `metadata.component.version`. |
+| `--root-purl-type <TYPE>` | string | (none) | Override the type segment of the root PURL. Defaults to `generic` when `--root-name` is set; this flag replaces that default. REQUIRES `--root-name`. Mutually exclusive with `--no-root-purl`. See [`--root-purl-type`](#--root-purl-type-type). |
+| `--no-root-purl` | bool | off | Omit the root component's PURL entirely from the emitted SBOM. REQUIRES `--root-name`. Mutually exclusive with `--root-purl-type`. See [`--no-root-purl`](#--no-root-purl). |
 | `--creator <TYPE: NAME>` | string (repeatable) | (none) | Attach a creator entry to the SBOM. |
 | `--annotator <TYPE: NAME>` | string (repeatable, paired) | (none) | Document-level annotator. Pair 1:1 with `--annotation-comment`. |
 | `--annotation-comment <TEXT>` | string (repeatable, paired) | (none) | Comment that pairs positionally with the preceding `--annotator`. |
@@ -973,6 +975,86 @@ version for project scans).
 
 ```bash
 mikebom sbom scan --path . --root-name acme-platform --root-version 2.4.1 --output platform.cdx.json
+```
+
+### `--root-purl-type <TYPE>`
+
+Override the type segment of the root component's PURL. By default,
+when `--root-name` is supplied, mikebom hardcodes the type to `generic`
+(`pkg:generic/<name>@<version>`). This flag replaces that default so
+the BOM subject's PURL can carry an operator-chosen ecosystem type.
+
+Useful when a downstream consumer keys software identity on
+`(pkg_type, name)` and an existing record was originally produced with
+a different type (e.g., a Go build emitted by another tool as
+`pkg:golang/...`, or a Maven build emitted as `pkg:maven/...`).
+Matching the existing type on re-scan keeps the SBOM landing on the
+existing identity row instead of spawning a new one.
+
+REQUIRES `--root-name` to be supplied at the same time (an explicit
+name accompanies the type-overriding output). Mutually exclusive with
+`--no-root-purl`.
+
+The type token is validated at parse time against the purl-spec
+charset `^[a-z][a-z0-9.+-]*$` (lowercase ASCII alphanumeric plus
+`.`/`+`/`-`, starting with a letter). Invalid values produce a
+clap-style error naming the flag.
+
+```bash
+mikebom sbom scan --path . --root-name github.com/example/svc \
+  --root-version v1.2.3 --root-purl-type golang \
+  --output svc.cdx.json
+# → metadata.component.purl = "pkg:golang/github.com%2Fexample%2Fsvc@v1.2.3"
+
+mikebom sbom scan --path . --root-name "@scope/pkg" --root-version 1.0.0 \
+  --root-purl-type npm --output pkg.cdx.json
+# → metadata.component.purl = "pkg:npm/%40scope%2Fpkg@1.0.0"
+```
+
+Applied identically across all three output formats: CycloneDX
+`metadata.component.purl`, SPDX 2.3 root Package
+`externalRefs[purl]`, SPDX 3 root `software_packageUrl` +
+`externalIdentifier[packageUrl]`.
+
+### `--no-root-purl`
+
+Omit the root component's PURL entirely from the emitted SBOM. The
+PURL slot is ABSENT (not null, not empty) in every format:
+
+- **CycloneDX**: `metadata.component.purl` field is omitted.
+- **SPDX 2.3**: the root Package's `externalRefs[]` contains no entry
+  with `referenceType: "purl"`. The CPE `externalRef` still emits.
+- **SPDX 3**: the root `software_Package` element has no
+  `software_packageUrl` field AND its `externalIdentifier[]` contains
+  no entry with `externalIdentifierType: "packageUrl"`. The CPE
+  externalIdentifier entry still emits.
+
+Useful when downstream consumers key software identity on
+`(pkg_type, name)` and the target record was originally produced by a
+tool that emitted no root PURL — reproducing that empty-type identity
+requires omitting the PURL here.
+
+REQUIRES `--root-name` to be supplied (an explicit name is the only
+identity signal once the PURL is dropped). Mutually exclusive with
+`--root-purl-type`.
+
+```bash
+mikebom sbom scan --path . --root-name my-svc --no-root-purl \
+  --output svc.cdx.json
+# → metadata.component.name = "my-svc"
+# → metadata.component.version = "..." (from --root-version or default)
+# → metadata.component.purl ABSENT
+```
+
+The name is taken from `--root-name` straight through to the
+component-name slot without PURL encoding — slashes and `@` in the
+name round-trip byte-for-byte, e.g.:
+
+```bash
+mikebom sbom scan --path . \
+  --root-name 767xxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com/pico-server \
+  --root-version 1.0.0 --no-root-purl --output image.cdx.json
+# → metadata.component.name preserves the full registry path verbatim
 ```
 
 ### `--creator <TYPE: NAME>`

--- a/mikebom-cli/src/cli/run.rs
+++ b/mikebom-cli/src/cli/run.rs
@@ -545,6 +545,9 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
         root_override: crate::generate::RootComponentOverride {
             name: args.root_name.clone(),
             version: args.root_version.clone(),
+            // trace-run doesn't currently expose the milestone-???
+            // root-purl-control flags; preserve back-compat defaults.
+            ..Default::default()
         },
         // Milestone 080 — forward aggregated user-supplied SBOM
         // metadata from the trace-run flags.

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -488,6 +488,51 @@ pub struct ScanArgs {
     )]
     pub root_version: Option<String>,
 
+    /// Override the type segment of the root component's PURL.
+    /// Defaults to `generic` when `--root-name` is set; this flag
+    /// replaces that default so the BOM subject's PURL carries an
+    /// operator-supplied ecosystem type. Example: `--root-purl-type
+    /// golang --root-name github.com/example/svc` produces
+    /// `pkg:golang/github.com/example/svc@<version>`.
+    ///
+    /// Validated at parse time against the purl-spec type charset
+    /// (`^[a-z][a-z0-9.+-]*$`). REQUIRES `--root-name`. Mutually
+    /// exclusive with `--no-root-purl`.
+    ///
+    /// Applied identically across all three output formats: CDX
+    /// `metadata.component.purl`, SPDX 2.3 root Package
+    /// `externalRefs[purl]`, SPDX 3 root `software_packageUrl` +
+    /// `externalIdentifier[packageUrl]`.
+    #[arg(
+        long = "root-purl-type",
+        value_name = "TYPE",
+        value_parser = validate_root_purl_type,
+        requires = "root_name",
+        conflicts_with = "no_root_purl",
+    )]
+    pub root_purl_type: Option<String>,
+
+    /// Omit the root component's PURL entirely from the emitted SBOM.
+    /// CDX: `metadata.component.purl` field absent. SPDX 2.3: no
+    /// `purl` entry in the root Package's `externalRefs[]`. SPDX 3:
+    /// no `software_packageUrl` AND no `externalIdentifier[]` entry
+    /// with `externalIdentifierType: "packageUrl"`.
+    ///
+    /// Useful when downstream consumers key software identity on
+    /// `(type, name)` and a target record was originally produced by
+    /// a tool that emitted no root PURL — reproducing that empty-type
+    /// identity requires omitting the PURL here.
+    ///
+    /// REQUIRES `--root-name` (an explicit name is the only identity
+    /// signal once the PURL is dropped). Mutually exclusive with
+    /// `--root-purl-type`.
+    #[arg(
+        long = "no-root-purl",
+        requires = "root_name",
+        conflicts_with = "root_purl_type",
+    )]
+    pub no_root_purl: bool,
+
     // ────────────────────────────────────────────────────────────
     // Milestone 080 — user-provided SBOM metadata. See
     // `specs/080-user-sbom-metadata/` for the full design.
@@ -791,6 +836,28 @@ pub(crate) fn validate_root_name(value: &str) -> Result<String, String> {
 /// with the canonical flag-name string.
 pub(crate) fn validate_root_version(value: &str) -> Result<String, String> {
     validate_root_field(value, "--root-version")
+}
+
+/// Clap value_parser for `--root-purl-type`. Enforces the purl-spec
+/// type-token charset (`^[a-z][a-z0-9.+-]*$`). The `packageurl` crate
+/// would reject non-conforming tokens at PURL construction time
+/// downstream, but pre-validating at parse time gives the operator a
+/// fast, flag-named error instead of an opaque "PURL construction
+/// failed" message during emission.
+pub(crate) fn validate_root_purl_type(value: &str) -> Result<String, String> {
+    use std::sync::LazyLock;
+    static RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+        regex::Regex::new(r"^[a-z][a-z0-9.+-]*$")
+            .expect("root-purl-type regex compiles")
+    });
+    if RE.is_match(value) {
+        Ok(value.to_string())
+    } else {
+        Err(format!(
+            "--root-purl-type `{value}` is not a valid purl-spec type token \
+             (expected lowercase ASCII alphanumeric + `.+-`, starting with a letter)"
+        ))
+    }
 }
 
 /// Parse a `--id <scheme>=<value>` flag for a user-defined identifier.
@@ -2156,6 +2223,8 @@ pub async fn execute(
         root_override: crate::generate::RootComponentOverride {
             name: args.root_name.clone(),
             version: args.root_version.clone(),
+            purl_type: args.root_purl_type.clone(),
+            omit_purl: args.no_root_purl,
         },
         // Milestone 080: user-provided SBOM metadata aggregated from
         // the new flags (--creator / --annotator / --annotation-comment
@@ -2897,6 +2966,8 @@ mod tests {
             component_id: vec![],
             root_name: None,
             root_version: None,
+            root_purl_type: None,
+            no_root_purl: false,
             // Milestone 080 — defaults for new fields keep the test
             // helper's "minimal flags" contract intact.
             creator: vec![],

--- a/mikebom-cli/src/generate/cyclonedx/builder.rs
+++ b/mikebom-cli/src/generate/cyclonedx/builder.rs
@@ -1953,7 +1953,8 @@ mod tests {
             .with_root_override(crate::generate::RootComponentOverride {
                 name: Some("widget-svc".to_string()),
                 version: Some("1.2.3".to_string()),
-            });
+            ..Default::default()
+        });
         let components = vec![make_component("serde", "1.0.0")];
         let integrity = clean_integrity();
         let bom = builder
@@ -1978,7 +1979,8 @@ mod tests {
             .with_root_override(crate::generate::RootComponentOverride {
                 name: Some("widget-svc".to_string()),
                 version: Some("1.2.3".to_string()),
-            });
+            ..Default::default()
+        });
         let components = vec![
             make_main_module_component("cargo", "foo-internal", "0.5.1"),
             make_component("serde", "1.0.0"),
@@ -2056,7 +2058,8 @@ mod tests {
         .with_root_override(crate::generate::RootComponentOverride {
             name: Some("widget-svc".to_string()),
             version: Some("1.2.3".to_string()),
-        });
+        ..Default::default()
+    });
         let components = vec![make_component("serde", "1.0.0")];
         let integrity = clean_integrity();
         let bom = builder

--- a/mikebom-cli/src/generate/cyclonedx/metadata.rs
+++ b/mikebom-cli/src/generate/cyclonedx/metadata.rs
@@ -7,7 +7,7 @@ use mikebom_common::types::license::SpdxExpression;
 use mikebom_common::types::purl::encode_purl_segment;
 use serde_json::json;
 
-use crate::generate::{percent_encode_purl_name, RootComponentOverride};
+use crate::generate::RootComponentOverride;
 
 /// Normalize a string for inclusion in a CPE 2.3 segment.
 ///
@@ -276,11 +276,14 @@ pub fn build_metadata(
                 .version
                 .clone()
                 .unwrap_or_else(|| target_version.to_string());
-            let purl = format!(
-                "pkg:generic/{}@{}",
-                percent_encode_purl_name(&name),
-                percent_encode_purl_name(&version),
-            );
+            // Milestone N+1: `build_subject_purl` returns `None` when
+            // `--no-root-purl` is in effect; the empty-string fallback
+            // here is safe because the `purl` JSON field is post-
+            // processed off the emitted `metadata.component` below
+            // when `omit_purl` is set.
+            let purl = root_override
+                .build_subject_purl(&name, &version)
+                .unwrap_or_default();
             (name, version, purl)
         } else if let Some(c) = main_module {
             (
@@ -461,6 +464,18 @@ pub fn build_metadata(
         },
         "properties": properties,
     });
+
+    // Milestone N+1: `--no-root-purl` drops the `purl` field from
+    // `metadata.component` entirely. The CDX 1.6 schema makes `purl`
+    // optional, so absence (vs null) is the spec-correct shape.
+    if root_override.omit_purl {
+        if let Some(comp_obj) = metadata
+            .get_mut("component")
+            .and_then(|v| v.as_object_mut())
+        {
+            comp_obj.remove("purl");
+        }
+    }
 
     // Milestone 080 — first user-supplied `Organization:` creator
     // populates CDX 1.6 `metadata.manufacturer` (single-valued slot

--- a/mikebom-cli/src/generate/mod.rs
+++ b/mikebom-cli/src/generate/mod.rs
@@ -199,6 +199,20 @@ pub struct RootComponentOverride {
     /// When `Some(version)`, replaces the auto-derived version field
     /// across all three formats. Validated at CLI parse per VR-077-001.
     pub version: Option<String>,
+    /// Override the type segment of the root component's PURL.
+    /// `None` keeps the default `generic`. `Some("golang")` produces
+    /// `pkg:golang/<name>@<version>` instead of `pkg:generic/...`.
+    /// Validated at CLI parse against the purl-spec type charset
+    /// (`^[a-z][a-z0-9.+-]*$`). REQUIRES `name` to be `Some`.
+    /// Mutually exclusive with `omit_purl`.
+    pub purl_type: Option<String>,
+    /// When `true`, the root component is emitted WITHOUT a PURL at
+    /// all. CDX: `metadata.component.purl` field absent. SPDX 2.3: no
+    /// `purl` entry in the root Package's `externalRefs[]`. SPDX 3:
+    /// no `software_packageUrl` AND no `externalIdentifier[]` entry
+    /// with `externalIdentifierType: "packageUrl"`. REQUIRES `name`
+    /// to be `Some`. Mutually exclusive with `purl_type`.
+    pub omit_purl: bool,
 }
 
 impl RootComponentOverride {
@@ -207,7 +221,27 @@ impl RootComponentOverride {
     /// module components from the emitted `components[]` array per
     /// the 2026-05-06 clean-replacement clarification.
     pub fn is_active(&self) -> bool {
-        self.name.is_some() || self.version.is_some()
+        self.name.is_some()
+            || self.version.is_some()
+            || self.purl_type.is_some()
+            || self.omit_purl
+    }
+
+    /// Build the PURL string for the BOM subject given the resolved
+    /// name + version. Returns `None` when `omit_purl` is set — the
+    /// caller MUST skip the PURL emission slot entirely. Otherwise
+    /// returns `pkg:<type>/<name>@<version>` with type defaulting to
+    /// `generic` and name/version percent-encoded per RFC 3986.
+    pub fn build_subject_purl(&self, name: &str, version: &str) -> Option<String> {
+        if self.omit_purl {
+            return None;
+        }
+        let type_token = self.purl_type.as_deref().unwrap_or("generic");
+        Some(format!(
+            "pkg:{type_token}/{}@{}",
+            percent_encode_purl_name(name),
+            percent_encode_purl_name(version),
+        ))
     }
 }
 
@@ -470,7 +504,8 @@ mod tests {
         let o = RootComponentOverride {
             name: Some("widget-svc".to_string()),
             version: None,
-        };
+        ..Default::default()
+    };
         assert!(o.is_active());
     }
 
@@ -479,7 +514,8 @@ mod tests {
         let o = RootComponentOverride {
             name: None,
             version: Some("1.2.3".to_string()),
-        };
+        ..Default::default()
+    };
         assert!(o.is_active());
     }
 
@@ -488,7 +524,8 @@ mod tests {
         let o = RootComponentOverride {
             name: Some("widget-svc".to_string()),
             version: Some("1.2.3".to_string()),
-        };
+        ..Default::default()
+    };
         assert!(o.is_active());
     }
 

--- a/mikebom-cli/src/generate/spdx/document.rs
+++ b/mikebom-cli/src/generate/spdx/document.rs
@@ -391,6 +391,7 @@ pub fn build_document(
             &namespace,
             artifacts.root_override.name.as_deref(),
             artifacts.root_override.version.as_deref(),
+            &artifacts.root_override,
         );
         (vec![id], Some(root))
     } else if main_module_indices.len() == 1 {
@@ -772,6 +773,7 @@ fn synthesize_root_with_override(
     namespace: &SpdxDocumentNamespace,
     override_name: Option<&str>,
     override_version: Option<&str>,
+    root_override: &crate::generate::RootComponentOverride,
 ) -> (SpdxId, super::packages::SpdxPackage) {
     use super::packages::{
         SpdxExternalRef, SpdxExternalRefCategory, SpdxLicenseField, SpdxPackage,
@@ -796,11 +798,10 @@ fn synthesize_root_with_override(
     let encoded = BASE32_NOPAD.encode(&digest);
     let id = SpdxId::synthetic_root(&encoded[..16]);
 
-    // PURL uses RFC 3986 percent-encoding for the override path
-    // (research §1) so npm-scoped names round-trip.
-    let purl_name = crate::generate::percent_encode_purl_name(name);
-    let purl_version = crate::generate::percent_encode_purl_name(version);
-    let synth_purl = format!("pkg:generic/{purl_name}@{purl_version}");
+    // PURL — uses `build_subject_purl` so `--root-purl-type` selects
+    // the type segment and `--no-root-purl` returns `None`, in which
+    // case we DO NOT emit the `purl` externalRef.
+    let purl_opt = root_override.build_subject_purl(name, version);
 
     // CPE uses `cpe_escape`-style sanitization for both segments; reuse
     // the existing sanitize_for_coord helper which matches the CDX
@@ -809,6 +810,22 @@ fn synthesize_root_with_override(
     let cpe_version = sanitize_for_coord(version);
     let synth_cpe =
         format!("cpe:2.3:a:mikebom:{cpe_name}:{cpe_version}:*:*:*:*:*:*:*");
+
+    let mut external_refs: Vec<SpdxExternalRef> = Vec::with_capacity(2);
+    if let Some(synth_purl) = purl_opt {
+        external_refs.push(SpdxExternalRef {
+            category: SpdxExternalRefCategory::PackageManager,
+            ref_type: "purl".to_string(),
+            locator: synth_purl,
+            comment: None,
+        });
+    }
+    external_refs.push(SpdxExternalRef {
+        category: SpdxExternalRefCategory::Security,
+        ref_type: "cpe23Type".to_string(),
+        locator: synth_cpe,
+        comment: None,
+    });
 
     let root = SpdxPackage {
         spdx_id: id.clone(),
@@ -822,20 +839,7 @@ fn synthesize_root_with_override(
         license_declared: SpdxLicenseField::NoAssertion,
         license_concluded: SpdxLicenseField::NoAssertion,
         copyright_text: None,
-        external_refs: vec![
-            SpdxExternalRef {
-                category: SpdxExternalRefCategory::PackageManager,
-                ref_type: "purl".to_string(),
-                locator: synth_purl,
-                comment: None,
-            },
-            SpdxExternalRef {
-                category: SpdxExternalRefCategory::Security,
-                ref_type: "cpe23Type".to_string(),
-                locator: synth_cpe,
-                comment: None,
-            },
-        ],
+        external_refs,
         annotations: Vec::new(),
         primary_package_purpose: None,
     };
@@ -1227,7 +1231,8 @@ mod tests {
         arts.root_override = crate::generate::RootComponentOverride {
             name: Some(root_name.to_string()),
             version: Some(root_version.to_string()),
-        };
+        ..Default::default()
+    };
         arts
     }
 

--- a/mikebom-cli/src/generate/spdx/v3_document.rs
+++ b/mikebom-cli/src/generate/spdx/v3_document.rs
@@ -784,12 +784,19 @@ fn pick_root_iri(
             .as_deref()
             .unwrap_or(scan.target_name);
         let version = scan.root_override.version.as_deref().unwrap_or("0.0.0");
-        let purl_name = crate::generate::percent_encode_purl_name(name);
-        let purl_version = crate::generate::percent_encode_purl_name(version);
-        let synth_purl = format!("pkg:generic/{purl_name}@{purl_version}");
+        // Milestone N+1: `build_subject_purl` returns `None` when
+        // `--no-root-purl` is in effect; otherwise builds
+        // `pkg:<type>/<name>@<version>` with the type from
+        // `--root-purl-type` (default `generic`).
+        let synth_purl_opt = scan.root_override.build_subject_purl(name, version);
+        // IRI: hash the PURL when present, else hash `name@version` so
+        // the synthesized IRI stays stable across runs in the omit case.
+        let iri_seed = synth_purl_opt
+            .clone()
+            .unwrap_or_else(|| format!("{name}@{version}"));
         let synth_iri = format!(
             "{doc_iri}/pkg-root-{}",
-            hash_prefix(synth_purl.as_bytes(), 16)
+            hash_prefix(iri_seed.as_bytes(), 16)
         );
         // CPE: reuse `url_friendly` for sanitization parity with the
         // existing non-override path. CPE has its own escape rules
@@ -799,26 +806,38 @@ fn pick_root_iri(
             url_friendly(name),
             url_friendly(version),
         );
-        let synth_pkg = json!({
+        // Build externalIdentifier[] conditionally — CPE always, PURL
+        // only when present.
+        let mut ext_ids: Vec<serde_json::Value> = Vec::with_capacity(2);
+        ext_ids.push(json!({
+            "type": "ExternalIdentifier",
+            "externalIdentifierType": "cpe23",
+            "identifier": synth_cpe,
+        }));
+        if let Some(ref synth_purl) = synth_purl_opt {
+            ext_ids.push(json!({
+                "type": "ExternalIdentifier",
+                "externalIdentifierType": "packageUrl",
+                "identifier": synth_purl,
+            }));
+        }
+        let mut synth_pkg = json!({
             "type": "software_Package",
             "spdxId": synth_iri,
             "creationInfo": CREATION_INFO_ID,
             "name": name,
             "software_packageVersion": version,
-            "software_packageUrl": synth_purl,
-            "externalIdentifier": [
-                {
-                    "type": "ExternalIdentifier",
-                    "externalIdentifierType": "cpe23",
-                    "identifier": synth_cpe,
-                },
-                {
-                    "type": "ExternalIdentifier",
-                    "externalIdentifierType": "packageUrl",
-                    "identifier": synth_purl,
-                },
-            ],
+            "externalIdentifier": ext_ids,
         });
+        // Add software_packageUrl only when the PURL is present.
+        if let Some(synth_purl) = synth_purl_opt {
+            if let Some(obj) = synth_pkg.as_object_mut() {
+                obj.insert(
+                    "software_packageUrl".to_string(),
+                    serde_json::Value::String(synth_purl),
+                );
+            }
+        }
         packages.insert(0, synth_pkg);
         return (vec![synth_iri], true);
     }

--- a/mikebom-cli/tests/identifiers_root_purl_control.rs
+++ b/mikebom-cli/tests/identifiers_root_purl_control.rs
@@ -1,0 +1,570 @@
+//! Integration tests for the root-component PURL control flags
+//! (`--root-purl-type <TYPE>` and `--no-root-purl`).
+//!
+//! Both flags extend the existing milestone-077 `RootComponentOverride`
+//! surface — `--root-name` / `--root-version` already cover name and
+//! version; the new flags add producer-side control of the PURL itself.
+//!
+//! Coverage:
+//!
+//! - `--root-purl-type` × CDX + SPDX 2.3 + SPDX 3 × representative name
+//!   shapes (plain identifier, slashed Go module path, scoped npm
+//!   `@scope/name`, Maven `group/artifact`).
+//! - `--no-root-purl` × CDX + SPDX 2.3 + SPDX 3 — verifies the PURL
+//!   slot is ABSENT (not null, not empty) in every format.
+//! - Mutual exclusion + co-presence regressions: clap rejects both
+//!   flags simultaneously, and rejects either without `--root-name`.
+//! - Invalid type-token regressions: uppercase / whitespace inputs are
+//!   rejected at parse time with a flag-named error.
+
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+use std::path::Path;
+use std::process::Command;
+
+mod common;
+use common::bin;
+use common::normalize::apply_fake_home_env;
+
+// ---------------------------------------------------------------------
+// Helpers (cloned from identifiers_root_component_override.rs)
+// ---------------------------------------------------------------------
+
+fn run_scan_returning_json(
+    fake_home: &Path,
+    scan_target: &Path,
+    extra_args: &[&str],
+    out_format: &str,
+    out_filename: &str,
+) -> serde_json::Value {
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join(out_filename);
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home);
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(scan_target)
+        .arg("--format")
+        .arg(out_format)
+        .arg("--output")
+        .arg(format!("{out_format}={}", out_path.to_string_lossy()))
+        .arg("--no-deep-hash");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("scan runs");
+    assert!(
+        out.status.success(),
+        "scan failed: stderr={}\nstdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout),
+    );
+    let bytes = std::fs::read(&out_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    drop(out_dir);
+    parsed
+}
+
+fn run_scan_expecting_failure(
+    fake_home: &Path,
+    scan_target: &Path,
+    extra_args: &[&str],
+) -> (i32, String) {
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("out.cdx.json");
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home);
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(scan_target)
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(format!("cyclonedx-json={}", out_path.to_string_lossy()))
+        .arg("--no-deep-hash");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("scan runs");
+    let code = out.status.code().unwrap_or(-1);
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    drop(out_dir);
+    (code, stderr)
+}
+
+fn make_arbitrary_dir(name: &str) -> tempfile::TempDir {
+    tempfile::Builder::new().prefix(name).tempdir().unwrap()
+}
+
+/// Find the root `software_Package` element in an SPDX 3 `@graph`.
+fn spdx3_root_package(spdx3: &serde_json::Value) -> &serde_json::Value {
+    let root_iri = spdx3
+        .get("@graph")
+        .and_then(|g| g.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|e| {
+                e.get("type").and_then(|v| v.as_str()) == Some("SpdxDocument")
+            })
+        })
+        .and_then(|doc| doc.get("rootElement"))
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .expect("SPDX 3 rootElement IRI present");
+    spdx3
+        .get("@graph")
+        .and_then(|g| g.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|e| {
+                e.get("spdxId").and_then(|v| v.as_str()) == Some(root_iri)
+            })
+        })
+        .expect("SPDX 3 root package present in @graph")
+}
+
+// =====================================================================
+// `--root-purl-type` × CDX
+// =====================================================================
+
+#[test]
+fn root_purl_type_golang_with_slashed_name_cdx() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("svc");
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "github.com/example/svc",
+            "--root-version",
+            "v1.0.0",
+            "--root-purl-type",
+            "golang",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comp = &cdx["metadata"]["component"];
+    assert_eq!(comp["name"].as_str(), Some("github.com/example/svc"));
+    assert_eq!(comp["version"].as_str(), Some("v1.0.0"));
+    // The `/` in the name is percent-encoded as `%2F` per RFC 3986 in
+    // the percent_encode_purl_name helper.
+    assert_eq!(
+        comp["purl"].as_str(),
+        Some("pkg:golang/github.com%2Fexample%2Fsvc@v1.0.0")
+    );
+}
+
+#[test]
+fn root_purl_type_npm_scoped_name_cdx() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("pkg");
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "@scope/pkg",
+            "--root-version",
+            "1.0.0",
+            "--root-purl-type",
+            "npm",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comp = &cdx["metadata"]["component"];
+    // `@` → `%40`, `/` → `%2F` per percent_encode_purl_name.
+    assert_eq!(
+        comp["purl"].as_str(),
+        Some("pkg:npm/%40scope%2Fpkg@1.0.0")
+    );
+}
+
+#[test]
+fn root_purl_type_maven_groupartifact_cdx() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("artifact");
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "com.example/artifact",
+            "--root-version",
+            "1.0.0",
+            "--root-purl-type",
+            "maven",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comp = &cdx["metadata"]["component"];
+    assert_eq!(
+        comp["purl"].as_str(),
+        Some("pkg:maven/com.example%2Fartifact@1.0.0")
+    );
+}
+
+#[test]
+fn root_purl_type_plain_name_replaces_generic_default_cdx() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("widget");
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "widget-svc",
+            "--root-version",
+            "1.2.3",
+            "--root-purl-type",
+            "oci",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comp = &cdx["metadata"]["component"];
+    assert_eq!(comp["purl"].as_str(), Some("pkg:oci/widget-svc@1.2.3"));
+}
+
+// =====================================================================
+// `--root-purl-type` × SPDX 2.3
+// =====================================================================
+
+#[test]
+fn root_purl_type_golang_spdx23() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("svc");
+    let spdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "github.com/example/svc",
+            "--root-version",
+            "v1.0.0",
+            "--root-purl-type",
+            "golang",
+        ],
+        "spdx-2.3-json",
+        "out.spdx23.json",
+    );
+    // SPDX 2.3 root Package is packages[0] (synthesized root); the PURL
+    // rides externalRefs[].referenceLocator with referenceType="purl".
+    let root_pkg = &spdx["packages"][0];
+    assert_eq!(
+        root_pkg["name"].as_str(),
+        Some("github.com/example/svc")
+    );
+    let refs = root_pkg["externalRefs"].as_array().unwrap();
+    let purl_entry = refs
+        .iter()
+        .find(|r| r["referenceType"].as_str() == Some("purl"))
+        .expect("root Package has a purl externalRef");
+    assert_eq!(
+        purl_entry["referenceLocator"].as_str(),
+        Some("pkg:golang/github.com%2Fexample%2Fsvc@v1.0.0")
+    );
+}
+
+// =====================================================================
+// `--root-purl-type` × SPDX 3
+// =====================================================================
+
+#[test]
+fn root_purl_type_golang_spdx3() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("svc");
+    let spdx3 = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "github.com/example/svc",
+            "--root-version",
+            "v1.0.0",
+            "--root-purl-type",
+            "golang",
+        ],
+        "spdx-3-json",
+        "out.spdx3.json",
+    );
+    let root = spdx3_root_package(&spdx3);
+    let expected = "pkg:golang/github.com%2Fexample%2Fsvc@v1.0.0";
+    // Both emission slots: software_packageUrl AND externalIdentifier[packageUrl].
+    assert_eq!(
+        root["software_packageUrl"].as_str(),
+        Some(expected)
+    );
+    let ext_ids = root["externalIdentifier"].as_array().unwrap();
+    let purl_id = ext_ids
+        .iter()
+        .find(|i| i["externalIdentifierType"].as_str() == Some("packageUrl"))
+        .expect("SPDX 3 root has externalIdentifier[packageUrl]");
+    assert_eq!(purl_id["identifier"].as_str(), Some(expected));
+}
+
+// =====================================================================
+// `--no-root-purl` × CDX
+// =====================================================================
+
+#[test]
+fn no_root_purl_omits_field_cdx() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("svc");
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "my-svc",
+            "--root-version",
+            "1.0.0",
+            "--no-root-purl",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comp = &cdx["metadata"]["component"];
+    // Name + version still present.
+    assert_eq!(comp["name"].as_str(), Some("my-svc"));
+    assert_eq!(comp["version"].as_str(), Some("1.0.0"));
+    // `purl` field ABSENT (not null, not empty).
+    assert!(
+        comp.get("purl").is_none(),
+        "metadata.component.purl must be ABSENT when --no-root-purl is set; got {:?}",
+        comp.get("purl")
+    );
+}
+
+#[test]
+fn no_root_purl_with_full_registry_path_roundtrips_cdx() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("svc");
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "767xxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com/pico-server",
+            "--root-version",
+            "1.0.0",
+            "--no-root-purl",
+        ],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comp = &cdx["metadata"]["component"];
+    // Slashed identifier round-trips byte-for-byte — no PURL encoding involved.
+    assert_eq!(
+        comp["name"].as_str(),
+        Some("767xxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com/pico-server")
+    );
+    assert!(comp.get("purl").is_none());
+}
+
+// =====================================================================
+// `--no-root-purl` × SPDX 2.3
+// =====================================================================
+
+#[test]
+fn no_root_purl_omits_externalref_spdx23() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("svc");
+    let spdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "my-svc",
+            "--root-version",
+            "1.0.0",
+            "--no-root-purl",
+        ],
+        "spdx-2.3-json",
+        "out.spdx23.json",
+    );
+    let root_pkg = &spdx["packages"][0];
+    let refs = root_pkg["externalRefs"].as_array().unwrap();
+    let has_purl = refs
+        .iter()
+        .any(|r| r["referenceType"].as_str() == Some("purl"));
+    assert!(
+        !has_purl,
+        "root Package externalRefs[] must NOT contain a purl entry; got {refs:?}"
+    );
+    // CPE entry should still be present.
+    let has_cpe = refs
+        .iter()
+        .any(|r| r["referenceType"].as_str() == Some("cpe23Type"));
+    assert!(has_cpe, "CPE externalRef should still emit");
+}
+
+// =====================================================================
+// `--no-root-purl` × SPDX 3
+// =====================================================================
+
+#[test]
+fn no_root_purl_omits_software_packageurl_and_externalidentifier_spdx3() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("svc");
+    let spdx3 = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "my-svc",
+            "--root-version",
+            "1.0.0",
+            "--no-root-purl",
+        ],
+        "spdx-3-json",
+        "out.spdx3.json",
+    );
+    let root = spdx3_root_package(&spdx3);
+    // `software_packageUrl` field ABSENT.
+    assert!(
+        root.get("software_packageUrl").is_none(),
+        "software_packageUrl must be ABSENT; got {:?}",
+        root.get("software_packageUrl")
+    );
+    // externalIdentifier[] still present (CPE), but NO packageUrl entry.
+    let ext_ids = root["externalIdentifier"].as_array().unwrap();
+    let has_purl = ext_ids
+        .iter()
+        .any(|i| i["externalIdentifierType"].as_str() == Some("packageUrl"));
+    assert!(
+        !has_purl,
+        "externalIdentifier[] must NOT contain a packageUrl entry; got {ext_ids:?}"
+    );
+}
+
+// =====================================================================
+// Mutual-exclusion + co-presence + invalid-type regressions
+// =====================================================================
+
+#[test]
+fn mutex_root_purl_type_and_no_root_purl() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("svc");
+    let (code, stderr) = run_scan_expecting_failure(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "svc",
+            "--root-purl-type",
+            "golang",
+            "--no-root-purl",
+        ],
+    );
+    assert_ne!(code, 0, "expected non-zero exit; got 0");
+    assert!(
+        stderr.contains("conflicts with") || stderr.contains("cannot be used with"),
+        "stderr should explain the mutex; got: {stderr}"
+    );
+}
+
+#[test]
+fn root_purl_type_requires_root_name() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("svc");
+    let (code, stderr) = run_scan_expecting_failure(
+        fake_home.path(),
+        scan_target.path(),
+        &["--root-purl-type", "golang"],
+    );
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("--root-name") || stderr.contains("root-name") || stderr.contains("requires"),
+        "stderr should mention --root-name requirement; got: {stderr}"
+    );
+}
+
+#[test]
+fn no_root_purl_requires_root_name() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("svc");
+    let (code, stderr) = run_scan_expecting_failure(
+        fake_home.path(),
+        scan_target.path(),
+        &["--no-root-purl"],
+    );
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("--root-name") || stderr.contains("root-name") || stderr.contains("requires"),
+        "stderr should mention --root-name requirement; got: {stderr}"
+    );
+}
+
+#[test]
+fn invalid_root_purl_type_uppercase() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("svc");
+    let (code, stderr) = run_scan_expecting_failure(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "svc",
+            "--root-purl-type",
+            "FOO",
+        ],
+    );
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("--root-purl-type")
+            || stderr.contains("root-purl-type")
+            || stderr.contains("valid purl-spec type token"),
+        "stderr should name the invalid flag value; got: {stderr}"
+    );
+}
+
+#[test]
+fn invalid_root_purl_type_whitespace() {
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("svc");
+    let (code, stderr) = run_scan_expecting_failure(
+        fake_home.path(),
+        scan_target.path(),
+        &[
+            "--root-name",
+            "svc",
+            "--root-purl-type",
+            "has space",
+        ],
+    );
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("--root-purl-type")
+            || stderr.contains("root-purl-type")
+            || stderr.contains("valid purl-spec type token"),
+        "stderr should name the invalid flag value; got: {stderr}"
+    );
+}
+
+// =====================================================================
+// Back-compat: without the new flags, --root-name still defaults to generic
+// =====================================================================
+
+#[test]
+fn root_name_without_new_flags_still_produces_pkg_generic() {
+    // Regression: this test mirrors the existing milestone-077 default
+    // behavior. The new flags must NOT change the bytes when absent.
+    let fake_home = tempfile::tempdir().unwrap();
+    let scan_target = make_arbitrary_dir("svc");
+    let cdx = run_scan_returning_json(
+        fake_home.path(),
+        scan_target.path(),
+        &["--root-name", "widget-svc", "--root-version", "1.2.3"],
+        "cyclonedx-json",
+        "out.cdx.json",
+    );
+    let comp = &cdx["metadata"]["component"];
+    assert_eq!(comp["purl"].as_str(), Some("pkg:generic/widget-svc@1.2.3"));
+}


### PR DESCRIPTION
Adds two opt-in flags to `mikebom sbom scan` that give operators producer-side control of the root component's PURL across all three output formats (CycloneDX 1.6, SPDX 2.3, SPDX 3.0.1). **Default behavior unchanged** — `--root-name foo` continues to produce `pkg:generic/foo@<ver>` and absence of `--root-name` continues to produce the ecosystem-correct auto-derived PURL.

## What this PR adds

**`--root-purl-type <TYPE>`** — overrides the type segment of the auto-derived root PURL. Today, when `--root-name` is supplied, mikebom hardcodes `pkg:generic/<name>@<version>`. The new flag replaces that hardcoded `generic` with an operator-supplied type token.

```bash
mikebom sbom scan --path . --root-name github.com/example/svc \\
  --root-version v1.2.3 --root-purl-type golang
# → metadata.component.purl = \"pkg:golang/github.com%2Fexample%2Fsvc@v1.2.3\"
```

- Validated at parse time against the purl-spec type charset `^[a-z][a-z0-9.+-]*$`.
- REQUIRES `--root-name`.
- Mutually exclusive with `--no-root-purl` (clap-level conflict).

**`--no-root-purl`** — omits the root component's PURL entirely:
- CDX: `metadata.component.purl` field ABSENT.
- SPDX 2.3: root Package `externalRefs[]` contains no `purl` entry (CPE entry still emits).
- SPDX 3: root has neither `software_packageUrl` nor an `externalIdentifier[]` entry of type `packageUrl` (CPE externalIdentifier still emits).

```bash
mikebom sbom scan --path . --root-name my-svc --no-root-purl
# → metadata.component.purl ABSENT; name still present
```

- REQUIRES `--root-name` (explicit name is the only identity signal once the PURL is dropped).
- Mutually exclusive with `--root-purl-type`.

## Why

Downstream consumers that key software identity on `(pkg_type, name)` see multiple identity rows when the same software is scanned by tools that emit different type segments. The standing workaround has been to post-process mikebom's JSON output to rewrite or delete the root PURL. These flags make the override native + symmetric across all three formats.

## Implementation

Extends the existing milestone-077 `RootComponentOverride` struct at `mikebom-cli/src/generate/mod.rs:193` with two new fields (`purl_type: Option<String>`, `omit_purl: bool`) and a `build_subject_purl(&self, name, version) -> Option<String>` helper. Three emission sites replace their hardcoded `format!(\"pkg:generic/...\")` with calls to the helper:

- `cyclonedx/metadata.rs` — override branch + post-processing drop of `metadata.component.purl` when `omit_purl` is set.
- `spdx/document.rs::synthesize_root_with_override` — gains a `&RootComponentOverride` parameter and conditionally builds the `externalRefs` Vec.
- `spdx/v3_document.rs` — conditionally emits `software_packageUrl` field AND the `externalIdentifier[packageUrl]` entry. The synthesized IRI hashes the PURL when present, else `name@version` so the IRI stays stable across runs.

## Constitution compliance

| Principle | Status |
|---|---|
| I. Pure Rust, Zero C | ✓ no new deps |
| III. Fail Closed | ✓ invalid flag values exit non-zero at parse time via clap's value_parser |
| IV. Type-Driven Correctness | ✓ extends typed `RootComponentOverride` |
| V. Specification Compliance | ✓ flags control standards-native fields directly. No new mikebom:* annotation, no new parity-catalog C-row, no new Principle V audit |
| VII. Test Isolation | ✓ tempfile pattern reused from `identifiers_root_component_override.rs` |
| X. Transparency | ✓ producer-side control documented in `cli-reference.md` |

## Test plan

- [x] 16 binary-level integration tests at `mikebom-cli/tests/identifiers_root_purl_control.rs`:
  - 4 `--root-purl-type` × CDX (plain, slashed Go path, scoped npm, Maven group/artifact)
  - 1 `--root-purl-type` × SPDX 2.3
  - 1 `--root-purl-type` × SPDX 3 (covers BOTH `software_packageUrl` AND `externalIdentifier[packageUrl]`)
  - 2 `--no-root-purl` × CDX (including the full-registry-path round-trip)
  - 1 `--no-root-purl` × SPDX 2.3
  - 1 `--no-root-purl` × SPDX 3 (covers both PURL slots absent)
  - 2 mutex regressions + 2 co-presence regressions
  - 2 invalid-type-token regressions
  - 1 back-compat regression (no new flags → `pkg:generic/...` unchanged)
- [x] `MIKEBOM_SKIP_DOCKER_INTEGRATION=1 ./scripts/pre-pr.sh` green
- [x] `git diff main -- mikebom-cli/Cargo.toml mikebom-cli/Cargo.lock` shows ZERO additions

Docs: new \`### --root-purl-type <TYPE>\` + \`### --no-root-purl\` sections in `docs/user-guide/cli-reference.md` with worked examples. Two new rows in the scan-flags summary table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)