### PR TITLE
feat(cli): --root-purl single-flag form for the root component PURL (closes #359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 
 ## [Unreleased]
 
+### `--root-purl <PURL>` single-flag form for the root component PURL (closes #359)
+
+New CLI flag that the operator passes to express the BOM subject's
+PURL as a single, verbatim purl-spec string. Useful when downstream
+consumers expect a specific canonical PURL (matching their other
+data sources) and the operator wants to express it directly, including
+PURL features the milestone-077 discrete flags can't reach:
+
+- **Qualifiers** like `?arch=amd64`, `?distro=alpine-3.19`.
+- **Subpaths** like `#cmd/worker`.
+- **Custom namespace splits** like
+  `pkg:golang/github.com/example/svc` (slashed namespace).
+
+**Operator surface**:
+
+```
+mikebom sbom scan --path ... \
+  --root-purl 'pkg:golang/github.com/example/svc@v1.2.3?arch=amd64'
+```
+
+→ CDX `metadata.component.purl` / SPDX 2.3 root `externalRefs[purl]` /
+SPDX 3 root `software_packageUrl` + `externalIdentifier[packageUrl]`
+ALL emit the operator-supplied string verbatim. Name + version are
+parsed from the PURL (`packageurl`-crate spec parser) and surface on
+`metadata.component.name` / `versionInfo` / `software_packageVersion`
+accordingly.
+
+**Precedence + mutex**: `--root-purl` is clap-`conflicts_with`
+mutually exclusive with every discrete `--root-*` flag
+(`--root-name`, `--root-version`, `--root-purl-type`, `--no-root-purl`).
+Use one surface or the other, not both. The discrete milestone-077
+flags continue to work unchanged when `--root-purl` is absent
+(byte-identity preserved on existing scripts).
+
+**Validation**: parsed at clap-parse time via
+`mikebom_common::types::purl::Purl::new`; non-spec input fails fast
+with a clap-style error.
+
+**Decision (per the issue body)**: ship the single-flag form
+ALONGSIDE the discrete surface without starting a deprecation cycle.
+The migration's tradeoffs are documented; whether to deprecate the
+discrete flags in a future release stays an open question.
+
+**Tests**: 5 new integration tests
+(`mikebom-cli/tests/root_purl_flag.rs`) covering verbatim emission
+across all 3 formats, qualifier preservation, invalid-PURL clap
+rejection, mutex with `--root-name`, mutex with `--no-root-purl`,
+and absence-preserves-existing-behavior regression.
+
+No new Cargo dependencies. No golden churn (default behavior
+unchanged).
+
 ### `--conclude-licenses` operator-assertion flag (closes #363)
 
 New CLI flag that the operator passes to formally assert that the

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -3286,6 +3286,7 @@ mod tests {
             root_version: None,
             root_purl_type: None,
             no_root_purl: false,
+            root_purl: None,
             // Milestone 080 — defaults for new fields keep the test
             // helper's "minimal flags" contract intact.
             creator: vec![],

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -595,8 +595,41 @@ pub struct ScanArgs {
         long = "no-root-purl",
         requires = "root_name",
         conflicts_with = "root_purl_type",
+        conflicts_with = "root_purl",
     )]
     pub no_root_purl: bool,
+
+    /// Issue #359 — operator-supplied full PURL string for the root
+    /// component. When set, mikebom emits this PURL verbatim in every
+    /// format (CDX `metadata.component.purl`, SPDX 2.3 root Package
+    /// `externalRefs[purl]`, SPDX 3 root `software_packageUrl` +
+    /// `externalIdentifier[packageUrl]`). The BOM-subject `name` +
+    /// `version` are derived from the PURL itself (`packageurl`-crate
+    /// parser).
+    ///
+    /// Useful when downstream consumers expect a specific
+    /// canonical PURL and the operator wants to express it directly
+    /// — including PURL features the discrete flags don't reach
+    /// (qualifiers like `?arch=amd64`, subpaths like `#cmd/worker`,
+    /// custom namespace splits like `pkg:golang/github.com/example/svc`).
+    ///
+    /// Validated at parse time via `Purl::new`; non-spec input fails
+    /// fast with a clap-style error. Mutually exclusive with every
+    /// other `--root-*` flag (use one or the other, not both).
+    ///
+    /// Example: `--root-purl pkg:golang/github.com/example/svc@v1.2.3?arch=amd64`
+    /// → `metadata.component.purl = "pkg:golang/github.com/example/svc@v1.2.3?arch=amd64"`,
+    ///   name=`github.com/example/svc`, version=`v1.2.3`.
+    #[arg(
+        long = "root-purl",
+        value_name = "PURL",
+        value_parser = validate_root_purl,
+        conflicts_with = "root_name",
+        conflicts_with = "root_version",
+        conflicts_with = "root_purl_type",
+        conflicts_with = "no_root_purl",
+    )]
+    pub root_purl: Option<String>,
 
     // ────────────────────────────────────────────────────────────
     // Milestone 080 — user-provided SBOM metadata. See
@@ -923,6 +956,18 @@ pub(crate) fn validate_root_purl_type(value: &str) -> Result<String, String> {
              (expected lowercase ASCII alphanumeric + `.+-`, starting with a letter)"
         ))
     }
+}
+
+/// Issue #359 — `--root-purl <PURL>` validator. Defers to
+/// `mikebom_common::types::purl::Purl::new` (which delegates to the
+/// `packageurl` crate's spec-correct parser) so the operator gets the
+/// same error class clap surfaces for every other PURL-shaped input.
+/// Returns the canonicalized form on success so emission uses the same
+/// representation `Purl::new` would produce internally.
+pub(crate) fn validate_root_purl(value: &str) -> Result<String, String> {
+    mikebom_common::types::purl::Purl::new(value)
+        .map(|p| p.as_str().to_string())
+        .map_err(|e| format!("--root-purl `{value}` is not a valid PURL: {e}"))
 }
 
 /// Parse a `--id <scheme>=<value>` flag for a user-defined identifier.
@@ -1919,6 +1964,13 @@ pub async fn execute(
             version: args.root_version.clone(),
             purl_type: args.root_purl_type.clone(),
             omit_purl: args.no_root_purl,
+            // Issue #359 — the early root-selection helper above runs
+            // before the full RootComponentOverride is constructed.
+            // Pass the same #359 fields so the selector treats
+            // --root-purl identically to the final override.
+            full_purl: args.root_purl.clone(),
+            full_purl_name: None,
+            full_purl_version: None,
         };
         let selection = crate::generate::root_selector::select_root(
             &components,
@@ -2453,15 +2505,37 @@ pub async fn execute(
             scan_fs::file_tier::FileInventoryMode::Orphan => Some("orphan"),
             scan_fs::file_tier::FileInventoryMode::Full => Some("full"),
         },
-        // Milestone 077: operator-supplied overrides for the root
-        // component's name + version. Constructed from the new
-        // `--root-name` / `--root-version` CLI flags; defaults to
-        // both-None (back-compat) when neither flag is passed.
-        root_override: crate::generate::RootComponentOverride {
-            name: args.root_name.clone(),
-            version: args.root_version.clone(),
-            purl_type: args.root_purl_type.clone(),
-            omit_purl: args.no_root_purl,
+        // Milestone 077 + issue #359: operator-supplied overrides for
+        // the root component's name + version + PURL. Constructed
+        // from the `--root-name` / `--root-version` / `--root-purl-type`
+        // / `--no-root-purl` flags (milestone 077) plus the full-PURL
+        // shortcut `--root-purl` (#359). The discrete flags +
+        // `--root-purl` are clap-`conflicts_with` mutually exclusive so
+        // only one branch is populated at any time.
+        root_override: {
+            let (full_purl, full_name, full_version) = match args.root_purl.as_deref() {
+                Some(raw) => {
+                    let parsed = mikebom_common::types::purl::Purl::new(raw).expect(
+                        "--root-purl already validated at clap parse time via validate_root_purl",
+                    );
+                    let name = match parsed.namespace() {
+                        Some(ns) => format!("{ns}/{}", parsed.name()),
+                        None => parsed.name().to_string(),
+                    };
+                    let version = parsed.version().unwrap_or("").to_string();
+                    (Some(parsed.as_str().to_string()), Some(name), Some(version))
+                }
+                None => (None, None, None),
+            };
+            crate::generate::RootComponentOverride {
+                name: args.root_name.clone(),
+                version: args.root_version.clone(),
+                purl_type: args.root_purl_type.clone(),
+                omit_purl: args.no_root_purl,
+                full_purl,
+                full_purl_name: full_name,
+                full_purl_version: full_version,
+            }
         },
         // Milestone 080: user-provided SBOM metadata aggregated from
         // the new flags (--creator / --annotator / --annotation-comment

--- a/mikebom-cli/src/generate/cyclonedx/metadata.rs
+++ b/mikebom-cli/src/generate/cyclonedx/metadata.rs
@@ -311,13 +311,19 @@ pub fn build_metadata(
         String,
     ) = match &selection.subject {
         crate::generate::root_selector::ResolvedRootSubject::OperatorOverride => {
+            // Issue #359 — when `--root-purl <full>` is set, the BOM
+            // subject's name + version come from the parsed PURL.
+            // `resolved_name()` / `resolved_version()` apply the
+            // precedence (full-purl-parsed name wins over discrete
+            // `--root-name`); both fall back to the auto-derived
+            // target when neither is set.
             let name = root_override
-                .name
-                .clone()
+                .resolved_name()
+                .map(str::to_string)
                 .unwrap_or_else(|| target_name.to_string());
             let version = root_override
-                .version
-                .clone()
+                .resolved_version()
+                .map(str::to_string)
                 .unwrap_or_else(|| target_version.to_string());
             // Milestone 077/#358 — `build_subject_purl` returns `None`
             // when `--no-root-purl` is in effect; the empty-string

--- a/mikebom-cli/src/generate/mod.rs
+++ b/mikebom-cli/src/generate/mod.rs
@@ -231,6 +231,26 @@ pub struct RootComponentOverride {
     /// with `externalIdentifierType: "packageUrl"`. REQUIRES `name`
     /// to be `Some`. Mutually exclusive with `purl_type`.
     pub omit_purl: bool,
+    /// Issue #359 — operator-supplied full PURL string. When `Some(_)`,
+    /// it WINS over every other field on this struct:
+    /// `build_subject_purl` returns the value verbatim, and the BOM
+    /// subject's name/version are parsed from the PURL itself (the
+    /// `Purl` newtype validates at construction time, so the parse
+    /// can't fail at emission). Mutually exclusive at the CLI layer
+    /// with `name`/`version`/`purl_type`/`omit_purl` (clap
+    /// `conflicts_with`) so combinations of "full PURL" + "override
+    /// one piece of the PURL" can't reach the emission code.
+    pub full_purl: Option<String>,
+    /// Name parsed out of `full_purl` at CLI-flag construction time.
+    /// Surfaces in `metadata.component.name` (CDX) / root
+    /// `Package.name` (SPDX 2.3) / root element name (SPDX 3). Set
+    /// only when `full_purl` is `Some(_)`.
+    pub full_purl_name: Option<String>,
+    /// Version parsed out of `full_purl` at CLI-flag construction
+    /// time. Surfaces in `metadata.component.version` / `versionInfo`
+    /// / `software_packageVersion`. Set only when `full_purl` is
+    /// `Some(_)`.
+    pub full_purl_version: Option<String>,
 }
 
 impl RootComponentOverride {
@@ -243,14 +263,21 @@ impl RootComponentOverride {
             || self.version.is_some()
             || self.purl_type.is_some()
             || self.omit_purl
+            || self.full_purl.is_some()
     }
 
     /// Build the PURL string for the BOM subject given the resolved
-    /// name + version. Returns `None` when `omit_purl` is set — the
-    /// caller MUST skip the PURL emission slot entirely. Otherwise
-    /// returns `pkg:<type>/<name>@<version>` with type defaulting to
-    /// `generic` and name/version percent-encoded per RFC 3986.
+    /// name + version. Issue #359 takes precedence: when `full_purl`
+    /// is `Some(_)` the operator's verbatim PURL string is returned
+    /// (already validated by `Purl::new` at CLI parse time, so
+    /// downstream emission can trust it). Otherwise the existing
+    /// milestone-077 behavior applies — `None` for `omit_purl`,
+    /// `pkg:<type>/<name>@<version>` for everything else, with name +
+    /// version percent-encoded per RFC 3986.
     pub fn build_subject_purl(&self, name: &str, version: &str) -> Option<String> {
+        if let Some(full) = &self.full_purl {
+            return Some(full.clone());
+        }
         if self.omit_purl {
             return None;
         }
@@ -260,6 +287,27 @@ impl RootComponentOverride {
             percent_encode_purl_name(name),
             percent_encode_purl_name(version),
         ))
+    }
+
+    /// Issue #359 — resolved BOM-subject name. Returns the
+    /// PURL-parsed name when `full_purl` is set; otherwise falls back
+    /// to the discrete `name` override; otherwise `None` (caller uses
+    /// the auto-derived name). Callers MUST prefer this over reading
+    /// `self.name` directly so the new flag's parsed name is honored.
+    pub fn resolved_name(&self) -> Option<&str> {
+        if let Some(n) = self.full_purl_name.as_deref() {
+            return Some(n);
+        }
+        self.name.as_deref()
+    }
+
+    /// Issue #359 — resolved BOM-subject version. See
+    /// [`Self::resolved_name`] for the precedence contract.
+    pub fn resolved_version(&self) -> Option<&str> {
+        if let Some(v) = self.full_purl_version.as_deref() {
+            return Some(v);
+        }
+        self.version.as_deref()
     }
 }
 

--- a/mikebom-cli/tests/root_purl_flag.rs
+++ b/mikebom-cli/tests/root_purl_flag.rs
@@ -1,0 +1,257 @@
+//! Issue #359 — `--root-purl <PURL>` integration tests. The new
+//! single-flag form takes precedence over the discrete milestone-077
+//! `--root-name`/`--root-version`/`--root-purl-type`/`--no-root-purl`
+//! surface (clap-`conflicts_with` mutex); operators can express full
+//! purl-spec features the discrete flags don't reach (qualifiers,
+//! subpaths, custom namespace splits) and the value emits verbatim
+//! across CDX 1.6 / SPDX 2.3 / SPDX 3.
+
+use std::path::Path;
+use std::process::Command;
+
+fn run_scan_cdx(path: &Path, extra_args: &[&str]) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("sbom.cdx.json");
+    let mut cmd = Command::new(bin);
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(path)
+        .arg("--output")
+        .arg(&out_path)
+        .arg("--file-inventory=off")
+        .arg("--no-deep-hash");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let status = cmd.status().expect("mikebom should run");
+    assert!(status.success(), "scan failed: {extra_args:?}");
+    let raw = std::fs::read(&out_path).expect("read sbom");
+    serde_json::from_slice(&raw).expect("valid JSON")
+}
+
+fn run_scan_spdx23(path: &Path, extra_args: &[&str]) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("sbom.spdx.json");
+    let mut cmd = Command::new(bin);
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(path)
+        .arg("--format")
+        .arg("spdx-2.3-json")
+        .arg("--output")
+        .arg(format!("spdx-2.3-json={}", out_path.to_string_lossy()))
+        .arg("--file-inventory=off")
+        .arg("--no-deep-hash");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let status = cmd.status().expect("mikebom should run");
+    assert!(status.success(), "scan failed: {extra_args:?}");
+    let raw = std::fs::read(&out_path).expect("read spdx");
+    serde_json::from_slice(&raw).expect("valid JSON")
+}
+
+fn run_scan_spdx3(path: &Path, extra_args: &[&str]) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("sbom.spdx3.json");
+    let mut cmd = Command::new(bin);
+    cmd.arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(path)
+        .arg("--format")
+        .arg("spdx-3-json")
+        .arg("--output")
+        .arg(format!("spdx-3-json={}", out_path.to_string_lossy()))
+        .arg("--file-inventory=off")
+        .arg("--no-deep-hash");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let status = cmd.status().expect("mikebom should run");
+    assert!(status.success(), "scan failed: {extra_args:?}");
+    let raw = std::fs::read(&out_path).expect("read spdx3");
+    serde_json::from_slice(&raw).expect("valid JSON")
+}
+
+#[test]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+fn root_purl_flag_emits_verbatim_purl_across_all_three_formats() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path();
+    // The test PURL exercises features the discrete flags can't
+    // reach: a slashed-namespace (`github.com/example/svc`) and a
+    // qualifier (`?arch=amd64`). Both MUST survive to the wire.
+    let purl = "pkg:golang/github.com/example/svc@v1.2.3?arch=amd64";
+
+    let cdx = run_scan_cdx(path, &["--root-purl", purl]);
+    assert_eq!(
+        cdx["metadata"]["component"]["purl"].as_str(),
+        Some(purl),
+        "CDX metadata.component.purl must emit the operator-supplied PURL verbatim"
+    );
+    assert_eq!(
+        cdx["metadata"]["component"]["name"].as_str(),
+        Some("github.com/example/svc"),
+        "CDX metadata.component.name must equal the PURL's namespace-prefixed name"
+    );
+    assert_eq!(
+        cdx["metadata"]["component"]["version"].as_str(),
+        Some("v1.2.3"),
+        "CDX metadata.component.version must equal the PURL's version segment"
+    );
+
+    let spdx23 = run_scan_spdx23(path, &["--root-purl", purl]);
+    let root = spdx23["packages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|p| {
+            p["SPDXID"]
+                .as_str()
+                .is_some_and(|id| id.starts_with("SPDXRef-DocumentRoot"))
+        })
+        .expect("SPDX 2.3 root Package");
+    let purl_ref = root["externalRefs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["referenceType"].as_str() == Some("purl"))
+        .expect("root externalRefs[purl] entry");
+    assert_eq!(
+        purl_ref["referenceLocator"].as_str(),
+        Some(purl),
+        "SPDX 2.3 root externalRefs[purl] must equal the operator-supplied PURL verbatim"
+    );
+
+    let spdx3 = run_scan_spdx3(path, &["--root-purl", purl]);
+    let root3 = spdx3["@graph"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|el| {
+            el["type"].as_str() == Some("software_Package")
+                && el["software_packageUrl"].as_str() == Some(purl)
+        })
+        .expect("SPDX 3 root software_Package with verbatim PURL");
+    // The externalIdentifier[packageUrl] entry must also carry the
+    // same verbatim value (SPDX 3 emits both slots).
+    let ext_id = root3["externalIdentifier"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["externalIdentifierType"].as_str() == Some("packageUrl"))
+        .expect("root externalIdentifier[packageUrl] entry");
+    assert_eq!(
+        ext_id["identifier"].as_str(),
+        Some(purl),
+        "SPDX 3 root externalIdentifier[packageUrl].identifier must equal the operator-supplied PURL"
+    );
+}
+
+#[test]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+fn root_purl_invalid_value_exits_nonzero_at_clap_parse() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let out_path = tmp.path().join("out.cdx.json");
+    let status = Command::new(bin)
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(tmp.path())
+        .arg("--output")
+        .arg(&out_path)
+        .arg("--root-purl")
+        .arg("not-a-valid-purl")
+        .status()
+        .expect("mikebom should run");
+    assert!(
+        !status.success(),
+        "invalid --root-purl value must fail at clap parse time"
+    );
+}
+
+#[test]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+fn root_purl_conflicts_with_root_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let out_path = tmp.path().join("out.cdx.json");
+    let status = Command::new(bin)
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(tmp.path())
+        .arg("--output")
+        .arg(&out_path)
+        .arg("--root-purl")
+        .arg("pkg:generic/foo@1.0.0")
+        .arg("--root-name")
+        .arg("other-name")
+        .status()
+        .expect("mikebom should run");
+    assert!(
+        !status.success(),
+        "--root-purl + --root-name MUST be clap-rejected (mutually exclusive)"
+    );
+}
+
+#[test]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+fn root_purl_conflicts_with_no_root_purl() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let out_path = tmp.path().join("out.cdx.json");
+    let status = Command::new(bin)
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(tmp.path())
+        .arg("--output")
+        .arg(&out_path)
+        .arg("--root-purl")
+        .arg("pkg:generic/foo@1.0.0")
+        .arg("--root-name")
+        .arg("foo")
+        .arg("--no-root-purl")
+        .status()
+        .expect("mikebom should run");
+    assert!(
+        !status.success(),
+        "--root-purl + --no-root-purl MUST be clap-rejected (mutually exclusive)"
+    );
+}
+
+#[test]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+fn root_purl_absent_preserves_existing_root_name_behavior() {
+    // Regression guard for the milestone-077 surface: when
+    // --root-purl is NOT set, --root-name continues to produce the
+    // generic-typed default PURL exactly as before.
+    let tmp = tempfile::tempdir().unwrap();
+    let cdx = run_scan_cdx(tmp.path(), &["--root-name", "my-app", "--root-version", "9.9.9"]);
+    assert_eq!(
+        cdx["metadata"]["component"]["name"].as_str(),
+        Some("my-app")
+    );
+    assert_eq!(
+        cdx["metadata"]["component"]["version"].as_str(),
+        Some("9.9.9")
+    );
+    assert_eq!(
+        cdx["metadata"]["component"]["purl"].as_str(),
+        Some("pkg:generic/my-app@9.9.9")
+    );
+}


### PR DESCRIPTION
## Summary

Closes #359. New `--root-purl <PURL>` flag ships ALONGSIDE the discrete milestone-077 flags (no deprecation cycle) per the user's decision.

| Surface | Use case |
|---|---|
| `--root-name foo --root-version 1.0` | Natural fields, existing behavior unchanged |
| `--root-purl pkg:golang/github.com/example/svc@v1.2.3?arch=amd64` | Verbatim canonical PURL with qualifiers / subpaths / slashed namespaces |

clap-`conflicts_with` mutex between the two surfaces — use one, not both.

## End-to-end smoke

```
$ mikebom sbom scan --path . \
    --root-purl 'pkg:golang/github.com/example/svc@v1.2.3?arch=amd64'

# CDX  metadata.component.purl
# SPDX 2.3  root externalRefs[purl].referenceLocator
# SPDX 3  root software_packageUrl + externalIdentifier[packageUrl]
# → all three emit pkg:golang/github.com/example/svc@v1.2.3?arch=amd64 verbatim
#   name = github.com/example/svc, version = v1.2.3
```

Qualifier preserved across all three formats.

## Approach

| File | Change |
|---|---|
| `mikebom-cli/src/cli/scan_cmd.rs` | New `--root-purl` flag with `validate_root_purl` value-parser (delegates to `Purl::new`). `conflicts_with` against all 4 discrete `--root-*` flags. Construction site parses the PURL once at CLI parse time and stashes name + version on `RootComponentOverride`. |
| `mikebom-cli/src/generate/mod.rs` | `RootComponentOverride` gains `full_purl`, `full_purl_name`, `full_purl_version`. `is_active()` extended. `build_subject_purl` returns the verbatim string when set. New `resolved_name()` / `resolved_version()` accessors apply the precedence. |
| `mikebom-cli/src/generate/cyclonedx/metadata.rs` | `OperatorOverride` branch reads `resolved_name()` / `resolved_version()` instead of the raw discrete fields so the new flag's parsed values surface. |
| `mikebom-cli/tests/root_purl_flag.rs` | 5 new integration tests. |
| `CHANGELOG.md` | Unreleased entry with decision rationale. |

## Test plan

- [x] 5 new integration tests passing locally (`root_purl_flag.rs`)
- [x] Verbatim emission across CDX 1.6 / SPDX 2.3 / SPDX 3 with a qualifier — verified by hand + by test
- [x] Invalid PURL value fails fast at clap parse time
- [x] Mutex with `--root-name` + `--no-root-purl` — clap rejects with helpful message
- [x] Existing milestone-077 behavior unchanged when `--root-purl` is absent
- [x] No new Cargo dependencies
- [x] No golden churn (default behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)