### PR TITLE
fix(ci): add `// walker-audit:` sigil opt-out for the walker-audit gate (closes #378)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,28 @@ jobs:
           # match its own allow-list file (`walk.audit-allowlist.txt`
           # lives under scan_fs/ for adjacency per SC-005, and every
           # entry inside it contains the substring `fn walk_`).
-          LIVE=$(LC_ALL=C grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/ | sed "$STRIP_LINE_NUMBERS" | LC_ALL=C sort -u)
+          #
+          # Issue #378: a function whose name starts with `walk_` but
+          # does NOT walk the filesystem (in-memory iterators, test
+          # functions, etc.) MAY opt out of the audit by placing a
+          # `// walker-audit:` sigil comment on the line immediately
+          # above the function signature. The sigil's text after the
+          # colon is free-form developer audit-trail. The pre-filter
+          # below drops any match whose immediate predecessor line
+          # carries the sigil; surviving matches still go through the
+          # allow-list diff. Single sigil prefix per FR (issue body
+          # acceptance criteria); the prefix matches whole-token
+          # so `// walker-audit-elsewhere:` does NOT opt out.
+          LIVE=$(LC_ALL=C grep -rEn --include='*.rs' 'fn walk[_(]' mikebom-cli/src/scan_fs/ | while IFS=: read -r path line content; do
+            prev=$((line - 1))
+            if [ "$prev" -ge 1 ]; then
+              prev_line=$(LC_ALL=C sed -n "${prev}p" "$path" 2>/dev/null)
+              case "$prev_line" in
+                *"// walker-audit:"*) continue;;
+              esac
+            fi
+            printf '%s:%s:%s\n' "$path" "$line" "$content"
+          done | sed "$STRIP_LINE_NUMBERS" | LC_ALL=C sort -u)
 
           START_NS=$(date +%s%N 2>/dev/null || echo 0)
           if DIFF_OUT=$(diff -u <(printf '%s\n' "$EXPECTED") <(printf '%s\n' "$LIVE")); then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,39 @@ five-minute walkthrough in
 [`specs/114-safe-walk-migration/quickstart.md`](specs/114-safe-walk-migration/quickstart.md)
 covers `max_depth` / `should_skip` / callback shape choices.
 
-**Scenario B — your walker legitimately can't fit `safe_walk`.** Rare,
+**Scenario B — your function name starts with `walk_` but doesn't
+walk the filesystem.** Common false-positive class: in-memory
+iterators (`walk_nested_archives_in_bytes` iterates ZIP entries
+parsed from a `Vec<u8>`), tree-page walkers (`walk_schema_page`
+walks SQLite B-tree pages), or `#[test]` functions whose name
+shares the prefix of the unit under test. The grep gate can't
+distinguish these from real filesystem walkers — it's a literal
+`fn walk[_(]` match.
+
+Opt out at the function definition site with a sigil comment on
+the line IMMEDIATELY above the `fn` signature:
+
+```rust
+// walker-audit: false-positive — iterates in-memory zip entries, no filesystem traversal
+fn walk_nested_archives_in_bytes(...) { ... }
+```
+
+The text after `// walker-audit:` is free-form developer audit
+trail (kept short — one phrase explaining what the function does
+instead of walking the filesystem). The CI gate's pre-filter
+drops any match whose preceding line carries the
+`// walker-audit:` sigil before the allow-list diff runs, so the
+allow-list file stays minimal and only documents the genuine
+filesystem-walking exceptions.
+
+**Don't reach for the allow-list here**: an entry in
+`walk.audit-allowlist.txt` says "this fn is a real walker we
+accept"; a sigil says "this fn isn't a walker at all". The two
+are different audit categories. Issue #378 (the milestone-133
+follow-on) introduced the sigil escape hatch precisely so the
+allow-list can shrink to only the real walkers.
+
+**Scenario C — your walker legitimately can't fit `safe_walk`.** Rare,
 but possible (per-descent stateful pruning, parent-name-aware recursion,
 …). In the SAME PR, do two edits:
 

--- a/mikebom-cli/src/scan_fs/package_db/maven.rs
+++ b/mikebom-cli/src/scan_fs/package_db/maven.rs
@@ -1847,6 +1847,7 @@ pub(crate) fn jar_has_main_class_manifest(archive_path: &Path) -> bool {
     false
 }
 
+// walker-audit: false-positive — opens ONE caller-supplied JAR and iterates its zip entries; no directory traversal
 pub(crate) fn walk_jar_maven_meta(archive_path: &Path) -> Vec<EmbeddedMavenMeta> {
     let Ok(file) = std::fs::File::open(archive_path) else {
         return Vec::new();
@@ -2029,6 +2030,7 @@ fn compute_bytes_sha(bytes: &[u8]) -> [u8; 32] {
 /// `walk_nested_archives_in_bytes`, which DOES extract meta + recurse
 /// further (because at depth >=2 we're inside a vendored archive
 /// whose contents were not enumerated by the top-level walker).
+// walker-audit: false-positive — opens ONE caller-supplied JAR and iterates its zip entries; no directory traversal
 fn walk_nested_archives_in_jar_file(
     archive_path: &Path,
     outer_path_url: &str,
@@ -2103,6 +2105,7 @@ fn walk_nested_archives_in_jar_file(
 /// Walk an in-memory archive (already extracted from a parent JAR's
 /// nested entry) for `META-INF/maven/` AND further-nested
 /// `.jar`/`.war`/`.ear` entries. Recursive depth-bounded descent.
+// walker-audit: false-positive — iterates in-memory zip entries, no filesystem traversal
 fn walk_nested_archives_in_bytes(
     bytes: &[u8],
     outer_path_url: &str,
@@ -4467,6 +4470,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_jar_collects_coord_and_embedded_deps() {
         let dir = tempfile::tempdir().unwrap();
         let jar = dir.path().join("guava.jar");
@@ -4496,6 +4500,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_jar_attaches_sidecar_hash_when_present() {
         let dir = tempfile::tempdir().unwrap();
         let jar = dir.path().join("guava.jar");
@@ -4520,6 +4525,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_jar_no_sidecar_still_computes_archive_sha256() {
         // Even when no `.sha256`/`.sha512`/`.sha1` sidecar exists
         // alongside the JAR (the common container-image case where
@@ -4548,6 +4554,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_jar_with_sha1_sidecar_also_gets_sha256() {
         // When a SHA-1 sidecar (Maven Central default) exists, the
         // walker emits BOTH the sidecar hash AND a computed SHA-256,
@@ -4574,6 +4581,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_fat_jar_only_primary_coord_gets_archive_sha256() {
         // Fat / shaded JARs ship META-INF/maven dirs for their
         // vendored dependencies. The archive SHA-256 describes the
@@ -4609,6 +4617,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_jar_without_pom_xml_returns_empty_deps() {
         // A JAR that ships pom.properties but no pom.xml — should still
         // emit a coord entry with empty declared_deps.
@@ -4627,6 +4636,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_fat_jar_collects_one_meta_per_vendored_artifact() {
         // Shaded / uber JAR: multiple META-INF/maven/<g>/<a>/ directories,
         // each with its own pom.properties + pom.xml. Each yields a
@@ -6617,6 +6627,7 @@ mod tests {
     // in this tests module)
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_rootfs_poms_finds_multiple_cached_artifacts() {
         let dir = tempfile::tempdir().unwrap();
         let repo_root = dir.path().to_path_buf();
@@ -6652,6 +6663,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_rootfs_poms_skips_host_scoped_roots() {
         // A cache whose only root is in `host_roots` should produce
         // zero seeds even if the directory contains cached .pom files.
@@ -6684,6 +6696,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_rootfs_poms_ignores_sibling_non_pom_files() {
         let dir = tempfile::tempdir().unwrap();
         let repo_root = dir.path().to_path_buf();
@@ -6713,6 +6726,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_rootfs_poms_truncates_at_cap() {
         let dir = tempfile::tempdir().unwrap();
         let repo_root = dir.path().to_path_buf();
@@ -6733,6 +6747,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_rootfs_poms_handles_deep_group_paths() {
         let dir = tempfile::tempdir().unwrap();
         let repo_root = dir.path().to_path_buf();
@@ -6753,6 +6768,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_rootfs_poms_empty_cache_returns_nothing() {
         let dir = tempfile::tempdir().unwrap();
         let cache = MavenRepoCache::for_tests(vec![dir.path().to_path_buf()]);

--- a/mikebom-cli/src/scan_fs/package_db/npm/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/mod.rs
@@ -790,6 +790,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_ prefix of the unit under test
     fn walk_skips_node_modules_subtrees() {
         // Deliberately plant a package.json *inside* a node_modules/ —
         // this is a dependency's manifest, not a project root. The

--- a/mikebom-cli/src/scan_fs/package_db/npm/package_lock.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/package_lock.rs
@@ -789,6 +789,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_up_ prefix of the unit under test
     fn walk_up_resolution_picks_hoisted_when_parent_lacks_nested() {
         // Real-world molcajete bug: d3-dsv declares `commander: "7"`
         // and has NO nested commander; a DIFFERENT parent

--- a/mikebom-cli/src/scan_fs/package_db/nuget/directory_packages_props.rs
+++ b/mikebom-cli/src/scan_fs/package_db/nuget/directory_packages_props.rs
@@ -155,6 +155,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_up_ prefix of the unit under test
     fn walk_up_finds_props_in_ancestor() {
         let tmp = tempfile::tempdir().unwrap();
         let scan_root = tmp.path();
@@ -167,6 +168,7 @@ mod tests {
     }
 
     #[test]
+    // walker-audit: false-positive — #[test] function name shares the walk_up_ prefix of the unit under test
     fn walk_up_stops_at_scan_root() {
         let tmp = tempfile::tempdir().unwrap();
         let scan_root = tmp.path().join("project");

--- a/mikebom-cli/src/scan_fs/package_db/rpmdb_sqlite/schema.rs
+++ b/mikebom-cli/src/scan_fs/package_db/rpmdb_sqlite/schema.rs
@@ -50,6 +50,7 @@ where
     Ok(out)
 }
 
+// walker-audit: false-positive — walks SQLite B-tree pages in memory, no filesystem traversal
 fn walk_schema_page<F>(
     page_bytes: &[u8],
     is_first_page: bool,

--- a/mikebom-cli/src/scan_fs/walk.audit-allowlist.txt
+++ b/mikebom-cli/src/scan_fs/walk.audit-allowlist.txt
@@ -1,30 +1,9 @@
 mikebom-cli/src/scan_fs/binary/source_binding/cmake_observer.rs:fn walk_for_cmake_build_dirs(
 mikebom-cli/src/scan_fs/file_tier/walker.rs:pub(crate) fn walk_file_tier(
-mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_fat_jar_collects_one_meta_per_vendored_artifact() {
-mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_fat_jar_only_primary_coord_gets_archive_sha256() {
-mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_jar_attaches_sidecar_hash_when_present() {
-mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_jar_collects_coord_and_embedded_deps() {
-mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_jar_no_sidecar_still_computes_archive_sha256() {
-mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_jar_with_sha1_sidecar_also_gets_sha256() {
-mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_jar_without_pom_xml_returns_empty_deps() {
-mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_rootfs_poms_empty_cache_returns_nothing() {
-mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_rootfs_poms_finds_multiple_cached_artifacts() {
-mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_rootfs_poms_handles_deep_group_paths() {
-mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_rootfs_poms_ignores_sibling_non_pom_files() {
-mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_rootfs_poms_skips_host_scoped_roots() {
-mikebom-cli/src/scan_fs/package_db/maven.rs:    fn walk_rootfs_poms_truncates_at_cap() {
 mikebom-cli/src/scan_fs/package_db/maven.rs:    pub(crate) fn walk_rootfs_poms(
 mikebom-cli/src/scan_fs/package_db/maven.rs:fn walk_m2_jars(repo_cache: &MavenRepoCache) -> Vec<PathBuf> {
-mikebom-cli/src/scan_fs/package_db/maven.rs:fn walk_nested_archives_in_bytes(
-mikebom-cli/src/scan_fs/package_db/maven.rs:fn walk_nested_archives_in_jar_file(
-mikebom-cli/src/scan_fs/package_db/maven.rs:pub(crate) fn walk_jar_maven_meta(archive_path: &Path) -> Vec<EmbeddedMavenMeta> {
 mikebom-cli/src/scan_fs/package_db/maven_sidecar.rs:    fn walk(dir: &Path, depth: usize, out: &mut HashMap<String, PathBuf>) {
-mikebom-cli/src/scan_fs/package_db/npm/mod.rs:    fn walk_skips_node_modules_subtrees() {
-mikebom-cli/src/scan_fs/package_db/npm/package_lock.rs:    fn walk_up_resolution_picks_hoisted_when_parent_lacks_nested() {
 mikebom-cli/src/scan_fs/package_db/npm/walk.rs:fn walk_node_modules(
-mikebom-cli/src/scan_fs/package_db/nuget/directory_packages_props.rs:    fn walk_up_finds_props_in_ancestor() {
-mikebom-cli/src/scan_fs/package_db/nuget/directory_packages_props.rs:    fn walk_up_stops_at_scan_root() {
-mikebom-cli/src/scan_fs/package_db/rpmdb_sqlite/schema.rs:fn walk_schema_page<F>(
 mikebom-cli/src/scan_fs/walk.rs://! `fn walk_*` recursion implementing the same canonicalize-keyed
 mikebom-cli/src/scan_fs/walk.rs:fn walk_inner<F: FnMut(&Path)>(
 mikebom-cli/src/scan_fs/walker.rs:fn walk(dir: &Path, out: &mut Vec<PathBuf>) {


### PR DESCRIPTION
## Summary

Closes #378 — the walker-audit CI gate's syntactic `fn walk[_(]` grep has caused false positives in three separate PRs (#372, #377, #387's amend), each resolved by allowlisting or renaming instead of fixing the gate's signal-to-noise. This PR adopts the issue's Option 1: a `// walker-audit:` sigil comment on the line above a fn signature drops the match from the gate's pre-filter.

## Approach

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | Live-grep pipeline reads each match's preceding line via `sed -n ${prev}p`, skips matches whose prev line contains `// walker-audit:`. Pure POSIX shell; no new tool installations. |
| 21 source files | Sigil comment added above each false-positive fn (4 in-memory iterators + 17 `#[test]` fns). Each carries a one-phrase audit trail. |
| `walk.audit-allowlist.txt` | Shrinks from 31 → 10 entries — only genuine filesystem walkers remain. |
| `CONTRIBUTING.md` | New "Scenario B" walks contributors through the sigil opt-out and contrasts it with the allow-list. |

## Migration summary

**21 sites now carry the sigil**:

- **4 in-memory iterators**: `walk_schema_page` (SQLite B-tree), `walk_jar_maven_meta` + `walk_nested_archives_in_jar_file` (one-shot zip read), `walk_nested_archives_in_bytes` (in-memory zip).
- **17 `#[test]` fns** sharing the `walk_` / `walk_up_` prefix of the unit under test (maven 13, nuget 2, npm 2).

**10 allow-list entries remain** (real filesystem walkers): `walk_for_cmake_build_dirs`, `walk_file_tier`, `walk_rootfs_poms`, `walk_m2_jars`, `maven_sidecar::walk`, `walk_node_modules`, `walk.rs::walk_inner`, the `//! fn walk_*` docstring text, `walker::walk`, `walker::walk_and_hash`.

## Test plan

- [x] `cargo +stable clippy --workspace --all-targets` — zero errors
- [x] `cargo +stable test --workspace` — every suite `N passed; 0 failed` (153 result blocks ok, 0 failed)
- [x] Local diff: live-grep + sigil-filter pipeline diffs cleanly against the new 10-entry allowlist
- [x] CI shell logic verified with `#!/bin/bash` (matches CI's `shell: bash` directive)
- [x] No new Cargo dependencies
- [x] No golden churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)