### PR TITLE
fix(scan_fs/docker_image): tolerate `RepoTags: null` in docker save manifest (digest-pulled images)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 
 ## [Unreleased]
 
+### Fix: `RepoTags: null` in `docker save` manifest crashed image scans
+
+`mikebom sbom scan --image <registry>@sha256:<digest>` failed with
+`parsing manifest.json: invalid type: null, expected a sequence at line 1 column 106`
+when the source image had been pulled by digest without a tag — `docker save` then
+writes `"RepoTags": null` (a present field with a literal null value), which the
+`Vec<String>` field with `#[serde(default)]` did NOT tolerate (the `default`
+attribute only catches *missing* fields, not present-but-null ones). Discovered
+during milestone-132 MVP SC verification when scanning the audit baseline by its
+pinned `@sha256:` digest.
+
+The fix is one type change in `scan_fs/docker_image.rs::DockerManifestEntry`:
+`repo_tags: Vec<String>` → `repo_tags: Option<Vec<String>>`, plus
+`unwrap_or_default()` at the single use-site. Both null and absent now resolve to
+"no tag carried in the manifest." Three new focused deserializer tests cover the
+null, missing, and populated RepoTags states so the regression cannot silently
+return.
+
+Pre-fix workaround (no longer needed): `docker tag <registry>@<digest> <local-tag>`
+before scanning. Going forward, scanning digest-pinned images works directly.
+
 ### Stripped-Informational version annotation for syft-parity comparisons (milestone 132 US2)
 
 **Discrete deliverable**: implements FR-008 (companion annotation emission). **Does NOT

--- a/mikebom-cli/src/scan_fs/docker_image.rs
+++ b/mikebom-cli/src/scan_fs/docker_image.rs
@@ -59,8 +59,15 @@ pub struct ExtractedImage {
 struct DockerManifestEntry {
     #[serde(rename = "Config", default)]
     _config: String,
+    // `Option<Vec<String>>` (not `Vec<String>`) because `docker save` on an
+    // image that was pulled by digest (no tag) writes `"RepoTags": null` —
+    // a present field with a null value, which `#[serde(default)]` does NOT
+    // cover (default only catches *missing* fields). `Option` accepts both
+    // `null` and absence, and `unwrap_or_default()` at the use-site treats
+    // both as empty. Observed during milestone-132 MVP SC verification when
+    // `docker pull <repo>@sha256:<digest>` produced a tag-less image.
     #[serde(rename = "RepoTags", default)]
-    repo_tags: Vec<String>,
+    repo_tags: Option<Vec<String>>,
     #[serde(rename = "Layers", default)]
     layers: Vec<String>,
 }
@@ -81,7 +88,7 @@ pub fn extract(archive_path: &Path) -> Result<ExtractedImage> {
         bail!("manifest.json contains zero image entries");
     };
 
-    let repo_tag = image.repo_tags.into_iter().next();
+    let repo_tag = image.repo_tags.unwrap_or_default().into_iter().next();
     if image.layers.is_empty() {
         bail!("image manifest has zero layers — not a valid docker save tarball?");
     }
@@ -477,6 +484,53 @@ mod tests {
         // Forget the tmp so it isn't dropped+removed before the test reads it.
         let _ = tmp.persist(&path);
         path
+    }
+
+    #[test]
+    fn manifest_json_with_null_repo_tags_deserializes() {
+        // Regression: `docker save` on an image pulled by digest writes
+        // `"RepoTags": null` (a present field with literal null), which
+        // a `Vec<String>` field with `#[serde(default)]` did NOT tolerate
+        // (default only catches *missing* fields). Discovered during
+        // milestone-132 MVP SC verification when scanning the audit image
+        // by `@sha256:<digest>`. The fix is `Option<Vec<String>>` +
+        // `unwrap_or_default()` at the use-site.
+        let manifest = r#"[{"Config":"config.json","RepoTags":null,"Layers":["layer0/layer.tar"]}]"#;
+        let entries: Vec<DockerManifestEntry> =
+            serde_json::from_str(manifest).expect("null RepoTags must deserialize");
+        assert_eq!(entries.len(), 1);
+        assert!(
+            entries[0].repo_tags.is_none(),
+            "null RepoTags should land as Option::None, not be coerced to []",
+        );
+        assert_eq!(entries[0].layers, vec!["layer0/layer.tar".to_string()]);
+    }
+
+    #[test]
+    fn manifest_json_with_missing_repo_tags_deserializes() {
+        // Companion: `#[serde(default)]` still covers the missing-field
+        // case. Preserved coverage so future maintainers don't drop the
+        // `default` attribute thinking `Option` alone is enough — both
+        // missing AND null must work.
+        let manifest = r#"[{"Config":"config.json","Layers":["layer0/layer.tar"]}]"#;
+        let entries: Vec<DockerManifestEntry> =
+            serde_json::from_str(manifest).expect("missing RepoTags must deserialize");
+        assert!(entries[0].repo_tags.is_none());
+    }
+
+    #[test]
+    fn manifest_json_with_populated_repo_tags_deserializes() {
+        // Companion: tagged-image path still works (the existing
+        // build_fake_image helper exercises this end-to-end; the focused
+        // deserializer test below is here so all three RepoTags states
+        // are covered in one spot).
+        let manifest = r#"[{"Config":"config.json","RepoTags":["demo:latest"],"Layers":["layer0/layer.tar"]}]"#;
+        let entries: Vec<DockerManifestEntry> =
+            serde_json::from_str(manifest).expect("populated RepoTags must deserialize");
+        assert_eq!(
+            entries[0].repo_tags.as_deref(),
+            Some(&["demo:latest".to_string()][..]),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- One-line type change fixing `mikebom sbom scan --image <registry>@sha256:<digest>` for images pulled by digest without a tag.
- Discovered during milestone-132 MVP SC verification (PR #379) when scanning the pinned audit baseline; workaround at the time was `docker tag` before scanning.

## The bug

`docker save` on a tag-less image produces a `manifest.json` containing:

```json
[{"Config":"<config>.json","RepoTags":null,"Layers":[...]}]
```

The previous declaration

```rust
#[serde(rename = "RepoTags", default)]
repo_tags: Vec<String>,
```

did NOT tolerate that — `#[serde(default)]` covers a **missing** field, but `null` is a present field with a literal null value. Serde rejected with `invalid type: null, expected a sequence at line 1 column 106`, the scan failed, and the operator had no path to scan a digest-pinned image without a workaround.

## The fix

```rust
- repo_tags: Vec<String>,
+ repo_tags: Option<Vec<String>>,
```

plus `unwrap_or_default()` at the single use-site. Both `null` and absent now resolve to \"no tag carried in the manifest\" — identical behavior to today for the absent case, identical-to-tagged-image behavior for downstream consumers.

## Test coverage

Three new focused deserializer tests cover the three RepoTags states so the regression cannot silently return:

- `manifest_json_with_null_repo_tags_deserializes` — the bug; asserts `Option::None`, NOT \"silently coerced to `[]`\"
- `manifest_json_with_missing_repo_tags_deserializes` — preserves the existing `#[serde(default)]` coverage
- `manifest_json_with_populated_repo_tags_deserializes` — happy path tag-carried-through

Existing tarball-based end-to-end tests (`extract_minimal_image_populates_rootfs`, `whiteout_removes_earlier_layer_file`, etc.) are unchanged and still pass — they all build images with populated `RepoTags`, so the change is transparent to them.

## Test plan

- [x] `cargo +stable clippy --workspace --all-targets` — zero errors
- [x] `cargo +stable test --workspace` — all green. The three new tests pass; the existing 5 tests in `scan_fs::docker_image::tests` still pass.
- [x] `./scripts/pre-pr.sh` — `>>> all pre-PR checks passed.`

## Re-test against the milestone-132 audit baseline

After this lands, `mikebom sbom scan --image 767397973649.dkr.ecr.us-east-1.amazonaws.com/remediation-planner@sha256:4e7b05811ce4885d8a7183819b4e0e209662784fe24b7553ceea3d149e3c719c --offline --output /tmp/foo.cdx.json --root-name foo` should succeed directly — no `docker tag` workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)