### PR TITLE
feat(scan_fs/golang): emit pkg:golang/stdlib component on every Go scan (closes #364)

### DIFF
--- a/mikebom-cli/src/generate/cpe.rs
+++ b/mikebom-cli/src/generate/cpe.rs
@@ -120,6 +120,22 @@ pub fn synthesize_cpes(component: &ResolvedComponent) -> Vec<String> {
             push_unique(&mut vendors, &format!("python-{name}"));
         }
         "golang" | "go" => {
+            // Issue #364 — the synthetic `pkg:golang/stdlib` component
+            // emitted for every Go-source scan carries the Go toolchain
+            // version, which NVD lists under `cpe:2.3:a:golang:go:<v>`.
+            // Special-case the vendor + product so consumers can match
+            // Go stdlib CVEs (e.g. CVE-2024-34156 big.Int overflow)
+            // directly from the synthesized CPE rather than relying on
+            // post-processing.
+            if name == "stdlib" {
+                // The version string carries the `v`-prefix from the
+                // PURL (`pkg:golang/stdlib@v1.21.5`); strip it so the
+                // CPE matches NVD's bare-version convention.
+                let bare_version = version.trim_start_matches('v');
+                return vec![format!(
+                    "cpe:2.3:a:golang:go:{bare_version}:*:*:*:*:*:*:*"
+                )];
+            }
             push_unique(&mut vendors, name);
             if let Some(namespace) = component.purl.namespace() {
                 push_unique(&mut vendors, namespace);

--- a/mikebom-cli/src/scan_fs/package_db/golang/legacy.rs
+++ b/mikebom-cli/src/scan_fs/package_db/golang/legacy.rs
@@ -772,6 +772,55 @@ where
     out
 }
 
+/// Issue #364 — build a `stdlib` `PackageDbEntry` for a Go project
+/// whose go.mod declares `go <version>`. `bare_version` is the
+/// pre-stripped version string (no `v`/`go` prefix; e.g. `"1.21.5"`).
+/// The PURL takes the canonical syft shape
+/// (`pkg:golang/stdlib@v<version>`). Returns `None` if the version
+/// string can't be parsed into a valid PURL.
+fn build_stdlib_entry(
+    bare_version: &str,
+    source_path: &str,
+) -> Option<PackageDbEntry> {
+    let bare = bare_version;
+    let purl_str = format!("pkg:golang/stdlib@v{bare}");
+    let purl = match mikebom_common::types::purl::Purl::new(&purl_str) {
+        Ok(p) => p,
+        Err(_) => return None,
+    };
+    Some(PackageDbEntry {
+        build_inclusion: None,
+        purl,
+        name: "stdlib".to_string(),
+        version: format!("v{bare}"),
+        arch: None,
+        source_path: source_path.to_string(),
+        depends: Vec::new(),
+        maintainer: None,
+        licenses: Vec::new(),
+        lifecycle_scope: None,
+        requirement_range: None,
+        source_type: None,
+        buildinfo_status: None,
+        evidence_kind: None,
+        binary_class: None,
+        binary_stripped: None,
+        linkage_kind: None,
+        detected_go: None,
+        confidence: None,
+        binary_packed: None,
+        raw_version: None,
+        parent_purl: None,
+        npm_role: None,
+        co_owned_by: None,
+        hashes: Vec::new(),
+        sbom_tier: Some("source".to_string()),
+        shade_relocation: None,
+        extra_annotations: Default::default(),
+        binary_role: None,
+    })
+}
+
 /// Fetch a module's own go.mod from `cache` and return its direct
 /// `require`-d module names. Indirect entries are included (we can't
 /// tell post-hoc which of the upstream module's deps ended up in the
@@ -1942,6 +1991,43 @@ pub fn read(
             signals.graph_completeness_reasons = reason_classes.into_iter().collect();
         }
     }
+
+    // Issue #364 — emit a `stdlib` component per unique Go version seen
+    // across all parsed go.mod files. Runs AFTER every Go-specific
+    // classifier (mod-why, orphan-reason, graph-completeness) so the
+    // stdlib entry isn't misclassified by analyzers that key on
+    // import-graph reachability (stdlib has no go.sum entry / no
+    // upstream module-path in the user's go.mod graph, so the
+    // classifiers would falsely flag it as "not needed" or "orphan
+    // flat-attached"). Matches syft's `pkg:golang/stdlib@v<version>`
+    // emission shape so consumers can match either tool's stdlib CVEs
+    // (e.g. CVE-2024-34156 big.Int overflow) against the CPE
+    // `cpe:2.3:a:golang:go:<version>:*:*:*:*:*:*:*`.
+    let mut emitted_versions: HashSet<String> = HashSet::new();
+    for (project_root, doc, _sums) in &parsed_roots {
+        let Some(go_version) = doc.go_version.as_deref() else {
+            continue;
+        };
+        let bare = go_version
+            .trim()
+            .trim_start_matches('v')
+            .trim_start_matches("go");
+        if bare.is_empty() || !emitted_versions.insert(bare.to_string()) {
+            continue;
+        }
+        let go_sum_path = project_root.join("go.sum");
+        let source_path_for_evidence = if go_sum_path.is_file() {
+            go_sum_path
+                .to_string_lossy()
+                .into_owned()
+        } else {
+            project_root.join("go.mod").to_string_lossy().into_owned()
+        };
+        if let Some(entry) = build_stdlib_entry(bare, &source_path_for_evidence) {
+            out.push(entry);
+        }
+    }
+
     (out, signals)
 }
 

--- a/mikebom-cli/src/scan_fs/package_db/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/mod.rs
@@ -958,6 +958,15 @@ fn apply_go_mod_why_classification(entries: &mut [PackageDbEntry]) -> GoModWhyOu
         {
             continue;
         }
+        // Issue #364 — exclude the synthetic stdlib entry from the
+        // `go mod why` query input. Without this, `go mod why stdlib`
+        // returns Unresolved (stdlib isn't tracked in the user's import
+        // graph), which pads the FR-013 `analyzed=` / `unresolved=`
+        // counts and trips existing degrade-matrix tests. stdlib's
+        // build-inclusion stays None (= confirmed needed by default).
+        if e.name == "stdlib" {
+            continue;
+        }
         // FR-010: BuildInfo-confirmed entries are exempt from all
         // build-inclusion passes — don't spend budget on them.
         if buildinfo_present && !e.extra_annotations.contains_key("mikebom:not-linked") {

--- a/mikebom-cli/src/scan_fs/package_db/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/mod.rs
@@ -1086,6 +1086,14 @@ fn apply_go_mod_why_verdicts(
         {
             continue;
         }
+        // Issue #364 — the synthetic `pkg:golang/stdlib@v<version>`
+        // component is always present in the production build by
+        // definition. Skip mod-why classification (which would query
+        // `go mod why stdlib` and get back "not-needed" because stdlib
+        // isn't tracked in the user's import graph).
+        if e.name == "stdlib" {
+            continue;
+        }
         if e.build_inclusion.is_some() {
             continue;
         }

--- a/mikebom-cli/tests/fixtures/golden/cyclonedx/golang.cdx.json
+++ b/mikebom-cli/tests/fixtures/golden/cyclonedx/golang.cdx.json
@@ -631,6 +631,44 @@
       },
       "type": "library",
       "version": "v3.0.1"
+    },
+    {
+      "bom-ref": "pkg:golang/stdlib@v1.26.1",
+      "cpe": "cpe:2.3:a:golang:go:1.26.1:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}",
+            "location": "go.sum"
+          }
+        ]
+      },
+      "name": "stdlib",
+      "properties": [
+        {
+          "name": "mikebom:source-files",
+          "value": "[\"go.sum\"]"
+        },
+        {
+          "name": "mikebom:sbom-tier",
+          "value": "source"
+        }
+      ],
+      "purl": "pkg:golang/stdlib@v1.26.1",
+      "type": "library",
+      "version": "v1.26.1"
     }
   ],
   "compositions": [
@@ -648,7 +686,8 @@
         "pkg:golang/github.com/stretchr/testify@v1.11.1",
         "pkg:golang/golang.org/x/sys@v0.28.0",
         "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/stdlib@v1.26.1"
       ],
       "dependencies": [
         "pkg:golang/example.com/simple@v0.0.0-unknown",
@@ -662,7 +701,8 @@
         "pkg:golang/github.com/stretchr/testify@v1.11.1",
         "pkg:golang/golang.org/x/sys@v0.28.0",
         "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/stdlib@v1.26.1"
       ]
     },
     {
@@ -738,6 +778,10 @@
     {
       "dependsOn": [],
       "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:golang/stdlib@v1.26.1"
     }
   ],
   "metadata": {

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/golang.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/golang.spdx.json
@@ -62,7 +62,7 @@
   "documentDescribes": [
     "SPDXRef-Package-4BC3TYO5L6QI7GXM"
   ],
-  "documentNamespace": "https://mikebom.kusari.dev/spdx/K6KMFOLNHC6X3WI3LVQ2YVYUXMU5F6EP",
+  "documentNamespace": "https://mikebom.kusari.dev/spdx/TBYB74RMISIGT7O4BCMHWB3OIGOWFSGU",
   "name": "simple-module",
   "packages": [
     {
@@ -897,6 +897,53 @@
       "name": "gopkg.in/yaml.v3",
       "supplier": "Organization: gopkg.in",
       "versionInfo": "v3.0.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-5Z5YTQKEFAEY7U56",
+      "annotations": [
+        {
+          "annotationDate": "1970-01-01T00:00:00Z",
+          "annotationType": "OTHER",
+          "annotator": "Tool: mikebom-0.1.0-alpha.49",
+          "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "1970-01-01T00:00:00Z",
+          "annotationType": "OTHER",
+          "annotator": "Tool: mikebom-0.1.0-alpha.49",
+          "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}"
+        },
+        {
+          "annotationDate": "1970-01-01T00:00:00Z",
+          "annotationType": "OTHER",
+          "annotator": "Tool: mikebom-0.1.0-alpha.49",
+          "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "1970-01-01T00:00:00Z",
+          "annotationType": "OTHER",
+          "annotator": "Tool: mikebom-0.1.0-alpha.49",
+          "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:golang/stdlib@v1.26.1",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:golang:go:1.26.1:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "stdlib",
+      "versionInfo": "v1.26.1"
     }
   ],
   "relationships": [

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/golang.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/golang.spdx3.json
@@ -4,17 +4,17 @@
     {
       "creationInfo": "_:creation-info",
       "name": "mikebom contributors",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent/mikebom-contributors",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent/mikebom-contributors",
       "type": "Organization"
     },
     {
       "@id": "_:creation-info",
       "created": "1970-01-01T00:00:00Z",
       "createdBy": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent/mikebom-contributors"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent/mikebom-contributors"
       ],
       "createdUsing": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/tool/mikebom"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/tool/mikebom"
       ],
       "specVersion": "3.0.1",
       "type": "CreationInfo"
@@ -22,7 +22,7 @@
     {
       "creationInfo": "_:creation-info",
       "name": "mikebom-0.1.0-alpha.49",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/tool/mikebom",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/tool/mikebom",
       "type": "Tool"
     },
     {
@@ -37,21 +37,21 @@
       "dataLicense": "https://spdx.org/licenses/CC0-1.0",
       "name": "simple-module",
       "rootElement": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM"
       ],
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM",
       "type": "SpdxDocument"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "simple-module",
       "rootElement": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM"
       ],
       "software_sbomType": [
         "source"
       ],
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/sbom",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/sbom",
       "type": "software_Sbom"
     },
     {
@@ -77,8 +77,28 @@
       "software_packageUrl": "pkg:golang/example.com/simple@v0.0.0-unknown",
       "software_packageVersion": "v0.0.0-unknown",
       "software_primaryPurpose": "application",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-TJXDDWH2FBLDP7TA",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-TJXDDWH2FBLDP7TA",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:golang:go:1.26.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:golang/stdlib@v1.26.1",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "stdlib",
+      "software_packageUrl": "pkg:golang/stdlib@v1.26.1",
+      "software_packageVersion": "v1.26.1",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-5Z5YTQKEFAEY7U56",
       "type": "software_Package"
     },
     {
@@ -104,8 +124,8 @@
       "software_packageUrl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
       "software_packageVersion": "v1.0.0",
       "software_sourceInfo": "https://github.com/pmezard/go-difflib",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-6LPOVXNHYYPHFH7J",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-HOLDQLB4ZG2JENHT",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-6LPOVXNHYYPHFH7J",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-HOLDQLB4ZG2JENHT",
       "type": "software_Package"
     },
     {
@@ -130,8 +150,8 @@
       "name": "gopkg.in/yaml.v3",
       "software_packageUrl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
       "software_packageVersion": "v3.0.1",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-A3EJRWNXRJBCN4AR",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-P3H55RXVD3DOUGUX",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-A3EJRWNXRJBCN4AR",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-P3H55RXVD3DOUGUX",
       "type": "software_Package"
     },
     {
@@ -157,8 +177,8 @@
       "software_packageUrl": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
       "software_packageVersion": "v1.1.0",
       "software_sourceInfo": "https://github.com/inconshreveable/mousetrap",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-DJ3ZIKWTNBYO26BT",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-WDQXRU5U5VXMXD7I",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-DJ3ZIKWTNBYO26BT",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-WDQXRU5U5VXMXD7I",
       "type": "software_Package"
     },
     {
@@ -184,8 +204,8 @@
       "software_packageUrl": "pkg:golang/github.com/stretchr/testify@v1.11.1",
       "software_packageVersion": "v1.11.1",
       "software_sourceInfo": "https://github.com/stretchr/testify",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-FQD3O6TFIGWWRCL5",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-A2SLNI62QTZAA5ES",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-FQD3O6TFIGWWRCL5",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-A2SLNI62QTZAA5ES",
       "type": "software_Package"
     },
     {
@@ -211,8 +231,8 @@
       "software_packageUrl": "pkg:golang/github.com/sirupsen/logrus@v1.9.4",
       "software_packageVersion": "v1.9.4",
       "software_sourceInfo": "https://github.com/sirupsen/logrus",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JBX4TYZ3HEXJNFYD",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-RJY2MTGHCO6RNAH7",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JBX4TYZ3HEXJNFYD",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-RJY2MTGHCO6RNAH7",
       "type": "software_Package"
     },
     {
@@ -238,8 +258,8 @@
       "software_packageUrl": "pkg:golang/github.com/spf13/pflag@v1.0.9",
       "software_packageVersion": "v1.0.9",
       "software_sourceInfo": "https://github.com/spf13/pflag",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JOU7AJL2C6XXTUFK",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-7G3YT5IGRPAH7OYU",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JOU7AJL2C6XXTUFK",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-7G3YT5IGRPAH7OYU",
       "type": "software_Package"
     },
     {
@@ -264,8 +284,8 @@
       "name": "gopkg.in/check.v1",
       "software_packageUrl": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
       "software_packageVersion": "v0.0.0-20161208181325-20d25e280405",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-OPPLTPJ24FIGRUY2",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-P3H55RXVD3DOUGUX",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-OPPLTPJ24FIGRUY2",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-P3H55RXVD3DOUGUX",
       "type": "software_Package"
     },
     {
@@ -291,8 +311,8 @@
       "software_packageUrl": "pkg:golang/github.com/mattn/go-isatty@v0.0.21",
       "software_packageVersion": "v0.0.21",
       "software_sourceInfo": "https://github.com/mattn/go-isatty",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-UADJIBC3AU5U4VJC",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-JJFJHVXAR4WGQHI5",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-UADJIBC3AU5U4VJC",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-JJFJHVXAR4WGQHI5",
       "type": "software_Package"
     },
     {
@@ -317,8 +337,8 @@
       "name": "golang.org/x/sys",
       "software_packageUrl": "pkg:golang/golang.org/x/sys@v0.28.0",
       "software_packageVersion": "v0.28.0",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-XXDQJPHRGTN4ALYD",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-2ZDFNHBBEVR6S53W",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-XXDQJPHRGTN4ALYD",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-2ZDFNHBBEVR6S53W",
       "type": "software_Package"
     },
     {
@@ -344,8 +364,8 @@
       "software_packageUrl": "pkg:golang/github.com/spf13/cobra@v1.10.2",
       "software_packageVersion": "v1.10.2",
       "software_sourceInfo": "https://github.com/spf13/cobra",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZGOZVHQZC2RMR6GZ",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-7G3YT5IGRPAH7OYU",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZGOZVHQZC2RMR6GZ",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-7G3YT5IGRPAH7OYU",
       "type": "software_Package"
     },
     {
@@ -371,924 +391,956 @@
       "software_packageUrl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
       "software_packageVersion": "v1.1.1",
       "software_sourceInfo": "https://github.com/davecgh/go-spew",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZPQ6ND5QEI5V2QHC",
-      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-HFZXHVDIK5L5YRH3",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZPQ6ND5QEI5V2QHC",
+      "suppliedBy": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-HFZXHVDIK5L5YRH3",
       "type": "software_Package"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "golang.org/x",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-2ZDFNHBBEVR6S53W",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-2ZDFNHBBEVR6S53W",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/spf13",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-7G3YT5IGRPAH7OYU",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-7G3YT5IGRPAH7OYU",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/stretchr",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-A2SLNI62QTZAA5ES",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-A2SLNI62QTZAA5ES",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/davecgh",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-HFZXHVDIK5L5YRH3",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-HFZXHVDIK5L5YRH3",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/pmezard",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-HOLDQLB4ZG2JENHT",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-HOLDQLB4ZG2JENHT",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/mattn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-JJFJHVXAR4WGQHI5",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-JJFJHVXAR4WGQHI5",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "gopkg.in",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-P3H55RXVD3DOUGUX",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-P3H55RXVD3DOUGUX",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/sirupsen",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-RJY2MTGHCO6RNAH7",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-RJY2MTGHCO6RNAH7",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "example.com",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-TJXDDWH2FBLDP7TA",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-TJXDDWH2FBLDP7TA",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
       "name": "github.com/inconshreveable",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/agent-org-WDQXRU5U5VXMXD7I",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/agent-org-WDQXRU5U5VXMXD7I",
       "type": "Organization"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/rel-46BI72VSXP7ONL66",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/rel-43QPCU33JCVWZC57",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-XXDQJPHRGTN4ALYD"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-UADJIBC3AU5U4VJC"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/rel-7GUJIMPNNOPGUDUU",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/rel-53OF56RTDMBS2PAY",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JBX4TYZ3HEXJNFYD"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-OPPLTPJ24FIGRUY2"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/rel-7W3P4YRPABA74X6X",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/rel-5NVISOFB4JGOFWVQ",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZGOZVHQZC2RMR6GZ"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-A3EJRWNXRJBCN4AR"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/rel-BA4SMDCL7RUQC57N",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/rel-6XKVCS367IN3SB3O",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-DJ3ZIKWTNBYO26BT"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-6LPOVXNHYYPHFH7J"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/rel-BRKVJIVUK7NS3CF2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/rel-76MOXO2UBKLTUWIO",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-UADJIBC3AU5U4VJC"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZPQ6ND5QEI5V2QHC"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/rel-CTLVJZ3SW4IUO7EB",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/rel-ALMOZQGBJ3NHLVSW",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-6LPOVXNHYYPHFH7J"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZGOZVHQZC2RMR6GZ"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/rel-FWVIGSW5CL47NZPZ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/rel-B6W7I5EK7BCMBRMW",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZPQ6ND5QEI5V2QHC"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JBX4TYZ3HEXJNFYD"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/rel-GLRJSOP2T256VEES",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/rel-BFISLYXZM7KD6KWT",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JOU7AJL2C6XXTUFK"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JOU7AJL2C6XXTUFK"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
       "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/rel-GZJQMVKJAY5AUOF2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/rel-BWYDATDE3XQZBKFR",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-FQD3O6TFIGWWRCL5"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-XXDQJPHRGTN4ALYD"
       ],
       "type": "Relationship"
     },
     {
       "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/rel-QDIOEYLEYLYC3FJR",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-DJ3ZIKWTNBYO26BT"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/rel-VRYZLKAO5H5E47C5",
+      "to": [
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-FQD3O6TFIGWWRCL5"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "_:creation-info",
+      "from": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM",
       "relationshipType": "describes",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/rel-IBCCAFAROC4PNRW2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/rel-X2HWB4I5LS33323Y",
       "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM"
-      ],
-      "type": "Relationship"
-    },
-    {
-      "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
-      "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/rel-Q7E75DFSMENBH3UW",
-      "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-A3EJRWNXRJBCN4AR"
-      ],
-      "type": "Relationship"
-    },
-    {
-      "creationInfo": "_:creation-info",
-      "from": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
-      "relationshipType": "dependsOn",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/rel-SMDUVNH36J4YRMG7",
-      "to": [
-        "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-OPPLTPJ24FIGRUY2"
+        "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM"
       ],
       "type": "Relationship"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-25IZUOQCDGJ7EYVK",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JOU7AJL2C6XXTUFK",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-2AKF4VNE4QCEMAIQ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZGOZVHQZC2RMR6GZ",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-2GHVOIB2RZXAYUHA",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-2HQEIU2BILZSVPWK",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-UADJIBC3AU5U4VJC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-2KQPX7QHBTX6YNQY",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-XXDQJPHRGTN4ALYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-2N3HSR3VWG2UZGRL",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-FQD3O6TFIGWWRCL5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-2WRUIDNBG7FIZKR5",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-UADJIBC3AU5U4VJC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-35TBTLTTBYEYIB2R",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JOU7AJL2C6XXTUFK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-3BGR7ECVPARGJWYS",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:generation-context\",\"value\":\"filesystem-scan\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-2WIVEUP6CHLPNPYS",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:detected-go\",\"value\":\"true\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-36GT2SQ4UA64JE4G",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JOU7AJL2C6XXTUFK",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-3CEYY6WZMOM6WDKQ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"golang\"]}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-3FYO6T65QAZ2SZQD",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-XXDQJPHRGTN4ALYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-3I54Q3SGVKI7FHTQ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JOU7AJL2C6XXTUFK",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-3QBNEYCFAWOFCNUH",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:component-role\",\"value\":\"main-module\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-3QQ5XIFSQORJJRQR",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-FQD3O6TFIGWWRCL5",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-4IOSSF66OEGB7AXV",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:example.com\\\\/simple:example.com\\\\/simple:v0.0.0-unknown:*:*:*:*:*:*:*\",\"cpe:2.3:a:example.com:example.com\\\\/simple:v0.0.0-unknown:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-4QA6BUCRKK2IVISU",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.mod\",\"sha256\":\"cdd0a93d26463fdb57eb644821e6dce4545c75eddd034231f3e6f98f3c333888\"}]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-4UOHSXRAR3THY6JC",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JOU7AJL2C6XXTUFK",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-536MLWMHPEYA5OET",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-A3EJRWNXRJBCN4AR",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-5KMYMRFEMURCFFTF",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JBX4TYZ3HEXJNFYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-64MIFBM6YT2VQTUA",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-A3EJRWNXRJBCN4AR",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-6NU62NQXSXMBYA23",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-FQD3O6TFIGWWRCL5",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-6W3ACLBDBIBLTI7T",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-6WH7FE6JEDVCNYQQ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-FQD3O6TFIGWWRCL5",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-75XJEL4QNOHETMIQ",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-3TZL6DKIQ25U4TRJ",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-events-dropped\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-76ZQMIBRFMAZHK2D",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/inconshreveable\\\\/mousetrap:github.com\\\\/inconshreveable\\\\/mousetrap:v1.1.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/inconshreveable:github.com\\\\/inconshreveable\\\\/mousetrap:v1.1.0:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-DJ3ZIKWTNBYO26BT",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-7B54WCMDUBRU3T5C",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JBX4TYZ3HEXJNFYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-7QN7NUPMJVRISSKA",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZPQ6ND5QEI5V2QHC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-A37XFVUH7ANJB2AU",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:graph-completeness\",\"value\":\"partial\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-ALDCTJ6WPYPNGHMX",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/spf13\\\\/pflag:github.com\\\\/spf13\\\\/pflag:v1.0.9:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/spf13:github.com\\\\/spf13\\\\/pflag:v1.0.9:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JOU7AJL2C6XXTUFK",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-B4FAGBSD6KYM4UEU",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZPQ6ND5QEI5V2QHC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-B7DJGKKUUKBCJMHI",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JBX4TYZ3HEXJNFYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-C2DQNAB655HZELMQ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-OPPLTPJ24FIGRUY2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-DJB6VO4BRXV6UOAY",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZPQ6ND5QEI5V2QHC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-DNKYWOURWL4HZ2B7",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-OPPLTPJ24FIGRUY2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-E35F547NTCZWNSKG",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JOU7AJL2C6XXTUFK",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-EGKYFDGTRRHFALRU",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-DJ3ZIKWTNBYO26BT",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-EMMCCJR2WT7UQW7X",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JOU7AJL2C6XXTUFK",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-F3E5PQC5XHVFDNE3",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-6LPOVXNHYYPHFH7J",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-FVOKF3PU3OBMXWCN",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JBX4TYZ3HEXJNFYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-G5DJSL6K3AVZDHHI",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-XXDQJPHRGTN4ALYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-GVLRZQTRWHOXHKEB",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-XXDQJPHRGTN4ALYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-HCXPMR5JQOELB4T5",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-OPPLTPJ24FIGRUY2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-HNZGQYQI6EWK72RS",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-HR36SGEAQ7HFVUTY",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZPQ6ND5QEI5V2QHC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-HRACNKKZSJPHH4SG",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-FQD3O6TFIGWWRCL5",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-HT7MN3VSHAVDHX3P",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZGOZVHQZC2RMR6GZ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-I2IAYOL7NTKQWAVP",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-XXDQJPHRGTN4ALYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-ILB3WWED5XFY4XQU",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-UADJIBC3AU5U4VJC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-INU5IGYM2RCCQJBW",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-OPPLTPJ24FIGRUY2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-J3JBX4H4NYKT72UY",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/pmezard\\\\/go-difflib:github.com\\\\/pmezard\\\\/go-difflib:v1.0.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/pmezard:github.com\\\\/pmezard\\\\/go-difflib:v1.0.0:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-6LPOVXNHYYPHFH7J",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-JEDFQJ6BUVW72XOU",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-XXDQJPHRGTN4ALYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-JJEP55YFEZMJ3I22",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:golang.org\\\\/x\\\\/sys:golang.org\\\\/x\\\\/sys:v0.28.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:golang.org\\\\/x:golang.org\\\\/x\\\\/sys:v0.28.0:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-XXDQJPHRGTN4ALYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-JUST7PMROUCYNMEB",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-JYA5NGAXQDGU4JOF",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-DJ3ZIKWTNBYO26BT",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-K56PZKEA2DIJ7X45",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/mattn\\\\/go-isatty:github.com\\\\/mattn\\\\/go-isatty:v0.0.21:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/mattn:github.com\\\\/mattn\\\\/go-isatty:v0.0.21:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-UADJIBC3AU5U4VJC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-K7VZPT3KQIBWTVA5",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/sirupsen\\\\/logrus:github.com\\\\/sirupsen\\\\/logrus:v1.9.4:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/sirupsen:github.com\\\\/sirupsen\\\\/logrus:v1.9.4:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JBX4TYZ3HEXJNFYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-KGHUAIP7INHKHM4X",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-UADJIBC3AU5U4VJC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-KP7MWLTCMKUBWFGH",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-KSIHZH4MMKCMQRRP",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JBX4TYZ3HEXJNFYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-L2YQOMRUQBO7BNEW",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZGOZVHQZC2RMR6GZ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-L3BJT6SK2VDIPPKW",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-DJ3ZIKWTNBYO26BT",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-LGLQCWKWHEQ34M5D",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZGOZVHQZC2RMR6GZ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-LVB72QV5AVI2KGFM",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-A3EJRWNXRJBCN4AR",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-MC5XJES6T3E5XRPH",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-A3EJRWNXRJBCN4AR",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-MM3ZWSTVNUEXSSDI",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/spf13\\\\/cobra:github.com\\\\/spf13\\\\/cobra:v1.10.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/spf13:github.com\\\\/spf13\\\\/cobra:v1.10.2:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZGOZVHQZC2RMR6GZ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-MUZ7R6FLPEXIQARC",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-6LPOVXNHYYPHFH7J",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-NSPYZEYTYLK3C7OP",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-6LPOVXNHYYPHFH7J",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-OE4OFWV2AWSHSLRV",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-A3EJRWNXRJBCN4AR",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-OFQCLGF3JRQXC4TA",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZGOZVHQZC2RMR6GZ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-PAY4CEA22PBGW27E",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-6LPOVXNHYYPHFH7J",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-PE7YWG6EW3UDVIFQ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-FQD3O6TFIGWWRCL5",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-PLDAB7CFBBE2JXIE",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-OPPLTPJ24FIGRUY2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-PWJK5L4XLWEDTJJX",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-UADJIBC3AU5U4VJC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-PWNI7I7P22WRXAME",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-JBX4TYZ3HEXJNFYD",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-Q44KOFVNBQOWBL4V",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-6LPOVXNHYYPHFH7J",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-QD6GITRQQTZKBKZL",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-UADJIBC3AU5U4VJC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-QIERQZQGP4UUB3FT",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-44M5EWWXI7KDQQBD",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:gopkg.in\\\\/check.v1:gopkg.in\\\\/check.v1:v0.0.0-20161208181325-20d25e280405:*:*:*:*:*:*:*\",\"cpe:2.3:a:gopkg.in:gopkg.in\\\\/check.v1:v0.0.0-20161208181325-20d25e280405:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-OPPLTPJ24FIGRUY2",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-OPPLTPJ24FIGRUY2",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-QX7VUNPSAGD5DVL5",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZPQ6ND5QEI5V2QHC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-QY4EF23TXB6ODUUG",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-47S5Z4EI54ZANAJL",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-XXDQJPHRGTN4ALYD",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-UADJIBC3AU5U4VJC",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-RLPUGDQQ2X62M5IL",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-6LPOVXNHYYPHFH7J",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-S5QJNWW6YASTIASJ",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-OPPLTPJ24FIGRUY2",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-SJS7RVY4OIPID4II",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-UADJIBC3AU5U4VJC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-SRBMIA5MB4ESXSPH",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZGOZVHQZC2RMR6GZ",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-TDSEC6X3VNNWHKLR",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/davecgh\\\\/go-spew:github.com\\\\/davecgh\\\\/go-spew:v1.1.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/davecgh:github.com\\\\/davecgh\\\\/go-spew:v1.1.1:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZPQ6ND5QEI5V2QHC",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-USOCBAWVHOUSMKRL",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-DJ3ZIKWTNBYO26BT",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-V2GHW765MDRU4SEL",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-FQD3O6TFIGWWRCL5",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-V2SQYGXE4NEP4CNX",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-DJ3ZIKWTNBYO26BT",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-VY4BBAQJ574E2MQ3",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-A3EJRWNXRJBCN4AR",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-W4FDPEF2F2XP4YZT",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-4GFNQRIAXGQ4NGGL",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZGOZVHQZC2RMR6GZ",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JOU7AJL2C6XXTUFK",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-WKN5QXAWF3WD2ZIF",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-6TE3N4WBRELUXO43",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-X26VRHOCB5BJQYZV",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-6Z7GPPNUABQ7M2OS",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-UADJIBC3AU5U4VJC",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-A3EJRWNXRJBCN4AR",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-X6GVKYX7KXPM2IEN",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/stretchr\\\\/testify:github.com\\\\/stretchr\\\\/testify:v1.11.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/stretchr:github.com\\\\/stretchr\\\\/testify:v1.11.1:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-FQD3O6TFIGWWRCL5",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-74SM2LGZQBSRZILJ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-6LPOVXNHYYPHFH7J",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-XEECFS6RODZODXA2",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-7PB4RXEC2UNKZU7P",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JBX4TYZ3HEXJNFYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-A3LIDZVUP4YWQJED",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZPQ6ND5QEI5V2QHC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-A5IPYB6I7UU6T7IA",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-UADJIBC3AU5U4VJC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-ACUKHSZ4XC5DUNWL",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZGOZVHQZC2RMR6GZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-AWGROJ5JBS52ISV4",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JBX4TYZ3HEXJNFYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-BP55CVBCM3YTTSBI",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-ring-buffer-overflows\",\"value\":0}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-C6Z6M5D2F4V2JYSB",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/sirupsen\\\\/logrus:github.com\\\\/sirupsen\\\\/logrus:v1.9.4:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/sirupsen:github.com\\\\/sirupsen\\\\/logrus:v1.9.4:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JBX4TYZ3HEXJNFYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-CJJPKULQPBHO4RNR",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-XXDQJPHRGTN4ALYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-DISSYIEAT3ISUMA4",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-A3EJRWNXRJBCN4AR",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-DJT6FOJULZJFYMPM",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JOU7AJL2C6XXTUFK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-DMMEZEFBOIIQKSYM",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-DJ3ZIKWTNBYO26BT",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-EM5IYUJ7ONYFNDUS",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JOU7AJL2C6XXTUFK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-EQHU442KPSFDHXJ3",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/mattn\\\\/go-isatty:github.com\\\\/mattn\\\\/go-isatty:v0.0.21:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/mattn:github.com\\\\/mattn\\\\/go-isatty:v0.0.21:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-UADJIBC3AU5U4VJC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-ESI47K2XJUGY3E6L",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:detected-go\",\"value\":\"true\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-FAEVQ7FXZJMCZZPG",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZPQ6ND5QEI5V2QHC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-FJEP6YTSZRSIMHR6",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-ZPQ6ND5QEI5V2QHC",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-A3EJRWNXRJBCN4AR",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-XQ7YSQQHXAYWLESW",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-FMFLVRPBOABMLX7O",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-UADJIBC3AU5U4VJC",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-Y5MXFVJORDYDCDKU",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-FSX3XZG5RMBRC7AH",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-DJ3ZIKWTNBYO26BT",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JBX4TYZ3HEXJNFYD",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-Y7T4QMRQFKZMXUJM",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.mod\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-4BC3TYO5L6QI7GXM",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-H2E64NOA7PID2FWB",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:example.com\\\\/simple:example.com\\\\/simple:v0.0.0-unknown:*:*:*:*:*:*:*\",\"cpe:2.3:a:example.com:example.com\\\\/simple:v0.0.0-unknown:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
       "type": "Annotation"
     },
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/anno-ZBFQ7MBJLVULKWLG",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-HDCPL7YQN2KUK3SS",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-XXDQJPHRGTN4ALYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-HRZSVBXNVDEEJS2J",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"golang\"]}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-HTFRXFYA6XPSOBF7",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-DJ3ZIKWTNBYO26BT",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-HWNQTHXLXHHOZNAY",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-OPPLTPJ24FIGRUY2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-HXT6YROBX47CLWP5",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-6LPOVXNHYYPHFH7J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-I5AMJFGX3EUEH7Q3",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-5Z5YTQKEFAEY7U56",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-IAO4R523HKFOZRX5",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:gopkg.in\\\\/yaml.v3:gopkg.in\\\\/yaml.v3:v3.0.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:gopkg.in:gopkg.in\\\\/yaml.v3:v3.0.1:*:*:*:*:*:*:*\"]}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-F4M4KGTMJI37BGTAIJMT6YEK/pkg-A3EJRWNXRJBCN4AR",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-A3EJRWNXRJBCN4AR",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-IIEKZLTNGUPN3PCW",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JBX4TYZ3HEXJNFYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-IK7HBUNBMWMM2LTF",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:graph-completeness\",\"value\":\"partial\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-J2B7RRCY6JE3L2SP",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-OPPLTPJ24FIGRUY2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-J5NHVGOI2MEKJFHR",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZGOZVHQZC2RMR6GZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-JJA2TMJNXQ5HCBHL",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-JSXJN2BU6D2DCQUO",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZPQ6ND5QEI5V2QHC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-K2RWOLEL7KDPAHDR",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.mod\",\"sha256\":\"cdd0a93d26463fdb57eb644821e6dce4545c75eddd034231f3e6f98f3c333888\"}]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-KFGHX33CT75CF2C3",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-KPG7EQBMLJMJGSOA",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-OPPLTPJ24FIGRUY2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-KY3PU2SI7JPNDHPU",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/inconshreveable\\\\/mousetrap:github.com\\\\/inconshreveable\\\\/mousetrap:v1.1.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/inconshreveable:github.com\\\\/inconshreveable\\\\/mousetrap:v1.1.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-DJ3ZIKWTNBYO26BT",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-L2HLEQDKG6G6PCHC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-6LPOVXNHYYPHFH7J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-LM5M4CGEJMGXWJIK",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JOU7AJL2C6XXTUFK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-LQV5YNFBEOYXMDIR",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZGOZVHQZC2RMR6GZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-LRNYVZ6ST32K4GDU",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-5Z5YTQKEFAEY7U56",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-LZRV2RZKPA3FPFFI",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-DJ3ZIKWTNBYO26BT",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-MIAXYSKI5W7SDOQL",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/stretchr\\\\/testify:github.com\\\\/stretchr\\\\/testify:v1.11.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/stretchr:github.com\\\\/stretchr\\\\/testify:v1.11.1:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-FQD3O6TFIGWWRCL5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-MOG2DTFBJR3QWJCE",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JBX4TYZ3HEXJNFYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-MRODLKSYA2EWH4LY",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-DJ3ZIKWTNBYO26BT",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-N3WTJNS56IFCUXXT",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZPQ6ND5QEI5V2QHC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-NHYG7SFRH6E7ACQJ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-A3EJRWNXRJBCN4AR",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-NL57YDRW3OAWUFGC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-OPPLTPJ24FIGRUY2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-NMGG6NNA2JNINLXL",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/davecgh\\\\/go-spew:github.com\\\\/davecgh\\\\/go-spew:v1.1.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/davecgh:github.com\\\\/davecgh\\\\/go-spew:v1.1.1:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZPQ6ND5QEI5V2QHC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-NNU3G4V4S3LJPC7E",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JBX4TYZ3HEXJNFYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-NRGLQINFHUNYOATX",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/pmezard\\\\/go-difflib:github.com\\\\/pmezard\\\\/go-difflib:v1.0.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/pmezard:github.com\\\\/pmezard\\\\/go-difflib:v1.0.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-6LPOVXNHYYPHFH7J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-OGYLUO6B7AGM2M7T",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-FQD3O6TFIGWWRCL5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-PQMGAPV6WNESOALK",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-6LPOVXNHYYPHFH7J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-Q6PIRWBNO7Y5HTVJ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-6LPOVXNHYYPHFH7J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-QC33EG2RVZPZXU4X",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-RZRZKMHQDOSPS7SD",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-XXDQJPHRGTN4ALYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-TFL4CCBXROZMS5SJ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-5Z5YTQKEFAEY7U56",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-TOSBGBPB5ZFKAYJJ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.mod\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-U6KZUMLIRUDEZ7QQ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-FQD3O6TFIGWWRCL5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-V5L55PQT34FQD25M",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-OPPLTPJ24FIGRUY2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-VDF7FS73EGRTOUYU",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-A3EJRWNXRJBCN4AR",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-VRM6IQMT3D4PXNTC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZPQ6ND5QEI5V2QHC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-VWZABWWGHINLUCXC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JOU7AJL2C6XXTUFK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-WE7APVPJPCNI6HKL",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/spf13\\\\/cobra:github.com\\\\/spf13\\\\/cobra:v1.10.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/spf13:github.com\\\\/spf13\\\\/cobra:v1.10.2:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZGOZVHQZC2RMR6GZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-WTBKJ477EX3N2HZO",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-5Z5YTQKEFAEY7U56",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-WWM2XVGE5DE3PCPJ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-UADJIBC3AU5U4VJC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-X3CBSEZPCXQNNSEC",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:golang.org\\\\/x\\\\/sys:golang.org\\\\/x\\\\/sys:v0.28.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:golang.org\\\\/x:golang.org\\\\/x\\\\/sys:v0.28.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-XXDQJPHRGTN4ALYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-X3VYOA34MIXIHWS7",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-A3EJRWNXRJBCN4AR",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-XGIKHLVHJXJFTJHF",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-6LPOVXNHYYPHFH7J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-XGNUJYNA3U72IEXB",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZGOZVHQZC2RMR6GZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-XI6ZFH4BLACMSCH7",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-XXDQJPHRGTN4ALYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-XNUZRAPWCKJAXZGH",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-FQD3O6TFIGWWRCL5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-XRUEHXIXNGWVGWUK",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-FQD3O6TFIGWWRCL5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-XVDUJJ4GVSBEK4YD",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-DJ3ZIKWTNBYO26BT",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-XW2ODDCKLQX7WPZI",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/spf13\\\\/pflag:github.com\\\\/spf13\\\\/pflag:v1.0.9:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/spf13:github.com\\\\/spf13\\\\/pflag:v1.0.9:*:*:*:*:*:*:*\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-JOU7AJL2C6XXTUFK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-XWBLTCU245IEUOGU",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"9aded8247f7273dbceae5c01267f4c191edeaad5d26464d6fcc6cedadcd566be\"}]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-XXDQJPHRGTN4ALYD",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-XZO2KGY5WSKXA4II",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-YB4RFBKDTKTFKCCS",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:resolver-step\",\"value\":\"go-sum-fallback\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZGOZVHQZC2RMR6GZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-YC5AJ6F37LLG3HIJ",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:component-role\",\"value\":\"main-module\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-4BC3TYO5L6QI7GXM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-YH24EXGXMZKQEERP",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-DJ3ZIKWTNBYO26BT",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-YIADYZUJY7CQ2KA2",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:build-inclusion\",\"value\":\"unknown\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-FQD3O6TFIGWWRCL5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-ZOP7OYCHNNW7GHQW",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-OPPLTPJ24FIGRUY2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/anno-ZRNNMNRS47MIDOM3",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-GT6RIWF3WW67YAXHT7ILQTZM/pkg-ZPQ6ND5QEI5V2QHC",
       "type": "Annotation"
     }
   ]

--- a/mikebom-cli/tests/go_build_inclusion.rs
+++ b/mikebom-cli/tests/go_build_inclusion.rs
@@ -247,7 +247,10 @@ fn unknown_marker_in_all_three_formats() {
     // FR-011: the marker pass annotates in place; it never adds or
     // removes components. Pre-feature expectation for this fixture:
     // exactly the three go.sum modules (the main module collapses into
-    // metadata.component per milestone 084).
+    // metadata.component per milestone 084). Issue #364 adds one
+    // synthetic `pkg:golang/stdlib@...` component per Go scan; exclude
+    // it from the FR-011 count because it's orthogonal to the marker-
+    // pass invariant under test.
     let golang_count = cdx["components"]
         .as_array()
         .expect("components array")
@@ -255,7 +258,7 @@ fn unknown_marker_in_all_three_formats() {
         .filter(|c| {
             c["purl"]
                 .as_str()
-                .is_some_and(|p| p.starts_with("pkg:golang/"))
+                .is_some_and(|p| p.starts_with("pkg:golang/") && !p.starts_with("pkg:golang/stdlib"))
         })
         .count();
     assert_eq!(

--- a/mikebom-cli/tests/go_stdlib_component.rs
+++ b/mikebom-cli/tests/go_stdlib_component.rs
@@ -1,0 +1,91 @@
+//! Issue #364 integration test — Go SBOMs include a `stdlib`
+//! component carrying the Go toolchain version from the project's
+//! go.mod. Closes the vulnerability-scanning gap (e.g. CVE-2024-34156
+//! big.Int overflow) on the same shape syft v1.42.3 produces:
+//!
+//!   PURL: pkg:golang/stdlib@v<go-version>
+//!   CPE:  cpe:2.3:a:golang:go:<go-version>:*:*:*:*:*:*:*
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn fixture(sub: &str) -> PathBuf {
+    PathBuf::from(env!("MIKEBOM_FIXTURES_DIR")).join(sub)
+}
+
+fn run_scan(path: &Path) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("sbom.cdx.json");
+    let status = Command::new(bin)
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(path)
+        .arg("--output")
+        .arg(&out_path)
+        .arg("--file-inventory=off")
+        .arg("--no-deep-hash")
+        .status()
+        .expect("mikebom should run");
+    assert!(status.success(), "scan failed");
+    let raw = std::fs::read(&out_path).expect("read sbom");
+    serde_json::from_slice(&raw).expect("valid JSON")
+}
+
+fn find_stdlib(sbom: &serde_json::Value) -> Option<&serde_json::Value> {
+    sbom["components"]
+        .as_array()?
+        .iter()
+        .find(|c| c["name"].as_str() == Some("stdlib"))
+}
+
+#[test]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+fn go_source_scan_emits_stdlib_component_with_purl_and_cpe() {
+    let path = fixture("go/simple-module");
+    let sbom = run_scan(&path);
+    let stdlib = find_stdlib(&sbom).expect("stdlib component must be emitted on a Go scan");
+
+    let purl = stdlib["purl"].as_str().unwrap_or("");
+    assert!(
+        purl.starts_with("pkg:golang/stdlib@v"),
+        "stdlib PURL must follow `pkg:golang/stdlib@v<version>`; got {purl:?}"
+    );
+
+    let cpe = stdlib["cpe"].as_str().unwrap_or("");
+    assert!(
+        cpe.starts_with("cpe:2.3:a:golang:go:"),
+        "stdlib CPE must use NVD's `golang:go` vendor/product slug; got {cpe:?}"
+    );
+    // The CPE version segment must match the PURL version with the
+    // `v`-prefix stripped (NVD's bare-version convention).
+    let purl_version = purl.trim_start_matches("pkg:golang/stdlib@v");
+    let expected_cpe_prefix = format!("cpe:2.3:a:golang:go:{purl_version}:");
+    assert!(
+        cpe.starts_with(&expected_cpe_prefix),
+        "stdlib CPE version segment {cpe:?} must match the PURL bare version {purl_version:?}"
+    );
+
+    assert_eq!(
+        stdlib["type"].as_str(),
+        Some("library"),
+        "stdlib CDX type must be `library`"
+    );
+
+    // Build-inclusion misclassification regression: stdlib must NOT
+    // carry `mikebom:build-inclusion = "not-needed"` (false positive
+    // from `go mod why stdlib` returning "package not in import
+    // graph"). See `apply_go_mod_why_verdicts` stdlib skip.
+    let props = stdlib["properties"].as_array().cloned().unwrap_or_default();
+    for p in &props {
+        if p["name"].as_str() == Some("mikebom:build-inclusion") {
+            assert_ne!(
+                p["value"].as_str(),
+                Some("not-needed"),
+                "stdlib MUST NOT be classified `not-needed` (#364 regression)"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #364 — Go stdlib vulnerability-scanning gap with syft. Every Go-project scan now emits one synthetic stdlib component per unique `go` directive seen in parsed go.mod files.

| Field | Value |
|---|---|
| name  | `stdlib` |
| type  | `library` |
| PURL  | `pkg:golang/stdlib@v<go-version>` (matches syft v1.42.3) |
| CPE   | `cpe:2.3:a:golang:go:<go-version>:*:*:*:*:*:*:*` |

Vulnerability scanners (Trivy, Grype) that key on stdlib CPE CVEs (e.g. **CVE-2024-34156** big.Int overflow, **CVE-2023-39325** HTTP/2 rapid reset) now have the data they need; CRA compliance tools can identify the Go runtime version.

## Approach

| File | Change |
|---|---|
| `scan_fs/package_db/golang/legacy.rs` | New `build_stdlib_entry()` helper + emission at the end of `read()` (after all per-go.mod classifiers). Per-go.mod dedup by version. |
| `scan_fs/package_db/mod.rs` | `apply_go_mod_why_verdicts` skips entries with `name == "stdlib"` — otherwise `go mod why stdlib` returns "not in import graph" and the entry is falsely classified `mikebom:build-inclusion = "not-needed"` + `scope: "excluded"`. |
| `generate/cpe.rs` | Special-case CPE synthesis for `pkg:golang/stdlib`: emits `cpe:2.3:a:golang:go:<version>:*:...` (NVD canonical) instead of the default `vendor=name=stdlib`. |
| `tests/go_stdlib_component.rs` | Integration test asserts PURL + CPE shape, matching versions, library type, and no `not-needed` misclassification. |
| `tests/fixtures/golden/{cdx,spdx-2.3,spdx-3}/golang.*` | Regenerated with +1 stdlib component per format. |

## Smoke test

```
$ mikebom sbom scan --path go/simple-module --output sbom.cdx.json
$ jq '.components[] | select(.name == "stdlib")' sbom.cdx.json
{
  "type": "library",
  "name": "stdlib",
  "version": "v1.26.1",
  "purl": "pkg:golang/stdlib@v1.26.1",
  "cpe": "cpe:2.3:a:golang:go:1.26.1:*:*:*:*:*:*:*",
  "bom-ref": "pkg:golang/stdlib@v1.26.1"
}
```

## Test plan

- [x] New `go_stdlib_component` integration test passing locally
- [ ] Local pre-PR was 17/153 blocks before shortcut — the docker-daemon integration suite was again unusually slow today (~5 min on its own). CI lanes will verify the remainder.
- [x] Existing golang fixture regenerated (CDX + SPDX 2.3 + SPDX 3 +1 component each)
- [x] No new Cargo dependencies
- [x] No new `mikebom:*` annotations / C-rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)