### PR TITLE
fix(scan_fs/walk): refuse to follow symlinks that escape the rootfs sandbox (closes #396)

### DIFF
--- a/mikebom-cli/src/scan_fs/walk.rs
+++ b/mikebom-cli/src/scan_fs/walk.rs
@@ -173,12 +173,19 @@ pub(crate) struct WalkConfig<'a> {
 ///   posture).
 pub(crate) fn safe_walk<F: FnMut(&Path)>(rootfs: &Path, cfg: &WalkConfig, mut visit: F) {
     let mut visited: HashSet<PathBuf> = HashSet::new();
-    walk_inner(rootfs, rootfs, 0, cfg, &mut visit, &mut visited);
+    // Canonicalize once. Used by `walk_inner` to enforce the rootfs
+    // sandbox: any child dir whose canonical form falls outside this
+    // prefix is rejected, preventing absolute symlinks inside an
+    // extracted image rootfs (e.g. alpine's `/var/run -> /run`) from
+    // pulling host filesystem content into the SBOM. Issue #396.
+    let canonical_rootfs = std::fs::canonicalize(rootfs).unwrap_or_else(|_| rootfs.to_path_buf());
+    walk_inner(rootfs, rootfs, &canonical_rootfs, 0, cfg, &mut visit, &mut visited);
 }
 
 fn walk_inner<F: FnMut(&Path)>(
     dir: &Path,
     rootfs: &Path,
+    canonical_rootfs: &Path,
     depth: usize,
     cfg: &WalkConfig,
     visit: &mut F,
@@ -241,7 +248,39 @@ fn walk_inner<F: FnMut(&Path)>(
                 }
             }
         }
-        walk_inner(&path, rootfs, depth + 1, cfg, visit, visited);
+        // Issue #396 — sandbox enforcement: refuse to follow a directory
+        // whose canonical form escapes the rootfs. Without this check
+        // an absolute symlink inside the extracted image (e.g.
+        // alpine's `var/run -> /run`) silently pulls the host
+        // filesystem's content into the SBOM. The canonicalize call
+        // resolves the FULL symlink chain on every descent; if it
+        // returns an error (broken / dangling symlink, permission
+        // denied), the entry is rejected — safer than the fail-open
+        // tolerance policy elsewhere in this function because the
+        // alternative is leaking host content.
+        match std::fs::canonicalize(&path) {
+            Ok(canonical_child) => {
+                if !canonical_child.starts_with(canonical_rootfs) {
+                    tracing::debug!(
+                        candidate = %path.display(),
+                        canonical = %canonical_child.display(),
+                        rootfs = %canonical_rootfs.display(),
+                        cause = "rootfs-sandbox-escape",
+                        "safe_walk: refusing to follow symlink that escapes the rootfs"
+                    );
+                    continue;
+                }
+            }
+            Err(_) => {
+                tracing::debug!(
+                    candidate = %path.display(),
+                    cause = "canonicalize-failed",
+                    "safe_walk: cannot canonicalize directory; skipping"
+                );
+                continue;
+            }
+        }
+        walk_inner(&path, rootfs, canonical_rootfs, depth + 1, cfg, visit, visited);
     }
 }
 
@@ -592,6 +631,89 @@ mod tests {
         assert!(
             !*saw_inside.borrow(),
             "pattern match suppresses descent into the matched subtree"
+        );
+    }
+
+    /// Issue #396 — `safe_walk` MUST NOT follow an absolute symlink
+    /// that escapes the rootfs sandbox. Reproduces the alpine
+    /// `/var/run -> /run` case that pulled the operator's host
+    /// filesystem (Nix-managed `/var/run/current-system/sw/bin/...`)
+    /// into every image-scan SBOM.
+    #[cfg(unix)]
+    #[test]
+    fn rootfs_sandbox_blocks_absolute_symlink_escape() {
+        // Build a tempdir tree:
+        //   <tmp>/rootfs/in_sandbox/   (a real dir inside the sandbox)
+        //   <tmp>/rootfs/escape   ->   <tmp>/host/sentinel  (an absolute symlink that points outside)
+        //   <tmp>/host/sentinel/poison  (a child file the walker MUST NOT visit)
+        let tmp = tempfile::tempdir().unwrap();
+        let rootfs = tmp.path().join("rootfs");
+        let host_target = tmp.path().join("host/sentinel");
+        std::fs::create_dir_all(rootfs.join("in_sandbox")).unwrap();
+        std::fs::create_dir_all(&host_target).unwrap();
+        std::fs::write(host_target.join("poison"), b"host content").unwrap();
+        // Canonicalize the target path so the symlink uses an absolute
+        // path the way image rootfs symlinks do (`var/run -> /run`).
+        let host_target_canonical = std::fs::canonicalize(&host_target).unwrap();
+        std::os::unix::fs::symlink(&host_target_canonical, rootfs.join("escape")).unwrap();
+
+        let set = ExclusionSet::new_empty();
+        let skip = no_skip();
+        let cfg = WalkConfig {
+            max_depth: 6,
+            should_skip: &skip,
+            exclude_set: &set,
+        };
+        let saw_in_sandbox = RefCell::new(false);
+        let saw_poison = RefCell::new(false);
+        safe_walk(&rootfs, &cfg, |p| {
+            if p.file_name().and_then(|s| s.to_str()) == Some("in_sandbox") {
+                *saw_in_sandbox.borrow_mut() = true;
+            }
+            if p.file_name().and_then(|s| s.to_str()) == Some("poison") {
+                *saw_poison.borrow_mut() = true;
+            }
+        });
+        assert!(
+            *saw_in_sandbox.borrow(),
+            "real directory inside the sandbox must still be visited"
+        );
+        assert!(
+            !*saw_poison.borrow(),
+            "safe_walk MUST NOT follow an absolute symlink out of the rootfs (issue #396 regression)"
+        );
+    }
+
+    /// Issue #396 follow-up — relative symlinks that resolve to a
+    /// path STILL UNDER the rootfs are followed normally. The escape
+    /// guard only fires on absolute / parent-traversal symlinks that
+    /// land outside the rootfs canonical prefix.
+    #[cfg(unix)]
+    #[test]
+    fn rootfs_sandbox_allows_in_sandbox_symlinks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let rootfs = tmp.path().join("rootfs");
+        std::fs::create_dir_all(rootfs.join("real")).unwrap();
+        std::fs::write(rootfs.join("real/inside-file"), b"inside").unwrap();
+        // Relative symlink that stays under the rootfs.
+        std::os::unix::fs::symlink("real", rootfs.join("alias")).unwrap();
+
+        let set = ExclusionSet::new_empty();
+        let skip = no_skip();
+        let cfg = WalkConfig {
+            max_depth: 6,
+            should_skip: &skip,
+            exclude_set: &set,
+        };
+        let saw_inside = RefCell::new(false);
+        safe_walk(&rootfs, &cfg, |p| {
+            if p.file_name().and_then(|s| s.to_str()) == Some("inside-file") {
+                *saw_inside.borrow_mut() = true;
+            }
+        });
+        assert!(
+            *saw_inside.borrow(),
+            "in-sandbox relative symlink must be followed normally"
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes #396. `safe_walk` now refuses to follow a directory symlink whose canonical form falls outside the rootfs root.

## Reproduction (alpine:3.19 on macOS Docker / colima, NixOS-managed `/var/run/current-system`)

| Metric | Before | After |
|---|---|---|
| Components | 463 (15 apk + **448 host Go contamination**) | 15 (alpine apk base, as expected) |
| Wall clock | 1m23s | **0.72s** |
| SBOM size | 906 KB | 36 KB |

Three problems in one (per issue body):
1. **Correctness**: SBOMs contained components that weren't in the image.
2. **Privacy**: SBOMs leaked which dev tools the operator had installed (`syft`, `ko`, `buf`, `crane`, `fzf`, etc.).
3. **Performance**: scans walked the entire host's `/var/run/current-system` subtree.

The docker-daemon CI integration test took ~5min today vs ~30s yesterday with no mikebom change explaining the delta — symptom only became visible because my Nix-rebuilt host today happens to have more content there. **Bug dates to milestone 114 (~4 weeks of silently corrupt SBOMs).**

## Approach

| File | Change |
|---|---|
| `mikebom-cli/src/scan_fs/walk.rs` | `safe_walk` canonicalizes rootfs once at entry; `walk_inner` takes `canonical_rootfs: &Path` and verifies every child dir's `canonicalize()` `starts_with(canonical_rootfs)` before recursing. Failure to canonicalize is also a skip (fail-closed). Tracing emits `cause = "rootfs-sandbox-escape"` / `"canonicalize-failed"` at debug level. |
| Same file — `mod tests` | 2 new `cfg(unix)`-gated tests: `rootfs_sandbox_blocks_absolute_symlink_escape` (host-symlink escape) + `rootfs_sandbox_allows_in_sandbox_symlinks` (in-sandbox relative symlinks still followed). |

## Test plan

- [x] 15/15 `scan_fs::walk` unit tests pass (13 pre-existing + 2 new)
- [x] alpine:3.19 smoke test: 15 components in 0.72s (above table)
- [x] No new Cargo dependencies
- [x] No new C-rows / annotations

CI to verify the broader suite — and notably to confirm the docker-daemon integration test is back to its ~30s baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)