### PR TITLE
feat(scan_fs): file-tier component emission infrastructure (milestone 133 US1.A scaffolding)

### DIFF
--- a/mikebom-cli/src/scan_fs/file_tier/content_shape.rs
+++ b/mikebom-cli/src/scan_fs/file_tier/content_shape.rs
@@ -1,0 +1,505 @@
+#![allow(dead_code)] // US1.A scaffolding; US1.B wires every entry point in.
+
+//! Milestone 133 US1 — content-shape allowlist per FR-005.
+//!
+//! Files surviving [`classify`] qualify for file-tier emission;
+//! every other file is silently skipped (the SBOM doesn't grow). The
+//! exclusion list is tighter than a naïve "every binary file": source
+//! code / docs / configs are explicitly excluded by extension, AND
+//! known package-install path prefixes (`**/node_modules/**`,
+//! `**/.cargo/registry/**`, etc.) are stripped via [`build_orphan_exclusion_globs`]
+//! because those directories ARE the package-tier reader's domain —
+//! we don't double-emit content the package-DB reader already
+//! claims.
+//!
+//! **Allowlist** (FR-005, tightened per FR-022 projection): ELF /
+//! PE / Mach-O binary magic; shared libs by extension; archives by
+//! extension; lone manifests WITH no adjacent lockfile; exec
+//! scripts.
+//!
+//! **Hard exclusion** (FR-005): source-code / plain-text /
+//! structured-config extensions, plus the path-prefix list captured
+//! in [`ORPHAN_PATH_EXCLUSIONS`].
+
+use std::path::Path;
+
+use globset::{Glob, GlobSetBuilder};
+
+/// FR-005 content-shape classification for a single file. Variants
+/// are mutually exclusive — the classifier picks the first matching
+/// shape and returns; downstream emission keys off the variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContentShape {
+    /// ELF executable / shared object — magic bytes `\x7FELF`.
+    ElfBinary,
+    /// Windows Portable Executable — `MZ\x90\x00` (DOS stub at file head).
+    PeBinary,
+    /// Mach-O — 32-bit `\xFE\xED\xFA\xCE` or 64-bit `\xFE\xED\xFA\xCF`
+    /// (also handles the reverse-endian variants `\xCE\xFA\xED\xFE`
+    /// and `\xCF\xFA\xED\xFE`).
+    MachoBinary,
+    /// `.so` / `.dylib` / `.dll` by extension when magic didn't classify
+    /// as one of the binary variants above (e.g. an empty/stub `.so`).
+    SharedLib,
+    /// `.jar` / `.war` / `.ear` / generic `.zip` not already opened by
+    /// mikebom's archive walkers.
+    JavaOrArchive,
+    /// `.deb` / `.rpm` / `.apk` not already opened by the OS-package
+    /// readers.
+    OsPackage,
+    /// `.tar.gz` / `.tgz` / `.tar.xz` / `.tar.bz2` / `.tar` not already
+    /// opened by mikebom's archive walkers.
+    CompressedArchive,
+    /// Lone package manifest with no adjacent lockfile — `package.json`
+    /// without sibling `package-lock.json` etc. The adjacent-lockfile
+    /// check is performed inside [`classify`] before this variant
+    /// returns.
+    LoneManifest,
+    /// Any file with `#!` magic in its first two bytes (executable bit
+    /// not enforced — image rootfs scans frequently lose POSIX perms in
+    /// transit, and a shebang is signal enough).
+    ExecScript,
+}
+
+/// FR-005 path-prefix exclusion list. Known package install roots
+/// where the package-tier reader knows the package identity via
+/// PURL but hasn't yet been extended to emit per-file path coverage.
+/// These directories' contents are silently skipped by [`classify`]
+/// regardless of content shape — pragmatic stop-gap until US2
+/// reader expansion (milestone 134+) fills in `evidence.occurrences[]`
+/// for those readers.
+///
+/// Glob-matched via `globset::GlobSet`. The leading `**/` makes
+/// each pattern rootfs-anchored — accepts e.g. `usr/share/dotnet/...`
+/// AND `opt/some-app/usr/share/dotnet/...`.
+pub(crate) const ORPHAN_PATH_EXCLUSIONS: &[&str] = &[
+    "**/dotnet/packs/**",
+    "**/dotnet/shared/**",
+    "**/dotnet/sdk/**",
+    "**/dotnet/store/**",
+    "**/usr/share/dotnet/**",
+    "**/node_modules/**",
+    "**/lib/python*/site-packages/**",
+    "**/.cargo/registry/**",
+    "**/ruby/gems/**",
+    "**/jvm/openjdk*/lib/**",
+];
+
+/// FR-005 content-shape EXCLUSION list — extensions of files that
+/// MUST NOT be emitted as file-tier components regardless of any
+/// other classification. Matches case-insensitively against the final
+/// component of the file's name.
+const EXCLUDED_EXTENSIONS: &[&str] = &[
+    // Source code
+    "rs", "py", "go", "c", "cpp", "cc", "cxx", "h", "hpp", "cs", "java", "js", "ts", "jsx", "tsx",
+    "rb", "php", "swift", "kt", "kts", "scala", "clj", "ex", "exs", "erl", "lua", "pl", "pm",
+    // Plain text / docs
+    "md", "txt", "rst", "adoc", "asciidoc", "tex",
+    // Structured config
+    "json", "yaml", "yml", "toml", "ini", "conf", "cfg",
+    // XML — *only* when it's not one of the known archive shapes (jar/war/ear are
+    // ZIP-archives and their classification is by-extension above, NOT here, so
+    // raw `.xml` falls through to this exclusion).
+    "xml",
+    // Build configs (separate set to make intent clear in code)
+    "Dockerfile", "Makefile", "Rakefile", "Gemfile",
+    // CI/scaffolding
+    "lock", "sum", "list",
+];
+
+/// Lone-manifest filenames that qualify for FR-005's lone-manifest
+/// classification IF and only if the FR-005 adjacent-lockfile check
+/// at the call site fails to find a sibling lockfile.
+const LONE_MANIFEST_FILENAMES: &[&str] = &[
+    "package.json",
+    "Cargo.toml",
+    "pom.xml",
+    "requirements.txt",
+    "Gemfile",
+    "go.mod",
+];
+
+/// Lockfile filenames whose presence in the same directory (or for
+/// `Cargo.lock`, any parent up to the workspace root) disqualifies
+/// the manifest from `LoneManifest` classification.
+const SIBLING_LOCKFILES_BY_MANIFEST: &[(&str, &[&str])] = &[
+    (
+        "package.json",
+        &["package-lock.json", "yarn.lock", "pnpm-lock.yaml"],
+    ),
+    ("Cargo.toml", &["Cargo.lock"]),
+    ("requirements.txt", &["requirements-freeze.txt", "pyproject.toml"]),
+    ("Gemfile", &["Gemfile.lock"]),
+    ("go.mod", &["go.sum"]),
+];
+
+/// Build the path-prefix exclusion `GlobSet` once per scan. Failure
+/// to compile any pattern returns an empty `GlobSet` — fail-open
+/// here because the patterns are checked-in constants and a build
+/// failure at runtime would silently disable the exclusion list.
+/// We log via `tracing::warn!` instead, then return the empty set.
+pub(crate) fn build_orphan_exclusion_globs() -> globset::GlobSet {
+    let mut builder = GlobSetBuilder::new();
+    for pat in ORPHAN_PATH_EXCLUSIONS {
+        match Glob::new(pat) {
+            Ok(glob) => {
+                builder.add(glob);
+            }
+            Err(err) => {
+                tracing::warn!(
+                    pattern = pat,
+                    error = %err,
+                    "orphan-exclusion glob failed to compile; entry skipped"
+                );
+            }
+        }
+    }
+    builder.build().unwrap_or_else(|err| {
+        tracing::warn!(
+            error = %err,
+            "orphan-exclusion GlobSet failed to build; falling back to empty set"
+        );
+        globset::GlobSet::empty()
+    })
+}
+
+/// FR-005 classifier. Returns `Some(ContentShape)` when the file
+/// qualifies for file-tier emission; `None` when it should be
+/// skipped (excluded by extension, by path prefix, or by absence of
+/// any matching shape).
+///
+/// The classifier is a PURE FUNCTION (no I/O on `rel_path`,
+/// `rootfs_root`, or `exclusion_globs`); the SHA-256 hashing and
+/// adjacent-lockfile filesystem probes happen in the caller
+/// (`walker.rs`). This keeps the function unit-testable without
+/// touching the filesystem and lets the walker batch I/O.
+pub(crate) fn classify(
+    rel_path: &Path,
+    head_bytes: &[u8],
+    exclusion_globs: &globset::GlobSet,
+    lockfile_check: impl FnOnce() -> bool,
+) -> Option<ContentShape> {
+    // 1. Path-prefix exclusion list. Anything under `**/node_modules/**`
+    //    or `**/.cargo/registry/**` etc. is package-tier territory —
+    //    silently skip regardless of shape.
+    if exclusion_globs.is_match(rel_path) {
+        return None;
+    }
+
+    // 2. Extension-based hard exclusion (source code / docs / configs).
+    //    Compare case-insensitively against the file's extension.
+    let lower_filename = rel_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_ascii_lowercase());
+    if let Some(name) = lower_filename.as_deref() {
+        if EXCLUDED_EXTENSIONS.iter().any(|ext| {
+            // Match full filename for extensionless build configs
+            // (Dockerfile, Makefile, Rakefile, Gemfile).
+            ext.eq_ignore_ascii_case(name) ||
+            // Match dot-extension for source / docs / configs.
+            (name.ends_with(&format!(".{}", ext.to_ascii_lowercase())))
+        }) {
+            // Special case: lone manifests are excluded from the
+            // hard exclusion (we WANT to classify them as
+            // `LoneManifest` when there's no adjacent lockfile).
+            // Check separately below.
+            let is_lone_candidate = rel_path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(|s| LONE_MANIFEST_FILENAMES.contains(&s))
+                .unwrap_or(false);
+            if !is_lone_candidate {
+                return None;
+            }
+        }
+    }
+
+    // 3. Magic-number probe (highest signal): ELF / PE / Mach-O.
+    if let Some(shape) = magic_classify(head_bytes) {
+        return Some(shape);
+    }
+
+    // 4. Extension-based positive classification when magic didn't fire.
+    if let Some(name) = lower_filename.as_deref() {
+        if name.ends_with(".so")
+            || name.contains(".so.") // versioned (libfoo.so.1, .so.1.2.3)
+            || name.ends_with(".dylib")
+            || name.ends_with(".dll")
+        {
+            return Some(ContentShape::SharedLib);
+        }
+        if name.ends_with(".jar")
+            || name.ends_with(".war")
+            || name.ends_with(".ear")
+            || name.ends_with(".zip")
+        {
+            return Some(ContentShape::JavaOrArchive);
+        }
+        if name.ends_with(".deb") || name.ends_with(".rpm") || name.ends_with(".apk") {
+            return Some(ContentShape::OsPackage);
+        }
+        if name.ends_with(".tar.gz")
+            || name.ends_with(".tgz")
+            || name.ends_with(".tar.xz")
+            || name.ends_with(".tar.bz2")
+            || name.ends_with(".tar")
+        {
+            return Some(ContentShape::CompressedArchive);
+        }
+    }
+
+    // 5. Lone manifest with FR-005 adjacent-lockfile check.
+    let is_lone_candidate = rel_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| LONE_MANIFEST_FILENAMES.contains(&s))
+        .unwrap_or(false);
+    if is_lone_candidate {
+        // Caller's closure performs the I/O-bound sibling check;
+        // returns `true` when a lockfile is found (NOT lone).
+        if !lockfile_check() {
+            return Some(ContentShape::LoneManifest);
+        }
+        return None;
+    }
+
+    // 6. Executable script: first two bytes `#!`.
+    if head_bytes.len() >= 2 && head_bytes[0] == b'#' && head_bytes[1] == b'!' {
+        return Some(ContentShape::ExecScript);
+    }
+
+    // 7. No match — silently skip.
+    None
+}
+
+/// Return the lockfile names that disqualify a given manifest name
+/// from `LoneManifest` classification. Used by the walker to drive
+/// the adjacent-lockfile probe. Empty slice for manifests with no
+/// FR-005 sibling-lockfile rule.
+pub(crate) fn sibling_lockfiles_for(manifest_filename: &str) -> &'static [&'static str] {
+    for (mname, locks) in SIBLING_LOCKFILES_BY_MANIFEST {
+        if *mname == manifest_filename {
+            return locks;
+        }
+    }
+    &[]
+}
+
+/// `pom.xml` is special: there's no Maven lockfile, but the
+/// presence of a `target/` build-output sibling means "real build,
+/// not vendored source-tree signal". Caller probes for the
+/// directory; this helper just exposes the name string.
+pub(crate) const POM_BUILD_OUTPUT_DIR: &str = "target";
+
+fn magic_classify(head: &[u8]) -> Option<ContentShape> {
+    if head.len() >= 4 && &head[0..4] == b"\x7FELF" {
+        return Some(ContentShape::ElfBinary);
+    }
+    if head.len() >= 2 && &head[0..2] == b"MZ" {
+        return Some(ContentShape::PeBinary);
+    }
+    if head.len() >= 4 {
+        let m = &head[0..4];
+        if m == b"\xFE\xED\xFA\xCE"
+            || m == b"\xFE\xED\xFA\xCF"
+            || m == b"\xCE\xFA\xED\xFE"
+            || m == b"\xCF\xFA\xED\xFE"
+        {
+            return Some(ContentShape::MachoBinary);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn empty_globs() -> globset::GlobSet {
+        globset::GlobSet::empty()
+    }
+
+    #[test]
+    fn elf_binary_magic_classifies() {
+        let g = empty_globs();
+        let shape = classify(
+            &PathBuf::from("opt/custom/tool"),
+            b"\x7FELF\x02\x01\x01\x00",
+            &g,
+            || false,
+        );
+        assert_eq!(shape, Some(ContentShape::ElfBinary));
+    }
+
+    #[test]
+    fn pe_binary_magic_classifies() {
+        let g = empty_globs();
+        let shape = classify(
+            &PathBuf::from("opt/tools/foo.exe"),
+            b"MZ\x90\x00\x03\x00\x00\x00",
+            &g,
+            || false,
+        );
+        assert_eq!(shape, Some(ContentShape::PeBinary));
+    }
+
+    #[test]
+    fn macho_binary_magic_classifies() {
+        let g = empty_globs();
+        let shape = classify(
+            &PathBuf::from("usr/local/bin/foo"),
+            b"\xFE\xED\xFA\xCF\x07\x00\x00\x01",
+            &g,
+            || false,
+        );
+        assert_eq!(shape, Some(ContentShape::MachoBinary));
+    }
+
+    #[test]
+    fn versioned_shared_lib_classifies() {
+        let g = empty_globs();
+        let shape = classify(&PathBuf::from("usr/lib/libfoo.so.1.2"), &[], &g, || false);
+        assert_eq!(shape, Some(ContentShape::SharedLib));
+    }
+
+    #[test]
+    fn rust_source_file_skipped() {
+        let g = empty_globs();
+        let shape = classify(&PathBuf::from("app/src/main.rs"), b"fn main()", &g, || false);
+        assert_eq!(shape, None);
+    }
+
+    #[test]
+    fn yaml_config_skipped() {
+        let g = empty_globs();
+        let shape = classify(&PathBuf::from("etc/foo.yaml"), b"a:", &g, || false);
+        assert_eq!(shape, None);
+    }
+
+    #[test]
+    fn lone_manifest_no_adjacent_lockfile_classifies() {
+        let g = empty_globs();
+        let shape = classify(
+            &PathBuf::from("app/Cargo.toml"),
+            b"[package]",
+            &g,
+            || false, // no lockfile
+        );
+        assert_eq!(shape, Some(ContentShape::LoneManifest));
+    }
+
+    #[test]
+    fn manifest_with_adjacent_lockfile_skipped() {
+        let g = empty_globs();
+        let shape = classify(
+            &PathBuf::from("app/Cargo.toml"),
+            b"[package]",
+            &g,
+            || true, // lockfile present
+        );
+        assert_eq!(shape, None);
+    }
+
+    #[test]
+    fn shebang_script_classifies() {
+        let g = empty_globs();
+        let shape = classify(&PathBuf::from("usr/local/bin/run"), b"#!/bin/sh\n", &g, || {
+            false
+        });
+        assert_eq!(shape, Some(ContentShape::ExecScript));
+    }
+
+    #[test]
+    fn jar_classifies_as_archive() {
+        let g = empty_globs();
+        let shape = classify(&PathBuf::from("opt/app.jar"), &[], &g, || false);
+        assert_eq!(shape, Some(ContentShape::JavaOrArchive));
+    }
+
+    #[test]
+    fn deb_classifies_as_os_package() {
+        let g = empty_globs();
+        let shape = classify(
+            &PathBuf::from("tmp/foo_1.0_amd64.deb"),
+            &[],
+            &g,
+            || false,
+        );
+        assert_eq!(shape, Some(ContentShape::OsPackage));
+    }
+
+    #[test]
+    fn tarball_classifies_as_compressed_archive() {
+        let g = empty_globs();
+        let shape = classify(
+            &PathBuf::from("opt/foo-1.0.tar.gz"),
+            &[],
+            &g,
+            || false,
+        );
+        assert_eq!(shape, Some(ContentShape::CompressedArchive));
+    }
+
+    #[test]
+    fn path_prefix_exclusion_skips_dotnet_packs() {
+        let globs = build_orphan_exclusion_globs();
+        // ELF magic + path under dotnet/packs/ → skip.
+        let shape = classify(
+            &PathBuf::from("usr/share/dotnet/packs/Microsoft.NETCore.App.Runtime.linux-musl-x64/8.0.27/runtimes/linux-musl-x64/lib/net8.0/System.Diagnostics.Tools.dll"),
+            b"MZ\x90\x00",
+            &globs,
+            || false,
+        );
+        assert_eq!(shape, None);
+    }
+
+    #[test]
+    fn path_prefix_exclusion_skips_node_modules() {
+        let globs = build_orphan_exclusion_globs();
+        let shape = classify(
+            &PathBuf::from("app/node_modules/.bin/express"),
+            b"\x7FELF",
+            &globs,
+            || false,
+        );
+        assert_eq!(shape, None);
+    }
+
+    #[test]
+    fn path_prefix_exclusion_skips_cargo_registry() {
+        let globs = build_orphan_exclusion_globs();
+        let shape = classify(
+            &PathBuf::from("root/.cargo/registry/src/index.crates.io/serde-1.0.0/Cargo.toml"),
+            b"[package]",
+            &globs,
+            || false,
+        );
+        assert_eq!(shape, None);
+    }
+
+    #[test]
+    fn sibling_lockfile_lookup_for_known_manifest_returns_nonempty_slice() {
+        assert_eq!(
+            sibling_lockfiles_for("package.json"),
+            &["package-lock.json", "yarn.lock", "pnpm-lock.yaml"]
+        );
+        assert_eq!(sibling_lockfiles_for("Cargo.toml"), &["Cargo.lock"]);
+        assert_eq!(sibling_lockfiles_for("Gemfile"), &["Gemfile.lock"]);
+    }
+
+    #[test]
+    fn sibling_lockfile_lookup_for_unknown_manifest_returns_empty_slice() {
+        assert!(sibling_lockfiles_for("notarealmanifest.toml").is_empty());
+    }
+
+    #[test]
+    fn build_orphan_exclusion_globs_compiles_all_patterns() {
+        let g = build_orphan_exclusion_globs();
+        assert!(g.is_match("foo/dotnet/packs/bar"));
+        assert!(g.is_match("foo/node_modules/baz"));
+        assert!(g.is_match("foo/lib/python3.11/site-packages/qux"));
+    }
+}

--- a/mikebom-cli/src/scan_fs/file_tier/dedupe.rs
+++ b/mikebom-cli/src/scan_fs/file_tier/dedupe.rs
@@ -1,0 +1,277 @@
+#![allow(dead_code)] // US1.A scaffolding; US1.B wires every entry point in.
+
+//! Milestone 133 US1 — FR-011 hybrid dedupe index.
+//!
+//! Before the file-tier walker emits an entry, it consults this
+//! index to know whether a candidate file is ALREADY claimed by a
+//! package-tier or binary-tier component. Claim sources:
+//!
+//! - **Path coverage**: every component's `evidence.occurrences[]`
+//!   `location` field. After milestone 133 US2.3 (already shipped)
+//!   this field covers 2925 / 2926 components (99.96 %) on the
+//!   audit baseline — every cargo / npm / nuget / maven / pypi /
+//!   gem / golang component PLUS every OS-package (apk / dpkg /
+//!   rpm) deep-hash occurrence.
+//!
+//! - **Hash coverage**: every component's `hashes[]` SHA-256 value
+//!   (binary-tier components from milestone-104 readers carry per-
+//!   file hashes; some package-tier readers also carry manifest-
+//!   level hashes — both flow into the same set).
+//!
+//! **`mikebom:component-paths` is NOT consulted**: the spec's
+//! original FR-011 references this property name, but mikebom has
+//! never emitted it. US2.3 ships standards-native `evidence.occurrences[]`
+//! instead; that's the source this index reads from.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use mikebom_common::resolution::ResolvedComponent;
+use mikebom_common::types::hash::HashAlgorithm;
+
+/// Hybrid dedupe set per FR-011 (CORRECTED): a candidate file is
+/// covered when EITHER its rootfs-relative path appears in any
+/// component's `evidence.occurrences[].location` OR its SHA-256
+/// matches any component's `hashes[]` entry.
+///
+/// Built once per scan AFTER all package-DB and binary-tier
+/// readers complete. Immutable thereafter.
+#[derive(Debug, Default)]
+pub(crate) struct DedupeIndex {
+    /// Rootfs-relative paths claimed by a package-tier or
+    /// binary-tier component via the CDX-native `evidence.occurrences[]`
+    /// field. Per the milestone-133 US2.1 normalization convention
+    /// every path here is rootfs-relative with NO leading `/`.
+    claimed_paths: HashSet<PathBuf>,
+    /// Lowercase-hex SHA-256 hashes claimed by ANY component's
+    /// `hashes[]` field. Captures binary-tier per-file hashes
+    /// (milestone 104) AND OS-package deep-hash component roots
+    /// (milestones 038 / 039 / 040).
+    claimed_hashes: HashSet<String>,
+}
+
+impl DedupeIndex {
+    /// Build the index from the already-resolved component vector.
+    /// MUST be called AFTER every reader (package-DB, binary-tier,
+    /// enrichment) completes — the walker reads downstream of
+    /// component resolution so the index has full coverage at
+    /// inspection time.
+    pub(crate) fn build(components: &[ResolvedComponent]) -> Self {
+        let mut claimed_paths: HashSet<PathBuf> = HashSet::new();
+        let mut claimed_hashes: HashSet<String> = HashSet::new();
+
+        for c in components {
+            for occ in &c.occurrences {
+                // Strip leading `/` to match the no-leading-`/`
+                // convention from FR-007 / FR-012. Occurrences
+                // populated by US2.3 are already rootfs-relative
+                // without leading `/`; OS-package deep-hash
+                // occurrences (apk / dpkg / rpm) use the
+                // dpkg-declared path WITH leading `/`. Normalize
+                // here so both shapes index identically.
+                let normalized = occ.location.trim_start_matches('/');
+                claimed_paths.insert(PathBuf::from(normalized));
+            }
+            for hash in &c.hashes {
+                if hash.algorithm == HashAlgorithm::Sha256 {
+                    // `HexString::new` lowercases at construction;
+                    // `as_str` returns the lowercased canonical form.
+                    claimed_hashes.insert(hash.value.as_str().to_string());
+                }
+            }
+        }
+
+        Self {
+            claimed_paths,
+            claimed_hashes,
+        }
+    }
+
+    /// FR-011 hybrid coverage check. Returns `true` when the file
+    /// is COVERED (skip file-tier emission), `false` when it's
+    /// orphan (emit).
+    ///
+    /// Path comparison uses the same rootfs-relative + no-leading-`/`
+    /// normalization the index applied at build time. Hash
+    /// comparison uses lowercase-hex.
+    pub(crate) fn is_covered(&self, rel_path: &Path, sha256_hex: &str) -> bool {
+        let normalized = rel_path.strip_prefix("/").unwrap_or(rel_path);
+        if self.claimed_paths.contains(normalized) {
+            return true;
+        }
+        if self.claimed_hashes.contains(&sha256_hex.to_ascii_lowercase()) {
+            return true;
+        }
+        false
+    }
+
+    /// Diagnostic counter — how many distinct paths the index
+    /// claims. Used by skip-counter / inventory annotations.
+    pub(crate) fn claimed_path_count(&self) -> usize {
+        self.claimed_paths.len()
+    }
+
+    /// Diagnostic counter — how many distinct SHA-256 hashes the
+    /// index claims.
+    pub(crate) fn claimed_hash_count(&self) -> usize {
+        self.claimed_hashes.len()
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+    use mikebom_common::resolution::{
+        FileOccurrence, ResolutionEvidence, ResolutionTechnique, ResolvedComponent,
+    };
+    use mikebom_common::types::hash::{ContentHash, HashAlgorithm};
+    use mikebom_common::types::purl::Purl;
+    use std::path::PathBuf;
+
+    fn make_component(occurrences: Vec<FileOccurrence>, hashes: Vec<ContentHash>) -> ResolvedComponent {
+        ResolvedComponent {
+            name: "x".to_string(),
+            version: "1.0".to_string(),
+            purl: Purl::new("pkg:generic/x@1.0").unwrap(),
+            evidence: ResolutionEvidence {
+                technique: ResolutionTechnique::PackageDatabase,
+                confidence: 0.85,
+                source_connection_ids: vec![],
+                source_file_paths: vec![],
+                deps_dev_match: None,
+            },
+            licenses: vec![],
+            concluded_licenses: vec![],
+            hashes,
+            supplier: None,
+            cpes: vec![],
+            advisories: vec![],
+            occurrences,
+            lifecycle_scope: None,
+            build_inclusion: None,
+            requirement_range: None,
+            source_type: None,
+            sbom_tier: None,
+            buildinfo_status: None,
+            evidence_kind: None,
+            binary_class: None,
+            binary_stripped: None,
+            linkage_kind: None,
+            detected_go: None,
+            confidence: None,
+            binary_packed: None,
+            npm_role: None,
+            raw_version: None,
+            parent_purl: None,
+            co_owned_by: None,
+            shade_relocation: None,
+            external_references: vec![],
+            extra_annotations: std::collections::BTreeMap::new(),
+            binary_role: None,
+        }
+    }
+
+    fn occ(location: &str, sha256: &str) -> FileOccurrence {
+        FileOccurrence {
+            location: location.to_string(),
+            sha256: sha256.to_string(),
+            md5_legacy: None,
+            apk_sha1: None,
+            rpm_file_digest: None,
+        }
+    }
+
+    #[test]
+    fn empty_index_covers_nothing() {
+        let idx = DedupeIndex::build(&[]);
+        assert!(!idx.is_covered(&PathBuf::from("usr/bin/jq"), "abc"));
+        assert_eq!(idx.claimed_path_count(), 0);
+        assert_eq!(idx.claimed_hash_count(), 0);
+    }
+
+    #[test]
+    fn path_with_leading_slash_indexes_no_leading_slash() {
+        let c = make_component(
+            vec![occ("/usr/bin/jq", "deadbeef")],
+            vec![],
+        );
+        let idx = DedupeIndex::build(&[c]);
+        assert!(idx.is_covered(&PathBuf::from("usr/bin/jq"), ""));
+    }
+
+    #[test]
+    fn rootfs_relative_occurrence_indexes_same() {
+        let c = make_component(
+            vec![occ("app/Cargo.lock", "deadbeef")],
+            vec![],
+        );
+        let idx = DedupeIndex::build(&[c]);
+        assert!(idx.is_covered(&PathBuf::from("app/Cargo.lock"), ""));
+    }
+
+    fn sha256_full(seed: &str) -> ContentHash {
+        // Repeat the 8-char seed 8 times → 64-char lowercase hex.
+        let hex = seed.repeat(8);
+        ContentHash::with_algorithm(HashAlgorithm::Sha256, &hex).unwrap()
+    }
+
+    #[test]
+    fn hash_coverage_works() {
+        let c = make_component(vec![], vec![sha256_full("ab12cd34")]);
+        let idx = DedupeIndex::build(&[c]);
+        assert!(idx.is_covered(&PathBuf::from("anywhere"), &"ab12cd34".repeat(8)));
+    }
+
+    #[test]
+    fn hash_coverage_ignores_non_sha256() {
+        // SHA-512 is 128 hex chars; build with the same algorithm
+        // and verify SHA-256 lookup misses.
+        let h = ContentHash::with_algorithm(
+            HashAlgorithm::Sha512,
+            &"deadbeef".repeat(16),
+        )
+        .unwrap();
+        let c = make_component(vec![], vec![h]);
+        let idx = DedupeIndex::build(&[c]);
+        assert!(!idx.is_covered(&PathBuf::from("anywhere"), &"deadbeef".repeat(8)));
+    }
+
+    #[test]
+    fn unknown_path_and_hash_returns_false() {
+        let c = make_component(vec![occ("usr/bin/jq", "abc")], vec![]);
+        let idx = DedupeIndex::build(&[c]);
+        assert!(!idx.is_covered(&PathBuf::from("opt/custom-tool"), "xyz"));
+    }
+
+    #[test]
+    fn diagnostic_counters_report_expected_counts() {
+        let c1 = make_component(
+            vec![occ("usr/bin/jq", "h1"), occ("usr/bin/jq.1.gz", "h2")],
+            vec![sha256_full("deadbeef")],
+        );
+        let c2 = make_component(vec![occ("usr/bin/curl", "h3")], vec![]);
+        let idx = DedupeIndex::build(&[c1, c2]);
+        assert_eq!(idx.claimed_path_count(), 3);
+        assert_eq!(idx.claimed_hash_count(), 1);
+    }
+
+    #[test]
+    fn hash_match_is_case_insensitive() {
+        // HexString normalizes to lowercase at construction. So
+        // even if the caller passes uppercase, the index stores
+        // lowercase. The lookup also lowercases. Both paths
+        // converge on lowercase comparison.
+        let c = make_component(
+            vec![],
+            vec![ContentHash::with_algorithm(
+                HashAlgorithm::Sha256,
+                &"ABCDEF12".repeat(8),
+            )
+            .unwrap()],
+        );
+        let idx = DedupeIndex::build(&[c]);
+        assert!(idx.is_covered(&PathBuf::from("anywhere"), &"abcdef12".repeat(8)));
+        assert!(idx.is_covered(&PathBuf::from("anywhere"), &"ABCDEF12".repeat(8)));
+    }
+}

--- a/mikebom-cli/src/scan_fs/file_tier/mod.rs
+++ b/mikebom-cli/src/scan_fs/file_tier/mod.rs
@@ -1,0 +1,184 @@
+// US1.A scaffolding lint suppression — every entry point in this
+// module is reachable from inside `scan_fs::file_tier` and from the
+// per-module #[cfg(test)] suites, but no production caller invokes
+// the walker yet. US1.B (next PR) wires it into `scan_cmd::scan`,
+// after which this allow is removed.
+#![allow(dead_code)]
+
+//! Milestone 133 US1 — file-tier component emission infrastructure.
+//!
+//! **Scope** (US1.A scaffolding): this module is the home of the
+//! orphan file-tier walker, content-shape classifier, and hybrid
+//! dedupe index. **US1.A is infrastructure-only**: the walker is
+//! callable from inside this module, the unit tests exercise every
+//! module independently, but the scan pipeline does not yet invoke
+//! the walker — that integration ships in US1.B alongside the new
+//! `--file-inventory` CLI flag, default flip, multi-format SBOM
+//! emission, and the new C-rows. Until US1.B lands, every entry
+//! point here is dead code from the production pipeline's
+//! perspective.
+//!
+//! **Architecture** (per `specs/133-file-tier-components/data-model.md`):
+//!
+//! - [`ContentShape`] — content-shape allowlist enum (ELF / PE /
+//!   Mach-O / shared lib / archive / OS package / lone manifest /
+//!   exec script) and the per-file [`content_shape::classify`]
+//!   function that applies FR-005's allowlist + path-prefix
+//!   exclusion + adjacent-lockfile rule.
+//! - [`dedupe::DedupeIndex`] — FR-011 hybrid dedupe: paths
+//!   claimed by any package-tier component via the
+//!   `evidence.occurrences[]` field (populated by milestone
+//!   133 US2.3 for every reader) OR per-file SHA-256 hashes
+//!   carried by binary-tier components. Built once per scan
+//!   AFTER all package + binary readers complete.
+//! - [`walker::walk_file_tier`] — drives `safe_walk` over the
+//!   rootfs, classifies each file via [`ContentShape`], hashes
+//!   surviving files via streaming SHA-256, dedupes against the
+//!   index, and accumulates [`FileTierEntry`] records keyed by
+//!   SHA-256 (per FR-006 per-unique-hash dedupe).
+//!
+//! **`mikebom:component-paths` is a spec fabrication**: the
+//! original FR-011 wording references a `mikebom:component-paths`
+//! property that mikebom never emitted. US2 (already merged at
+//! PR US2.1 / US2.2 / US2.3) ships `mikebom:source-files`,
+//! `mikebom:layer-digest`, and standards-native
+//! `evidence.occurrences[]`. The DedupeIndex here reads from the
+//! third — `evidence.occurrences[]` — which after US2.3 covers
+//! 2925 / 2926 components (99.96 %) on the audit baseline.
+
+pub(crate) mod content_shape;
+pub(crate) mod dedupe;
+pub(crate) mod walker;
+
+use std::path::PathBuf;
+
+pub(crate) use content_shape::ContentShape;
+
+/// Per-unique-content file-tier accumulator entry. One
+/// `FileTierEntry` per unique SHA-256 observed on the rootfs;
+/// multiple paths with identical content collapse to a single
+/// entry whose `paths` Vec carries every observed path
+/// (sort-stable per FR-007).
+///
+/// **Conversion to `ResolvedComponent`** lives in US1.B
+/// (`crate::scan_fs::file_tier::mod::file_tier_entry_to_component`)
+/// alongside the new C-rows that surface
+/// `mikebom:component-tier`, `mikebom:file-paths`,
+/// `mikebom:file-paths-truncated`. This entry type is the
+/// in-process accumulator; emission shape comes later.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FileTierEntry {
+    /// Lowercase-hex SHA-256 of the file's bytes. Computed via
+    /// streaming hash (8 KB chunk buffer) to avoid loading huge
+    /// files into memory. Mandatory per FR-008.
+    pub(crate) sha256_hex: String,
+    /// Every path observed for this content, sorted lex-ascending
+    /// per FR-007. Rootfs-relative + no leading `/` per the FR-007
+    /// / FR-012 convention.
+    pub(crate) paths: Vec<PathBuf>,
+    /// Content-shape classification that allowed this entry. One
+    /// per entry — every path the entry covers had the same shape
+    /// at insert time (matching basenames + matching magic bytes).
+    pub(crate) shape: ContentShape,
+    /// File size in bytes at scan time. Per-content (matches the
+    /// SHA-256 anchor): all paths for the entry share the same
+    /// content so size is invariant.
+    pub(crate) size_bytes: u64,
+}
+
+impl FileTierEntry {
+    /// Construct a new entry from the first path observed for a
+    /// content hash. Subsequent observations of the same hash
+    /// extend the existing entry via [`FileTierEntry::push_path`].
+    pub(crate) fn new(
+        sha256_hex: String,
+        first_path: PathBuf,
+        shape: ContentShape,
+        size_bytes: u64,
+    ) -> Self {
+        Self {
+            sha256_hex,
+            paths: vec![first_path],
+            shape,
+            size_bytes,
+        }
+    }
+
+    /// Append a path to an existing entry. Caller is responsible
+    /// for ensuring the hash already matched and the entry is the
+    /// one indexed under the same hash. The `paths` Vec is kept in
+    /// insertion order during accumulation; the final sort runs
+    /// once at finalization via [`FileTierEntry::finalize`].
+    pub(crate) fn push_path(&mut self, path: PathBuf) {
+        self.paths.push(path);
+    }
+
+    /// Sort `paths` lex-ascending per FR-007. Called once per
+    /// entry at walk completion.
+    pub(crate) fn finalize(&mut self) {
+        self.paths.sort();
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn new_entry_starts_with_one_path() {
+        let e = FileTierEntry::new(
+            "abc123".to_string(),
+            PathBuf::from("opt/foo"),
+            ContentShape::ElfBinary,
+            42,
+        );
+        assert_eq!(e.paths.len(), 1);
+        assert_eq!(e.paths[0], PathBuf::from("opt/foo"));
+        assert_eq!(e.sha256_hex, "abc123");
+        assert_eq!(e.shape, ContentShape::ElfBinary);
+        assert_eq!(e.size_bytes, 42);
+    }
+
+    #[test]
+    fn push_path_appends_in_order() {
+        let mut e = FileTierEntry::new(
+            "abc123".to_string(),
+            PathBuf::from("z/last"),
+            ContentShape::ElfBinary,
+            10,
+        );
+        e.push_path(PathBuf::from("a/first"));
+        e.push_path(PathBuf::from("m/middle"));
+        assert_eq!(
+            e.paths,
+            vec![
+                PathBuf::from("z/last"),
+                PathBuf::from("a/first"),
+                PathBuf::from("m/middle"),
+            ]
+        );
+    }
+
+    #[test]
+    fn finalize_sorts_paths_lex_ascending() {
+        let mut e = FileTierEntry::new(
+            "abc123".to_string(),
+            PathBuf::from("z/last"),
+            ContentShape::ElfBinary,
+            10,
+        );
+        e.push_path(PathBuf::from("a/first"));
+        e.push_path(PathBuf::from("m/middle"));
+        e.finalize();
+        assert_eq!(
+            e.paths,
+            vec![
+                PathBuf::from("a/first"),
+                PathBuf::from("m/middle"),
+                PathBuf::from("z/last"),
+            ]
+        );
+    }
+}

--- a/mikebom-cli/src/scan_fs/file_tier/walker.rs
+++ b/mikebom-cli/src/scan_fs/file_tier/walker.rs
@@ -1,0 +1,523 @@
+#![allow(dead_code)] // US1.A scaffolding; US1.B wires every entry point in.
+
+//! Milestone 133 US1 — orphan file-tier walker.
+//!
+//! Drives `safe_walk` over the rootfs, classifies each file via
+//! [`super::content_shape::classify`], hashes survivors with
+//! streaming SHA-256, dedupes against the [`super::dedupe::DedupeIndex`],
+//! and accumulates per-unique-hash [`super::FileTierEntry`] records.
+//!
+//! **Walker is callable but not yet integrated**: this module is
+//! reachable from inside `scan_fs::file_tier` but the production
+//! scan pipeline does NOT invoke it yet — that integration ships
+//! in US1.B alongside the new `--file-inventory` CLI flag, default
+//! flip, multi-format SBOM emission, and the new C-rows.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use sha2::Digest;
+
+use super::content_shape::{
+    classify, sibling_lockfiles_for, ContentShape, POM_BUILD_OUTPUT_DIR,
+};
+use super::dedupe::DedupeIndex;
+use super::FileTierEntry;
+
+/// Per-scan configuration for [`walk_file_tier`]. No defaults; all
+/// fields supplied by the caller.
+pub(crate) struct WalkerConfig<'a> {
+    /// Maximum file size (in bytes) to consider for file-tier
+    /// emission. Files larger than this are skipped and counted in
+    /// [`WalkerStats::oversize_skipped`]. Per FR-010 the production
+    /// default is 100 MB; tests pass any value.
+    pub size_limit_bytes: u64,
+    /// Compiled `**`-pattern exclusion set from
+    /// [`super::content_shape::build_orphan_exclusion_globs`]. Built
+    /// once per scan by the caller.
+    pub exclusion_globs: &'a globset::GlobSet,
+    /// FR-011 hybrid dedupe index. Built once per scan after every
+    /// reader completes.
+    pub dedupe_index: &'a DedupeIndex,
+}
+
+/// Diagnostic skip-counters. Emitted as document-level annotations
+/// per Principle X (`mikebom:file-inventory-skipped-oversize` etc.)
+/// in US1.B. US1.A returns them but the SBOM emission code does
+/// not yet read them.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct WalkerStats {
+    /// Files skipped because their size exceeded `size_limit_bytes`.
+    pub oversize_skipped: usize,
+    /// Files skipped because they were special files (devices,
+    /// sockets, FIFOs) or otherwise non-regular.
+    pub special_skipped: usize,
+    /// Files skipped because mikebom couldn't open or read them
+    /// (permissions, missing, mid-flight delete).
+    pub unreadable_skipped: usize,
+    /// Files skipped because the dedupe index reported them
+    /// covered (path OR hash match against an already-emitted
+    /// component).
+    pub dedupe_skipped: usize,
+    /// Files skipped because [`classify`] returned `None`
+    /// (content shape didn't match the allowlist, OR path was on
+    /// the exclusion list).
+    pub shape_skipped: usize,
+    /// Files hashed AND surviving every filter — converted to
+    /// `FileTierEntry` records.
+    pub emitted: usize,
+}
+
+/// Walk the rootfs, classify + hash + dedupe each file, and return
+/// per-unique-hash [`FileTierEntry`] records plus diagnostic stats.
+///
+/// The returned Vec is sorted by SHA-256 hex for deterministic
+/// downstream ordering. Each entry's `paths` Vec is sorted
+/// lex-ascending per FR-007. Caller is responsible for the final
+/// `FileTierEntry → ResolvedComponent` conversion (US1.B).
+pub(crate) fn walk_file_tier(
+    rootfs: &Path,
+    cfg: &WalkerConfig<'_>,
+) -> (Vec<FileTierEntry>, WalkerStats) {
+    let mut entries: HashMap<String, FileTierEntry> = HashMap::new();
+    let mut stats = WalkerStats::default();
+
+    let empty_exclude = crate::scan_fs::package_db::exclude_path::ExclusionSet::new_empty();
+    let walk_cfg = crate::scan_fs::walk::WalkConfig {
+        max_depth: 32,
+        should_skip: &|_candidate, _root| false,
+        exclude_set: &empty_exclude,
+    };
+
+    crate::scan_fs::walk::safe_walk(rootfs, &walk_cfg, |abs_path| {
+        // Only files are interesting. `safe_walk` invokes the
+        // visit closure for both directories and files; we
+        // discriminate here.
+        let meta = match std::fs::symlink_metadata(abs_path) {
+            Ok(m) => m,
+            Err(_) => {
+                stats.unreadable_skipped += 1;
+                return;
+            }
+        };
+        if meta.is_dir() || meta.file_type().is_symlink() {
+            return;
+        }
+        if !meta.is_file() {
+            // Devices, sockets, FIFOs, char/block specials.
+            stats.special_skipped += 1;
+            return;
+        }
+        if meta.len() > cfg.size_limit_bytes {
+            stats.oversize_skipped += 1;
+            return;
+        }
+
+        // Build the rootfs-relative path. `safe_walk` hands us the
+        // absolute path; strip the rootfs prefix and clear any
+        // leading `/`.
+        let Ok(rel_abs) = abs_path.strip_prefix(rootfs) else {
+            // Not under rootfs (shouldn't happen given safe_walk's
+            // contract, but defense-in-depth).
+            return;
+        };
+        let rel_path: PathBuf = rel_abs.to_path_buf();
+
+        // Read first 8 bytes for the magic-number probe. 8 covers
+        // every magic we check (ELF=4, PE=2, Mach-O=4, shebang=2).
+        let mut head_bytes = [0u8; 8];
+        let head_len = match std::fs::File::open(abs_path)
+            .and_then(|mut f| f.read(&mut head_bytes))
+        {
+            Ok(n) => n,
+            Err(_) => {
+                stats.unreadable_skipped += 1;
+                return;
+            }
+        };
+        let head_slice = &head_bytes[..head_len];
+
+        // Adjacent-lockfile probe — pulled into a closure so the
+        // classifier stays I/O-free.
+        let manifest_name = rel_path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_string());
+        let abs_path_owned = abs_path.to_path_buf();
+        let lockfile_check = move || lockfile_present_for(&abs_path_owned, manifest_name.as_deref());
+
+        let shape = match classify(&rel_path, head_slice, cfg.exclusion_globs, lockfile_check) {
+            Some(s) => s,
+            None => {
+                stats.shape_skipped += 1;
+                return;
+            }
+        };
+
+        // Stream-hash the file's bytes.
+        let sha = match streaming_sha256_hex(abs_path) {
+            Some(s) => s,
+            None => {
+                stats.unreadable_skipped += 1;
+                return;
+            }
+        };
+
+        // FR-011 hybrid dedupe.
+        if cfg.dedupe_index.is_covered(&rel_path, &sha) {
+            stats.dedupe_skipped += 1;
+            return;
+        }
+
+        // Accumulate per-unique-hash. Multiple paths with identical
+        // content collapse to one entry via `push_path`.
+        match entries.get_mut(&sha) {
+            Some(existing) => existing.push_path(rel_path),
+            None => {
+                entries.insert(
+                    sha.clone(),
+                    FileTierEntry::new(sha, rel_path, shape, meta.len()),
+                );
+            }
+        }
+        stats.emitted += 1;
+    });
+
+    // Finalize: sort each entry's paths per FR-007, then sort
+    // entries by SHA-256 hex for deterministic output ordering.
+    let mut out: Vec<FileTierEntry> = entries
+        .into_values()
+        .map(|mut e| {
+            e.finalize();
+            e
+        })
+        .collect();
+    out.sort_by(|a, b| a.sha256_hex.cmp(&b.sha256_hex));
+    (out, stats)
+}
+
+/// FR-005 adjacent-lockfile probe for a candidate lone manifest.
+/// Returns `true` when a disqualifying lockfile is present nearby.
+///
+/// Per FR-005:
+/// - `package.json` checks siblings for the npm/yarn/pnpm lockfiles.
+/// - `Cargo.toml` walks parents up to 8 levels looking for `Cargo.lock`.
+/// - `pom.xml` checks for a sibling `target/` build-output directory.
+/// - `requirements.txt` / `Gemfile` / `go.mod` check siblings for
+///   their respective lockfiles.
+fn lockfile_present_for(abs_manifest: &Path, manifest_filename: Option<&str>) -> bool {
+    let Some(name) = manifest_filename else {
+        return false;
+    };
+    let Some(parent) = abs_manifest.parent() else {
+        return false;
+    };
+
+    // pom.xml: sibling `target/` dir is the signal.
+    if name == "pom.xml" {
+        return parent.join(POM_BUILD_OUTPUT_DIR).is_dir();
+    }
+
+    // Cargo.toml: walk up to 8 ancestors looking for Cargo.lock.
+    if name == "Cargo.toml" {
+        let mut current: Option<&Path> = Some(parent);
+        for _ in 0..=8 {
+            let Some(dir) = current else {
+                break;
+            };
+            if dir.join("Cargo.lock").is_file() {
+                return true;
+            }
+            current = dir.parent();
+        }
+        return false;
+    }
+
+    // Every other manifest: sibling lockfile match.
+    let siblings = sibling_lockfiles_for(name);
+    siblings.iter().any(|lock| parent.join(lock).is_file())
+}
+
+/// Stream SHA-256 the file's bytes in 8 KB chunks. Returns
+/// lowercase-hex. `None` on any I/O failure.
+fn streaming_sha256_hex(abs_path: &Path) -> Option<String> {
+    let mut f = std::fs::File::open(abs_path).ok()?;
+    let mut hasher = sha2::Sha256::new();
+    let mut buf = [0u8; 8 * 1024];
+    loop {
+        let n = f.read(&mut buf).ok()?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Some(hex_encode(&hasher.finalize()))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{:02x}", b));
+    }
+    out
+}
+
+// Re-export for test helpers below. Unused-marker silencer:
+// `WalkerStats` and `WalkerConfig` are referenced by US1.B
+// integration code that hasn't landed yet; the `dead_code` allow
+// keeps US1.A's lint gate green without suppressing the warning
+// crate-wide.
+#[allow(dead_code)]
+fn _unused_lints_silencer() {
+    let _ = ContentShape::ElfBinary;
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+    use crate::scan_fs::file_tier::content_shape::build_orphan_exclusion_globs;
+    use sha2::Digest;
+    use tempfile::TempDir;
+
+    fn empty_dedupe() -> DedupeIndex {
+        DedupeIndex::default()
+    }
+
+    fn make_globs() -> globset::GlobSet {
+        build_orphan_exclusion_globs()
+    }
+
+    fn write_file(dir: &Path, rel: &str, bytes: &[u8]) -> PathBuf {
+        let p = dir.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, bytes).unwrap();
+        p
+    }
+
+    fn sha256_of(bytes: &[u8]) -> String {
+        let mut h = sha2::Sha256::new();
+        h.update(bytes);
+        hex_encode(&h.finalize())
+    }
+
+    #[test]
+    fn empty_rootfs_returns_no_entries() {
+        let tmp = TempDir::new().unwrap();
+        let g = make_globs();
+        let d = empty_dedupe();
+        let cfg = WalkerConfig {
+            size_limit_bytes: 100 * 1024 * 1024,
+            exclusion_globs: &g,
+            dedupe_index: &d,
+        };
+        let (entries, stats) = walk_file_tier(tmp.path(), &cfg);
+        assert!(entries.is_empty());
+        assert_eq!(stats.emitted, 0);
+    }
+
+    #[test]
+    fn elf_binary_emits_one_entry() {
+        let tmp = TempDir::new().unwrap();
+        let payload = b"\x7FELF\x02\x01\x01\x00rest-of-file";
+        write_file(tmp.path(), "opt/custom-tool", payload);
+        let g = make_globs();
+        let d = empty_dedupe();
+        let cfg = WalkerConfig {
+            size_limit_bytes: 100 * 1024 * 1024,
+            exclusion_globs: &g,
+            dedupe_index: &d,
+        };
+        let (entries, stats) = walk_file_tier(tmp.path(), &cfg);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].shape, ContentShape::ElfBinary);
+        assert_eq!(entries[0].sha256_hex, sha256_of(payload));
+        assert_eq!(entries[0].paths.len(), 1);
+        assert_eq!(entries[0].paths[0], PathBuf::from("opt/custom-tool"));
+        assert_eq!(stats.emitted, 1);
+    }
+
+    #[test]
+    fn source_file_skipped_by_classifier() {
+        let tmp = TempDir::new().unwrap();
+        write_file(tmp.path(), "app/src/main.rs", b"fn main() {}");
+        let g = make_globs();
+        let d = empty_dedupe();
+        let cfg = WalkerConfig {
+            size_limit_bytes: 100 * 1024 * 1024,
+            exclusion_globs: &g,
+            dedupe_index: &d,
+        };
+        let (entries, stats) = walk_file_tier(tmp.path(), &cfg);
+        assert!(entries.is_empty());
+        assert_eq!(stats.shape_skipped, 1);
+        assert_eq!(stats.emitted, 0);
+    }
+
+    #[test]
+    fn duplicate_content_at_two_paths_collapses_to_one_entry() {
+        let tmp = TempDir::new().unwrap();
+        let payload = b"\x7FELF\x02\x01\x01\x00duplicated";
+        write_file(tmp.path(), "opt/a", payload);
+        write_file(tmp.path(), "opt/b", payload);
+        let g = make_globs();
+        let d = empty_dedupe();
+        let cfg = WalkerConfig {
+            size_limit_bytes: 100 * 1024 * 1024,
+            exclusion_globs: &g,
+            dedupe_index: &d,
+        };
+        let (entries, _stats) = walk_file_tier(tmp.path(), &cfg);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].paths.len(), 2);
+        // FR-007: paths sorted lex-ascending.
+        assert_eq!(
+            entries[0].paths,
+            vec![PathBuf::from("opt/a"), PathBuf::from("opt/b")]
+        );
+    }
+
+    #[test]
+    fn dedupe_index_path_match_skips_file() {
+        let tmp = TempDir::new().unwrap();
+        let payload = b"\x7FELF\x02\x01\x01\x00owned-by-pkg";
+        write_file(tmp.path(), "usr/bin/jq", payload);
+        let g = make_globs();
+        // Forge a DedupeIndex that already claims `usr/bin/jq`.
+        use mikebom_common::resolution::{
+            FileOccurrence, ResolutionEvidence, ResolutionTechnique, ResolvedComponent,
+        };
+        use mikebom_common::types::purl::Purl;
+        let claim = ResolvedComponent {
+            name: "jq".to_string(),
+            version: "1.6".to_string(),
+            purl: Purl::new("pkg:deb/debian/jq@1.6").unwrap(),
+            evidence: ResolutionEvidence {
+                technique: ResolutionTechnique::PackageDatabase,
+                confidence: 1.0,
+                source_connection_ids: vec![],
+                source_file_paths: vec![],
+                deps_dev_match: None,
+            },
+            licenses: vec![],
+            concluded_licenses: vec![],
+            hashes: vec![],
+            supplier: None,
+            cpes: vec![],
+            advisories: vec![],
+            occurrences: vec![FileOccurrence {
+                location: "usr/bin/jq".to_string(),
+                sha256: "x".to_string(),
+                md5_legacy: None,
+                apk_sha1: None,
+                rpm_file_digest: None,
+            }],
+            lifecycle_scope: None,
+            build_inclusion: None,
+            requirement_range: None,
+            source_type: None,
+            sbom_tier: None,
+            buildinfo_status: None,
+            evidence_kind: None,
+            binary_class: None,
+            binary_stripped: None,
+            linkage_kind: None,
+            detected_go: None,
+            confidence: None,
+            binary_packed: None,
+            npm_role: None,
+            raw_version: None,
+            parent_purl: None,
+            co_owned_by: None,
+            shade_relocation: None,
+            external_references: vec![],
+            extra_annotations: std::collections::BTreeMap::new(),
+            binary_role: None,
+        };
+        let d = DedupeIndex::build(&[claim]);
+        let cfg = WalkerConfig {
+            size_limit_bytes: 100 * 1024 * 1024,
+            exclusion_globs: &g,
+            dedupe_index: &d,
+        };
+        let (entries, stats) = walk_file_tier(tmp.path(), &cfg);
+        assert!(entries.is_empty());
+        assert_eq!(stats.dedupe_skipped, 1);
+        assert_eq!(stats.emitted, 0);
+    }
+
+    #[test]
+    fn oversize_file_skipped_with_counter_increment() {
+        let tmp = TempDir::new().unwrap();
+        // Two ELF magic + 10 bytes; size_limit_bytes=8 is below.
+        let payload = b"\x7FELF\x02\x01\x01\x00aaaaaaaaaa";
+        write_file(tmp.path(), "opt/big", payload);
+        let g = make_globs();
+        let d = empty_dedupe();
+        let cfg = WalkerConfig {
+            size_limit_bytes: 8,
+            exclusion_globs: &g,
+            dedupe_index: &d,
+        };
+        let (entries, stats) = walk_file_tier(tmp.path(), &cfg);
+        assert!(entries.is_empty());
+        assert_eq!(stats.oversize_skipped, 1);
+        assert_eq!(stats.emitted, 0);
+    }
+
+    #[test]
+    fn lone_cargo_toml_emits_when_no_cargo_lock() {
+        let tmp = TempDir::new().unwrap();
+        write_file(tmp.path(), "app/Cargo.toml", b"[package]\nname=\"x\"\n");
+        let g = make_globs();
+        let d = empty_dedupe();
+        let cfg = WalkerConfig {
+            size_limit_bytes: 100 * 1024 * 1024,
+            exclusion_globs: &g,
+            dedupe_index: &d,
+        };
+        let (entries, stats) = walk_file_tier(tmp.path(), &cfg);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].shape, ContentShape::LoneManifest);
+        assert_eq!(stats.emitted, 1);
+    }
+
+    #[test]
+    fn cargo_toml_with_sibling_cargo_lock_is_skipped() {
+        let tmp = TempDir::new().unwrap();
+        write_file(tmp.path(), "app/Cargo.toml", b"[package]\nname=\"x\"\n");
+        write_file(tmp.path(), "app/Cargo.lock", b"# locked");
+        let g = make_globs();
+        let d = empty_dedupe();
+        let cfg = WalkerConfig {
+            size_limit_bytes: 100 * 1024 * 1024,
+            exclusion_globs: &g,
+            dedupe_index: &d,
+        };
+        let (entries, stats) = walk_file_tier(tmp.path(), &cfg);
+        // Cargo.lock is the locked manifest, ends with .lock → excluded.
+        // Cargo.toml has sibling .lock → not lone → skipped.
+        assert!(entries.is_empty());
+        assert_eq!(stats.shape_skipped, 2);
+    }
+
+    #[test]
+    fn entries_returned_sorted_by_sha256() {
+        let tmp = TempDir::new().unwrap();
+        let p1 = b"\x7FELF\x02\x01\x01\x00aaa";
+        let p2 = b"\x7FELF\x02\x01\x01\x00bbb";
+        write_file(tmp.path(), "opt/a", p1);
+        write_file(tmp.path(), "opt/b", p2);
+        let g = make_globs();
+        let d = empty_dedupe();
+        let cfg = WalkerConfig {
+            size_limit_bytes: 100 * 1024 * 1024,
+            exclusion_globs: &g,
+            dedupe_index: &d,
+        };
+        let (entries, _stats) = walk_file_tier(tmp.path(), &cfg);
+        assert_eq!(entries.len(), 2);
+        assert!(entries[0].sha256_hex < entries[1].sha256_hex);
+    }
+}

--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -13,6 +13,14 @@ pub mod binary;
 pub mod dedup;
 pub mod docker_daemon;
 pub mod docker_image;
+// Milestone 133 US1.A scaffolding — orphan file-tier walker,
+// content-shape classifier, hybrid dedupe. The submodules are
+// pub(crate) and their entry points are reachable from inside
+// `scan_fs::file_tier` but the production scan pipeline does NOT
+// yet invoke them. US1.B wires the walker into `scan_cmd::scan`
+// alongside the new `--file-inventory` CLI flag, multi-format
+// SBOM emission, and the new C-rows.
+pub(crate) mod file_tier;
 #[cfg(feature = "oci-registry")]
 pub mod oci_pull;
 pub mod os_release;

--- a/mikebom-cli/src/scan_fs/walk.audit-allowlist.txt
+++ b/mikebom-cli/src/scan_fs/walk.audit-allowlist.txt
@@ -1,4 +1,5 @@
 mikebom-cli/src/scan_fs/binary/source_binding/cmake_observer.rs:fn walk_for_cmake_build_dirs(
+mikebom-cli/src/scan_fs/file_tier/walker.rs:pub(crate) fn walk_file_tier(
 mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_fat_jar_collects_one_meta_per_vendored_artifact() {
 mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_fat_jar_only_primary_coord_gets_archive_sha256() {
 mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_jar_attaches_sidecar_hash_when_present() {


### PR DESCRIPTION
## Summary

- Lays down the scaffolding for US1's orphan file-tier emission: a new `scan_fs/file_tier/` module with three submodules (`content_shape.rs`, `dedupe.rs`, `walker.rs`) + a `FileTierEntry` accumulator type.
- **Production scan path does NOT invoke this code yet.** US1.B (next PR) wires the walker into `scan_cmd::scan`, adds the `--file-inventory` CLI flag, flips the default to `orphan`, adds multi-format SBOM emission, and adds the new C-rows.
- 38 new unit tests covering each entry point. Pre-PR gate green: 152 result blocks ok, 0 failed; bin test count 2171 → 2209.

## Spec corrections embedded

The original FR-011 referenced `mikebom:component-paths`, which mikebom never emitted. After US2.3 (PR #386), the standards-native equivalent is the CDX `evidence.occurrences[].location` field — populated for 99.96 % of audit-baseline components. `DedupeIndex` reads from that, not the fabricated property name. `FileInventoryMode` is NOT introduced in this PR — that surface is US1.B's job.

## Approach

| File | Change |
|---|---|
| `scan_fs/file_tier/content_shape.rs` | `ContentShape` enum (9 variants) + pure `classify` function + `ORPHAN_PATH_EXCLUSIONS` const + `build_orphan_exclusion_globs()` helper + adjacent-lockfile lookup table. 17 unit tests. |
| `scan_fs/file_tier/dedupe.rs` | `DedupeIndex` reading `ResolvedComponent.occurrences[].location` (path coverage) + `hashes[]` SHA-256 entries (hash coverage). FR-007 leading-`/` normalization at index and lookup time. 8 unit tests. |
| `scan_fs/file_tier/walker.rs` | `walk_file_tier(rootfs, cfg)` drives `safe_walk`, reads first 8 bytes for magic probe, calls `classify`, stream-hashes via 8 KB chunked SHA-256, dedupes against `DedupeIndex`, accumulates per-unique-hash `FileTierEntry` records. `WalkerStats` skip-counters. `lockfile_present_for` implements FR-005's adjacent-lockfile probe (sibling for npm/gem/python/go, ancestor walk ≤8 levels for cargo, sibling `target/` dir for maven). 9 unit tests. |
| `scan_fs/file_tier/mod.rs` | Module entry + `FileTierEntry { sha256_hex, paths, shape, size_bytes }` accumulator with `new` / `push_path` / `finalize` (FR-007 lex-sort). 3 unit tests. |
| `scan_fs/mod.rs` | `pub(crate) mod file_tier;` with inline US1.A-vs-US1.B narration. |

The four new files carry a top-of-file `#![allow(dead_code)]` inner attribute with a US1.A rationale — without it, clippy trips on every public item because no production caller invokes the walker yet. US1.B's first commit removes those attributes when wiring lands.

## Test plan

- [x] `cargo +stable clippy --workspace --all-targets` — zero errors
- [x] `cargo +stable test --workspace` — every suite `N passed; 0 failed` (152 result blocks ok, 0 failed)
- [x] 38 new file_tier unit tests pass (17 content_shape + 8 dedupe + 9 walker + 3 mod)
- [x] Existing bin test suite count rises 2171 → 2209
- [x] No golden churn (zero changes to fixtures)
- [x] No new Cargo dependencies

## Constitution check

| Principle | Status |
|---|---|
| I. Pure Rust, Zero C | ✓ — no new transitive C deps |
| III. Fail Closed | ✓ — classifier returns `Option`; walker silently skips on I/O failure with skip-counter increment |
| IV. Type-Driven Correctness | ✓ — `ContentShape` enum + `FileTierEntry` typed struct |
| V. Specification Compliance | ✓ — no new annotations/C-rows in this PR (US1.B owns those) |
| VII. Test Isolation | ✓ — tempfile-based walker tests |
| X. Transparency | ✓ — `WalkerStats` skip-counters ready for US1.B annotation emission |

## Next: US1.B

- Add `--file-inventory={off|orphan|full}` CLI flag + `FileInventoryMode` enum
- Wire `walk_file_tier` into `scan_cmd::scan` after enrichment
- Flip default to `orphan` per spec FR-015 + the Q1 clarification
- Add `FileTierEntry → ResolvedComponent` conversion
- Multi-format emission (CDX `type = "file"`, SPDX 2.3 `Package` with `filesAnalyzed: false`, SPDX 3 `software_File`)
- 6 new C-rows: `mikebom:component-tier`, `mikebom:file-paths`, `mikebom:file-paths-truncated`, `mikebom:file-inventory-skipped-oversize`, `mikebom:file-inventory-skipped-special-files`, `mikebom:file-inventory-unreadable`
- Goldens regen (declared churn per FR-004 / SC-005)

🤖 Generated with [Claude Code](https://claude.com/claude-code)