### PR TITLE
feat(scan_fs): supplier external-reference URLs for cargo / NuGet / nested Maven (milestone 131 US3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 
 ## [Unreleased]
 
+### Supplier external-reference URL synthesis for cargo / NuGet / nested Maven (milestone 131 US3)
+
+Closes the Supplier Attribution scorecard regression from milestone 130. The post-130 audit
+showed mikebom's supplier-attribution score dropping from 4/5 to 2/5 because the three new
+reader paths (cargo-auditable, .deps.json, PE/CLR managed-assembly metadata, nested-JAR) emit
+no `externalReferences[]` URLs. This PR backfills synthetic registry-website URLs derived from
+each component's PURL.
+
+**`mikebom-cli/src/scan_fs/mod.rs::external_refs_from_purl` extensions**:
+
+- **cargo**: `pkg:cargo/<name>@<version>` → `externalReferences[].url = "https://crates.io/crates/<name>/<version>"` with `type = "website"` (FR-017).
+- **nuget**: `pkg:nuget/<name>@<version>` → `externalReferences[].url = "https://www.nuget.org/packages/<name>/<version>"` with `type = "website"` (FR-018).
+- **maven-nested**: `pkg:maven/<g>/<a>@<v>` components carrying `mikebom:source-mechanism = "maven-jar-nested"` (from milestone 130 US2) → `externalReferences[].url = "https://search.maven.org/artifact/<g>/<a>/<v>/jar"` with `type = "website"` (FR-019). Top-level JARs unchanged so the existing milestone-009 sidecar-derived URLs aren't clobbered.
+- **cargo with `git+https://...` source field**: cargo-auditable's `source` field is parsed for `git+`-prefixed URLs at `binary/entry.rs::cargo_auditable_packages_to_entries`. When matched, the cleaned URL (sans `git+` prefix, sans trailing `.git`, sans `#<rev>` fragment) is stashed under the new C98 `mikebom:cargo-vcs-source-url` plumbing annotation. The downstream `external_refs_from_purl` helper reads this and emits an additional `type = "vcs"` ExternalReference (FR-020). Provenance is preserved: the VCS URL came from the build-time cargo-auditable declaration, not from PURL-heuristic guessing.
+
+**New annotation key catalogued (C98)**: `mikebom:cargo-vcs-source-url` — see `specs/131-quality-metadata-backfill/contracts/annotation-schema.md` for the full Principle V audit narrative. The annotation is in-process plumbing; the native CDX `externalReferences[]` entry is the wire-format primary.
+
+**Golden churn**: 3 fixtures (`cargo.cdx.json` + `cargo.spdx.json` + `cargo.spdx3.json`) gain the new `externalReferences[].url = "https://crates.io/..."` entries — purely additive, no existing fields modified. This is the intentional FR-017 behavior; the spec's SC-005 byte-identity claim was overly strict for US3 (only goldens without cargo/nuget/maven-nested components remain byte-identical). For images without cargo / nuget / maven-nested components (pure-Python, pure-Go, etc.), the readers are no-ops and goldens stay byte-identical.
+
+**15 new unit tests**: 6 in `scan_fs::external_refs_tests` (cargo / nuget / maven-nested / maven-top-level-skip / cargo-with-vcs / golang preservation) + 9 in `binary::entry::tests` (git source parsing — strip-prefix-and-fragment, dot-git, http/https, registry/local/unknown reject, ssh reject, end-to-end emission).
+
+**Follow-ups tracked separately**:
+- **US1** (PE/CLR Phase B — CustomAttribute walking for InformationalVersion + FileVersion) — resolves 373 VERSION_MISMATCH cases. ~300 LOC ECMA-335 walk. See `specs/131-quality-metadata-backfill/spec.md` US1.
+- **US2** (license backfill — nested-JAR `<licenses>` + PE/CLR LICENSE.txt fingerprint-matching + cargo-auditable `registry-required` annotation) — License Coverage 1/5 → ≥3/5. See spec.md US2.
+
 ### PE/CLR managed-assembly metadata reader (milestone 130 US3, Phase A)
 
 Closes the third and final track in milestone 130: extracting NuGet package coordinates from `.dll`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ Auto-generated from all feature plans. Last updated: 2026-06-18
 - Rust stable (workspace toolchain inherited from milestones 001–128; no nightly required). + Existing only — `object = "0.36"` (workspace; ELF section reading for `.dep-v0` per (129-binary-tier-readers)
 - N/A — all state in-process per scan; no caches, no persistence. Matches every milestone since 002. (129-binary-tier-readers)
 - Rust stable (workspace toolchain inherited from milestones 001–129; no nightly + Existing only — `object = "0.36"` (workspace; ELF section reading for the (130-binary-tier-completion)
+- Rust stable (workspace toolchain inherited from milestones 001–130; no + Existing only — `object = "0.36"` (workspace; reused for the US1 (131-quality-metadata-backfill)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -205,9 +206,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 131-quality-metadata-backfill: Added Rust stable (workspace toolchain inherited from milestones 001–130; no + Existing only — `object = "0.36"` (workspace; reused for the US1
 - 130-binary-tier-completion: Added Rust stable (workspace toolchain inherited from milestones 001–129; no nightly + Existing only — `object = "0.36"` (workspace; ELF section reading for the
 - 129-binary-tier-readers: Added Rust stable (workspace toolchain inherited from milestones 001–128; no nightly required). + Existing only — `object = "0.36"` (workspace; ELF section reading for `.dep-v0` per
-- 128-yocto-recipe-enrich: Added Rust stable (workspace toolchain inherited from milestones 001–127; no nightly required). + Existing only — `regex` (already direct dep since milestones 113 + 127), `std::str::Lines` (recipe-body parsing), `std::path::{Path, PathBuf}` + `std::fs::canonicalize` (layer attribution + include resolution), `mikebom_common::types::license::SpdxExpression::try_canonical` (LICENSE canonicalization), `mikebom_common::types::purl::Purl::new` (PURL construction, already validates against purl-spec), `tracing`, `anyhow`, `serde`/`serde_json`. **Zero new Cargo dependencies.**
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/scan_fs/binary/entry.rs
+++ b/mikebom-cli/src/scan_fs/binary/entry.rs
@@ -338,6 +338,20 @@ pub(super) fn cargo_auditable_packages_to_entries(
                     serde_json::Value::String(pkg.source.clone()),
                 );
             }
+            // Milestone 131 US3 (FR-020 + C98): when the source field
+            // carries a parseable `git+https://...` URL, extract it
+            // (stripping the `git+` prefix, any trailing `.git`, and
+            // the `#<rev>` fragment) and stash under
+            // `mikebom:cargo-vcs-source-url`. The downstream
+            // `external_refs_from_purl` helper at scan_fs/mod.rs reads
+            // this annotation to emit a `vcs`-type ExternalReference
+            // on the resolved component.
+            if let Some(vcs_url) = parse_cargo_auditable_git_source(&pkg.source) {
+                extra.insert(
+                    "mikebom:cargo-vcs-source-url".to_string(),
+                    serde_json::Value::String(vcs_url),
+                );
+            }
             Some(PackageDbEntry {
                 build_inclusion: None,
                 purl,
@@ -389,6 +403,31 @@ pub(super) fn cargo_auditable_packages_to_entries(
     });
 
     entries
+}
+
+/// Milestone 131 US3 (FR-020): parse a cargo-auditable `source` field
+/// for a `git+https://...` URL and return the cleaned URL. Strips the
+/// `git+` prefix, any trailing `.git`, and the `#<rev>` fragment per
+/// CDX best practice. Returns `None` when the source field isn't a
+/// git URL (registry/local/unknown all return None).
+///
+/// Examples:
+/// - `"git+https://github.com/serde-rs/serde.git#a1b2c3d"` → `Some("https://github.com/serde-rs/serde")`
+/// - `"git+https://gitlab.com/foo/bar"` → `Some("https://gitlab.com/foo/bar")`
+/// - `"registry"` / `"local"` / `"unknown"` → `None`
+pub(super) fn parse_cargo_auditable_git_source(source: &str) -> Option<String> {
+    let stripped = source.strip_prefix("git+")?;
+    // Drop the #<rev> fragment if present.
+    let no_fragment = stripped.split('#').next().unwrap_or(stripped);
+    // Drop trailing `.git` if present.
+    let no_dotgit = no_fragment
+        .strip_suffix(".git")
+        .unwrap_or(no_fragment);
+    // Sanity: must look like an http(s) URL.
+    if !no_dotgit.starts_with("https://") && !no_dotgit.starts_with("http://") {
+        return None;
+    }
+    Some(no_dotgit.to_string())
 }
 
 /// Cross-format scan result. Common fields populated from all three
@@ -1515,5 +1554,87 @@ mod tests {
         assert!(!entries[0]
             .extra_annotations
             .contains_key("mikebom:cargo-auditable-kind"));
+    }
+
+    // ============================================================
+    // Milestone 131 US3 — parse_cargo_auditable_git_source.
+    // ============================================================
+
+    #[test]
+    fn parse_git_source_strips_prefix_and_rev_fragment() {
+        let out = parse_cargo_auditable_git_source(
+            "git+https://github.com/serde-rs/serde.git#a1b2c3d4e5f6",
+        );
+        assert_eq!(out, Some("https://github.com/serde-rs/serde".to_string()));
+    }
+
+    #[test]
+    fn parse_git_source_strips_dotgit_when_no_fragment() {
+        let out =
+            parse_cargo_auditable_git_source("git+https://github.com/serde-rs/serde.git");
+        assert_eq!(out, Some("https://github.com/serde-rs/serde".to_string()));
+    }
+
+    #[test]
+    fn parse_git_source_passes_through_url_without_dotgit() {
+        let out = parse_cargo_auditable_git_source("git+https://gitlab.com/foo/bar");
+        assert_eq!(out, Some("https://gitlab.com/foo/bar".to_string()));
+    }
+
+    #[test]
+    fn parse_git_source_handles_http_not_only_https() {
+        let out = parse_cargo_auditable_git_source("git+http://internal.example/foo.git");
+        assert_eq!(out, Some("http://internal.example/foo".to_string()));
+    }
+
+    #[test]
+    fn parse_git_source_returns_none_for_registry() {
+        assert!(parse_cargo_auditable_git_source("registry").is_none());
+    }
+
+    #[test]
+    fn parse_git_source_returns_none_for_local() {
+        assert!(parse_cargo_auditable_git_source("local").is_none());
+    }
+
+    #[test]
+    fn parse_git_source_returns_none_for_unknown() {
+        assert!(parse_cargo_auditable_git_source("unknown").is_none());
+    }
+
+    #[test]
+    fn parse_git_source_returns_none_for_non_http_scheme() {
+        // `git+ssh://...` not supported (rare, requires keypair anyway).
+        assert!(parse_cargo_auditable_git_source("git+ssh://git@github.com/foo/bar.git").is_none());
+    }
+
+    #[test]
+    fn cargo_auditable_packages_to_entries_emits_vcs_url_for_git_source() {
+        use super::cargo_auditable::{CargoAuditableManifest, CargoAuditablePackage};
+        let manifest = CargoAuditableManifest {
+            packages: vec![CargoAuditablePackage {
+                name: "mycrate".to_string(),
+                version: "0.1.0".to_string(),
+                source: "git+https://github.com/example/mycrate.git#abc123".to_string(),
+                kind: Some("runtime".to_string()),
+                dependencies: vec![],
+                root: false,
+            }],
+        };
+        let file_level_purl = mikebom_common::types::purl::Purl::new(
+            "pkg:generic/binary?file-sha256=deadbeef",
+        )
+        .unwrap();
+        let path = std::path::PathBuf::from("/bin/binary");
+        let entries =
+            cargo_auditable_packages_to_entries(&manifest, &file_level_purl, &path);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0]
+                .extra_annotations
+                .get("mikebom:cargo-vcs-source-url")
+                .and_then(|v| v.as_str()),
+            Some("https://github.com/example/mycrate"),
+        );
     }
 }

--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -595,7 +595,7 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
                 parent_purl: entry.parent_purl.clone(),
                 co_owned_by: entry.co_owned_by.clone(),
                 shade_relocation: entry.shade_relocation,
-                external_references: external_refs_from_purl(&entry.purl),
+                external_references: external_refs_from_purl(&entry.purl, &entry.extra_annotations),
                 extra_annotations: entry.extra_annotations.clone(),
                 // Milestone 104 — propagate role from PackageDbEntry
                 // (set by the binary reader's `make_file_level_component`).
@@ -967,39 +967,92 @@ fn supplier_from_purl(purl: &mikebom_common::types::purl::Purl) -> Option<String
 /// Derive VCS / website external references from a PURL when the
 /// module path embeds them. Currently limited to Go modules whose
 /// canonical form starts with a known repo host — that's where the
-/// signal is unambiguous. npm / cargo / pypi / maven need deps.dev
-/// or registry metadata to find the repo URL and are populated
-/// elsewhere (out of scope for this pass).
+/// signal is unambiguous.
+///
+/// Milestone 131 US3: extended to synthesize canonical registry
+/// `website` URLs for `pkg:cargo`, `pkg:nuget`, and nested
+/// `pkg:maven` components (FR-017..019), plus a `vcs` URL parsed
+/// from cargo-auditable's `source` field when carried via the C98
+/// `mikebom:cargo-vcs-source-url` plumbing annotation (FR-020).
 fn external_refs_from_purl(
     purl: &mikebom_common::types::purl::Purl,
+    extra_annotations: &std::collections::BTreeMap<String, serde_json::Value>,
 ) -> Vec<mikebom_common::resolution::ExternalReference> {
     use mikebom_common::resolution::ExternalReference;
     let mut out = Vec::new();
-    if purl.ecosystem() != "golang" {
-        return out;
+    let ecosystem = purl.ecosystem();
+    let name = purl.name();
+    let version = purl.version().unwrap_or_default();
+    match ecosystem {
+        "golang" => {
+            // Existing milestone-001 heuristic.
+            if let Some(namespace) = purl.namespace() {
+                let segments: Vec<&str> = namespace.split('/').collect();
+                if segments.len() >= 2 {
+                    let host = segments[0];
+                    if matches!(host, "github.com" | "gitlab.com" | "bitbucket.org") {
+                        let org = segments[1];
+                        let repo = name;
+                        out.push(ExternalReference {
+                            ref_type: "vcs".to_string(),
+                            url: format!("https://{host}/{org}/{repo}"),
+                        });
+                    }
+                }
+            }
+        }
+        "cargo" if !name.is_empty() && !version.is_empty() => {
+            // FR-017: crates.io registry website.
+            out.push(ExternalReference {
+                ref_type: "website".to_string(),
+                url: format!("https://crates.io/crates/{name}/{version}"),
+            });
+        }
+        "nuget" if !name.is_empty() && !version.is_empty() => {
+            // FR-018: nuget.org registry website.
+            out.push(ExternalReference {
+                ref_type: "website".to_string(),
+                url: format!("https://www.nuget.org/packages/{name}/{version}"),
+            });
+        }
+        "maven" => {
+            // FR-019: search.maven.org canonical per-artifact URL.
+            // Gated on `mikebom:source-mechanism = "maven-jar-nested"` so the
+            // existing top-level milestone-009 reader's sidecar-derived URLs
+            // aren't clobbered.
+            let is_nested = extra_annotations
+                .get("mikebom:source-mechanism")
+                .and_then(|v| v.as_str())
+                == Some("maven-jar-nested");
+            if is_nested {
+                if let Some(namespace) = purl.namespace() {
+                    if !namespace.is_empty() && !name.is_empty() && !version.is_empty() {
+                        out.push(ExternalReference {
+                            ref_type: "website".to_string(),
+                            url: format!(
+                                "https://search.maven.org/artifact/{namespace}/{name}/{version}/jar"
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+        _ => {}
     }
-    let Some(namespace) = purl.namespace() else {
-        return out;
-    };
-    // `pkg:golang/github.com/sirupsen/logrus@v1.9.3` → namespace
-    // `github.com/sirupsen`, name `logrus` → vcs
-    // `https://github.com/sirupsen/logrus`. Same shape for gitlab
-    // and bitbucket. Anything else (gopkg.in, custom vanity
-    // domains) needs deps.dev and skips here.
-    let segments: Vec<&str> = namespace.split('/').collect();
-    if segments.len() < 2 {
-        return out;
+    // FR-020: emit a `vcs`-type ExternalReference when cargo-auditable
+    // carried a parseable `git+https://...` source field. The URL
+    // itself flows through the C98 `mikebom:cargo-vcs-source-url`
+    // plumbing annotation, populated upstream at
+    // `binary/entry.rs::cargo_auditable_packages_to_entries`.
+    if let Some(vcs_url) = extra_annotations
+        .get("mikebom:cargo-vcs-source-url")
+        .and_then(|v| v.as_str())
+    {
+        out.push(ExternalReference {
+            ref_type: "vcs".to_string(),
+            url: vcs_url.to_string(),
+        });
     }
-    let host = segments[0];
-    if !matches!(host, "github.com" | "gitlab.com" | "bitbucket.org") {
-        return out;
-    }
-    let org = segments[1];
-    let repo = purl.name();
-    out.push(ExternalReference {
-        ref_type: "vcs".to_string(),
-        url: format!("https://{host}/{org}/{repo}"),
-    });
     out
 }
 
@@ -1040,6 +1093,88 @@ mod supplier_tests {
     fn cargo_has_none() {
         let p = Purl::new("pkg:cargo/serde@1.0.197").unwrap();
         assert_eq!(supplier_from_purl(&p), None);
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod external_refs_tests {
+    use super::external_refs_from_purl;
+    use mikebom_common::types::purl::Purl;
+    use std::collections::BTreeMap;
+
+    fn no_annotations() -> BTreeMap<String, serde_json::Value> {
+        BTreeMap::new()
+    }
+
+    #[test]
+    fn cargo_purl_emits_crates_io_website() {
+        let p = Purl::new("pkg:cargo/serde@1.0.197").unwrap();
+        let refs = external_refs_from_purl(&p, &no_annotations());
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].ref_type, "website");
+        assert_eq!(refs[0].url, "https://crates.io/crates/serde/1.0.197");
+    }
+
+    #[test]
+    fn nuget_purl_emits_nuget_org_website() {
+        let p = Purl::new("pkg:nuget/Microsoft.AspNetCore@8.0.27").unwrap();
+        let refs = external_refs_from_purl(&p, &no_annotations());
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].ref_type, "website");
+        assert_eq!(refs[0].url, "https://www.nuget.org/packages/Microsoft.AspNetCore/8.0.27");
+    }
+
+    #[test]
+    fn maven_nested_emits_search_maven_website_when_gated() {
+        let p = Purl::new("pkg:maven/com.example/foo@1.0.0").unwrap();
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "mikebom:source-mechanism".to_string(),
+            serde_json::Value::String("maven-jar-nested".to_string()),
+        );
+        let refs = external_refs_from_purl(&p, &annotations);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].ref_type, "website");
+        assert_eq!(
+            refs[0].url,
+            "https://search.maven.org/artifact/com.example/foo/1.0.0/jar"
+        );
+    }
+
+    #[test]
+    fn maven_top_level_does_not_emit_website() {
+        // Top-level maven JARs (no source-mechanism annotation) get
+        // their URLs from sidecar paths elsewhere; we don't synthesize
+        // here to avoid clobbering.
+        let p = Purl::new("pkg:maven/com.example/foo@1.0.0").unwrap();
+        let refs = external_refs_from_purl(&p, &no_annotations());
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn cargo_with_vcs_annotation_emits_both_website_and_vcs() {
+        let p = Purl::new("pkg:cargo/serde@1.0.197").unwrap();
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "mikebom:cargo-vcs-source-url".to_string(),
+            serde_json::Value::String("https://github.com/serde-rs/serde".to_string()),
+        );
+        let refs = external_refs_from_purl(&p, &annotations);
+        assert_eq!(refs.len(), 2);
+        // Order: website first (ecosystem branch), then vcs (cross-cutting).
+        assert_eq!(refs[0].ref_type, "website");
+        assert_eq!(refs[1].ref_type, "vcs");
+        assert_eq!(refs[1].url, "https://github.com/serde-rs/serde");
+    }
+
+    #[test]
+    fn golang_heuristic_preserved() {
+        let p = Purl::new("pkg:golang/github.com/sirupsen/logrus@v1.9.3").unwrap();
+        let refs = external_refs_from_purl(&p, &no_annotations());
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].ref_type, "vcs");
+        assert_eq!(refs[0].url, "https://github.com/sirupsen/logrus");
     }
 }
 

--- a/mikebom-cli/tests/fixtures/golden/cyclonedx/cargo.cdx.json
+++ b/mikebom-cli/tests/fixtures/golden/cyclonedx/cargo.cdx.json
@@ -18,6 +18,12 @@
           }
         ]
       },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://crates.io/crates/anyhow/1.0.80"
+        }
+      ],
       "name": "anyhow",
       "properties": [
         {
@@ -50,6 +56,12 @@
           }
         ]
       },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://crates.io/crates/my-app/0.1.0"
+        }
+      ],
       "name": "my-app",
       "properties": [
         {
@@ -86,6 +98,12 @@
           }
         ]
       },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://crates.io/crates/my-fork/0.1.0"
+        }
+      ],
       "name": "my-fork",
       "properties": [
         {
@@ -122,6 +140,12 @@
           }
         ]
       },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://crates.io/crates/proc-macro2/1.0.76"
+        }
+      ],
       "name": "proc-macro2",
       "properties": [
         {
@@ -154,6 +178,12 @@
           }
         ]
       },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://crates.io/crates/quote/1.0.35"
+        }
+      ],
       "name": "quote",
       "properties": [
         {
@@ -186,6 +216,12 @@
           }
         ]
       },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://crates.io/crates/serde/1.0.197"
+        }
+      ],
       "name": "serde",
       "properties": [
         {
@@ -218,6 +254,12 @@
           }
         ]
       },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://crates.io/crates/serde_derive/1.0.197"
+        }
+      ],
       "name": "serde_derive",
       "properties": [
         {
@@ -250,6 +292,12 @@
           }
         ]
       },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://crates.io/crates/syn/2.0.48"
+        }
+      ],
       "name": "syn",
       "properties": [
         {
@@ -282,6 +330,12 @@
           }
         ]
       },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://crates.io/crates/unicode-ident/1.0.12"
+        }
+      ],
       "name": "unicode-ident",
       "properties": [
         {
@@ -314,6 +368,12 @@
           }
         ]
       },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://crates.io/crates/workspace-local/0.1.0"
+        }
+      ],
       "name": "workspace-local",
       "properties": [
         {

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/cargo.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/cargo.spdx.json
@@ -114,6 +114,11 @@
           "referenceCategory": "SECURITY",
           "referenceLocator": "cpe:2.3:a:anyhow:anyhow:1.0.80:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "OTHER",
+          "referenceLocator": "https://crates.io/crates/anyhow/1.0.80",
+          "referenceType": "website"
         }
       ],
       "filesAnalyzed": false,
@@ -161,6 +166,11 @@
           "referenceCategory": "SECURITY",
           "referenceLocator": "cpe:2.3:a:my-app:my-app:0.1.0:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "OTHER",
+          "referenceLocator": "https://crates.io/crates/my-app/0.1.0",
+          "referenceType": "website"
         }
       ],
       "filesAnalyzed": false,
@@ -208,6 +218,11 @@
           "referenceCategory": "SECURITY",
           "referenceLocator": "cpe:2.3:a:my-fork:my-fork:0.1.0:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "OTHER",
+          "referenceLocator": "https://crates.io/crates/my-fork/0.1.0",
+          "referenceType": "website"
         }
       ],
       "filesAnalyzed": false,
@@ -249,6 +264,11 @@
           "referenceCategory": "SECURITY",
           "referenceLocator": "cpe:2.3:a:proc-macro2:proc-macro2:1.0.76:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "OTHER",
+          "referenceLocator": "https://crates.io/crates/proc-macro2/1.0.76",
+          "referenceType": "website"
         }
       ],
       "filesAnalyzed": false,
@@ -290,6 +310,11 @@
           "referenceCategory": "SECURITY",
           "referenceLocator": "cpe:2.3:a:quote:quote:1.0.35:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "OTHER",
+          "referenceLocator": "https://crates.io/crates/quote/1.0.35",
+          "referenceType": "website"
         }
       ],
       "filesAnalyzed": false,
@@ -331,6 +356,11 @@
           "referenceCategory": "SECURITY",
           "referenceLocator": "cpe:2.3:a:serde:serde:1.0.197:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "OTHER",
+          "referenceLocator": "https://crates.io/crates/serde/1.0.197",
+          "referenceType": "website"
         }
       ],
       "filesAnalyzed": false,
@@ -372,6 +402,11 @@
           "referenceCategory": "SECURITY",
           "referenceLocator": "cpe:2.3:a:serde_derive:serde_derive:1.0.197:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "OTHER",
+          "referenceLocator": "https://crates.io/crates/serde_derive/1.0.197",
+          "referenceType": "website"
         }
       ],
       "filesAnalyzed": false,
@@ -413,6 +448,11 @@
           "referenceCategory": "SECURITY",
           "referenceLocator": "cpe:2.3:a:syn:syn:2.0.48:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "OTHER",
+          "referenceLocator": "https://crates.io/crates/syn/2.0.48",
+          "referenceType": "website"
         }
       ],
       "filesAnalyzed": false,
@@ -454,6 +494,11 @@
           "referenceCategory": "SECURITY",
           "referenceLocator": "cpe:2.3:a:unicode-ident:unicode-ident:1.0.12:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "OTHER",
+          "referenceLocator": "https://crates.io/crates/unicode-ident/1.0.12",
+          "referenceType": "website"
         }
       ],
       "filesAnalyzed": false,
@@ -501,6 +546,11 @@
           "referenceCategory": "SECURITY",
           "referenceLocator": "cpe:2.3:a:workspace-local:workspace-local:0.1.0:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "OTHER",
+          "referenceLocator": "https://crates.io/crates/workspace-local/0.1.0",
+          "referenceType": "website"
         }
       ],
       "filesAnalyzed": false,

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/cargo.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/cargo.spdx3.json
@@ -89,6 +89,7 @@
         }
       ],
       "name": "my-app",
+      "software_homePage": "https://crates.io/crates/my-app/0.1.0",
       "software_packageUrl": "pkg:cargo/my-app@0.1.0",
       "software_packageVersion": "0.1.0",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-NHPD5OIWCMJW4CWJBH2Y6UWR/pkg-7I3OEASNAR5ZCRZY",
@@ -109,6 +110,7 @@
         }
       ],
       "name": "quote",
+      "software_homePage": "https://crates.io/crates/quote/1.0.35",
       "software_packageUrl": "pkg:cargo/quote@1.0.35",
       "software_packageVersion": "1.0.35",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-NHPD5OIWCMJW4CWJBH2Y6UWR/pkg-7QZEBQB7QRFNI5M5",
@@ -129,6 +131,7 @@
         }
       ],
       "name": "my-fork",
+      "software_homePage": "https://crates.io/crates/my-fork/0.1.0",
       "software_packageUrl": "pkg:cargo/my-fork@0.1.0",
       "software_packageVersion": "0.1.0",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-NHPD5OIWCMJW4CWJBH2Y6UWR/pkg-AMQQ7AE3OQIQRIZH",
@@ -149,6 +152,7 @@
         }
       ],
       "name": "syn",
+      "software_homePage": "https://crates.io/crates/syn/2.0.48",
       "software_packageUrl": "pkg:cargo/syn@2.0.48",
       "software_packageVersion": "2.0.48",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-NHPD5OIWCMJW4CWJBH2Y6UWR/pkg-BKMD7Y4M3VJPWGQM",
@@ -169,6 +173,7 @@
         }
       ],
       "name": "serde_derive",
+      "software_homePage": "https://crates.io/crates/serde_derive/1.0.197",
       "software_packageUrl": "pkg:cargo/serde_derive@1.0.197",
       "software_packageVersion": "1.0.197",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-NHPD5OIWCMJW4CWJBH2Y6UWR/pkg-CDE3XEXSDOGUXIZT",
@@ -189,6 +194,7 @@
         }
       ],
       "name": "unicode-ident",
+      "software_homePage": "https://crates.io/crates/unicode-ident/1.0.12",
       "software_packageUrl": "pkg:cargo/unicode-ident@1.0.12",
       "software_packageVersion": "1.0.12",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-NHPD5OIWCMJW4CWJBH2Y6UWR/pkg-E3KDPHV32PPHGGT4",
@@ -209,6 +215,7 @@
         }
       ],
       "name": "anyhow",
+      "software_homePage": "https://crates.io/crates/anyhow/1.0.80",
       "software_packageUrl": "pkg:cargo/anyhow@1.0.80",
       "software_packageVersion": "1.0.80",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-NHPD5OIWCMJW4CWJBH2Y6UWR/pkg-IYTSKXZIE4RF3PSV",
@@ -229,6 +236,7 @@
         }
       ],
       "name": "workspace-local",
+      "software_homePage": "https://crates.io/crates/workspace-local/0.1.0",
       "software_packageUrl": "pkg:cargo/workspace-local@0.1.0",
       "software_packageVersion": "0.1.0",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-NHPD5OIWCMJW4CWJBH2Y6UWR/pkg-SADUYFXP4BC6PE4A",
@@ -249,6 +257,7 @@
         }
       ],
       "name": "serde",
+      "software_homePage": "https://crates.io/crates/serde/1.0.197",
       "software_packageUrl": "pkg:cargo/serde@1.0.197",
       "software_packageVersion": "1.0.197",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-NHPD5OIWCMJW4CWJBH2Y6UWR/pkg-UFXHU3P5DZAY42HF",
@@ -269,6 +278,7 @@
         }
       ],
       "name": "proc-macro2",
+      "software_homePage": "https://crates.io/crates/proc-macro2/1.0.76",
       "software_packageUrl": "pkg:cargo/proc-macro2@1.0.76",
       "software_packageVersion": "1.0.76",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-NHPD5OIWCMJW4CWJBH2Y6UWR/pkg-Z72PVEYDZTEVUFVQ",

--- a/specs/131-quality-metadata-backfill/checklists/requirements.md
+++ b/specs/131-quality-metadata-backfill/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Quality metadata backfill for milestone-130 new components
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-19
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec inherits the milestone-129 clarification Q3 version-ladder verbatim. The 2026-06-18
+  resource-assembly culture-set dedup clarification from milestone 130 US3 also carries forward.
+  No new clarifications surfaced — the three follow-ups (CustomAttribute walking, license
+  backfill, supplier URL synthesis) are well-bounded with documented input formats.
+- Spec cites existing code file paths (e.g. `nuget/pe_clr.rs`) for grounding — these identify
+  EXISTING extension targets, not prescribed new architecture. Permitted per the milestone-130
+  precedent.
+- Validation passed on first iteration.

--- a/specs/131-quality-metadata-backfill/contracts/annotation-schema.md
+++ b/specs/131-quality-metadata-backfill/contracts/annotation-schema.md
@@ -1,0 +1,125 @@
+# Annotation schema contract — milestone 131
+
+**One new `mikebom:*` annotation key.** All other quality-metadata fields milestone 131 introduces
+flow through **standards-native** CDX `licenses[]` + `externalReferences[]` and SPDX `licenseDeclared`
++ `externalRefs[]` — no `mikebom:*` annotation needed.
+
+## C96: `mikebom:license-source`
+
+**Scope**: component
+
+**Values** (sorted lex):
+
+- `"package-dir"` — PE/CLR US2a: a `LICENSE` / `LICENSE.txt` / etc. file was found in the assembly's
+  parent-directory walk (depth 3) and the first 4 KB are embedded in the component's
+  `licenses[].license.text`.
+- `"package-dir-no-license"` — PE/CLR US2a: the assembly was probed but no license file was found
+  in the 3-level upward walk. The annotation signals "we looked and came up empty" — actionable
+  for downstream auditors deciding whether to backfill manually.
+- `"pom-xml"` — Maven nested-JAR US2b: the nested JAR's `META-INF/maven/<g>/<a>/pom.xml` carried a
+  `<licenses>` element whose contents flowed into the component's `licenses[]` field via the
+  existing top-level path's `SpdxExpression::try_canonical`.
+- `"registry-required"` — cargo-auditable US2c: the component's `source` is `"crates-io"`; the
+  license is published on `https://crates.io/api/v1/crates/<name>/<version>` but not extracted by
+  this milestone. Signal for a future deps.dev enrichment milestone.
+
+**Emitted by**: PE/CLR reader (US2a + US2b through the maven path), cargo-auditable per-crate
+emission helper at `binary/entry.rs::cargo_auditable_packages_to_entries` (US2c).
+
+**Principle V audit**:
+
+- CDX 1.6 native equivalent? `licenses[].license.text` carries the license payload; `acknowledgement`
+  carries "concluded" vs "declared". Neither tracks the EXTRACTION SOURCE (file path, registry URL,
+  etc.). **No.**
+- SPDX 2.3 native equivalent? `licenseDeclared` vs `licenseConcluded` similarly distinguish
+  inferred-vs-declared but not the extraction source. **No.**
+- SPDX 3 native equivalent? `software_declaredLicense` + `software_concludedLicense` distinguish
+  the same axis but not extraction source. **No.**
+
+**Verdict**: Valid parity-bridging extension per the Principle V "finer-grained information the
+standard does not express" carve-out. Useful for audit/forensic review of mikebom's license
+coverage — a license claim sourced from a registry API call has different trust properties than
+one extracted from a checked-in LICENSE.txt file or a `<licenses>` element in a pom.xml.
+
+## C97: `mikebom:license-text-sha256`
+
+**Scope**: component
+
+**Value**: hex-encoded SHA-256 of the license file's first 4 KB (the same window the FR-013
+fingerprint-matcher probes). Emitted ONLY when the file is found but no SPDX-fingerprint match
+fires — gives downstream tools a stable identifier for cross-referencing the same license body
+across packages.
+
+**Emitted by**: PE/CLR US2a, only on the "found but unrecognized" branch.
+
+**Principle V audit**:
+
+- CDX 1.6 native equivalent? `licenses[].license.text` could carry the body verbatim, but mikebom
+  rejects this path (FR-013 + Principle IV — the existing `SpdxExpression` type can't carry
+  free-text). The SHA-256 is an out-of-band identifier the standard doesn't have a slot for. **No.**
+- SPDX 2.3 native equivalent? `Package.licenseDeclared` accepts `NOASSERTION` / `LicenseRef-<id>`;
+  the `hasExtractedLicensingInfo[]` block carries free-text via `extractedText`. mikebom could
+  emit a `LicenseRef-<sha-prefix>` + `extractedText` body — that's a meaningful future
+  improvement but out-of-scope here (it would push 4 KB of body into every emitted SBOM). **No
+  precise per-package-hash native equivalent.**
+- SPDX 3 native equivalent? Same shape as SPDX 2.3. **No.**
+
+**Verdict**: Valid parity-bridging extension. Useful for the "we saw something here but couldn't
+classify it" audit trail without ballooning SBOM size.
+
+## C98: `mikebom:cargo-vcs-source-url`
+
+**Scope**: component
+
+**Value**: the parsed VCS URL from the cargo-auditable `.dep-v0` section's `source` field, stripped
+of the `git+` prefix, the trailing `.git`, and the `#<rev>` fragment. Example:
+`"https://github.com/serde-rs/serde"`.
+
+**Emitted by**: cargo-auditable per-crate emission at
+`binary/entry.rs::cargo_auditable_packages_to_entries`, only when the `source` field matches
+`^git\+(https?://[^#]+?)(\.git)?(#[a-f0-9]+)?$`. The downstream `scan_fs/mod.rs::supplier_from_purl`
+helper consumes this annotation to emit a `vcs`-type CDX `externalReferences[]` entry on the
+component.
+
+**Principle V audit**:
+
+- CDX 1.6 native equivalent? CDX `externalReferences[].url` with `type = "vcs"` IS the native
+  emission path — and milestone 131 uses it. The annotation itself is the in-process **plumbing
+  channel** from the cargo-auditable parse site (which knows the source field) to the URL
+  synthesis layer (which only sees the PURL). Not a wire-format substitute for the native
+  ExternalReference — both ship.
+- SPDX 2.3 / 3 native equivalent? `Package.externalRefs[]` with category `OTHER` covers the
+  emission. Same as CDX — the annotation is plumbing, the native ExternalReference is the
+  wire-format primary.
+
+**Verdict**: Valid parity-bridging extension as the cross-module plumbing channel. The annotation
+preserves the **provenance** of the VCS URL — it came from the cargo-auditable build-time `source`
+field declaration, not from a heuristic guess against the PURL name (which is what
+`supplier_from_purl` does for golang/github). Auditors comparing two SBOMs can verify the
+VCS-source claim's grounding by checking this annotation's presence.
+
+## Cross-cutting catalog wiring
+
+The C96 row MUST be:
+
+1. Catalogued in `docs/reference/sbom-format-mapping.md` with the audit narrative above.
+2. Registered as a `cdx_anno!`, `spdx23_anno!`, and `spdx3_anno!` entry in
+   `mikebom-cli/src/parity/extractors/{cdx,spdx2,spdx3}.rs`.
+3. Registered as a `ParityExtractor` slice entry in `mikebom-cli/src/parity/extractors/mod.rs`
+   with matching `use` imports.
+4. Covered by the existing `extractors_table_is_sorted_by_row_id` +
+   `every_catalog_row_has_an_extractor` shape tests (no new test added).
+
+## Standards-native fields used (no `mikebom:*` annotation needed)
+
+For reference — these are emitted directly via existing format builders without any new
+annotation key:
+
+| Data | CDX 1.6 | SPDX 2.3 | SPDX 3 |
+|---|---|---|---|
+| License text (US2a) | `licenses[].license.text` | `Package.licenseDeclared` + `hasExtractedLicensingInfo[]` | `software_declaredLicense` |
+| License expression (US2b) | `licenses[].license.id` or `licenses[].expression` | `Package.licenseDeclared` | `software_declaredLicense` |
+| Supplier URL (US3) | `externalReferences[].url` with `type=website` | `Package.externalRefs[]` with category=PACKAGE-MANAGER | `Element.externalRef[]` |
+| VCS URL (US3) | `externalReferences[].url` with `type=vcs` | `Package.externalRefs[]` with category=OTHER | `Element.externalRef[]` |
+
+All four are existing-channel reuse — no new emission code in the format builders.

--- a/specs/131-quality-metadata-backfill/plan.md
+++ b/specs/131-quality-metadata-backfill/plan.md
@@ -1,0 +1,233 @@
+# Implementation Plan: Quality metadata backfill for milestone-130 new components
+
+**Branch**: `131-quality-metadata-backfill` | **Date**: 2026-06-19 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/131-quality-metadata-backfill/spec.md`
+
+## Summary
+
+Three tracks, prioritized by audit-image scorecard regression magnitude:
+
+1. **US1 (P1)** — PE/CLR `CustomAttribute` walking (Phase B). Extends the milestone-130
+   `pe_clr.rs` reader with the `CustomAttribute` table (token 0x0C) parser per ECMA-335 §II.22.10
+   to extract `AssemblyInformationalVersionAttribute` + `AssemblyFileVersionAttribute` strings.
+   PURL version routes through the milestone-129 Q3 ladder (Informational > File > 4-tuple).
+   Resolves all 373 VERSION_MISMATCH cases on the audit image. ~300 LOC.
+2. **US2 (P2)** — License backfill on the three new reader paths. (a) Nested-JAR walker reuses
+   the existing `parse_pom_xml`'s `<licenses>` extraction (already extracted by the milestone-009
+   top-level path; needs to flow through milestone-130's nested-emit path). (b) PE/CLR reader
+   probes the assembly's parent directory for `LICENSE` / `LICENSE.txt` / `LICENSE.md` /
+   `COPYING` / `COPYING.txt` (case-insensitive). When found, emit the first 4 KB as
+   `PackageDbEntry.licenses` via the existing `SpdxExpression::from_free_text` path with a
+   `mikebom:license-source = "package-dir"` annotation. (c) cargo-auditable components from
+   `source = "crates-io"` get a `mikebom:license-source = "registry-required"` annotation.
+   Targets License Coverage 1/5 → ≥3/5.
+3. **US3 (P3)** — Supplier external-reference URL synthesis. Extends the existing
+   `mikebom-cli/src/scan_fs/mod.rs::supplier_from_purl` function with new heuristic patterns for
+   `pkg:cargo`, `pkg:nuget`, and `pkg:maven` (nested-only via source-mechanism gate). Parses
+   cargo-auditable `source = "git+https://..."` for VCS references. Targets Supplier Attribution
+   2/5 → ≥3/5.
+
+Per SC-007, each user story is independently shippable. Recommended cadence: three sequential PRs
+matching milestone 130's pattern. US1 is the largest single piece (~300 LOC); US2 and US3 are
+~150 LOC each.
+
+**Zero new Cargo dependencies.**
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–130; no
+nightly required).
+
+**Primary Dependencies**: Existing only — `object = "0.36"` (workspace; reused for the US1
+CustomAttribute table extension to the existing pe_clr.rs metadata walker), `quick-xml` (workspace;
+reused for US2 nested-JAR `<licenses>` parsing via the existing `parse_pom_xml` helper), `regex`
+(workspace; reused for US3 cargo-auditable `git+https://...` source parsing), `tracing`, `anyhow`,
+`thiserror`. **No new Cargo dependencies.**
+
+**Storage**: N/A — all state in-process per scan; no caches, no persistence. Matches every
+milestone since 002.
+
+**Testing**: Standard `cargo +stable test --workspace`. New unit tests inside the three modified
+files: `nuget/pe_clr.rs` (US1), `package_db/maven.rs` (US2 nested licenses),
+`scan_fs/mod.rs::supplier_tests` (US3). Integration tests deferred — the end-to-end audit-image
+scorecard comparison is the acceptance gate (SC-001..SC-004 + SC-006).
+
+**Target Platform**: Linux rootfs (`mikebom sbom scan --image` invariant from milestones 001+).
+
+**Project Type**: CLI tool (the `mikebom sbom scan` polyglot-scanner pipeline). Not the eBPF
+trace pipeline.
+
+**Performance Goals**:
+- US1 CustomAttribute walking: <5ms per managed DLL (small fixed-size table walks).
+- US2 nested-JAR license extraction: zero-cost extension to existing parse_pom_xml call.
+- US3 URL synthesis: <1µs per PURL (pure-string template formatting).
+- Total scan time growth on the audit image: <30% relative to milestone 130 (per SC-006).
+
+**Constraints**:
+- Zero new Cargo dependencies (verified via `cargo tree -p mikebom`).
+- Byte-identity preservation across the 33 alpha.48 goldens (verified via
+  `./scripts/regen-goldens.sh` producing zero `.cdx.json` / `.spdx.json` churn).
+- All three reader paths MUST respect `--offline` and `--exclude-path`.
+- US2's package-directory probe per FR-013 is bounded to 4 KB per license file.
+
+**Scale/Scope**:
+- US1: ~300 LOC extension to `pe_clr.rs`. New ECMA-335 wire-format parsers for `MemberRef`,
+  `TypeRef`, blob-prolog decoder. Predicted reduction: 373 → <20 VERSION_MISMATCH cases.
+- US2: ~150 LOC across `nuget/pe_clr.rs` (license-file probing) + `package_db/maven.rs` (nested
+  license propagation) + `binary/entry.rs` (cargo-auditable registry-required annotation).
+  Predicted lift: 1/5 → ≥3/5.
+- US3: ~100 LOC extension to `scan_fs/mod.rs::supplier_from_purl` + tests. Predicted lift:
+  2/5 → ≥3/5.
+- 1 new `mikebom:*` annotation key catalogued (C96): `mikebom:license-source` with values
+  `"package-dir"` / `"pom-xml"` / `"registry-required"` / `"package-dir-no-license"`.
+
+## Constitution Check
+
+Audit against `mikebom Constitution v1.4.0`:
+
+| Principle | Verdict | Notes |
+|---|---|---|
+| I. Pure Rust, Zero C | ✓ Pass | All extensions Rust; zero new transitive deps. |
+| II. eBPF-Only Observation | ✓ N/A | Polyglot-scanner pipeline. |
+| III. Fail Closed | ✓ Pass | Parse failures emit `warn` + skip; scan continues. US1's CustomAttribute walk failures fall through to the existing Phase A 4-tuple ladder rung (no silent omission). |
+| IV. Type-Driven Correctness | ✓ Pass | All new PURLs flow through `Purl::new`. CustomAttribute parsing uses typed enums for coded-index discrimination. No `.unwrap()` in production. |
+| V. Specification Compliance | ⚠ Audit pending | **1 new `mikebom:*` key** (`license-source`) — parity-bridging extension. Neither CDX `licenses[].license.text` nor SPDX `licenseDeclared` has a "where the license came from" sub-field. Catalogued in `contracts/annotation-schema.md` with full Principle V audit narrative. The four cargo / nuget / maven supplier URLs use **standards-native** CDX `externalReferences[].url` directly — no `mikebom:*` annotation for the URLs. |
+| VI. Three-Crate Architecture | ✓ Pass | All new code lives in `mikebom-cli`. |
+| VII. Test Isolation | ✓ Pass | All tests unprivileged. |
+| VIII. Completeness | ✓ Improves | US1 resolves 373 silent VERSION_MISMATCH cases; US2 surfaces licenses pre-130 silently dropped; US3 surfaces supplier URLs pre-130 silently absent. |
+| IX. Accuracy | ✓ Pass | All emitted versions / licenses / URLs derived from the artifact itself (Assembly metadata, pom.xml, LICENSE.txt) OR synthesized from PURL via documented registry conventions (crates.io / nuget.org / search.maven.org). No heuristic guessing. |
+| X. Transparency | ✓ Pass | `mikebom:license-source` is exactly the kind of transparency annotation Principle X envisions. |
+| XI. Enrichment | ✓ Pass | Reuses existing milestone-097 `mikebom:cpe-candidates` channel. |
+| XII. External Data Source Enrichment | ✓ Pass | NO external lookups in this milestone. URL synthesis is pure-string PURL templating. The `crates-io = "registry-required"` annotation signals downstream tools (a future deps.dev milestone) where to look — does not consult external sources itself per FR-014. |
+
+**Strict Boundaries**: All four boundaries hold (no lockfile discovery, no MITM, no C deps, no
+`.unwrap()` in production).
+
+**Gate verdict**: PASS with the catalog-narrative requirement folded into the plan.
+
+## Project Structure
+
+```text
+specs/131-quality-metadata-backfill/
+├── plan.md              # This file
+├── spec.md              # Feature spec (exists)
+├── research.md          # Phase 0 output (this command)
+├── data-model.md        # Phase 1 output (this command)
+├── quickstart.md        # Phase 1 output (this command)
+├── contracts/
+│   └── annotation-schema.md     # 1 new mikebom:* key (license-source) with Principle V audit
+├── checklists/
+│   └── requirements.md  # Spec-quality checklist (exists from /speckit-specify)
+└── tasks.md             # Phase 2 output (/speckit-tasks; NOT created by this command)
+```
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/
+├── src/
+│   ├── scan_fs/
+│   │   ├── mod.rs                            # MODIFIED — US3 supplier_from_purl extensions
+│   │   └── package_db/
+│   │       ├── maven.rs                      # MODIFIED — US2 nested-JAR <licenses> propagation
+│   │       └── nuget/
+│   │           └── pe_clr.rs                 # MODIFIED — US1 CustomAttribute table walking
+│   │                                         #          + US2 LICENSE.txt package-dir probe
+│   ├── scan_fs/binary/
+│   │   └── entry.rs                          # MODIFIED — US2 cargo-auditable license-source annotation
+│   └── parity/
+│       └── extractors/
+│           ├── cdx.rs                        # +1 cdx_anno! entry (C96 mikebom:license-source)
+│           ├── spdx2.rs                      # +1 spdx23_anno! entry
+│           ├── spdx3.rs                      # +1 spdx3_anno! entry
+│           └── mod.rs                        # +1 ParityExtractor slice entry
+└── tests/
+    └── (unit tests added inline; integration tests deferred)
+
+docs/reference/sbom-format-mapping.md         # +1 C-row (C96) with Principle V audit
+CHANGELOG.md                                  # +1 milestone-131 entry under [Unreleased]
+```
+
+**Structure Decision**: No new modules. Four surgical extensions to existing modules:
+- `nuget/pe_clr.rs` — US1 (CustomAttribute walking) + US2 (LICENSE.txt probing).
+- `package_db/maven.rs` — US2 (nested-JAR license propagation through the milestone-130 walker).
+- `scan_fs/mod.rs::supplier_from_purl` — US3 (URL synthesis heuristic extensions).
+- `binary/entry.rs` — US2 (cargo-auditable license-source annotation).
+
+## Phase 0: Outline & Research
+
+See [research.md](./research.md).
+
+Research topics covered:
+
+1. **US1 CustomAttribute table layout** — ECMA-335 §II.22.10. Columns: `Parent` (HasCustomAttribute
+   coded index), `Type` (CustomAttributeType coded index), `Value` (`#Blob` heap reference).
+2. **Coded-index resolution** — `Type` resolves through `MemberRef` (token 0x0A) or `MethodDef`
+   (token 0x06). For `AssemblyInformationalVersionAttribute`'s `.ctor`, the path is MemberRef →
+   TypeRef (token 0x01) → `#Strings` heap.
+3. **Custom-attribute blob serialization** — ECMA-335 §II.23.3. Prolog: u16 `0x0001`. Then
+   serialized arguments: each fixed argument is encoded inline (for `string` argument: a
+   variable-length encoded length-prefix followed by UTF-8 bytes per the SerString format).
+4. **US2 license-file probe paths** — `.NET` runtime store packages typically place LICENSE files
+   at `/usr/share/dotnet/packs/<name>/<ver>/`. Per-assembly probe walks up from the `.dll`'s
+   parent dir up to a reasonable depth (3 levels) looking for case-insensitive
+   `LICENSE` / `LICENSE.txt` / `LICENSE.md` / `COPYING`.
+5. **US2 nested-JAR `<licenses>` extraction** — The existing `parse_pom_xml` already extracts
+   `licenses` (`Vec<License>`) when present. The milestone-130 nested walker calls `parse_pom_xml`
+   only for `dependencies` — the licenses field is currently discarded. Fix: thread it through
+   the walker's `EmbeddedMavenMeta` struct (add field) or via the existing `extra_annotations`
+   channel.
+6. **US3 supplier URL conventions** — crates.io: `https://crates.io/crates/<name>/<version>`.
+   NuGet: `https://www.nuget.org/packages/<name>/<version>`. Maven Central:
+   `https://search.maven.org/artifact/<g>/<a>/<v>/jar`. The cargo-auditable `source` field's
+   `git+https://...` form matches the pattern `^git\+(https?://[^#]+)(#[a-f0-9]+)?$`.
+
+## Phase 1: Design & Contracts
+
+See [contracts/annotation-schema.md](./contracts/annotation-schema.md).
+
+**1 new `mikebom:*` annotation key** (C96):
+- `mikebom:license-source` — emitted on every component for which milestone 131 attempted license
+  extraction. Values: `"package-dir"` (LICENSE.txt found and embedded), `"pom-xml"` (nested-JAR's
+  pom.xml carried `<licenses>`), `"registry-required"` (cargo-auditable crates-io entry; license
+  available externally), `"package-dir-no-license"` (probed but absent). Catalogued with full
+  Principle V audit narrative.
+
+### Data Model
+
+No new entities. US1 extends the existing `ManagedAssembly` struct with `informational_version:
+Option<String>` and `file_version: Option<String>` fields. US2 reuses the existing
+`PackageDbEntry.licenses: Vec<SpdxExpression>` field. US3 reuses the existing PURL → external-reference
+synthesis at `scan_fs/mod.rs::supplier_from_purl`.
+
+### Reader Behavior Contract
+
+- **US1 / `pe_clr.rs`**: after `parse_tables_stream` reads Assembly row 0, walk the
+  CustomAttribute table for `Type` rows whose resolved typeref-name equals
+  `"AssemblyInformationalVersionAttribute"` or `"AssemblyFileVersionAttribute"`. Decode each match's
+  Value blob into a UTF-8 string. Populate the new `ManagedAssembly` fields. PURL version selection
+  per FR-008 ladder.
+- **US2a / `pe_clr.rs`**: per managed assembly emitted, probe the assembly's parent dir for
+  `LICENSE` / etc. variants. When found, read the first 4 KB and emit as
+  `PackageDbEntry.licenses` via the existing text-license path. Set
+  `mikebom:license-source = "package-dir"`. When not found, set
+  `mikebom:license-source = "package-dir-no-license"`.
+- **US2b / `maven.rs`**: in the nested-JAR walker's emission site, pass nested-JAR licenses
+  (already extracted by `parse_pom_xml`) through to the emitted `PackageDbEntry.licenses`. Set
+  `mikebom:license-source = "pom-xml"`.
+- **US2c / `binary/entry.rs`**: in `cargo_auditable_packages_to_entries`, for each
+  `packages[]` entry whose `source == "crates-io"`, emit
+  `mikebom:license-source = "registry-required"` annotation.
+- **US3 / `scan_fs/mod.rs::supplier_from_purl`**: add `pkg:cargo`, `pkg:nuget`, `pkg:maven`
+  heuristics returning `ExternalReference { ref_type: "website", url: ... }`. For cargo with
+  `source = "git+https://..."` parseable, ALSO return a `vcs` reference. Existing golang/gitlab/
+  bitbucket heuristics unchanged.
+
+### Agent context update
+
+After Phase 1, the plan invokes `.specify/scripts/bash/update-agent-context.sh claude` which
+appends a milestone-131 entry to CLAUDE.md.
+
+## Complexity Tracking
+
+> Nothing requiring complexity-tracking entries. Four surgical extensions to existing modules.

--- a/specs/131-quality-metadata-backfill/quickstart.md
+++ b/specs/131-quality-metadata-backfill/quickstart.md
@@ -1,0 +1,70 @@
+# Quickstart — milestone 131
+
+Three operator-facing scenarios mirroring milestone-130's quickstart shape.
+
+## Scenario 1 — Version-fidelity on .NET image (US1)
+
+After milestone 131, `pkg:nuget` PURLs from PE/CLR-derived components carry the published
+`AssemblyInformationalVersion` (semver-style, matches NuGet.org) instead of the AssemblyVersion
+4-tuple.
+
+```sh
+mikebom sbom scan --image mcr.microsoft.com/dotnet/runtime:8.0-alpine \
+    --output cyclonedx-json=/tmp/dotnet-runtime-131.cdx.json
+```
+
+**Expected output**:
+
+```sh
+# Pre-131: Microsoft.AspNetCore@8.0.0.0 (AssemblyVersion 4-tuple)
+# Post-131: Microsoft.AspNetCore@8.0.27-servicing.26230.7 (InformationalVersion)
+jq -r '.components[] | select(.name == "Microsoft.AspNetCore") | .version' /tmp/dotnet-runtime-131.cdx.json
+```
+
+For the audit image, expect <20 VERSION_MISMATCH residual against syft (vs 373 pre-131).
+
+## Scenario 2 — License coverage on the audit image (US2)
+
+```sh
+mikebom sbom scan \
+    --image 767397973649.dkr.ecr.us-east-1.amazonaws.com/remediation-planner:latest \
+    --output cyclonedx-json=/tmp/rp-131.cdx.json \
+    --offline
+
+jq -r '.components[] | select(.licenses // [] | length > 0) | .name' /tmp/rp-131.cdx.json | wc -l
+# Expected: ≥1,500 components carrying license info (vs pre-131 ~700)
+```
+
+## Scenario 3 — Supplier external-references (US3)
+
+```sh
+jq -r '.components[] | select((.purl // "") | startswith("pkg:cargo")) | (.externalReferences // [])[0].url' /tmp/rp-131.cdx.json | head -3
+# Expected: https://crates.io/crates/serde/1.0.193 etc.
+
+jq -r '.components[] | select((.purl // "") | startswith("pkg:nuget")) | (.externalReferences // [])[0].url' /tmp/rp-131.cdx.json | head -3
+# Expected: https://www.nuget.org/packages/Microsoft.AspNetCore.App.Runtime.wolfi.20230201-x64/8.0.27
+
+jq -r '.components[] | select((.purl // "") | startswith("pkg:maven")) | select(.properties[]? | (.name == "mikebom:source-mechanism") and (.value == "maven-jar-nested")) | (.externalReferences // [])[0].url' /tmp/rp-131.cdx.json | head -3
+# Expected: https://search.maven.org/artifact/<g>/<a>/<v>/jar
+```
+
+## End-to-end sbom-comparison verification
+
+```sh
+/Users/mlieberman/Projects/sbom-comparison/sbom-comparison --format summary \
+    /tmp/rp-131.cdx.json \
+    ~/Downloads/remediation-planner-syft-image-sbom.json
+
+# Expected post-131 scorecard:
+#   Version Accuracy:        5/5 (was 4/5 pre-131)
+#   License Coverage:        ≥3/5 (was 1/5)
+#   Supplier Attribution:    ≥3/5 (was 2/5)
+#   OVERALL weighted:        ≥3.0 (was 2.4) — mikebom leads syft by ≥0.5 points (SC-001).
+```
+
+## Byte-identity verification (SC-005)
+
+```sh
+./scripts/regen-goldens.sh && git status --short mikebom-cli/tests/fixtures/
+# Expected: zero .cdx.json / .spdx.json churn across 33 alpha.48 goldens.
+```

--- a/specs/131-quality-metadata-backfill/research.md
+++ b/specs/131-quality-metadata-backfill/research.md
@@ -1,0 +1,152 @@
+# Research: Quality metadata backfill (milestone 131)
+
+## R1. ECMA-335 §II.22.10 — `CustomAttribute` table (US1)
+
+**Decision**: Walk the `CustomAttribute` table (token 0x0C) after Assembly row 0 extraction. Each
+row's columns are:
+
+- `Parent` — HasCustomAttribute coded index (5-bit tag); identifies the metadata element the
+  attribute is attached to. For an `AssemblyInformationalVersionAttribute`, the parent is the
+  Assembly itself (tag 14, row 1).
+- `Type` — CustomAttributeType coded index (3-bit tag); resolves to `MethodDef` (tag 2) or
+  `MemberRef` (tag 3) — virtually always the latter for assembly-attributes since the
+  attribute's `.ctor` lives in an external assembly (`System.Reflection.dll`).
+- `Value` — `#Blob` heap reference; the serialized attribute argument.
+
+**Rationale**: ECMA-335 §II.22.10 documents this table layout verbatim. The CustomAttribute table
+is present in virtually every managed assembly because the C# compiler emits at least
+`AssemblyCompanyAttribute` + `AssemblyDescriptionAttribute` + `AssemblyVersionAttribute` per
+standard build. For our scope (extracting Informational + File versions), we filter rows by
+resolving the `Type` column's TypeRef name through the `#Strings` heap.
+
+**Filter implementation**: For each CustomAttribute row whose `Type` tag is 3 (MemberRef):
+1. Decode the row-index portion to get the MemberRef table row number.
+2. Read that MemberRef row's `Class` column (a MemberRefParent coded index — usually tag 1 for
+   TypeRef) and `Name` column (`#Strings` index, expected to be `".ctor"`).
+3. Resolve the TypeRef row's `TypeName` (`#Strings` index) and compare to
+   `"AssemblyInformationalVersionAttribute"` / `"AssemblyFileVersionAttribute"`.
+
+## R2. ECMA-335 §II.23.3 — Custom-attribute blob serialization (US1)
+
+**Decision**: For each filtered CustomAttribute row, decode its Value blob:
+
+1. Read the blob length prefix (`#Blob` heap entries are length-prefixed; the length itself is
+   encoded as the ECMA-335 §II.24.2.4 compressed-integer format — 1, 2, or 4 bytes).
+2. The blob payload starts with a 2-byte prolog `0x0001` (`u16` little-endian).
+3. After the prolog, the fixed arguments are serialized inline. For
+   `AssemblyInformationalVersionAttribute(string)` / `AssemblyFileVersionAttribute(string)`, this
+   is a single `SerString` argument:
+   - Length prefix (compressed integer, ECMA-335 §II.24.2.4 — 1 byte for length <128, 2 bytes for
+     128≤length<16384, 4 bytes for ≥16384).
+   - UTF-8 bytes of the string.
+   - Special case: a length prefix of `0xFF` denotes a null string (treat as `None`).
+4. After the fixed argument(s), the named-argument count follows (2 bytes), then each named
+   argument. For our purposes, all named arguments are ignored.
+
+**Rationale**: The blob format is rigidly defined in §II.23.3 ("Custom attributes"). Real-world
+`AssemblyInformationalVersionAttribute` values are short strings (under 100 chars), so the
+1-byte length-prefix case dominates; we still handle all three width cases for correctness.
+
+## R3. Coded-index width derivation (US1)
+
+**Decision**: Use the milestone-130 Phase A row-width computation verbatim. For the
+CustomAttribute table specifically, three coded-indices need width derivation:
+- `HasCustomAttribute` (5-bit tag, 21 referenced tables) — almost always 4 bytes on real assemblies
+  with >100 rows in any of the referenced tables.
+- `CustomAttributeType` (3-bit tag, 5 referenced tables — Method, MemberRef, etc.) — usually
+  2 bytes.
+- The `#Blob` heap index width (`heap_sizes & 0x04` bit) — 2 or 4 bytes.
+
+**Rationale**: Inherit milestone-130 US3's `compute_row_size` function with the existing
+`coded_idx_width` helper. The Phase A sanity-filter caveat carries forward — for some assemblies
+the row offsets misalign and we get an unparseable `Value` blob length. The fail-closed behavior
+(Principle III) handles this: parse failure → fall through to the next-lower ladder rung silently.
+
+## R4. License-file probe paths (US2a)
+
+**Decision**: For each emitted PE/CLR `pkg:nuget` component, probe the assembly's parent directory
+walking up to 3 levels, looking for case-insensitive matches against:
+- `LICENSE`
+- `LICENSE.txt`
+- `LICENSE.md`
+- `COPYING`
+- `COPYING.txt`
+
+The .NET runtime store convention places these at the package's version-directory root (e.g.
+`/usr/share/dotnet/packs/Microsoft.AspNetCore.App.Ref/8.0.27/LICENSE.TXT`). The 3-level walk
+upward from the `.dll`'s parent dir covers this layout AND the nested `ref/net8.0/` subdirectory
+pattern.
+
+**Rationale**: Empirically, the .NET runtime store and SDK pack layouts place LICENSE files at
+the package-version root. A 3-level walk balances coverage with avoiding accidentally adopting a
+license file from a sibling package. The 4 KB read cap (FR-013) prevents pathological
+license-file-as-DDoS attacks while accommodating realistic license texts (MIT ~1 KB, Apache-2.0
+~10 KB — the latter gets truncated at 4 KB with the prefix being self-identifying).
+
+## R5. Nested-JAR `<licenses>` extraction (US2b)
+
+**Decision**: Plumb the existing `parse_pom_xml` output's `licenses` field through milestone-130's
+nested walker.
+
+**Rationale**: The function already extracts `<licenses>` for top-level JAR usage. The
+milestone-130 nested walker discards this output in favor of just `dependencies`. The fix is
+~20 LOC: add a `nested_licenses` field to the emit path or use the existing
+`PackageDbEntry.licenses` field directly. SpdxExpression construction reuses the existing
+`SpdxExpression::try_canonical` helper from the top-level path.
+
+## R6. cargo-auditable license-source annotation (US2c)
+
+**Decision**: At the cargo-auditable per-crate emission site (`binary/entry.rs::cargo_auditable_packages_to_entries`), for each `packages[]` entry whose `source ==
+"crates-io"` (or starts with `"registry+https://"` — both forms are observed in real-world
+manifests), populate `PackageDbEntry.extra_annotations.insert("mikebom:license-source",
+"registry-required")`.
+
+**Rationale**: Constitution Principle XII permits external-source enrichment but doesn't require
+it. Marking these components with `registry-required` signals downstream tooling (a future
+deps.dev milestone) where to look without consulting the registry from inside this milestone.
+For local-path / git deps, no annotation is added (we don't know where the license is).
+
+## R7. Supplier URL conventions (US3)
+
+**Decision**: Extend `scan_fs/mod.rs::supplier_from_purl` with three new heuristic patterns:
+
+| PURL type | Synthesized URL |
+|---|---|
+| `pkg:cargo/<name>@<version>` | `https://crates.io/crates/<name>/<version>` (type=website) |
+| `pkg:nuget/<name>@<version>` | `https://www.nuget.org/packages/<name>/<version>` (type=website) |
+| `pkg:maven/<g>/<a>@<v>` | `https://search.maven.org/artifact/<g>/<a>/<v>/jar` (type=website) |
+
+For the maven case, gate the synthesis on the existing `mikebom:source-mechanism` annotation
+being `"maven-jar-nested"` — top-level JARs may already get a sidecar-derived URL elsewhere; we
+don't want to clobber.
+
+For the cargo case, ADDITIONALLY parse the `.dep-v0` `source` field. If it matches
+`^git\+(https?://[^#]+?)(\.git)?(#[a-f0-9]+)?$`, emit a `vcs`-type ExternalReference with the
+captured URL (sans trailing `.git`, sans the `#<rev>` fragment). The cargo-auditable source field
+flows through `binary/entry.rs::cargo_auditable_packages_to_entries`; the parsed VCS URL goes into
+`PackageDbEntry.extra_annotations` or directly into a new `ExternalReference` on the entry.
+
+**Rationale**: All three URL patterns are documented registry conventions (crates.io's REST API
+documents the URL shape; nuget.org's package page URL is stable; search.maven.org's per-artifact
+JAR-download URL is stable). The VCS pattern matches the upstream cargo-auditable spec example.
+
+## R8. Constitutional fail-closed behavior (cross-cutting)
+
+**Decision**: Every new parser failure (CustomAttribute decode, license-file read, source-field
+regex mismatch) emits a single `warn`-level log and falls through to the next-lower behavior:
+US1 → Phase A 4-tuple ladder rung; US2 → `mikebom:license-source = "package-dir-no-license"`;
+US3 → no external-reference emitted for that component. No silent omission; no `unwrap()`;
+no Constitution Principle III violation.
+
+## Decisions summary
+
+| ID | Topic | Decision | Status |
+|---|---|---|---|
+| R1 | CustomAttribute table layout | Walk via §II.22.10; filter by resolved TypeRef name | Decided |
+| R2 | Blob serialization | Decode prolog `01 00` + compressed-int + UTF-8 string | Decided |
+| R3 | Coded-index widths | Reuse milestone-130 `compute_row_size` + `coded_idx_width` | Decided |
+| R4 | License-file probe paths | 3-level upward walk; 5 filename variants; 4 KB read cap | Decided |
+| R5 | Nested-JAR licenses | Plumb `parse_pom_xml.licenses` through milestone-130 walker | Decided |
+| R6 | cargo-auditable license-source | `"registry-required"` annotation for crates-io entries | Decided |
+| R7 | Supplier URL templates | crates.io / nuget.org / search.maven.org + git+ parser | Decided |
+| R8 | Fail-closed behavior | Single warn + fall through; no silent omission | Decided |

--- a/specs/131-quality-metadata-backfill/spec.md
+++ b/specs/131-quality-metadata-backfill/spec.md
@@ -1,0 +1,346 @@
+# Feature Specification: Quality metadata backfill for milestone-130 new components
+
+**Feature Branch**: `131-quality-metadata-backfill`
+**Created**: 2026-06-19
+**Status**: Draft
+**Input**: User description: "lets continue"
+
+## Context
+
+Milestone 130 added **1,903 new components** to the audit-image SBOM (1,049 → 2,952) across three new
+reader paths: cargo-auditable binary (US1), maven nested-JAR (US2), and PE/CLR managed-assembly
+metadata (US3 Phase A). The post-milestone-130 sbom-comparison scorecard against syft showed:
+
+| Dimension | Pre-130 | Post-130 | Δ |
+|---|---|---|---|
+| Completeness (common-package overlap with syft) | 942 | **1,920** | **+978** |
+| Unique-to-mikebom | 133 | **1,032** | **+899** |
+| Version Accuracy | 5/5 | 4/5 | -1 (373 mismatches) |
+| License Coverage | 3/5 | **1/5** | **-2** |
+| Dependency Graph | 4/5 | 2/5 | -2 |
+| Supplier Attribution | 4/5 | **2/5** | **-2** |
+| **OVERALL weighted** | **3.3** | **2.4** | **-0.9** |
+
+The weighted-score regression is structural: milestone 130 added **identity** without **enrichment**.
+The cargo-auditable ELF section carries the crate graph but no licenses or suppliers; PE/CLR Assembly
+table metadata carries name+version but the license info lives in attached `.txt` LICENSE files
+that mikebom doesn't read; nested-JAR `pom.properties` carries coordinates but mikebom only extracts
+license expressions from top-level JAR `pom.xml`, not nested ones. The high-quality dimensions that
+alpha.48 scored well on (license, supplier, dep-graph, version-accuracy) got diluted by 1,900 new
+low-metadata components.
+
+This feature restores those quality scores by backfilling the missing metadata on each of the three
+new readers, in priority order by the regression's magnitude.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Version fidelity for PE/CLR assemblies (Priority: P1)
+
+A platform engineer scans a .NET-bearing container image and inspects the emitted SBOM. They expect
+the `pkg:nuget/<name>@<version>` PURLs to match what NuGet.org publishes for the same package —
+specifically the `AssemblyInformationalVersion` (a semver-style string like
+`"8.0.27-servicing.26230.7+sha.a1b2c3d"`) rather than the CLR-binding `AssemblyVersion` 4-tuple
+(`"8.0.0.0"`). This matches what OSV / NVD / GitHub Advisories index against.
+
+**Why this priority**: Single highest-ROI regression fix. Resolves all **373 VERSION_MISMATCH**
+cases from the post-130 sbom-comparison. Restores Version Accuracy from 4/5 to 5/5. Bounded scope:
+extend the existing milestone-130 US3 reader's metadata-table walk with `CustomAttribute` table
+(token 0x0C) extraction. ~300 LOC.
+
+**Independent Test**: Run `mikebom sbom scan --image
+mcr.microsoft.com/dotnet/runtime:8.0-alpine`. For every `pkg:nuget` component sourced from
+`mikebom:source-mechanism = "dotnet-assembly-metadata"`, the emitted version MUST match the value
+of the assembly's `AssemblyInformationalVersionAttribute` custom attribute (when present),
+falling back to `AssemblyFileVersionAttribute`, falling back to the Assembly table's 4-tuple
+`AssemblyVersion` per the milestone-129 clarification Q3 ladder.
+
+**Acceptance Scenarios**:
+
+1. **Given** an assembly carrying `AssemblyInformationalVersionAttribute("8.0.27-servicing.26230.7")`,
+   **When** the engineer scans the image, **Then** the emitted SBOM contains
+   `pkg:nuget/<name>@8.0.27-servicing.26230.7` AND the component carries
+   `mikebom:assembly-version-informational = "8.0.27-servicing.26230.7"` annotation.
+2. **Given** an assembly with `AssemblyFileVersionAttribute("8.0.27.26230")` but no
+   `InformationalVersion`, **When** the engineer scans, **Then** the emitted PURL version is
+   `8.0.27.26230` AND `mikebom:assembly-version-file = "8.0.27.26230"` is set.
+3. **Given** an assembly with NEITHER `Informational` NOR `File` version attributes, **When** the
+   engineer scans, **Then** the PURL version is the Assembly table's 4-tuple
+   (existing Phase A behavior — no regression).
+4. **Given** the post-131 SBOM compared against syft v1.42.3 baseline, **When** the engineer runs
+   `sbom-comparison`, **Then** the VERSION_MISMATCH count drops from 373 to fewer than 20 (residual
+   cases are real disagreements, not Phase-A-truncation artifacts).
+
+---
+
+### User Story 2 — License coverage backfill for new components (Priority: P2)
+
+The same platform engineer expects the SBOM's `pkg:cargo`, `pkg:nuget`, and nested `pkg:maven`
+components to carry license expressions (CDX `licenses[].license.id` or `licenses[].expression`)
+matching the package's declared license. Pre-131, the 1,116 cargo + 819 nuget + nested maven
+components emit with empty `licenses[]`, dropping the License Coverage score from 3/5 to 1/5.
+
+**Why this priority**: Largest single point loss on the weighted scorecard (-2 points). Each of the
+three new reader paths has a documented license source that mikebom can extract without external
+network calls:
+
+- **cargo-auditable**: each `packages[]` entry carries a `source` field; for crates-io packages,
+  the license string is NOT in the `.dep-v0` section itself, but mikebom can OPT to mark the
+  component with `mikebom:license-source = "registry-required"` so downstream tools (or a future
+  deps.dev-enrichment milestone) know where to look.
+- **PE/CLR**: managed assemblies' package directory in `/usr/share/dotnet/...` typically has a
+  `LICENSE.txt` sibling file that mikebom can read.
+- **Nested-JAR (`maven-jar-nested`)**: each nested JAR's `pom.xml` (which mikebom already extracts
+  for the top-level reader) contains `<licenses>` — mikebom currently parses this for top-level
+  JARs but skips it for nested ones.
+
+**Independent Test**: After scanning the audit image with milestone-131 applied, the License
+Coverage scorecard dimension MUST be ≥3/5 (vs post-130 1/5). Verifiable via `sbom-comparison
+--format summary`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a nested JAR carrying a `META-INF/maven/<g>/<a>/pom.xml` with a `<licenses>` element
+   declaring `<name>Apache License 2.0</name>`, **When** the engineer scans, **Then** the emitted
+   `pkg:maven/<g>/<a>@<v>` nested component carries `licenses[].license.id = "Apache-2.0"`.
+2. **Given** a `.NET` assembly DLL whose package directory (`/usr/share/dotnet/packs/<name>/<ver>/`)
+   contains a `LICENSE.txt` file, **When** the engineer scans, **Then** the emitted
+   `pkg:nuget/<name>@<ver>` component carries `licenses[].license.text` populated from the file's
+   contents (capped at 4 KB per FR-013).
+3. **Given** a cargo-auditable entry whose `source` is `"crates-io"` but mikebom has no local
+   license source, **When** the engineer scans, **Then** the emitted `pkg:cargo` component carries
+   `mikebom:license-source = "registry-required"` annotation, signaling downstream tools that the
+   license is available from `index.crates.io/...` (no automatic emission of a placeholder).
+
+---
+
+### User Story 3 — Supplier attribution backfill (Priority: P3)
+
+The same platform engineer expects the SBOM's `pkg:cargo`, `pkg:nuget`, and nested `pkg:maven`
+components to carry supplier metadata (CDX `externalReferences[].url`). Pre-131, supplier
+attribution dropped from 4/5 to 2/5 because the new readers don't emit external references.
+
+**Why this priority**: Second-largest scorecard regression (-2). Bounded implementation: each
+ecosystem has a canonical supplier-URL pattern (`https://crates.io/crates/<name>`,
+`https://www.nuget.org/packages/<name>`, `https://search.maven.org/artifact/<g>/<a>/<v>/jar`)
+that mikebom can synthesize from the PURL alone — no external lookups required.
+
+**Independent Test**: After scanning the audit image with milestone-131 applied, the Supplier
+Attribution scorecard dimension MUST be ≥3/5 (vs post-130 2/5). Verifiable via `sbom-comparison`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `pkg:cargo/<name>@<version>` component from cargo-auditable, **When** the engineer
+   scans, **Then** the emitted component carries:
+   - `externalReferences[].type = "website"` with `url = "https://crates.io/crates/<name>/<version>"`
+   - `externalReferences[].type = "vcs"` with `url = "<host>/<owner>/<repo>"` IF and only if
+     the `source` field in `.dep-v0` carries a parseable `git+https://...` URL.
+2. **Given** a `pkg:nuget/<name>@<version>` component from `.deps.json` OR `dotnet-assembly-metadata`,
+   **When** the engineer scans, **Then** the emitted component carries
+   `externalReferences[].url = "https://www.nuget.org/packages/<name>/<version>"` with
+   `type = "website"`.
+3. **Given** a nested `pkg:maven/<g>/<a>@<v>` component, **When** the engineer scans, **Then** the
+   emitted component carries
+   `externalReferences[].url = "https://search.maven.org/artifact/<g>/<a>/<v>/jar"`.
+
+---
+
+### Edge Cases
+
+- **PE/CLR `InformationalVersion` with build metadata `+`**: A version string like
+  `"8.0.27-servicing.26230.7+sha.a1b2c3d"` contains a `+` which must be URL-encoded in the PURL
+  (`+` becomes `%2B`). The existing `mikebom_common::types::purl::Purl::new` constructor handles
+  this per the milestone-005 PURL convention.
+- **CustomAttribute row references a `MemberRef` that references a `TypeRef` outside the assembly**:
+  the `TypeRef` table's `ResolutionScope` column points to an `AssemblyRef` row. mikebom MUST resolve
+  through this to extract the canonical attribute type name. Failure to resolve → silent fall-through
+  to the next-lower rung of the version ladder.
+- **Nested JAR with `<licenses>` element pointing to a parent POM**: a child `pom.xml` may omit
+  `<licenses>` and rely on the parent POM's declaration. milestone 131 scope is per-nested-JAR
+  license extraction ONLY; parent-POM resolution for nested JARs is OUT of scope (deferred).
+- **PE/CLR assembly's package directory has no `LICENSE.txt`**: emit the component with empty
+  `licenses[]` AND a `mikebom:license-source = "package-dir-no-license"` annotation. Don't fall
+  back to inferring license from name or guessing.
+- **cargo-auditable `source = "git+https://...#<sha>"`**: parse to extract owner/repo for an
+  optional `pkg:github/<owner>/<repo>@<sha>` shadow-PURL emission (similar to milestone-128's Yocto
+  FR-002a). Mark with `mikebom:source-mechanism-secondary = "git-host-typed"`. Out of scope if the
+  source field is malformed.
+- **External-reference URL conflict (e.g. cargo crate with same name as npm package)**: the
+  emitted `externalReferences[].url` is namespaced by the PURL's ecosystem prefix — `crates.io`,
+  `nuget.org`, etc. — so name collisions across ecosystems cannot produce a wrong URL.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Cross-cutting (all three stories)
+
+- **FR-001**: Every component emitted with milestone-131 metadata MUST flow through the existing
+  emission pipelines unchanged at the format-builder level (CDX `licenses[]` / `externalReferences[]`
+  / SPDX 2.3 `licenseDeclared` / `externalRefs[]` / SPDX 3 `software_declaredLicense`).
+- **FR-002**: All new metadata fields MUST use **standards-native** CDX / SPDX 2.3 / SPDX 3
+  constructs first per Constitution Principle V. Mikebom-prefix annotations are permitted ONLY
+  where the standards-native field cannot carry the semantic (e.g.
+  `mikebom:license-source = "registry-required"` for the cargo crates-io-required case).
+- **FR-003**: Byte-identity preservation across the 33 alpha.48 goldens.
+- **FR-004**: No new Cargo dependencies.
+
+#### US1 — PE/CLR CustomAttribute walking (Phase B)
+
+- **FR-005**: System MUST walk the `CustomAttribute` table (token 0x0C) in the `#~` metadata stream
+  to identify rows whose `Type` column resolves (through `MemberRef` → `TypeRef` → `#Strings` heap)
+  to `"AssemblyInformationalVersionAttribute"` or `"AssemblyFileVersionAttribute"`.
+- **FR-006**: For each matching row, system MUST decode the attribute's `Value` blob: the blob's
+  prolog is `01 00`, followed by a UTF-8 length-prefixed string (per ECMA-335 §II.23.3).
+- **FR-007**: The decoded string MUST be stored on the `ManagedAssembly` struct's
+  `informational_version` or `file_version` field per attribute type.
+- **FR-008**: The PURL version MUST follow the milestone-129 clarification Q3 fallback ladder:
+  `AssemblyInformationalVersion → AssemblyFileVersion → AssemblyVersion 4-tuple`. When
+  Informational is present, the PURL version is the Informational string verbatim (subject to
+  PURL percent-encoding rules per FR-009).
+- **FR-009**: A version string containing `+` or other PURL-reserved characters MUST be
+  percent-encoded via the existing `mikebom_common::types::purl::Purl::new` constructor's
+  validation pass. Malformed-after-encoding strings emit a single `warn` and fall through to the
+  next-lower rung of the ladder.
+- **FR-010**: The component MUST carry separate annotations for each EXTRACTED version field:
+  `mikebom:assembly-version-informational`, `mikebom:assembly-version-file`,
+  `mikebom:assembly-version-runtime`. Missing fields produce no annotation.
+- **FR-011**: For the audit image, the post-131 `mikebom-vs-syft` VERSION_MISMATCH count MUST drop
+  to <20 (vs post-130 373). Residual cases reflect real disagreements, not Phase-A truncation.
+
+#### US2 — License coverage backfill
+
+- **FR-012**: For nested-JAR `pkg:maven/<g>/<a>@<v>` components (milestone 130 US2 source-mechanism
+  `"maven-jar-nested"`), the system MUST parse the nested JAR's `META-INF/maven/<g>/<a>/pom.xml`
+  for `<licenses>` declarations and emit them via the same path as top-level JAR licenses.
+- **FR-013**: For PE/CLR `pkg:nuget/<name>@<v>` components, the system MUST probe the package
+  directory (typically `/usr/share/dotnet/packs/<name>/<v>/` or the parent of the `.dll`'s file
+  path) for a `LICENSE`, `LICENSE.txt`, `LICENSE.md`, `COPYING`, or `COPYING.txt` file (case-
+  insensitive). When found, the system MUST attempt to detect the SPDX license ID by
+  fingerprint-matching the first 4 KB against the canonical opening text of common SPDX licenses:
+  `"Apache License"` (→ `Apache-2.0`), `"MIT License"` / `"Permission is hereby granted, free of charge"` (→ `MIT`),
+  `"BSD 3-Clause"` / `"Redistribution and use in source and binary forms"` (→ `BSD-3-Clause`),
+  `"BSD 2-Clause"` (→ `BSD-2-Clause`), `"GNU General Public License"` + `"version 3"` (→ `GPL-3.0`),
+  `"GNU General Public License"` + `"version 2"` (→ `GPL-2.0`). When a match fires, emit the
+  resolved SPDX ID as a `SpdxExpression` via the existing `try_canonical` path and populate the
+  component's `licenses[].license.id` (CDX) / `Package.licenseDeclared` (SPDX 2.3) /
+  `software_declaredLicense` (SPDX 3). When the file is found but no fingerprint matches, emit
+  `mikebom:license-source = "package-dir-unrecognized"` and `mikebom:license-text-sha256 = <hex>`
+  so downstream tools can identify the license externally. mikebom MUST NOT embed the raw
+  license text in the SBOM (the existing `SpdxExpression` type validates SPDX-canonical strings;
+  free-text bodies would fail Constitution Principle IV's type-driven correctness invariant).
+- **FR-014**: For cargo-auditable `pkg:cargo` components from a `crates-io` source, the system
+  MUST emit a `mikebom:license-source = "registry-required"` annotation signaling that the license
+  is available externally but not extracted by this milestone (Constitution Principle XII —
+  external enrichment is permitted but not required; defer to a future deps.dev milestone).
+- **FR-015**: For PE/CLR components where no license file is found, the system MUST emit a
+  `mikebom:license-source = "package-dir-no-license"` annotation. Mikebom MUST NOT fabricate
+  license expressions.
+- **FR-016**: For the audit image, the post-131 License Coverage score from `sbom-comparison` MUST
+  be ≥3/5 (vs post-130 1/5).
+
+#### US3 — Supplier attribution backfill
+
+- **FR-017**: For every `pkg:cargo/<name>@<version>` component, the system MUST emit
+  `externalReferences[].type = "website"` with
+  `url = "https://crates.io/crates/<name>/<version>"` (URL-encoded per the PURL spec for any
+  reserved characters in `<name>` or `<version>`).
+- **FR-018**: For every `pkg:nuget/<name>@<version>` component (regardless of source-mechanism),
+  the system MUST emit
+  `externalReferences[].url = "https://www.nuget.org/packages/<name>/<version>"` with
+  `type = "website"`.
+- **FR-019**: For every nested `pkg:maven/<g>/<a>@<v>` component, the system MUST emit
+  `externalReferences[].url = "https://search.maven.org/artifact/<g>/<a>/<v>/jar"` with
+  `type = "website"`.
+- **FR-020**: When the cargo-auditable `source` field is parseable as `"git+https://<host>/<owner>/<repo>(\.git)?(#<rev>)?"`,
+  the system MUST emit an additional `externalReferences[].type = "vcs"` with
+  `url = "<host>/<owner>/<repo>"` (without trailing `.git`, without the `#<rev>` fragment per CDX
+  best practice).
+- **FR-021**: For the audit image, the post-131 Supplier Attribution score MUST be ≥3/5 (vs
+  post-130 2/5).
+
+#### Catalog / parity bookkeeping
+
+- **FR-022**: Any new `mikebom:*` annotation key MUST be catalogued in
+  `docs/reference/sbom-format-mapping.md` with full Principle V audit narrative per the milestone-128
+  convention. New keys this milestone introduces:
+  - `mikebom:license-source` (US2)
+  - `mikebom:license-text-sha256` (US2, when license file is found but fingerprint doesn't match)
+  - `mikebom:cargo-vcs-source-url` (US3, when cargo-auditable `source` field carries a parseable `git+https://...` URL — preserves the build-time-declared VCS reference)
+- **FR-023**: Each catalogued key MUST be registered as a `ParityExtractor` slice entry with
+  matching `cdx_anno!` / `spdx23_anno!` / `spdx3_anno!` macros, emitting `SymmetricEqual` across
+  all three formats.
+
+### Key Entities
+
+- **`CustomAttribute` row** (US1): ECMA-335 §II.22.10 metadata-table entry. Columns:
+  `Parent` (HasCustomAttribute coded index), `Type` (CustomAttributeType coded index),
+  `Value` (`#Blob` heap reference). The `Value` blob's wire format is documented in §II.23.3:
+  prolog `0x0001` + serialized argument list.
+- **`MemberRef` row** (US1, transitive): ECMA-335 §II.22.25. Used to resolve the `Type` column
+  of CustomAttribute through to a TypeRef + a method name like `".ctor"`.
+- **`TypeRef` row** (US1, transitive): ECMA-335 §II.22.38. Used to resolve to the
+  `#Strings`-heap-indexed type name (`"AssemblyInformationalVersionAttribute"`,
+  `"AssemblyFileVersionAttribute"`).
+- **License-source enum** (US2): `"package-dir"` (extracted from `LICENSE.txt`), `"pom-xml"`
+  (extracted from nested `pom.xml`), `"registry-required"` (deferred to external enrichment),
+  `"package-dir-no-license"` (probed but absent).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For the audit image (`remediation-planner:latest`), the post-131 `sbom-comparison`
+  weighted score MUST exceed syft by ≥0.5 points (vs post-130 syft-leads-by-0.1).
+- **SC-002**: VERSION_MISMATCH count drops from 373 to <20 (US1 acceptance gate).
+- **SC-003**: License Coverage score moves from 1/5 to ≥3/5 (US2 acceptance gate).
+- **SC-004**: Supplier Attribution score moves from 2/5 to ≥3/5 (US3 acceptance gate).
+- **SC-005**: Byte-identity preserved across the 33 alpha.48 goldens (FR-003).
+- **SC-006**: Total scan time growth on the audit image MUST be under 30% relative to milestone 130.
+- **SC-007**: Each user story is independently shippable per the milestone-130 cadence —
+  three sequential PRs (US1 → US2 → US3) OR a single bundled PR if confidence is high after US1
+  lands.
+
+## Assumptions
+
+- The Phase B CustomAttribute walking is bounded by the same ECMA-335 row-width approximation
+  caveat that milestone 130 US3 documented. The post-131 sanity-filter rejection rate may stay
+  in the 5-10% range until a future milestone implements full §II.22 row-width computation.
+- LICENSE / LICENSE.txt / COPYING file probing in the PE/CLR package directory is a best-effort
+  match. Some Microsoft packages ship the license inside the `.nupkg` archive (deferred — not
+  shipped in container images), inside the runtime store at a non-standard path (rare), or
+  reference an SPDX expression in the `.nuspec` (not shipped in container images either). The
+  net License Coverage gain may be smaller than 3/5 → 4/5; targeting 3/5 minimum.
+- External-references URL synthesis is purely PURL-derived; no external lookups. For supplier
+  metadata beyond the canonical registry URL (e.g. company name, contact email), defer to a future
+  deps.dev-enrichment milestone — out of scope here.
+- The audit image (`remediation-planner:latest`) is the standing acceptance baseline. A future
+  audit-corpus expansion (additional images) is out of scope.
+
+## Out of Scope
+
+- Full ECMA-335 §II.22 row-width computation (the Phase B follow-up to Phase B's CustomAttribute
+  walking). Tracked for a separate milestone after US1 lands.
+- deps.dev / PurlDB online enrichment for the cargo licenses + Microsoft NuGet supplier metadata.
+- Parent-POM resolution for nested JARs (some children rely on the parent for `<licenses>`).
+- Reading license metadata from `.nuspec` files (not shipped in container images).
+- Reading license metadata from PE `VS_VERSIONINFO` resource blocks (separate PE resource walker
+  — large work item, deferred).
+- Adding `externalReferences` to ecosystems milestone 131 doesn't touch (apk, dpkg, rpm, npm,
+  gem, pip — those have their own conventions already handled by their existing readers).
+
+## Dependencies
+
+- Existing milestone-130 US3 PE/CLR reader at `mikebom-cli/src/scan_fs/package_db/nuget/pe_clr.rs`.
+- Existing milestone-130 US2 nested-JAR walker at `mikebom-cli/src/scan_fs/package_db/maven.rs`.
+- Existing milestone-029 cargo-auditable reader at `mikebom-cli/src/scan_fs/binary/cargo_auditable.rs`.
+- Existing milestone-009 top-level maven reader's `<licenses>` parser at the same maven.rs.
+- Existing CDX / SPDX 2.3 / SPDX 3 `licenses[]` + `externalReferences[]` emission paths.
+- Existing milestone-097 `mikebom:cpe-candidates` annotation channel (reused for new components).
+- Existing milestone-128 parity catalog C-row system in `docs/reference/sbom-format-mapping.md`
+  (1 new C-row for `mikebom:license-source`).
+- The `mikebom_common::types::purl::Purl::new` constructor for PURL validation + percent-encoding
+  on the version string with `+` / etc.
+- The `object` crate (workspace dep; used for the US1 metadata-table walking).
+- The `quick-xml` crate (workspace dep; used for nested-JAR `<licenses>` parsing — reused).
+- The milestone-130 audit corpus (`/Users/mlieberman/Projects/sbom-comparison/sbom-comparison` tool
+  + the syft baseline + the `remediation-planner:latest` ECR image) for end-to-end SC verification.

--- a/specs/131-quality-metadata-backfill/tasks.md
+++ b/specs/131-quality-metadata-backfill/tasks.md
@@ -1,0 +1,222 @@
+---
+
+description: "Task list for milestone 131 — Quality metadata backfill (PE/CLR Phase B + license backfill + supplier URLs)"
+
+---
+
+# Tasks: Quality metadata backfill (milestone 131)
+
+**Input**: Design documents from `/specs/131-quality-metadata-backfill/`
+**Prerequisites**: plan.md, spec.md, research.md, contracts/annotation-schema.md, quickstart.md
+
+**Tests**: REQUIRED. The spec's user story acceptance scenarios are Given/When/Then; SC-001..006
+are verified end-to-end via the audit-image scorecard comparison. Inline unit tests for new helpers.
+
+**Organization**: Three sequential PRs per milestone-130 cadence — US1 → US2 → US3. US1 is the
+largest single piece (~300 LOC ECMA-335 CustomAttribute walking); US2 + US3 are ~150 LOC each.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to ([US1], [US2], [US3])
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm milestone 130 fully landed on main; baseline existing tests.
+
+- [ ] T001 Run `git rev-parse --abbrev-ref HEAD` and confirm `131-quality-metadata-backfill`. Run `git log -5 --oneline main` and confirm the three milestone-130 PRs (cargo-auditable gate fix #371, maven nested-JAR #372, PE/CLR US3 Phase A #373) are all merged.
+- [ ] T002 [P] Run `cargo +stable build -p mikebom` baseline. Confirm clean.
+- [ ] T003 [P] Run `cargo +stable test -p mikebom --bin mikebom nuget::pe_clr maven::tests cargo_auditable` and confirm milestone-130 tests pass.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: None. All three user stories are independent and parallelizable.
+
+**Checkpoint**: User story implementation can begin in parallel.
+
+---
+
+## Phase 3: User Story 1 — PE/CLR Phase B `CustomAttribute` walking (Priority: P1) 🎯 MVP
+
+**Goal**: Walk the CustomAttribute table (token 0x0C) in `pe_clr.rs` to extract
+`AssemblyInformationalVersion` + `AssemblyFileVersion` strings. PURL version routes through the
+milestone-129 Q3 ladder. Resolves all 373 VERSION_MISMATCH cases on the audit image.
+
+**Independent Test**: Run `mikebom sbom scan --image mcr.microsoft.com/dotnet/runtime:8.0-alpine`;
+confirm `Microsoft.AspNetCore` component emits with `@8.0.27-servicing.26230.7` (InformationalVersion)
+instead of `@8.0.0.0` (AssemblyVersion 4-tuple).
+
+### Data model
+
+- [ ] T004 [US1] In `mikebom-cli/src/scan_fs/package_db/nuget/pe_clr.rs`, extend the `ManagedAssembly` struct with two new fields per data-model.md: `informational_version: Option<String>` and `file_version: Option<String>`. Defaults to `None`. Update the `Debug, Clone` derivations to cover them.
+
+### CustomAttribute parser
+
+- [ ] T005 [US1] Add a helper `compute_row_size_extended(token, widths, rows)` that extends the existing milestone-130 `compute_row_size` to include `CustomAttribute` (token 0x0C). The CustomAttribute row layout: `Parent` (HasCustomAttribute coded index, 5-bit tag, 21 referenced tables) + `Type` (CustomAttributeType coded index, 3-bit tag, 5 referenced tables) + `Value` (#Blob index). Width derivation per research R3.
+- [ ] T006 [US1] Add helper `parse_compressed_int(bytes: &[u8], offset: usize) -> Option<(u32, usize)>` decoding the ECMA-335 §II.24.2.4 compressed integer format: high bit 0 = 1-byte (length <128); high two bits 10 = 2-byte (length <16384); high three bits 110 = 4-byte. Returns the decoded value + bytes consumed.
+- [ ] T007 [US1] Add helper `decode_serstring(blob: &[u8], offset: usize) -> Option<(Option<String>, usize)>` per research R2: read the compressed-int length; `0xFF` byte → null string (returns `(None, 1)`); otherwise read `length` UTF-8 bytes into a `String`. Returns `(Some(s), consumed)` or `(None, 1)` for null.
+- [ ] T008 [US1] Add helper `read_typeref_name(tables: &[u8], headers: &TableHeaders, strings: &[u8], row_index: u32) -> Option<&str>` that reads TypeRef table row `row_index`'s `TypeName` column (`#Strings` index) and resolves to the heap-stored type name. Use existing milestone-130 `read_string_heap`.
+- [ ] T009 [US1] Add helper `resolve_customattribute_type_name(row_index: u32, tag: u8, tables, headers, strings) -> Option<String>` that, given a CustomAttributeType coded index (tag bits + table-row bits), dispatches to MemberRef (tag=3) or MethodDef (tag=2). For MemberRef: read the row's `Class` column (a MemberRefParent coded index — usually TypeRef tag=1), resolve through to TypeRef, return TypeName. For MethodDef: return `None` (defining assembly's own attribute, not relevant).
+- [ ] T010 [US1] Add helper `walk_custom_attributes(tables, headers, strings, blob_heap) -> Vec<(String, Option<String>)>` that walks every CustomAttribute table row. For each: decode `Parent` (HasCustomAttribute coded index — filter to rows where the parent is the Assembly table); resolve `Type` via `resolve_customattribute_type_name`; if the resolved type name is `"AssemblyInformationalVersionAttribute"` or `"AssemblyFileVersionAttribute"`, decode the `Value` blob (compressed-int length-prefixed, prolog `01 00`, then `decode_serstring` for the string argument). Returns a vector of `(type_name, version_string)` tuples.
+- [ ] T011 [US1] In `parse_tables_stream`, after the existing Assembly row 0 extraction, call `walk_custom_attributes`. Populate the new `ManagedAssembly.informational_version` / `.file_version` fields based on matched rows. Multi-row Assembly tables (rare) — first match wins.
+
+### PURL version routing
+
+- [ ] T012 [US1] Add method `ManagedAssembly::purl_version_with_ladder()` that returns the version string per FR-008 ladder: `informational_version.clone().or_else(|| file_version.clone()).unwrap_or_else(|| self.version.to_string())`. Replace the existing `version.to_string()` call site in `AssemblyAccumulator::absorb` to use the new method.
+- [ ] T013 [US1] Per FR-009, the `Purl::new` constructor handles version percent-encoding (e.g. `+` → `%2B`) automatically — verify via a unit test that builds a PURL from an `InformationalVersion` containing `+`. Document in the test that the existing constructor's behavior satisfies FR-009.
+- [ ] T014 [US1] In `AssemblyAccumulator::flatten`, populate the `mikebom:assembly-version-informational` and `mikebom:assembly-version-file` annotations from the accumulated representative's new fields, when present. The existing `mikebom:assembly-version-runtime` (4-tuple) emission stays unchanged per FR-010.
+
+### Unit tests
+
+- [ ] T015 [US1] Add unit tests inside `pe_clr.rs`: (a) `parse_compressed_int` for 1/2/4-byte cases + invalid prefix; (b) `decode_serstring` for short string, null (0xFF), and empty; (c) `purl_version_with_ladder` for all three rungs (Informational present, only File, only 4-tuple); (d) PURL construction with a `+` in the version round-trips correctly.
+
+### US1 verification
+
+- [ ] T016 [US1] Run `cargo +stable test -p mikebom --bin mikebom nuget::pe_clr` and confirm all new + existing tests pass.
+- [ ] T017 [US1] Build release; scan the audit image with US1 only; compare via `sbom-comparison --format summary /tmp/us1.cdx.json ~/Downloads/remediation-planner-syft-image-sbom.json`. Assert VERSION_MISMATCH count drops from 373 to <20 (SC-002).
+
+**Checkpoint**: US1 fully functional. SC-002 verifiable.
+
+---
+
+## Phase 4: User Story 2 — License coverage backfill (Priority: P2)
+
+**Goal**: Add license metadata to the three new reader paths from milestone 130.
+
+**Independent Test**: After US2, run `sbom-comparison --format summary` on the audit image; assert
+License Coverage moves from 1/5 to ≥3/5.
+
+### US2a — PE/CLR LICENSE.txt probe
+
+- [ ] T018 [US2] In `mikebom-cli/src/scan_fs/package_db/nuget/pe_clr.rs`, add a helper `probe_license_file(dll_path: &Path, max_depth: u8) -> Option<(Vec<u8>, PathBuf)>` per research R4. Walks up to 3 levels above `dll_path`'s parent, looking for case-insensitive `LICENSE`, `LICENSE.txt`, `LICENSE.md`, `COPYING`, `COPYING.txt`. Returns the first match's first 4 KB of bytes + the file path. Returns `None` if no match.
+- [ ] T019 [US2] Add a helper `fingerprint_license(bytes: &[u8]) -> Option<&'static str>` per FR-013 that matches the first 4 KB against canonical opening-text patterns of common SPDX licenses: `"Apache License"` → `"Apache-2.0"`; `"MIT License"` OR `"Permission is hereby granted, free of charge"` → `"MIT"`; `"BSD 3-Clause"` OR (`"Redistribution"` AND 3-clause text) → `"BSD-3-Clause"`; `"BSD 2-Clause"` → `"BSD-2-Clause"`; `"GNU General Public License"` + `"version 3"` → `"GPL-3.0"`; same + `"version 2"` → `"GPL-2.0"`. Returns `None` for non-matching texts (signals the C97 fallback path).
+- [ ] T020 [US2] In the `AssemblyAccumulator::absorb` call site (`read()` function), after a successful managed-assembly parse, call `probe_license_file(path, 3)`. When `Some((bytes, file_path))`: call `fingerprint_license(&bytes)`. If `Some(spdx_id)`: set `PackageDbEntry.licenses` to a one-element `Vec<SpdxExpression>` via `SpdxExpression::try_canonical(spdx_id)`; emit `mikebom:license-source = "package-dir"`. If `None`: compute `sha256(&bytes)`, emit `mikebom:license-source = "package-dir-unrecognized"` + `mikebom:license-text-sha256 = <hex>` (C97). When the outer `probe_license_file` returns `None`: emit `mikebom:license-source = "package-dir-no-license"` per FR-015. Plumb the result through the accumulator's emission path (add `license_id: Option<&'static str>` + `license_sha256: Option<String>` fields to `AccumulatedAssembly`).
+
+### US2b — Nested-JAR license propagation
+
+- [ ] T021 [US2] In `mikebom-cli/src/scan_fs/package_db/maven.rs`, locate the nested-walker's emission site at `extract_nested_meta`. The existing top-level path uses `parse_pom_xml(pom_xml_bytes).licenses` — currently this output is discarded in the nested path. Add a step that extracts `parse_pom_xml(bytes).licenses` for each nested entry's `pom.xml`, canonicalizes each via `SpdxExpression::try_canonical`, and serializes the resulting `Vec<SpdxExpression>` as a JSON value under the existing `EmbeddedMavenMeta.extra_annotations["mikebom:nested-licenses"]` key (consistent with the milestone-130 `extra_annotations` plumbing pattern — no new struct field on `EmbeddedMavenMeta`).
+- [ ] T022 [US2] Update `jar_pom_to_entry` to consume the new `mikebom:nested-licenses` annotation when present, deserialize it back to `Vec<SpdxExpression>`, and populate `PackageDbEntry.licenses` accordingly. Add `mikebom:license-source = "pom-xml"` annotation when at least one license was extracted.
+
+### US2c — cargo-auditable registry-required annotation
+
+- [ ] T023 [US2] In `mikebom-cli/src/scan_fs/binary/entry.rs::cargo_auditable_packages_to_entries`, for each `packages[]` entry: check the `source` field. When `source == "crates-io"` OR `source.starts_with("registry+https://")`, add `extra_annotations.insert("mikebom:license-source", "registry-required")` to the emitted `PackageDbEntry`. For `source == "local"` / `git+...` / `unknown`, no annotation is added.
+
+### Unit tests (US2)
+
+- [ ] T024 [US2] Add a unit test in `pe_clr.rs`: build a `TempDir` containing `<tmp>/pkgs/Microsoft.AspNetCore.App.Ref/8.0.0/ref/net8.0/Microsoft.AspNetCore.dll` AND `<tmp>/pkgs/Microsoft.AspNetCore.App.Ref/8.0.0/LICENSE.TXT` (case-mixed name) with synthetic text. Call `probe_license_file(dll_path, 3)`; assert returns `Some((text, path))` where `text` matches the file contents.
+- [ ] T025 [US2] Add a unit test in `pe_clr.rs`: build the same `TempDir` WITHOUT the LICENSE file. Assert `probe_license_file` returns `None`.
+- [ ] T026 [US2] Add a unit test in `maven.rs`: build a synthetic nested JAR carrying a `pom.xml` declaring `<licenses><license><name>Apache License 2.0</name></license></licenses>`. Use the milestone-130 `walk_jar_maven_meta`; assert the resulting nested `EmbeddedMavenMeta` carries the license annotation OR the new licenses field.
+
+### US2 verification
+
+- [ ] T027 [US2] Run `cargo +stable test -p mikebom --bin mikebom nuget::pe_clr maven::tests cargo_auditable` — confirm all new + existing tests pass.
+- [ ] T028 [US2] Build release; scan audit image with US1 + US2; verify License Coverage scorecard moves to ≥3/5 (SC-003).
+
+**Checkpoint**: US2 fully functional. SC-003 verifiable.
+
+---
+
+## Phase 5: User Story 3 — Supplier external-reference URL synthesis (Priority: P3)
+
+**Goal**: Synthesize canonical registry URLs (`crates.io`, `nuget.org`, `search.maven.org`) for
+the new components.
+
+**Independent Test**: After US3, run `sbom-comparison --format summary`; assert Supplier
+Attribution moves from 2/5 to ≥3/5.
+
+### Implementation
+
+- [ ] T029 [US3] In `mikebom-cli/src/scan_fs/mod.rs::supplier_from_purl`, add a `pkg:cargo/<name>@<version>` branch: emit `ExternalReference { ref_type: "website", url: format!("https://crates.io/crates/{name}/{version}") }`. Both segments URL-encoded via the existing `urlencoding::encode` (already in dep closure) or the `Purl::name` / `.version` accessors which return decoded strings.
+- [ ] T030 [US3] In the same function, add a `pkg:nuget/<name>@<version>` branch: emit `url = format!("https://www.nuget.org/packages/{name}/{version}")`.
+- [ ] T031 [US3] In the same function, add a `pkg:maven/<g>/<a>@<v>` branch: emit `url = format!("https://search.maven.org/artifact/{group}/{artifact}/{version}/jar")`. Gate emission on the component carrying `mikebom:source-mechanism = "maven-jar-nested"` annotation (use existing extra_annotations probe).
+- [ ] T032 [US3] In `mikebom-cli/src/scan_fs/binary/entry.rs::cargo_auditable_packages_to_entries`, for each entry whose `source` matches `^git\+(https?://[^#]+?)(\.git)?(#[a-f0-9]+)?$` (compile a `regex::Regex` lazily via `once_cell::sync::Lazy` or `std::sync::OnceLock`), extract the captured URL group (strip trailing `.git` and any `#<rev>` fragment) and add `extra_annotations.insert("mikebom:cargo-vcs-source-url", "<url>")`. This is the catalogued C98 plumbing annotation; per contracts/annotation-schema.md C98, the annotation preserves the provenance signal that the URL came from the build-time cargo-auditable source declaration (not from PURL-heuristic guessing).
+- [ ] T033 [US3] In `scan_fs/mod.rs::supplier_from_purl` (or wherever the per-component external-refs are computed), check for the `mikebom:cargo-vcs-source-url` annotation. When present, emit an additional `ExternalReference { ref_type: "vcs", url: <annotation value> }`. The native CDX `externalReferences[]` entry is the wire-format primary; the C98 annotation continues to ride alongside on the component as the provenance audit trail.
+
+### Unit tests (US3)
+
+- [ ] T034 [US3] In `scan_fs/mod.rs::supplier_tests`, add tests for: cargo PURL → crates.io URL; nuget PURL → nuget.org URL; maven PURL with `maven-jar-nested` source-mechanism annotation → search.maven.org URL; maven PURL without that annotation → no synthetic URL (top-level path's existing handling preserved).
+- [ ] T035 [US3] In `binary/entry.rs::tests`, add a test for the `git+https://github.com/X/Y.git#<rev>` source-field parse: assert the captured URL is `https://github.com/X/Y` (sans `.git`, sans `#<rev>`).
+
+### US3 verification
+
+- [ ] T036 [US3] Run `cargo +stable test -p mikebom` — confirm all tests pass.
+- [ ] T037 [US3] Build release; scan audit image with all three USs landed; run `sbom-comparison --format summary`. Assert: Version Accuracy = 5/5; License Coverage ≥ 3/5; Supplier Attribution ≥ 3/5; OVERALL ≥ 3.0 (mikebom leads syft by ≥ 0.5).
+
+**Checkpoint**: US3 fully functional. SC-001 + SC-004 verifiable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Verification
+
+- [ ] T038 Catalogue C96 `mikebom:license-source`, C97 `mikebom:license-text-sha256`, and C98 `mikebom:cargo-vcs-source-url` in `docs/reference/sbom-format-mapping.md` per contracts/annotation-schema.md. Grep the file for the highest existing C-NN; pin C96..C98 (or next-available range).
+- [ ] T039 [P] Register C96, C97, C98 as `cdx_anno!` entries in `mikebom-cli/src/parity/extractors/cdx.rs`.
+- [ ] T040 [P] Register C96, C97, C98 as `spdx23_anno!` entries in `spdx2.rs`.
+- [ ] T041 [P] Register C96, C97, C98 as `spdx3_anno!` entries in `spdx3.rs`.
+- [ ] T042 Register C96, C97, C98 as `ParityExtractor` slice entries in `mikebom-cli/src/parity/extractors/mod.rs` with matching `use` imports. Confirm shape tests pass (`extractors_table_is_sorted_by_row_id`, `every_catalog_row_has_an_extractor`).
+- [ ] T043 Run SC-005 byte-identity verification: `./scripts/regen-goldens.sh` produces zero `.cdx.json` / `.spdx.json` churn.
+- [ ] T044 Run SC-006 performance verification: time the audit-image scan pre vs post; assert wall-clock growth <30%.
+- [ ] T045 Update `CHANGELOG.md` `[Unreleased]` section with the milestone-131 entry. Document the three USs + the new C96 annotation + the audit-image scorecard transformation (2.4 → ≥3.0).
+- [ ] T046 Run the pre-PR gate: `./scripts/pre-pr.sh` confirms `>>> all pre-PR checks passed.` Fix any clippy lints surfaced.
+- [ ] T047 Commit + push the `131-quality-metadata-backfill` branch.
+- [ ] T048 Open PR via `gh pr create` with the summary referencing the post-131 scorecard expectations + the milestone-131 PR template.
+
+---
+
+## Dependency Graph
+
+```text
+Phase 1 (Setup) ───→ Phase 2 (empty) ───┬──→ Phase 3 (US1, P1) ──┐
+                                        │                         ├──→ Phase 6 (Polish)
+                                        ├──→ Phase 4 (US2, P2) ──┤
+                                        │                         │
+                                        └──→ Phase 5 (US3, P3) ──┘
+```
+
+Phases 3/4/5 are **independent**.
+
+## Parallel Execution Opportunities
+
+**Within Phase 1**: T002 + T003 in parallel.
+
+**Within Phase 3 (US1)**: T005..T011 are sequential (single-file dependencies); T015 (unit tests) parallel
+with implementation completion. T016 + T017 sequential.
+
+**Within Phase 4 (US2)**: T018..T020 (US2a) ‖ T021..T022 (US2b) ‖ T023 (US2c) — three independent
+sub-tracks. T024 ‖ T025 ‖ T026 (three unit tests in different files).
+
+**Within Phase 5 (US3)**: T029..T033 sequential within same file (`scan_fs/mod.rs` + `binary/entry.rs`).
+T034 ‖ T035.
+
+**Within Phase 6**: T039 ‖ T040 ‖ T041 (three extractor files).
+
+**Across stories**: after Phase 2 checkpoint, US1 ‖ US2 ‖ US3 can run on separate branches.
+
+## Implementation Strategy
+
+**Recommended cadence: three sequential PRs.**
+
+- **PR 1: US1 only** — ~300 LOC CustomAttribute walking. Resolves 373 VERSION_MISMATCH cases (SC-002).
+- **PR 2: US2 only** — ~150 LOC across three file modifications. License Coverage 1/5 → ≥3/5 (SC-003).
+- **PR 3: US3 only** — ~100 LOC URL-synthesis heuristics. Supplier Attribution 2/5 → ≥3/5 (SC-004).
+
+Alternatively bundle all three in one PR if confidence is high after US1 lands locally — the
+spec/plan support this. The split is the **safer default**.
+
+**MVP scope: US1 alone.** Single largest scorecard regression fix.
+
+**Risk callouts**:
+
+- T010 (`walk_custom_attributes`) is the most complex single task — CustomAttribute coded-index
+  resolution through MemberRef → TypeRef → #Strings is mechanical but tedious. Time-box at 1 day;
+  if it slips, the fallback is to add `pelite = "0.10"` as a dependency (burning the "zero new
+  Cargo deps" constraint). Decision point: document in tasks.md as a comment if the fallback is
+  exercised.
+- T021 (nested-JAR license propagation) requires touching the milestone-130 walker's per-entry
+  emission path. Verify byte-identity preservation (top-level JAR emissions unchanged) via the
+  existing milestone-009 maven tests.
+- T037 (end-to-end scorecard verification) depends on all three USs landing. If only US1 ships,
+  run T037 with just SC-001/SC-002 + acknowledge SC-003/SC-004 deferred.


### PR DESCRIPTION
## Summary

Closes the Supplier Attribution scorecard regression from milestone 130. The three new milestone-130 reader paths (cargo-auditable binary, .deps.json, PE/CLR managed-assembly metadata, nested-JAR) emit no `externalReferences[]` URLs; this PR backfills synthetic registry-website URLs derived from each component's PURL.

## Synthesized URLs

`mikebom-cli/src/scan_fs/mod.rs::external_refs_from_purl` extensions:

| PURL pattern | Synthesized URL | Type |
|---|---|---|
| `pkg:cargo/<n>@<v>` | `https://crates.io/crates/<n>/<v>` | website (FR-017) |
| `pkg:nuget/<n>@<v>` | `https://www.nuget.org/packages/<n>/<v>` | website (FR-018) |
| `pkg:maven/<g>/<a>@<v>` with `mikebom:source-mechanism = \"maven-jar-nested\"` | `https://search.maven.org/artifact/<g>/<a>/<v>/jar` | website (FR-019) |
| cargo + `source = \"git+https://...\"` | cleaned URL (no `git+` prefix, no `.git` suffix, no `#<rev>` fragment) | vcs (FR-020) |

Top-level Maven JARs are NOT URL-synthesized here so the existing milestone-009 sidecar-derived URLs aren't clobbered.

## Cargo VCS URL provenance

cargo-auditable's `source` field is parsed at `binary/entry.rs::cargo_auditable_packages_to_entries`. When the field matches `git+(https?://...)(\.git)?(#<rev>)?`, the cleaned URL is stashed under the new C98 `mikebom:cargo-vcs-source-url` plumbing annotation. The downstream `external_refs_from_purl` helper reads this annotation and emits the `vcs` ExternalReference. The annotation **preserves provenance**: the VCS URL came from the build-time cargo-auditable declaration, not from a heuristic guess against the PURL name.

## New annotation key (C98)

`mikebom:cargo-vcs-source-url` — catalogued in `specs/131-quality-metadata-backfill/contracts/annotation-schema.md` with full Principle V audit narrative. The annotation is in-process plumbing; the native CDX `externalReferences[].url` entry is the wire-format primary.

## Golden churn (intentional)

3 fixtures gain new `externalReferences[].url` entries — purely additive, no existing fields modified:
- `mikebom-cli/tests/fixtures/golden/cyclonedx/cargo.cdx.json`
- `mikebom-cli/tests/fixtures/golden/spdx-2.3/cargo.spdx.json`
- `mikebom-cli/tests/fixtures/golden/spdx-3/cargo.spdx3.json`

This is the intentional FR-017 behavior. The spec's SC-005 byte-identity claim was overly strict for US3 — only goldens **without** cargo / nuget / maven-nested components remain byte-identical. For images without those ecosystems (pure-Python, pure-Go, etc.), the readers are no-ops and goldens stay byte-identical.

## Out-of-scope (tracked for follow-up PRs)

Per the milestone-131 plan's three-PR cadence:

- **US1** — PE/CLR Phase B CustomAttribute walking for `InformationalVersion` + `FileVersion`. Resolves 373 VERSION_MISMATCH cases. ~300 LOC ECMA-335 hand-roll.
- **US2** — License backfill across cargo / nuget / nested-Maven. License Coverage 1/5 → ≥3/5.

Spec / plan / research / contracts / quickstart for the full milestone live in `specs/131-quality-metadata-backfill/`.

## Test plan

- [x] \`cargo +stable clippy --workspace --all-targets -- -D warnings\` — zero errors / zero warnings
- [x] \`cargo +stable test --workspace\` — every suite \`ok. N passed; 0 failed\`
- [x] 15 new unit tests pass:
  - 6 in `scan_fs::external_refs_tests` (cargo / nuget / maven-nested / maven-top-level-skip / cargo-with-vcs / golang preservation)
  - 9 in `binary::entry::tests` (git source parsing edge cases + end-to-end emission)
- [x] Golden churn limited to 3 cargo fixtures; diff is purely additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)