### PR TITLE
fix(resolve/path_resolver): backslash normalization for Windows host (#210 bug 2/3)

### DIFF
--- a/mikebom-cli/src/resolve/path_resolver.rs
+++ b/mikebom-cli/src/resolve/path_resolver.rs
@@ -21,6 +21,16 @@ fn resolve_path(path: &str) -> Option<Purl> {
 /// stamped verbatim — callers decide the shape (scan-mode package-DB
 /// readers use `<namespace>-<VERSION_ID>`, e.g. `debian-12`).
 pub fn resolve_path_with_context(path: &str, deb_codename: Option<&str>) -> Option<Purl> {
+    // The matchers below anchor on forward-slash patterns like
+    // `.cargo/registry/cache/`, `/pkg/mod/`, `node_modules/`. On Windows
+    // hosts the input contains backslash separators, so normalize them
+    // to forward slashes so the matchers fire consistently across both
+    // lanes. POSIX inputs already use `/`, so the replace is semantically
+    // a no-op there (literal `\` in a POSIX filename is rare enough that
+    // package-shaped patterns wouldn't match it anyway).
+    let normalized = path.replace('\\', "/");
+    let path = normalized.as_str();
+
     None.or_else(|| resolve_cargo_path(path))
         .or_else(|| resolve_pip_path(path))
         .or_else(|| resolve_npm_path(path))

--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -1477,14 +1477,6 @@ pub enum ScanError {
 mod tests {
     use super::*;
 
-    // Milestone 100: `#[cfg(unix)]` — the cargo-cache pattern
-    // matcher in `path_resolver` matches against forward-slash path
-    // strings like `.cargo/registry/cache/`. On Windows, native paths
-    // use backslash so the matcher returns 0 components. Fixing the
-    // matcher is out of scope for milestone 100 (FR-006: path-string
-    // normalization is for SBOM JSON output only, not internal path
-    // matching); tracked in a follow-up ticket.
-    #[cfg(unix)]
     #[test]
     fn scan_picks_up_cargo_crate_filenames() {
         // A path_resolver::resolve_cargo_path-compatible path resolves to
@@ -1602,10 +1594,6 @@ Architecture: arm64
         assert_eq!(rel.relationship_type, RelationshipType::DependsOn);
     }
 
-    // Milestone 100: `#[cfg(unix)]` — exercises dpkg (Linux-only)
-    // and the path-resolver cargo-cache matcher; both have Windows
-    // gaps tracked in the follow-up.
-    #[cfg(unix)]
     #[test]
     fn filename_resolved_and_dpkg_resolved_dedupe_into_one_component() {
         // Real-world case: the .deb artefact sits in apt's cache AND
@@ -1695,9 +1683,6 @@ Architecture: arm64
         );
     }
 
-    // Milestone 100: `#[cfg(unix)]` — dpkg-coupling + path-resolver
-    // gap, same as the previous dedup test.
-    #[cfg(unix)]
     #[test]
     fn filename_with_percent_encoded_plus_merges_with_dpkg_plain_plus() {
         // Regression: apt names the cache file with `%2B` but dpkg


### PR DESCRIPTION
## Summary

- Normalize `\\` → `/` at the single entry point in `resolve_path_with_context` so the matchers fire on Windows hosts where native paths use backslash separators.
- Drop `#[cfg(unix)]` from `scan_picks_up_cargo_crate_filenames` + the two filename↔dpkg dedup tests.

Second of three production-code fixes deferred to #210. Bug 1 in #404 (HOME/USERPROFILE). Remaining: Bug 3 (oci-cache atomic rename on Windows).

The replace is unconditional rather than `#[cfg(windows)]`-gated: POSIX inputs already use `/`, so the call is semantically a no-op there. A literal `\\` in a POSIX filename is rare enough that package-shaped patterns wouldn't match it anyway.

## Test plan

- [ ] Linux + macOS lanes: existing path-resolver tests still pass (no behavioral change for POSIX inputs)
- [ ] **Windows lane**: un-gated tests now exercise the resolver and dedup pipeline; they pass
- [ ] No new `mikebom:*` annotation / no SBOM-format surface change → byte-identity goldens unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)