### PR TITLE
fix(scan_fs/docker_image): rewrite absolute symlink targets to rootfs-anchored form (closes #401)

### DIFF
--- a/mikebom-cli/src/scan_fs/docker_image.rs
+++ b/mikebom-cli/src/scan_fs/docker_image.rs
@@ -180,6 +180,12 @@ pub fn extract(archive_path: &Path) -> Result<ExtractedImage> {
 /// - `var/run -> /run` → `var/run -> ../run` (1 `..`)
 /// - `usr/lib64 -> /lib64` → `usr/lib64 -> ../lib64`
 /// - `var/lib/dpkg/status -> /etc/passwd` → `../../../etc/passwd`
+///
+/// `#[cfg(unix)]`-gated to match the only call site in
+/// `extract_layer_over_rootfs`. Windows image scans skip this path
+/// (Windows symlink semantics differ enough that the rewrite would
+/// need to be re-validated there).
+#[cfg(unix)]
 fn rewrite_symlink_target_if_absolute<R: std::io::Read>(
     link_rel_path: &Path,
     entry: &tar::Entry<'_, R>,

--- a/mikebom-cli/src/scan_fs/docker_image.rs
+++ b/mikebom-cli/src/scan_fs/docker_image.rs
@@ -164,6 +164,43 @@ pub fn extract(archive_path: &Path) -> Result<ExtractedImage> {
     })
 }
 
+/// Issue #401 — when a tar Symlink entry's target is absolute
+/// (`/run`, `/lib64`, `/usr/bin`, ...), rewrite it to be a relative
+/// path that climbs back to the rootfs root and then descends into
+/// the target. Returns `Some(rewritten_target)` when the rewrite
+/// applies; `None` when the target is already relative.
+///
+/// Algorithm: for a symlink at rootfs-relative path
+/// `<parent_dir>/<link_name>` whose target is the absolute path
+/// `/x/y/z`, the rewritten target is `(../ × N)x/y/z` where N is
+/// the component count of `parent_dir`. This canonicalizes to
+/// `<rootfs>/x/y/z` instead of host `/x/y/z`.
+///
+/// Examples:
+/// - `var/run -> /run` → `var/run -> ../run` (1 `..`)
+/// - `usr/lib64 -> /lib64` → `usr/lib64 -> ../lib64`
+/// - `var/lib/dpkg/status -> /etc/passwd` → `../../../etc/passwd`
+fn rewrite_symlink_target_if_absolute<R: std::io::Read>(
+    link_rel_path: &Path,
+    entry: &tar::Entry<'_, R>,
+) -> Option<PathBuf> {
+    let target = entry.link_name().ok()??.into_owned();
+    if !target.is_absolute() {
+        return None;
+    }
+    let bare_target = target.strip_prefix("/").unwrap_or(&target).to_path_buf();
+    let parent_depth = link_rel_path
+        .parent()
+        .map(|p| p.components().count())
+        .unwrap_or(0);
+    let mut rewritten = PathBuf::new();
+    for _ in 0..parent_depth {
+        rewritten.push("..");
+    }
+    rewritten.push(bare_target);
+    Some(rewritten)
+}
+
 /// Read a single named entry out of a tar archive into a `Vec<u8>`. The
 /// outer tarball is opened from scratch, scanned for the entry, and
 /// closed. `tar::Archive` doesn't let us hold a mutable borrow on the
@@ -425,6 +462,51 @@ fn extract_layer_over_rootfs(layer_bytes: &[u8], rootfs: &Path) -> Result<Vec<St
             entry_type,
             tar::EntryType::Regular | tar::EntryType::Symlink | tar::EntryType::Continuous,
         );
+
+        // Issue #401 — symlink-target host-fs escape. Container
+        // images legitimately ship absolute symlinks for distro
+        // compatibility (`var/run -> /run`, `usr/lib64 -> /lib64`,
+        // `bin -> /usr/bin`, ...). When `unpack_in` creates these
+        // verbatim, the symlink at `<rootfs>/var/run` points at the
+        // HOST's `/run` — every reader that touches that path
+        // (deep-hash, OS-package readers, os_release) then reads
+        // host content. PR #397 fixed the `safe_walk` directory
+        // walker; this fix closes the per-file-read variant.
+        //
+        // Treatment: rewrite absolute targets to be relative +
+        // rootfs-anchored. `<rootfs>/var/run -> /run` becomes
+        // `<rootfs>/var/run -> ../run`, which resolves to
+        // `<rootfs>/run` instead of host `/run`. In-image semantics
+        // preserved; host escape blocked.
+        #[cfg(unix)]
+        if entry_type == tar::EntryType::Symlink {
+            if let Some(rewrite) = rewrite_symlink_target_if_absolute(&path, &e) {
+                let link_abs = rootfs.join(&path);
+                if link_abs.exists() {
+                    // Layer overlay: later layer's symlink replaces
+                    // an earlier file/symlink at the same path.
+                    let _ = fs::remove_file(&link_abs);
+                }
+                match std::os::unix::fs::symlink(&rewrite, &link_abs) {
+                    Ok(()) => {
+                        tracing::debug!(
+                            link = %path.display(),
+                            rewritten = %rewrite.display(),
+                            "rewrote absolute symlink target to rootfs-anchored form (#401)"
+                        );
+                        paths_written.push(path.to_string_lossy().into_owned());
+                        continue;
+                    }
+                    Err(err) => {
+                        tracing::debug!(
+                            link = %path.display(),
+                            error = %err,
+                            "failed to create rewritten symlink; falling back to default unpack"
+                        );
+                    }
+                }
+            }
+        }
 
         if let Err(err) = e.unpack_in(rootfs) {
             tracing::debug!(path = %path.display(), error = %err, "failed to unpack entry");
@@ -895,6 +977,111 @@ mod tests {
     /// the cleanup loop's `rootfs.join(<wh-path>)` + `fs::remove_*`
     /// resolved `..` during the stat call — granting a malicious
     /// image a delete primitive on the operator's host filesystem.
+    /// Issue #401 — tar Symlink entries with absolute targets must
+    /// be rewritten at extraction time so the resulting symlink
+    /// resolves inside the rootfs. Without this, every downstream
+    /// reader (deep-hash, dpkg, apk, os_release) that touches the
+    /// path follows the absolute target to the HOST filesystem.
+    #[cfg(unix)]
+    #[test]
+    fn absolute_symlink_target_is_rewritten_to_rootfs_anchored_form() {
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs");
+        std::fs::create_dir_all(&rootfs).unwrap();
+
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut ar = tar::Builder::new(&mut buf);
+
+            let mut h1 = tar::Header::new_gnu();
+            h1.set_path("var/run").unwrap();
+            h1.set_size(0);
+            h1.set_entry_type(tar::EntryType::Symlink);
+            h1.set_link_name("/run").unwrap();
+            h1.set_mode(0o777);
+            h1.set_cksum();
+            ar.append(&h1, std::io::empty()).unwrap();
+
+            let mut h2 = tar::Header::new_gnu();
+            h2.set_path("usr/lib64").unwrap();
+            h2.set_size(0);
+            h2.set_entry_type(tar::EntryType::Symlink);
+            h2.set_link_name("/lib64").unwrap();
+            h2.set_mode(0o777);
+            h2.set_cksum();
+            ar.append(&h2, std::io::empty()).unwrap();
+
+            let mut h3 = tar::Header::new_gnu();
+            h3.set_path("var/lib/dpkg/status").unwrap();
+            h3.set_size(0);
+            h3.set_entry_type(tar::EntryType::Symlink);
+            h3.set_link_name("/etc/passwd").unwrap();
+            h3.set_mode(0o644);
+            h3.set_cksum();
+            ar.append(&h3, std::io::empty()).unwrap();
+
+            ar.into_inner().unwrap();
+        }
+
+        extract_layer_over_rootfs(&buf, &rootfs).unwrap();
+
+        assert_eq!(
+            std::fs::read_link(rootfs.join("var/run")).unwrap(),
+            PathBuf::from("../run"),
+            "var/run -> /run must rewrite to ../run"
+        );
+        assert_eq!(
+            std::fs::read_link(rootfs.join("usr/lib64")).unwrap(),
+            PathBuf::from("../lib64"),
+            "usr/lib64 -> /lib64 must rewrite to ../lib64"
+        );
+        assert_eq!(
+            std::fs::read_link(rootfs.join("var/lib/dpkg/status")).unwrap(),
+            PathBuf::from("../../../etc/passwd"),
+            "var/lib/dpkg/status -> /etc/passwd must rewrite to ../../../etc/passwd"
+        );
+
+        // Sandbox property: every rewritten symlink must be relative.
+        for p in ["var/run", "usr/lib64", "var/lib/dpkg/status"] {
+            let target = std::fs::read_link(rootfs.join(p)).unwrap();
+            assert!(
+                !target.is_absolute(),
+                "rewritten symlink at {p} target {target:?} must be relative"
+            );
+        }
+    }
+
+    /// Issue #401 — relative symlink targets (already in-image-safe)
+    /// pass through unchanged.
+    #[cfg(unix)]
+    #[test]
+    fn relative_symlink_targets_are_left_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs");
+        std::fs::create_dir_all(&rootfs).unwrap();
+
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut ar = tar::Builder::new(&mut buf);
+            let mut h = tar::Header::new_gnu();
+            h.set_path("opt/symlink").unwrap();
+            h.set_size(0);
+            h.set_entry_type(tar::EntryType::Symlink);
+            h.set_link_name("../in-rootfs-target").unwrap();
+            h.set_mode(0o777);
+            h.set_cksum();
+            ar.append(&h, std::io::empty()).unwrap();
+            ar.into_inner().unwrap();
+        }
+        extract_layer_over_rootfs(&buf, &rootfs).unwrap();
+
+        assert_eq!(
+            std::fs::read_link(rootfs.join("opt/symlink")).unwrap(),
+            PathBuf::from("../in-rootfs-target"),
+            "relative symlinks must pass through unchanged"
+        );
+    }
+
     #[test]
     fn whiteout_with_parent_dir_escape_is_rejected() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Closes #401. Completes the image-scan host-fs escape audit started after #396.

| Surface | Status |
|---|---|
| Directory walkers (`safe_walk`) | ✅ fixed by #397 |
| Whiteout cleanup (`extract_layer_over_rootfs`) | ✅ fixed by #400 |
| Per-file reads through absolute symlinks | **fixed in this PR** |

## The bug

Container images legitimately ship absolute symlinks for distro compatibility (`/var/run -> /run` on Debian/Alpine, `/usr/lib64 -> /lib64` on Fedora, `/bin -> /usr/bin`, etc.). When `tar::Entry::unpack_in` creates these verbatim into a tempdir at `/tmp/.../mikebom-image-XXX/rootfs/`, the symlink at `<rootfs>/var/run` has target `/run` — an ABSOLUTE path that resolves to the HOST's `/run`, not `<rootfs>/run`.

The attack: a malicious image with crafted symlink entries can direct every downstream `fs::read*` call to host files:

```
var/lib/dpkg/status -> /etc/passwd
var/lib/dpkg/info/malicious.list -> /home/operator/.ssh
```

The deep-hash path is the worst — a malicious `.list` containing host paths gets host-file SHA-256 fingerprints emitted in `evidence.occurrences[]`.

## Fix (Option A from the issue body)

Rewrite absolute symlink targets at extraction time so the result resolves INSIDE the rootfs. One chokepoint fixes every downstream reader without per-reader changes.

```
<rootfs>/var/run -> /run                    becomes  -> ../run
<rootfs>/usr/lib64 -> /lib64                becomes  -> ../lib64
<rootfs>/var/lib/dpkg/status -> /etc/passwd becomes  -> ../../../etc/passwd
```

**Algorithm**: for a symlink at `<parent_dir>/<link_name>` whose target is `/x/y/z`, the rewritten target is `(../ × N)x/y/z` where N is the component count of `parent_dir`. Canonicalizes to `<rootfs>/x/y/z`.

## Approach

| File | Change |
|---|---|
| `mikebom-cli/src/scan_fs/docker_image.rs` | New `rewrite_symlink_target_if_absolute` helper. In `extract_layer_over_rootfs`, intercept Symlink entries with absolute targets, create them manually via `std::os::unix::fs::symlink` with the rewritten target. Falls through to default `unpack_in` for relative targets (already safe). `#[cfg(unix)]`-gated. |

## Test plan

- [x] 2 new regression tests passing (`absolute_symlink_target_is_rewritten_to_rootfs_anchored_form`, `relative_symlink_targets_are_left_alone`)
- [x] All 20 `docker_image::tests` pass (18 pre-existing + 2 new)
- [x] `cargo build --all-targets` clean
- [x] Smoke test: alpine:3.19 → 15 apk components in 1.5s (no regression)
- [x] No new Cargo dependencies
- [x] No golden churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)