### PR TITLE
feat(scan_fs): wire orphan file-tier walker into CDX scan path (milestone 133 US1.B — opt-in MVP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,85 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 
 ## [Unreleased]
 
+### File-tier emission opt-in via `--file-inventory=orphan` (milestone 133 US1.B — CDX MVP)
+
+Lays down the operator-facing surface and the production CDX emission
+path for orphan file-tier components — unattributed binaries / vendored
+libraries with no package metadata / embedded archives that mikebom
+silently omitted before milestone 133.
+
+**Default = OFF in US1.B** (preserves pre-milestone-133 byte-identity
+on every existing scan). US1.C flips the default to `orphan` and
+declares the SBOM-change.
+
+**New flags**:
+
+- `--file-inventory={off|orphan|full}` — gates orphan walker
+  invocation. `off` skips it entirely (default); `orphan` runs the
+  walker with the FR-011 hybrid dedupe; `full` runs with dedupe
+  bypassed (emits a component per surviving content-shape match
+  regardless of coverage).
+- `--file-inventory-size-limit <BYTES>` (default 100 MB per FR-010)
+  — files exceeding the cap are skipped; document-level skip
+  counters land in US1.C alongside the Principle-X annotations.
+
+**Emission shape** (CDX 1.6 — SPDX 2.3 + SPDX 3 polish is US1.C):
+
+- `type = "file"` (FR-001 — the CDX-native file-element shape).
+- `purl` field OMITTED (FR-009 — identity is via `bom-ref` +
+  SHA-256). The in-process `ResolvedComponent` carries a placeholder
+  `pkg:generic/file-tier?content-sha256=<hex>` PURL for type
+  uniformity; the CDX builder recognizes the
+  `mikebom:component-tier = "file"` annotation and skips the field
+  at write time.
+- `name = <basename-of-first-sorted-path>` (FR-009).
+- `hashes[]` carrying SHA-256 (FR-008).
+- `properties[]` includes:
+  - `mikebom:component-tier = "file"` (FR-002)
+  - `mikebom:file-paths = <JSON-encoded sorted array>` (FR-007 —
+    every path the entry covers, sorted lex-ascending, capped at
+    100 entries; `mikebom:file-paths-truncated = "true"` fires
+    when the cap was hit).
+
+The CDX-side flow rides through existing infrastructure — extra
+annotations land in `properties[]` via the builder's generic loop;
+no new C-row catalog entries needed in US1.B (US1.C adds them for
+cross-format parity).
+
+**Wiring**: `scan_cmd::scan` calls
+`scan_fs::file_tier::walker::walk_file_tier` AFTER every reader,
+enrichment, and `tag_components_with_layer_digest` pass — the FR-011
+hybrid dedupe index reads from `ResolvedComponent.occurrences[]`
+(populated by US2.3 for 99.96 % of audit-baseline components) AND
+from `ResolvedComponent.hashes[]` SHA-256 entries.
+
+**Tests**: 3 new integration tests (`file_tier_orphan_emit.rs`)
+asserting default-OFF preserves no file-tier emission, orphan mode
+emits the correct CDX shape (type, no purl, SHA-256, annotations),
+and invalid `--file-inventory` value exits non-zero. 4 new unit
+tests for `FileTierEntry::into_resolved_component` +
+`FileInventoryMode::parse`. Total file-tier unit count rises 38 → 42.
+
+**Coming in US1.C**:
+
+- Proper SPDX 2.3 file-tier emission (`filesAnalyzed: false`,
+  no `externalRef[purl]`).
+- Proper SPDX 3 file-element shape per FR-001 + research §SPDX 3
+  element type decision.
+- 6 new C-rows + parity extractors (`mikebom:component-tier`,
+  `mikebom:file-paths`, `mikebom:file-paths-truncated`,
+  `mikebom:file-inventory-skipped-oversize`,
+  `mikebom:file-inventory-skipped-special-files`,
+  `mikebom:file-inventory-unreadable`).
+- Default flip from `off` to `orphan`. **DECLARED BEHAVIOR CHANGE
+  on milestone 133** per the spec Q1 clarification — image-scan
+  SBOMs grow by ~180-440 file-tier components on the audit baseline
+  (SC-001 range). Operators wanting pre-133 byte-identity opt out
+  via `--file-inventory=off`.
+- Goldens regen + SC-001 / SC-002 verification.
+
+No new Cargo dependencies.
+
 ### `evidence.occurrences[]` populated for every language-ecosystem reader (milestone 133 US2.3)
 
 Closes the standards-native path-coverage gap on `evidence.occurrences[]`.

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -246,6 +246,35 @@ pub struct ScanArgs {
     #[arg(long)]
     pub no_deep_hash: bool,
 
+    /// Milestone 133 US1 — emit file-tier components for unattributed
+    /// content (custom binaries, vendored libraries with no manifest,
+    /// embedded archives) surviving the FR-005 content-shape allowlist.
+    ///
+    /// Modes:
+    /// - `off` (US1.B default — preserves pre-milestone-133 byte-
+    ///   identity): no file-tier emission.
+    /// - `orphan` (US1.C default — planned flip): emit components only
+    ///   for content NOT covered by any package-tier or binary-tier
+    ///   component's `evidence.occurrences[]` paths or `hashes[]`
+    ///   SHA-256 set (FR-011 hybrid dedupe).
+    /// - `full`: emit a component for every regular file surviving the
+    ///   FR-005 allowlist, regardless of dedupe coverage. Useful for
+    ///   forensic / compliance use cases cataloguing every hash on
+    ///   disk.
+    ///
+    /// Emitted file-tier components carry a `mikebom:component-tier =
+    /// "file"` annotation and a `mikebom:file-paths` JSON-encoded
+    /// array of every observed path for the unique content.
+    #[arg(long, value_name = "MODE", default_value = "off")]
+    pub file_inventory: String,
+
+    /// Maximum file size (bytes) considered for file-tier emission.
+    /// Files larger than this are skipped; the document-level
+    /// `mikebom:file-inventory-skipped-oversize` annotation reports
+    /// the skip count. Default 100 MB per FR-010.
+    #[arg(long, default_value_t = 100 * 1024 * 1024)]
+    pub file_inventory_size_limit: u64,
+
     /// Print a JSON summary to stdout after writing the SBOM.
     #[arg(long)]
     pub json: bool,
@@ -2251,6 +2280,51 @@ pub async fn execute(
         _extracted.as_ref().map(|e| &e.layer_path_map),
     );
 
+    // Milestone 133 US1.B (FR-002 + FR-015): file-tier emission for
+    // unattributed content (custom binaries, vendored libraries with
+    // no manifest, embedded archives). Runs AFTER every package /
+    // binary / enrichment step so the FR-011 hybrid dedupe sees the
+    // full claim set. Default `off` in US1.B — preserves pre-
+    // milestone-133 byte-identity. US1.C flips the default to
+    // `orphan`. `full` mode forwards an empty `DedupeIndex` so every
+    // surviving content-shape match emits regardless of coverage.
+    let file_inventory_mode = scan_fs::file_tier::FileInventoryMode::parse(&args.file_inventory)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "--file-inventory expects one of: off, orphan, full (got: {:?})",
+                args.file_inventory
+            )
+        })?;
+    if file_inventory_mode != scan_fs::file_tier::FileInventoryMode::Off {
+        let exclusion_globs = scan_fs::file_tier::content_shape::build_orphan_exclusion_globs();
+        let dedupe_index = match file_inventory_mode {
+            scan_fs::file_tier::FileInventoryMode::Full => {
+                // Full mode bypasses dedupe — caller wants every
+                // content-shape-passing file regardless of coverage.
+                scan_fs::file_tier::dedupe::DedupeIndex::default()
+            }
+            _ => scan_fs::file_tier::dedupe::DedupeIndex::build(&components),
+        };
+        let walker_cfg = scan_fs::file_tier::walker::WalkerConfig {
+            size_limit_bytes: args.file_inventory_size_limit,
+            exclusion_globs: &exclusion_globs,
+            dedupe_index: &dedupe_index,
+        };
+        let (entries, stats) =
+            scan_fs::file_tier::walker::walk_file_tier(&root_path, &walker_cfg);
+        tracing::info!(
+            file_tier_components = entries.len(),
+            mode = ?file_inventory_mode,
+            shape_skipped = stats.shape_skipped,
+            dedupe_skipped = stats.dedupe_skipped,
+            oversize_skipped = stats.oversize_skipped,
+            special_skipped = stats.special_skipped,
+            unreadable_skipped = stats.unreadable_skipped,
+            "file-tier walker complete"
+        );
+        components.extend(entries.into_iter().map(|e| e.into_resolved_component()));
+    }
+
     // Build the neutral artifacts bundle once and hand it to every
     // serializer the user requested — the single-pass guarantee of
     // FR-004 / SC-009.
@@ -3026,6 +3100,8 @@ mod tests {
             deb_codename: None,
             no_package_db: false,
             no_deep_hash: false,
+            file_inventory: "off".to_string(),
+            file_inventory_size_limit: 100 * 1024 * 1024,
             json: false,
             no_clearly_defined,
             no_deps_dev,

--- a/mikebom-cli/src/generate/cyclonedx/builder.rs
+++ b/mikebom-cli/src/generate/cyclonedx/builder.rs
@@ -585,19 +585,40 @@ impl CycloneDxBuilder {
                 Some(parent) => format!("{}#{}", component.purl.as_str(), parent),
                 None => component.purl.as_str().to_string(),
             };
-            let mut entry = json!({
-                "type": binary_role_to_cdx_type(component.binary_role),
-                "name": component.name,
-                "version": component.version,
-                "purl": component.purl.as_str(),
-                "bom-ref": bom_ref,
-                // Milestone 105 phase 2E: extra (None, &[]) params are
-                // the cross-reader-dedup emission slots. Wired through
-                // by US1-US6 reader phases — until then the call shape
-                // produces byte-identical output to the pre-milestone-
-                // 105 builder.
-                "evidence": build_evidence(&component.evidence, &component.occurrences, None, &[])
-            });
+            // Milestone 133 US1.B: file-tier components carry a
+            // `mikebom:component-tier = "file"` annotation. When
+            // present, override `type` to the CDX-native `"file"`
+            // (per FR-001) and OMIT `purl` (per FR-009 — the
+            // placeholder PURL is in-process identity only; the
+            // wire shape has no PURL for file-tier).
+            let is_file_tier = component
+                .extra_annotations
+                .get(crate::scan_fs::file_tier::COMPONENT_TIER_KEY)
+                .and_then(|v| v.as_str())
+                == Some(crate::scan_fs::file_tier::COMPONENT_TIER_FILE_VALUE);
+            let mut entry = if is_file_tier {
+                json!({
+                    "type": crate::scan_fs::file_tier::FILE_TIER_CDX_TYPE,
+                    "name": component.name,
+                    "version": component.version,
+                    "bom-ref": bom_ref,
+                    "evidence": build_evidence(&component.evidence, &component.occurrences, None, &[])
+                })
+            } else {
+                json!({
+                    "type": binary_role_to_cdx_type(component.binary_role),
+                    "name": component.name,
+                    "version": component.version,
+                    "purl": component.purl.as_str(),
+                    "bom-ref": bom_ref,
+                    // Milestone 105 phase 2E: extra (None, &[]) params are
+                    // the cross-reader-dedup emission slots. Wired through
+                    // by US1-US6 reader phases — until then the call shape
+                    // produces byte-identical output to the pre-milestone-
+                    // 105 builder.
+                    "evidence": build_evidence(&component.evidence, &component.occurrences, None, &[])
+                })
+            };
 
             // Milestone 052/part-2: native CDX `scope` field. Per
             // FR-010, components with non-Runtime lifecycle_scope

--- a/mikebom-cli/src/scan_fs/file_tier/content_shape.rs
+++ b/mikebom-cli/src/scan_fs/file_tier/content_shape.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)] // US1.A scaffolding; US1.B wires every entry point in.
+#![allow(dead_code)] // lifted by scan_cmd wiring at the bottom of this PR.
 
 //! Milestone 133 US1 — content-shape allowlist per FR-005.
 //!

--- a/mikebom-cli/src/scan_fs/file_tier/dedupe.rs
+++ b/mikebom-cli/src/scan_fs/file_tier/dedupe.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)] // US1.A scaffolding; US1.B wires every entry point in.
+#![allow(dead_code)] // lifted by scan_cmd wiring at the bottom of this PR.
 
 //! Milestone 133 US1 — FR-011 hybrid dedupe index.
 //!

--- a/mikebom-cli/src/scan_fs/file_tier/mod.rs
+++ b/mikebom-cli/src/scan_fs/file_tier/mod.rs
@@ -1,8 +1,7 @@
-// US1.A scaffolding lint suppression — every entry point in this
-// module is reachable from inside `scan_fs::file_tier` and from the
-// per-module #[cfg(test)] suites, but no production caller invokes
-// the walker yet. US1.B (next PR) wires it into `scan_cmd::scan`,
-// after which this allow is removed.
+// `dead_code` lifted in US1.B; remaining items reach production via
+// `scan_cmd::scan` once the integration in this PR lands. Allow
+// kept until the final wiring change in this PR makes every item
+// transitively reachable.
 #![allow(dead_code)]
 
 //! Milestone 133 US1 — file-tier component emission infrastructure.
@@ -50,9 +49,57 @@ pub(crate) mod content_shape;
 pub(crate) mod dedupe;
 pub(crate) mod walker;
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use mikebom_common::resolution::{
+    ResolutionEvidence, ResolutionTechnique, ResolvedComponent,
+};
+use mikebom_common::types::hash::{ContentHash, HashAlgorithm};
+use mikebom_common::types::purl::Purl;
+use serde_json::json;
+
 pub(crate) use content_shape::ContentShape;
+
+/// CDX component type emitted for file-tier components per FR-001.
+/// The CDX 1.6 schema reserves `"file"` for components that ARE
+/// files at a known path; mikebom file-tier entries qualify by
+/// definition (the SHA-256 hash IS the identity, paths are
+/// rootfs-relative).
+pub(crate) const FILE_TIER_CDX_TYPE: &str = "file";
+
+/// `mikebom:component-tier` annotation key. Mark every file-tier
+/// component with `value = "file"` per FR-002. Emission code paths
+/// (CDX `builder.rs`, SPDX 2.3 `packages.rs`, SPDX 3 packages
+/// builder) recognize this annotation and adapt — CDX overrides the
+/// `type` field and drops `purl`; the SPDX paths swap the element
+/// shape per the format's file-element semantics (US1.C polish).
+/// The scan-side code stays format-neutral per FR-017.
+pub(crate) const COMPONENT_TIER_KEY: &str = "mikebom:component-tier";
+
+/// Annotation value paired with [`COMPONENT_TIER_KEY`] for file-tier
+/// emission. Plain string per existing mikebom:* annotation
+/// conventions (compares equal in CDX property + SPDX annotation
+/// envelope round-trips).
+pub(crate) const COMPONENT_TIER_FILE_VALUE: &str = "file";
+
+/// `mikebom:file-paths` annotation key. Value is a JSON-encoded
+/// string array carrying every path the entry covers, sorted
+/// lex-ascending per FR-007. Capped at 100 entries; when the cap
+/// fires, the companion [`FILE_PATHS_TRUNCATED_KEY`] annotation is
+/// also set to `"true"`.
+pub(crate) const FILE_PATHS_KEY: &str = "mikebom:file-paths";
+
+/// `mikebom:file-paths-truncated` annotation key. Emitted alongside
+/// [`FILE_PATHS_KEY`] when the entry's path list was capped at the
+/// 100-entry limit (defensive — protects against pathological cases
+/// like a `.gitignore` file content duplicated across 1000s of nested
+/// repos).
+pub(crate) const FILE_PATHS_TRUNCATED_KEY: &str = "mikebom:file-paths-truncated";
+
+/// FR-007 / FR-002: cap the per-entry `paths[]` length at 100
+/// entries. Excess paths are dropped and the truncation flag fires.
+pub(crate) const FILE_PATHS_CAP: usize = 100;
 
 /// Per-unique-content file-tier accumulator entry. One
 /// `FileTierEntry` per unique SHA-256 observed on the rootfs;
@@ -118,6 +165,152 @@ impl FileTierEntry {
     pub(crate) fn finalize(&mut self) {
         self.paths.sort();
     }
+
+    /// Convert this file-tier accumulator entry into a
+    /// `ResolvedComponent` ready for the SBOM emission pipeline.
+    ///
+    /// **Placeholder PURL strategy** (FR-009 — "no PURL"):
+    /// `ResolvedComponent.purl` is non-optional, so we synthesize a
+    /// content-addressed placeholder PURL
+    /// (`pkg:generic/file-tier?content-sha256=<sha>`) for
+    /// in-process identity. The CDX / SPDX 2.3 / SPDX 3 emission
+    /// code paths recognize the [`COMPONENT_TIER_KEY`] annotation
+    /// and STRIP the PURL field at write time, so the on-disk SBOM
+    /// honors FR-009. The placeholder is never serialized.
+    ///
+    /// **Name** (FR-009): basename of the first sorted path.
+    ///
+    /// **Version**: empty string (file-tier components have no
+    /// version concept).
+    ///
+    /// **Hashes**: SHA-256 in the canonical `ContentHash` form.
+    ///
+    /// **Annotations** seeded:
+    /// - `mikebom:component-tier = "file"` (FR-002)
+    /// - `mikebom:file-paths = <JSON-encoded-sorted-array>` (FR-007)
+    /// - `mikebom:file-paths-truncated = "true"` (only when capped)
+    pub(crate) fn into_resolved_component(self) -> ResolvedComponent {
+        let basename = self
+            .paths
+            .first()
+            .and_then(|p| p.file_name())
+            .and_then(|s| s.to_str())
+            .unwrap_or("file")
+            .to_string();
+
+        let placeholder_purl_raw = format!(
+            "pkg:generic/file-tier?content-sha256={}",
+            self.sha256_hex
+        );
+        let purl = Purl::new(&placeholder_purl_raw)
+            .expect("placeholder file-tier PURL syntax is valid");
+
+        let hashes = ContentHash::with_algorithm(HashAlgorithm::Sha256, &self.sha256_hex)
+            .ok()
+            .map(|h| vec![h])
+            .unwrap_or_default();
+
+        // Cap path list at FILE_PATHS_CAP and set the truncated
+        // flag when we drop overflow. FR-007 demands sorted-
+        // ascending; `finalize()` already sorted, so a simple
+        // truncate keeps determinism.
+        let truncated = self.paths.len() > FILE_PATHS_CAP;
+        let mut paths_str: Vec<String> = self
+            .paths
+            .iter()
+            .take(FILE_PATHS_CAP)
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        // Keep sort-stable in the emitted property too.
+        paths_str.sort();
+
+        let mut extra_annotations: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+        extra_annotations.insert(
+            COMPONENT_TIER_KEY.to_string(),
+            json!(COMPONENT_TIER_FILE_VALUE),
+        );
+        if let Ok(file_paths_json) = serde_json::to_string(&paths_str) {
+            extra_annotations.insert(FILE_PATHS_KEY.to_string(), json!(file_paths_json));
+        }
+        if truncated {
+            extra_annotations.insert(FILE_PATHS_TRUNCATED_KEY.to_string(), json!("true"));
+        }
+
+        ResolvedComponent {
+            purl,
+            name: basename,
+            version: String::new(),
+            evidence: ResolutionEvidence {
+                technique: ResolutionTechnique::HashMatch,
+                confidence: 1.0,
+                source_connection_ids: vec![],
+                source_file_paths: paths_str.clone(),
+                deps_dev_match: None,
+            },
+            licenses: vec![],
+            concluded_licenses: vec![],
+            hashes,
+            supplier: None,
+            cpes: vec![],
+            advisories: vec![],
+            occurrences: vec![],
+            lifecycle_scope: None,
+            build_inclusion: None,
+            requirement_range: None,
+            source_type: None,
+            sbom_tier: None,
+            buildinfo_status: None,
+            evidence_kind: None,
+            binary_class: None,
+            binary_stripped: None,
+            linkage_kind: None,
+            detected_go: None,
+            confidence: None,
+            binary_packed: None,
+            npm_role: None,
+            raw_version: None,
+            parent_purl: None,
+            co_owned_by: None,
+            shade_relocation: None,
+            external_references: vec![],
+            extra_annotations,
+            binary_role: None,
+        }
+    }
+}
+
+/// Operator-facing file-inventory mode per FR-015. Wired through
+/// from the `--file-inventory` CLI flag to the orphan walker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileInventoryMode {
+    /// **Default (US1.B)**: no file-tier emission. Preserves
+    /// byte-identity with pre-milestone-133 SBOMs. US1.C flips
+    /// this default to [`FileInventoryMode::Orphan`].
+    Off,
+    /// **US1.C default (planned)**: emit file-tier components for
+    /// content surviving the FR-005 allowlist AND failing the
+    /// FR-011 hybrid dedupe.
+    Orphan,
+    /// **US3**: emit a file-tier component for every regular file
+    /// surviving the FR-005 allowlist, regardless of dedupe
+    /// coverage. Used by forensic / compliance consumers cataloguing
+    /// every hash on disk.
+    Full,
+}
+
+impl FileInventoryMode {
+    /// Parse the operator-facing string form. Accepts `off`,
+    /// `orphan`, `full` case-insensitively. Returns `None` for
+    /// unknown values so the CLI layer can produce a clap-style
+    /// error message.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "off" => Some(Self::Off),
+            "orphan" => Some(Self::Orphan),
+            "full" => Some(Self::Full),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -180,5 +373,98 @@ mod tests {
                 PathBuf::from("z/last"),
             ]
         );
+    }
+
+    #[test]
+    fn into_resolved_component_seeds_required_annotations() {
+        let mut e = FileTierEntry::new(
+            "0".repeat(64),
+            PathBuf::from("opt/custom/foo"),
+            ContentShape::ElfBinary,
+            42,
+        );
+        e.finalize();
+        let c = e.into_resolved_component();
+        assert_eq!(c.name, "foo");
+        assert_eq!(c.version, "");
+        assert_eq!(c.hashes.len(), 1);
+        assert_eq!(c.hashes[0].algorithm, HashAlgorithm::Sha256);
+        assert_eq!(
+            c.extra_annotations
+                .get(COMPONENT_TIER_KEY)
+                .and_then(|v| v.as_str()),
+            Some(COMPONENT_TIER_FILE_VALUE)
+        );
+        // file-paths emitted as JSON-encoded string array (matches
+        // the milestone 133 US2.1 source-files shape).
+        let fp = c
+            .extra_annotations
+            .get(FILE_PATHS_KEY)
+            .and_then(|v| v.as_str())
+            .expect("file-paths annotation present");
+        let parsed: Vec<String> = serde_json::from_str(fp).expect("file-paths JSON parses");
+        assert_eq!(parsed, vec!["opt/custom/foo".to_string()]);
+        // Single path → no truncated flag.
+        assert!(!c.extra_annotations.contains_key(FILE_PATHS_TRUNCATED_KEY));
+    }
+
+    #[test]
+    fn into_resolved_component_caps_paths_and_sets_truncated_flag() {
+        let mut e = FileTierEntry::new(
+            "1".repeat(64),
+            PathBuf::from("opt/dup-0"),
+            ContentShape::ElfBinary,
+            10,
+        );
+        for i in 1..FILE_PATHS_CAP + 5 {
+            e.push_path(PathBuf::from(format!("opt/dup-{i:03}")));
+        }
+        e.finalize();
+        let c = e.into_resolved_component();
+        let fp = c
+            .extra_annotations
+            .get(FILE_PATHS_KEY)
+            .and_then(|v| v.as_str())
+            .expect("file-paths annotation present");
+        let parsed: Vec<String> = serde_json::from_str(fp).expect("file-paths JSON parses");
+        assert_eq!(parsed.len(), FILE_PATHS_CAP);
+        assert_eq!(
+            c.extra_annotations
+                .get(FILE_PATHS_TRUNCATED_KEY)
+                .and_then(|v| v.as_str()),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn into_resolved_component_placeholder_purl_is_valid_and_content_addressed() {
+        let sha = "abcd".repeat(16);
+        let mut e = FileTierEntry::new(
+            sha.clone(),
+            PathBuf::from("opt/foo"),
+            ContentShape::ElfBinary,
+            10,
+        );
+        e.finalize();
+        let c = e.into_resolved_component();
+        // Placeholder PURL embeds the SHA-256 so different
+        // contents distinct identities even before the
+        // mikebom:component-tier-driven PURL drop at emission.
+        assert!(c.purl.as_str().contains(&sha));
+        assert!(c.purl.as_str().starts_with("pkg:generic/file-tier"));
+    }
+
+    #[test]
+    fn file_inventory_mode_parse_accepts_known_values() {
+        assert_eq!(FileInventoryMode::parse("off"), Some(FileInventoryMode::Off));
+        assert_eq!(
+            FileInventoryMode::parse("ORPHAN"),
+            Some(FileInventoryMode::Orphan)
+        );
+        assert_eq!(
+            FileInventoryMode::parse("full"),
+            Some(FileInventoryMode::Full)
+        );
+        assert_eq!(FileInventoryMode::parse("bogus"), None);
     }
 }

--- a/mikebom-cli/src/scan_fs/file_tier/walker.rs
+++ b/mikebom-cli/src/scan_fs/file_tier/walker.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)] // US1.A scaffolding; US1.B wires every entry point in.
+#![allow(dead_code)] // lifted by scan_cmd wiring at the bottom of this PR.
 
 //! Milestone 133 US1 — orphan file-tier walker.
 //!

--- a/mikebom-cli/tests/file_tier_orphan_emit.rs
+++ b/mikebom-cli/tests/file_tier_orphan_emit.rs
@@ -1,0 +1,176 @@
+//! Milestone 133 US1.B integration test — `--file-inventory=orphan`
+//! emits a CDX file-tier component for an unattributed binary, with
+//! no PURL and the `mikebom:component-tier = "file"` annotation.
+//!
+//! Default behavior (no flag) must NOT emit file-tier components —
+//! preserves the pre-milestone-133 byte-identity guarantee per FR-004
+//! / SC-005 until US1.C flips the default.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn write_file(dir: &Path, rel: &str, bytes: &[u8]) -> PathBuf {
+    let p = dir.join(rel);
+    std::fs::create_dir_all(p.parent().expect("rel path has parent"))
+        .expect("create test dir");
+    std::fs::write(&p, bytes).expect("write test file");
+    p
+}
+
+fn run_scan(path: &Path, extra_args: &[&str]) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("sbom.cdx.json");
+    let mut cmd = Command::new(bin);
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(path)
+        .arg("--output")
+        .arg(&out_path)
+        .arg("--no-deep-hash");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let status = cmd.status().expect("mikebom should run");
+    assert!(status.success(), "scan failed: {extra_args:?}");
+    let raw = std::fs::read(&out_path).expect("read sbom");
+    serde_json::from_slice(&raw).expect("valid JSON")
+}
+
+fn file_tier_components(sbom: &serde_json::Value) -> Vec<&serde_json::Value> {
+    let Some(comps) = sbom["components"].as_array() else {
+        return Vec::new();
+    };
+    comps
+        .iter()
+        .filter(|c| {
+            let Some(props) = c["properties"].as_array() else {
+                return false;
+            };
+            props.iter().any(|p| {
+                p["name"].as_str() == Some("mikebom:component-tier")
+                    && p["value"].as_str() == Some("file")
+            })
+        })
+        .collect()
+}
+
+#[test]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+fn default_mode_emits_no_file_tier_components() {
+    let tmp = tempfile::tempdir().unwrap();
+    // ELF magic header → would qualify in orphan mode.
+    write_file(
+        tmp.path(),
+        "opt/unattributed-binary",
+        b"\x7FELF\x02\x01\x01\x00rest-of-elf",
+    );
+    // Lone Cargo.toml → would qualify in orphan mode.
+    write_file(
+        tmp.path(),
+        "app/Cargo.toml",
+        b"[package]\nname = \"x\"\nversion = \"0.1.0\"\n",
+    );
+
+    let sbom = run_scan(tmp.path(), &[]);
+    let file_tier = file_tier_components(&sbom);
+    assert!(
+        file_tier.is_empty(),
+        "default mode must NOT emit file-tier components (US1.B contract); got {} entries",
+        file_tier.len()
+    );
+}
+
+#[test]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+fn orphan_mode_emits_file_tier_components_with_correct_shape() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_file(
+        tmp.path(),
+        "opt/unattributed-binary",
+        b"\x7FELF\x02\x01\x01\x00rest-of-elf",
+    );
+    write_file(
+        tmp.path(),
+        "app/Cargo.toml",
+        b"[package]\nname = \"x\"\nversion = \"0.1.0\"\n",
+    );
+
+    let sbom = run_scan(tmp.path(), &["--file-inventory=orphan"]);
+    let file_tier = file_tier_components(&sbom);
+    assert!(
+        file_tier.len() >= 2,
+        "expected at least 2 file-tier components (ELF + lone Cargo.toml); got {}",
+        file_tier.len()
+    );
+
+    for c in &file_tier {
+        // FR-001: CDX type = "file".
+        assert_eq!(
+            c["type"].as_str(),
+            Some("file"),
+            "file-tier component type must be `file`; got {:?}",
+            c["type"]
+        );
+        // FR-009: no PURL in the wire format.
+        assert!(
+            c["purl"].is_null(),
+            "file-tier component must NOT carry a `purl` field; got {:?}",
+            c["purl"]
+        );
+        // FR-008: SHA-256 mandatory.
+        let hashes = c["hashes"].as_array().expect("hashes array");
+        assert!(
+            hashes
+                .iter()
+                .any(|h| h["alg"].as_str() == Some("SHA-256")),
+            "file-tier component must carry a SHA-256 hash"
+        );
+        // FR-007: `mikebom:file-paths` JSON-encoded array.
+        let props = c["properties"].as_array().expect("properties array");
+        let fp = props
+            .iter()
+            .find(|p| p["name"].as_str() == Some("mikebom:file-paths"))
+            .and_then(|p| p["value"].as_str())
+            .expect("mikebom:file-paths annotation present");
+        let parsed: Vec<String> =
+            serde_json::from_str(fp).expect("mikebom:file-paths is JSON-encoded array");
+        assert!(
+            !parsed.is_empty(),
+            "mikebom:file-paths must list at least one path"
+        );
+        for p in &parsed {
+            assert!(
+                !p.starts_with('/'),
+                "file-paths entry {p:?} must not start with leading `/`"
+            );
+        }
+    }
+}
+
+#[test]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+fn invalid_file_inventory_flag_value_exits_nonzero() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_file(tmp.path(), "noop", b"");
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let out_path = tmp.path().join("sbom.cdx.json");
+    let status = Command::new(bin)
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(tmp.path())
+        .arg("--output")
+        .arg(&out_path)
+        .arg("--file-inventory=bogus")
+        .arg("--no-deep-hash")
+        .status()
+        .expect("mikebom should run");
+    assert!(
+        !status.success(),
+        "scan with invalid --file-inventory must exit non-zero"
+    );
+}


### PR DESCRIPTION
## Summary

- Operator-facing opt-in for file-tier component emission: `--file-inventory={off|orphan|full}` + `--file-inventory-size-limit <BYTES>`. Default `off` preserves pre-milestone-133 byte-identity on every existing scan.
- Production CDX wire shape: `type = "file"` (FR-001), `purl` field OMITTED (FR-009), name = basename of first sorted path, SHA-256 in `hashes[]`, `mikebom:component-tier = "file"` + `mikebom:file-paths` + `mikebom:file-paths-truncated` annotations land in `properties[]`.
- Default OFF in US1.B; US1.C flips the default to `orphan` and ships the declared SBOM-change. SPDX 2.3/3 file-element shape + 6 new C-rows + parity wiring also defer to US1.C.

## End-to-end smoke

Synthetic fixture with an unattributed ELF + a lone `Cargo.toml` (no sibling `Cargo.lock`):

```
mikebom scan --path tmp --file-inventory=orphan → 2 file-tier components
mikebom scan --path tmp (default)               → 0 file-tier components
```

Each emitted file-tier component carries:
- `"type": "file"`
- no `"purl"` field
- SHA-256 in `hashes[]`
- `mikebom:component-tier = "file"` + `mikebom:file-paths = "[\"app/Cargo.toml\"]"` properties

## Approach

| File | Change |
|---|---|
| `mikebom-cli/src/scan_fs/file_tier/mod.rs` | New `FileTierEntry::into_resolved_component(self)` that synthesizes a `pkg:generic/file-tier?content-sha256=<hex>` placeholder PURL + seeds `extra_annotations` with `mikebom:component-tier` + `mikebom:file-paths` (+ truncated flag at the 100-entry cap). New `FileInventoryMode` enum + `parse()`. 4 new unit tests. |
| `mikebom-cli/src/cli/scan_cmd.rs` | Two new `clap` args; wires `walk_file_tier` into the scan pipeline AFTER every reader / enrichment / `tag_components_with_layer_digest` pass so the FR-011 hybrid dedupe sees the complete claim set. `Full` mode constructs `DedupeIndex::default()` so every shape-match emits regardless of coverage. `Off` mode is a guard branch — zero runtime overhead, zero SBOM-shape change. |
| `mikebom-cli/src/generate/cyclonedx/builder.rs` | CDX component entry construction detects the `mikebom:component-tier = "file"` annotation. When present, the entry is `type = "file"` with no `purl` field; otherwise byte-identical to pre-feature emission. |
| `mikebom-cli/tests/file_tier_orphan_emit.rs` | 3 new integration tests: default-OFF preserves byte-identity, orphan mode emits the correct CDX shape, invalid flag value exits non-zero. |

## Spec corrections embedded

- `mikebom:component-paths` was a fabrication in FR-011 — the DedupeIndex (US1.A) reads from `ResolvedComponent.occurrences[]` (CDX-native, US2.3-shipped).
- `FileInventoryMode` enum is introduced in this PR (the spec T020 task referenced it as if it pre-existed; it didn't).

## Test plan

- [x] `cargo +stable clippy --workspace --all-targets` — zero errors
- [x] `cargo +stable test --workspace` — every suite `N passed; 0 failed` (153 result blocks ok, 0 failed)
- [x] Walker-audit allowlist gate clean (no new `fn walk[_(]` since US1.A)
- [x] Existing tests preserved (`scenario_1_scan_and_resolve_code_has_no_spdx3_struct_leaks` still passes — doc comments scrubbed of SPDX 3 struct names per FR-017)
- [x] file_tier unit tests: 38 → 42
- [x] Bin test count: 2209 → 2213
- [x] No new Cargo dependencies
- [x] No goldens regenerated (default OFF preserves byte-identity)

## Coming in US1.C (final US1 PR)

- Proper SPDX 2.3 file-tier emission (`filesAnalyzed: false`, no `externalRef[purl]`).
- Proper SPDX 3 file-element shape per FR-001 + research §SPDX 3 element type decision.
- 6 new C-rows + parity extractors (`mikebom:component-tier`, `mikebom:file-paths`, `mikebom:file-paths-truncated`, 3 `mikebom:file-inventory-skipped-*`).
- Default flip from `off` to `orphan` — **declared behavior change**: image-scan SBOMs grow by ~180-440 file-tier components on the audit baseline (SC-001 range).
- Goldens regen + SC-001 / SC-002 verification on the audit baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)