### PR TITLE
ci(realistic-projects): add maven + gem fixtures (#109 partial 2/3)

### DIFF
--- a/.github/workflows/realistic-projects.yml
+++ b/.github/workflows/realistic-projects.yml
@@ -90,6 +90,19 @@ jobs:
             url: https://github.com/BurntSushi/ripgrep.git
             tag: 14.1.1
             expected_min_components: 40
+          # Issue #109 — continued expansion: maven + gem. Floors
+          # start conservatively low (3-5) so the first CI run
+          # surfaces the empirical count without false-positives;
+          # a follow-up PR tightens them per the express/flask/
+          # ripgrep calibration pattern.
+          - name: jackson-databind
+            url: https://github.com/FasterXML/jackson-databind.git
+            tag: jackson-databind-3.1.4
+            expected_min_components: 5
+          - name: sinatra
+            url: https://github.com/sinatra/sinatra.git
+            tag: v4.2.1
+            expected_min_components: 3
         platform:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
## Summary

Continues #109's per-ecosystem expansion:

| Ecosystem | Fixture | Tag | Starting floor |
|---|---|---|---|
| maven | FasterXML/jackson-databind | jackson-databind-3.1.4 | 5 |
| gem | sinatra/sinatra | v4.2.1 | 3 |

Floors start conservatively low so the first CI run surfaces the empirical count without false-positives; a follow-up PR will tighten them per the express / flask / ripgrep calibration pattern shipped in #411.

## Fixture rationale

- **jackson-databind**: canonical Java JSON-binding library; single-module pom + sub-module poms; stable transitive dep set across the 3.1.x line. Smaller than apache/spark (the issue's suggestion) for tighter CI wall-clock.
- **sinatra**: small Ruby web framework with Gemfile + Gemfile.lock. Smaller than rails/rails (the issue's suggestion) for tighter CI wall-clock.

## Remaining for #109 closure

dpkg / apk / rpm rootfs scans + a polyglot project. All follow the same incremental-with-empirical-floor-calibration pattern.

## Test plan

- [ ] Both new jobs (jackson-databind + sinatra) complete within the 15-min job timeout on both platforms
- [ ] Component-floor + JSON-structure checks pass
- [ ] Component counts captured in job summaries for the next round of floor tightening

🤖 Generated with [Claude Code](https://claude.com/claude-code)