### PR TITLE
feat(scan_fs/package_db): Dart/Flutter pub ecosystem reader (closes #420)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-22
+Auto-generated from all feature plans. Last updated: 2026-06-23
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -154,6 +154,8 @@ Auto-generated from all feature plans. Last updated: 2026-06-22
 - Rust stable (workspace toolchain inherited from milestones 001–135; no nightly required for this user-space-only work). + Existing only — `serde`/`serde_json` (workspace; receipt + cask JSON parsing), `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror` (error propagation), `mikebom_common::types::purl::Purl` (PURL construction + validation). **No new Cargo dependencies.** Ruby-DSL `.rb` casks (pre-Homebrew-4.0) are intentionally NOT parsed per Constitution Principle I (Pure Rust, Zero C — extends to "no embedded scripting parsers" by spirit); they warn-and-skip with operator-visible diagnostic. (136-homebrew-reader)
 - N/A — all state is in-process for the duration of a single scan. Mirrors every OS-package reader since milestone 002. (136-homebrew-reader)
 - Rust stable (workspace toolchain inherited from milestones 001–135; no nightly required for this user-space-only work). + Existing only — `serde`/`serde_json` (workspace; receipt + cask JSON parsing), `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror` (error propagation), `mikebom_common::types::purl::Purl` (PURL construction + validation). **No new Cargo dependencies.** Ruby-DSL `.rb` casks (pre-Homebrew-4.0) are intentionally NOT parsed per Constitution Principle I (Pure Rust, Zero C — extends to "no embedded scripting parsers" by spirit); they warn-and-skip with operator-visible diagnostic. (136-homebrew-reader)
+- Rust stable (workspace toolchain inherited from milestones 001–136; no nightly required for this user-space-only work). + Existing only — `serde`/`serde_yaml = "0.9"` (workspace; already used by `npm/yarn_lock.rs` + `npm/pnpm_lock.rs`), `serde_json` for evidence-annotation construction, `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror` (error propagation), `mikebom_common::types::purl::Purl` (PURL construction + validation; the `pub` type is purl-spec-blessed). **No new Cargo dependencies.** (137-dart-pub-reader)
+- N/A — all state is in-process for the duration of a single scan. Mirrors every language-reader since milestone 002. (137-dart-pub-reader)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -216,9 +218,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 137-dart-pub-reader: Added Rust stable (workspace toolchain inherited from milestones 001–136; no nightly required for this user-space-only work). + Existing only — `serde`/`serde_yaml = "0.9"` (workspace; already used by `npm/yarn_lock.rs` + `npm/pnpm_lock.rs`), `serde_json` for evidence-annotation construction, `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror` (error propagation), `mikebom_common::types::purl::Purl` (PURL construction + validation; the `pub` type is purl-spec-blessed). **No new Cargo dependencies.**
 - 136-homebrew-reader: Added Rust stable (workspace toolchain inherited from milestones 001–135; no nightly required for this user-space-only work). + Existing only — `serde`/`serde_json` (workspace; receipt + cask JSON parsing), `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror` (error propagation), `mikebom_common::types::purl::Purl` (PURL construction + validation). **No new Cargo dependencies.** Ruby-DSL `.rb` casks (pre-Homebrew-4.0) are intentionally NOT parsed per Constitution Principle I (Pure Rust, Zero C — extends to "no embedded scripting parsers" by spirit); they warn-and-skip with operator-visible diagnostic.
 - 136-homebrew-reader: Added Rust stable (workspace toolchain inherited from milestones 001–135; no nightly required for this user-space-only work). + Existing only — `serde`/`serde_json` (workspace; receipt + cask JSON parsing), `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror` (error propagation), `mikebom_common::types::purl::Purl` (PURL construction + validation). **No new Cargo dependencies.** Ruby-DSL `.rb` casks (pre-Homebrew-4.0) are intentionally NOT parsed per Constitution Principle I (Pure Rust, Zero C — extends to "no embedded scripting parsers" by spirit); they warn-and-skip with operator-visible diagnostic.
-- 135-arch-alpm-reader: Added Rust stable (workspace toolchain inherited from milestones 001–134; no nightly required for this user-space-only work). + Existing only — `std::fs` (directory walk over `local/`), `tracing` (warn-and-skip on malformed per-package directories), `anyhow`/`thiserror` (error propagation), `mikebom_common::types::purl::Purl` (PURL construction + validation), the existing `mikebom-cli/src/scan_fs/os_release.rs` reader (distro detection). **No new Cargo dependencies.** The pacman `desc` and `files` formats are plain text — stdlib line iteration plus a small stanza-style state machine covers parsing.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/generate/cyclonedx/builder.rs
+++ b/mikebom-cli/src/generate/cyclonedx/builder.rs
@@ -973,13 +973,16 @@ impl CycloneDxBuilder {
                             | "alpm-local-db"
                             | "brew-install-receipt"
                             | "brew-cask-metadata"
+                            | "pubspec-lock"
+                            | "pubspec-yaml"
                     ),
                     "mikebom:evidence-kind value '{kind}' is not in the canonical \
                      enum (rpm-file | rpmdb-sqlite | rpmdb-bdb | \
                      dynamic-linkage | elf-note-package | \
                      embedded-version-string | symbol-fingerprint | \
                      python-stdlib-collapsed | jdk-runtime-collapsed | \
-                     alpm-local-db | brew-install-receipt | brew-cask-metadata)"
+                     alpm-local-db | brew-install-receipt | brew-cask-metadata | \
+                     pubspec-lock | pubspec-yaml)"
                 );
                 properties.push(json!({
                     "name": "mikebom:evidence-kind",

--- a/mikebom-cli/src/scan_fs/package_db/dart.rs
+++ b/mikebom-cli/src/scan_fs/package_db/dart.rs
@@ -1,0 +1,920 @@
+//! Milestone 137 — Dart/Flutter pub ecosystem reader.
+//!
+//! Discovers each `pubspec.yaml` under the scan root and emits one
+//! main-module component per project (FR-012) plus one component per
+//! lockfile entry when a sibling `pubspec.lock` is present (FR-002).
+//! When the lockfile is absent or malformed, falls back to design-tier
+//! emission from the manifest's `dependencies:` + `dev_dependencies:`
+//! blocks (FR-005 / R7).
+//!
+//! PURL shapes per FR-003 (confirmed against the purl-spec
+//! `pub-definition.md`):
+//!
+//! - **hosted**: `pkg:pub/<name>@<version>[?repository_url=<url>]`
+//!   (qualifier omitted when `description.url` is `https://pub.dev` or
+//!   the legacy `https://pub.dartlang.org`).
+//! - **git**:    `pkg:pub/<name>@<resolved-sha>?vcs_url=git+<url>[#<subpath>]`
+//!   (`git+` scheme prefix per purl-spec git-source convention;
+//!   `description.path` surfaces as the `#<subpath>` fragment when
+//!   non-trivial).
+//! - **path**:   `pkg:generic/<name>@<version>` placeholder + the
+//!   `mikebom:source-type = "pub-path"` annotation (path-deps have no
+//!   purl-spec-addressable identity per R1).
+//! - **sdk**:    `pkg:pub/<sdk-name>@0.0.0` (the literal `0.0.0` is
+//!   the purl-spec canonical example for SDK pseudo-deps).
+//!
+//! `mikebom:source-type` values use the `pub-` prefix to avoid
+//! collision with cargo's existing C1-row values (`git`/`path`/
+//! `registry`) — per R3 and milestone-122's `kmp-` precedent.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use mikebom_common::types::hash::ContentHash;
+use mikebom_common::types::purl::Purl;
+
+use super::exclude_path::ExclusionSet;
+use super::PackageDbEntry;
+
+/// Per-project source-tree depth bound for the pubspec walker. Mirrors
+/// the gem reader's MAX_PROJECT_ROOT_DEPTH (6) — Dart projects are
+/// typically a flat or shallow `lib/` + `test/` + `pubspec.yaml` at
+/// root; 6 covers Melos monorepos with `packages/<member>/pubspec.yaml`
+/// and pub workspaces.
+const MAX_DART_WALK_DEPTH: usize = 8;
+
+/// Directories the dart walker MUST NOT descend into. These never carry
+/// the developer's own `pubspec.yaml` and would only produce false-
+/// positive components from per-package cached metadata.
+fn should_skip_descent(name: &str) -> bool {
+    matches!(
+        name,
+        // pub's per-project download cache
+        ".dart_tool"
+        // pub-cache hosted/<host>/<pkg>-<ver>/pubspec.yaml entries
+        | ".pub-cache"
+        // Flutter framework's own build output
+        | "build"
+        // VCS metadata
+        | ".git"
+        | ".hg"
+        | ".svn"
+        // Node-style nested deps (rare in Dart but cheap to skip)
+        | "node_modules"
+    )
+}
+
+/// Reader-private serde representation of a `pubspec.yaml` (subset
+/// consumed by this reader per data-model.md).
+#[derive(Debug, Clone, serde::Deserialize)]
+#[allow(dead_code)]
+struct PubspecYaml {
+    name: String,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    dependencies: BTreeMap<String, serde_yaml::Value>,
+    #[serde(default)]
+    dev_dependencies: BTreeMap<String, serde_yaml::Value>,
+    #[serde(default)]
+    dependency_overrides: BTreeMap<String, serde_yaml::Value>,
+    #[serde(default)]
+    environment: Option<serde_yaml::Value>,
+}
+
+/// Reader-private serde representation of a `pubspec.lock`.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[allow(dead_code)]
+struct PubspecLock {
+    #[serde(default)]
+    packages: BTreeMap<String, LockfileEntry>,
+    #[serde(default)]
+    sdks: Option<serde_yaml::Value>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[allow(dead_code)]
+struct LockfileEntry {
+    dependency: String,
+    description: LockfileDescription,
+    source: String,
+    version: String,
+}
+
+/// Polymorphic `description:` per the lockfile's `source:` discriminator.
+/// For `source: sdk` the YAML is a bare scalar string (the SDK name);
+/// for hosted/git/path the YAML is a map. Use `#[serde(untagged)]` so
+/// serde tries each variant in declared order.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(untagged)]
+#[allow(dead_code)]
+enum LockfileDescription {
+    Sdk(String),
+    Map(LockfileDescriptionMap),
+}
+
+#[derive(Debug, Clone, serde::Deserialize, Default)]
+#[allow(dead_code)]
+struct LockfileDescriptionMap {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    sha256: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default, rename = "ref")]
+    ref_: Option<String>,
+    #[serde(default, rename = "resolved-ref")]
+    resolved_ref: Option<String>,
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    relative: Option<bool>,
+}
+
+/// Lifetime is per-scan; no persistence (matches every language-reader
+/// since milestone 002).
+pub fn read(
+    rootfs: &Path,
+    include_dev: bool,
+    exclude_set: &ExclusionSet,
+) -> Vec<PackageDbEntry> {
+    let mut out: Vec<PackageDbEntry> = Vec::new();
+    let mut seen_purls: HashSet<String> = HashSet::new();
+    let mut projects = 0usize;
+    let mut lockfile_projects = 0usize;
+    let mut design_tier_projects = 0usize;
+    let mut warned_lockfile_parse_failures = 0usize;
+
+    for pubspec_path in find_dart_projects(rootfs, exclude_set) {
+        let pubspec_yaml = match parse_pubspec_yaml(&pubspec_path) {
+            Ok(y) if !y.name.is_empty() => y,
+            Ok(_) => {
+                tracing::warn!(
+                    path = %pubspec_path.display(),
+                    "dart: pubspec.yaml missing required `name:` field; skipping main-module",
+                );
+                continue;
+            }
+            Err(err) => {
+                tracing::warn!(
+                    path = %pubspec_path.display(),
+                    error = %err,
+                    "dart: failed to parse pubspec.yaml; skipping project",
+                );
+                continue;
+            }
+        };
+        projects += 1;
+        let project_dir = match pubspec_path.parent() {
+            Some(d) => d,
+            None => continue,
+        };
+        let lockfile_path = project_dir.join("pubspec.lock");
+
+        let parsed_lockfile: Option<PubspecLock> = if lockfile_path.is_file() {
+            match parse_pubspec_lock(&lockfile_path) {
+                Ok(lock) => Some(lock),
+                Err(err) => {
+                    warned_lockfile_parse_failures += 1;
+                    tracing::warn!(
+                        path = %lockfile_path.display(),
+                        error = %err,
+                        "dart: failed to parse pubspec.lock, falling back to design-tier from pubspec.yaml",
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        // Emit the main-module first so dep-edge wiring can reference
+        // its bom-ref (the orchestrator's seen_purls dedup keeps a
+        // single main-module per project).
+        if let Some(main_module) =
+            emit_main_module(&pubspec_path, &pubspec_yaml, parsed_lockfile.as_ref(), include_dev)
+        {
+            let purl_key = main_module.purl.as_str().to_string();
+            if seen_purls.insert(purl_key) {
+                out.push(main_module);
+            }
+        }
+
+        match parsed_lockfile {
+            Some(lock) => {
+                lockfile_projects += 1;
+                let entries = emit_lockfile_entries(&lockfile_path, &lock, include_dev);
+                for entry in entries {
+                    let purl_key = entry.purl.as_str().to_string();
+                    if seen_purls.insert(purl_key) {
+                        out.push(entry);
+                    }
+                }
+            }
+            None => {
+                design_tier_projects += 1;
+                let entries =
+                    emit_design_tier_components(&pubspec_path, &pubspec_yaml, include_dev);
+                for entry in entries {
+                    let purl_key = entry.purl.as_str().to_string();
+                    if seen_purls.insert(purl_key) {
+                        out.push(entry);
+                    }
+                }
+            }
+        }
+    }
+
+    if !out.is_empty() || warned_lockfile_parse_failures > 0 {
+        tracing::info!(
+            rootfs = %rootfs.display(),
+            entries = out.len(),
+            projects,
+            lockfile_projects,
+            design_tier_projects,
+            warned_lockfile_parse_failures,
+            include_dev,
+            "parsed pubspec.yaml + pubspec.lock entries",
+        );
+    }
+    out
+}
+
+/// Walk the rootfs for `pubspec.yaml` files (milestone 114 safe_walk).
+/// Output is lex-sorted for cross-platform deterministic discovery.
+fn find_dart_projects(rootfs: &Path, exclude_set: &ExclusionSet) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let cfg = crate::scan_fs::walk::WalkConfig {
+        max_depth: MAX_DART_WALK_DEPTH,
+        should_skip: &|candidate: &Path, _rootfs: &Path| -> bool {
+            let Some(name) = candidate.file_name().and_then(|s| s.to_str()) else {
+                return true;
+            };
+            should_skip_descent(name)
+        },
+        exclude_set,
+    };
+    crate::scan_fs::walk::safe_walk(rootfs, &cfg, |path| {
+        if path.is_file()
+            && path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(|n| n.eq_ignore_ascii_case("pubspec.yaml"))
+                .unwrap_or(false)
+        {
+            out.push(path.to_path_buf());
+        }
+    });
+    out.sort();
+    out
+}
+
+fn parse_pubspec_yaml(path: &Path) -> anyhow::Result<PubspecYaml> {
+    let bytes = std::fs::read(path)
+        .map_err(|e| anyhow::anyhow!("read failed: {e}"))?;
+    let parsed: PubspecYaml = serde_yaml::from_slice(&bytes)
+        .map_err(|e| anyhow::anyhow!("yaml parse failed: {e}"))?;
+    Ok(parsed)
+}
+
+fn parse_pubspec_lock(path: &Path) -> anyhow::Result<PubspecLock> {
+    let bytes = std::fs::read(path)
+        .map_err(|e| anyhow::anyhow!("read failed: {e}"))?;
+    let parsed: PubspecLock = serde_yaml::from_slice(&bytes)
+        .map_err(|e| anyhow::anyhow!("yaml parse failed: {e}"))?;
+    Ok(parsed)
+}
+
+/// FR-012: emit one main-module per `pubspec.yaml` discovered.
+/// Returns `None` only when `name` is empty (validated by caller).
+fn emit_main_module(
+    pubspec_path: &Path,
+    pubspec_yaml: &PubspecYaml,
+    parsed_lockfile: Option<&PubspecLock>,
+    include_dev: bool,
+) -> Option<PackageDbEntry> {
+    let version = pubspec_yaml
+        .version
+        .clone()
+        .unwrap_or_else(|| "0.0.0-unknown".to_string());
+    let purl_str = format!("pkg:pub/{}@{}", pubspec_yaml.name, version);
+    let purl = Purl::new(&purl_str).ok()?;
+
+    let mut extra_annotations: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    extra_annotations.insert(
+        "mikebom:component-role".to_string(),
+        serde_json::Value::String("main-module".to_string()),
+    );
+    extra_annotations.insert(
+        "mikebom:source-type".to_string(),
+        serde_json::Value::String("pub-main-module".to_string()),
+    );
+
+    // Dep edges per FR-004: main-module → direct deps.
+    // Lockfile mode: lockfile's `direct main` + (if include_dev) `direct dev`
+    //   + `direct overridden` (R2 lifecycle mapping).
+    // Design-tier mode: pubspec.yaml's `dependencies` + (if include_dev) `dev_dependencies`.
+    let depends: Vec<String> = if let Some(lock) = parsed_lockfile {
+        lock.packages
+            .iter()
+            .filter(|(_, e)| match e.dependency.as_str() {
+                "direct main" | "direct overridden" => true,
+                "direct dev" => include_dev,
+                _ => false,
+            })
+            .map(|(name, _)| name.clone())
+            .collect()
+    } else {
+        let mut d: Vec<String> = pubspec_yaml.dependencies.keys().cloned().collect();
+        if include_dev {
+            d.extend(pubspec_yaml.dev_dependencies.keys().cloned());
+        }
+        d
+    };
+
+    Some(PackageDbEntry {
+        purl,
+        name: pubspec_yaml.name.clone(),
+        version,
+        arch: None,
+        source_path: pubspec_path.to_string_lossy().into_owned(),
+        depends,
+        maintainer: None,
+        licenses: Vec::new(),
+        lifecycle_scope: None,
+        requirement_range: None,
+        source_type: Some("pub-main-module".to_string()),
+        buildinfo_status: None,
+        sbom_tier: Some("source".to_string()),
+        evidence_kind: Some("pubspec-yaml".to_string()),
+        binary_class: None,
+        binary_stripped: None,
+        linkage_kind: None,
+        detected_go: None,
+        confidence: None,
+        binary_packed: None,
+        raw_version: None,
+        parent_purl: None,
+        npm_role: None,
+        co_owned_by: None,
+        hashes: Vec::new(),
+        shade_relocation: None,
+        extra_annotations,
+        binary_role: None,
+        build_inclusion: None,
+    })
+}
+
+/// FR-002 + FR-003 + FR-008: one component per lockfile entry, with
+/// per-source-type PURL + annotation shape.
+fn emit_lockfile_entries(
+    lockfile_path: &Path,
+    pubspec_lock: &PubspecLock,
+    include_dev: bool,
+) -> Vec<PackageDbEntry> {
+    use mikebom_common::resolution::LifecycleScope;
+
+    let mut out = Vec::new();
+    let source_path = lockfile_path.to_string_lossy().into_owned();
+    for (name, entry) in &pubspec_lock.packages {
+        if entry.dependency == "direct dev" && !include_dev {
+            continue;
+        }
+
+        let purl = match build_purl_for_lockfile_entry(name, entry) {
+            Ok(p) => p,
+            Err(err) => {
+                tracing::warn!(
+                    name = %name,
+                    path = %lockfile_path.display(),
+                    error = %err,
+                    "dart: skipping malformed lockfile entry",
+                );
+                continue;
+            }
+        };
+
+        let source_type_value = match entry.source.as_str() {
+            "hosted" => "pub-hosted",
+            "git" => "pub-git",
+            "path" => "pub-path",
+            "sdk" => "pub-sdk",
+            _ => continue,
+        };
+        let lifecycle_scope = if entry.dependency == "direct dev" {
+            Some(LifecycleScope::Development)
+        } else {
+            Some(LifecycleScope::Runtime)
+        };
+
+        let hashes = match (&entry.source[..], &entry.description) {
+            ("hosted", LockfileDescription::Map(m)) => match &m.sha256 {
+                Some(hex) if hex.len() == 64 && hex.chars().all(|c| c.is_ascii_hexdigit()) => {
+                    match ContentHash::sha256(hex) {
+                        Ok(h) => vec![h],
+                        Err(_) => Vec::new(),
+                    }
+                }
+                _ => Vec::new(),
+            },
+            _ => Vec::new(),
+        };
+
+        let extra_annotations = build_extra_annotations(entry, source_type_value);
+
+        out.push(PackageDbEntry {
+            purl,
+            name: name.clone(),
+            version: entry.version.clone(),
+            arch: None,
+            source_path: source_path.clone(),
+            depends: Vec::new(),
+            maintainer: None,
+            licenses: Vec::new(),
+            lifecycle_scope,
+            requirement_range: None,
+            source_type: Some(source_type_value.to_string()),
+            buildinfo_status: None,
+            sbom_tier: Some("source".to_string()),
+            evidence_kind: Some("pubspec-lock".to_string()),
+            binary_class: None,
+            binary_stripped: None,
+            linkage_kind: None,
+            detected_go: None,
+            confidence: None,
+            binary_packed: None,
+            raw_version: None,
+            parent_purl: None,
+            npm_role: None,
+            co_owned_by: None,
+            hashes,
+            shade_relocation: None,
+            extra_annotations,
+            binary_role: None,
+            build_inclusion: None,
+        });
+    }
+    out
+}
+
+/// FR-005: design-tier emission when no lockfile is present.
+fn emit_design_tier_components(
+    pubspec_path: &Path,
+    pubspec_yaml: &PubspecYaml,
+    include_dev: bool,
+) -> Vec<PackageDbEntry> {
+    use mikebom_common::resolution::LifecycleScope;
+
+    let mut out = Vec::new();
+    let source_path = pubspec_path.to_string_lossy().into_owned();
+
+    // Iterate runtime deps, then dev-deps when allowed. Skip the
+    // main-module's own name (defensive — shouldn't appear but
+    // pubspec.yaml is operator-authored).
+    let runtime_iter = pubspec_yaml
+        .dependencies
+        .iter()
+        .map(|(k, v)| (k, v, false));
+    let dev_iter = pubspec_yaml
+        .dev_dependencies
+        .iter()
+        .map(|(k, v)| (k, v, true));
+
+    for (name, value, is_dev) in runtime_iter.chain(dev_iter) {
+        if is_dev && !include_dev {
+            continue;
+        }
+        if name == &pubspec_yaml.name {
+            continue;
+        }
+
+        let constraint = constraint_from_yaml_value(value);
+        let purl_str = format!("pkg:pub/{name}@{constraint}");
+        let Ok(purl) = Purl::new(&purl_str) else {
+            tracing::warn!(
+                name = %name,
+                constraint = %constraint,
+                path = %pubspec_path.display(),
+                "dart: skipping design-tier entry with non-PURL-safe constraint string",
+            );
+            continue;
+        };
+
+        let lifecycle_scope = if is_dev {
+            Some(LifecycleScope::Development)
+        } else {
+            Some(LifecycleScope::Runtime)
+        };
+        let mut extra_annotations: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+        extra_annotations.insert(
+            "mikebom:source-type".to_string(),
+            serde_json::Value::String("pub-hosted".to_string()),
+        );
+
+        out.push(PackageDbEntry {
+            purl,
+            name: name.clone(),
+            version: constraint.clone(),
+            arch: None,
+            source_path: source_path.clone(),
+            depends: Vec::new(),
+            maintainer: None,
+            licenses: Vec::new(),
+            lifecycle_scope,
+            requirement_range: Some(constraint),
+            source_type: Some("pub-hosted".to_string()),
+            buildinfo_status: None,
+            sbom_tier: Some("design".to_string()),
+            evidence_kind: Some("pubspec-yaml".to_string()),
+            binary_class: None,
+            binary_stripped: None,
+            linkage_kind: None,
+            detected_go: None,
+            confidence: None,
+            binary_packed: None,
+            raw_version: None,
+            parent_purl: None,
+            npm_role: None,
+            co_owned_by: None,
+            hashes: Vec::new(),
+            shade_relocation: None,
+            extra_annotations,
+            binary_role: None,
+            build_inclusion: None,
+        });
+    }
+    out
+}
+
+/// Extract a constraint string from the heterogeneous YAML value form
+/// of a pubspec.yaml dependency entry. Scalar strings (`^1.0.0`) are
+/// passed through verbatim. Map forms (`path:`, `git:`, `sdk:`) are
+/// design-tier-best-effort and map to the literal `"unspecified"`
+/// placeholder — design-tier emission cannot resolve non-hosted
+/// sources without a lockfile.
+fn constraint_from_yaml_value(value: &serde_yaml::Value) -> String {
+    match value {
+        serde_yaml::Value::String(s) => sanitize_purl_version(s),
+        serde_yaml::Value::Number(n) => n.to_string(),
+        serde_yaml::Value::Null => "unspecified".to_string(),
+        _ => "unspecified".to_string(),
+    }
+}
+
+/// PURL version segments forbid `/` (per PURL spec). Replace with `_`
+/// for design-tier emission so the constraint round-trips into a valid
+/// PURL. Other PURL-sensitive chars (e.g. `?`, `#`) are similarly
+/// neutralized. The raw constraint is preserved verbatim in
+/// `requirement_range`; this transform applies only to the version
+/// segment.
+fn sanitize_purl_version(raw: &str) -> String {
+    raw.chars()
+        .map(|c| match c {
+            '/' | '?' | '#' | ' ' => '_',
+            other => other,
+        })
+        .collect()
+}
+
+/// FR-003 PURL construction per source type.
+fn build_purl_for_lockfile_entry(
+    name: &str,
+    entry: &LockfileEntry,
+) -> Result<Purl, String> {
+    let purl_str = match (entry.source.as_str(), &entry.description) {
+        ("hosted", LockfileDescription::Map(m)) => {
+            let mut s = format!("pkg:pub/{}@{}", name, entry.version);
+            if let Some(url) = m.url.as_deref() {
+                if url != "https://pub.dev" && url != "https://pub.dartlang.org" {
+                    s.push_str("?repository_url=");
+                    s.push_str(&minimal_qualifier_encode(url));
+                }
+            }
+            s
+        }
+        ("git", LockfileDescription::Map(m)) => {
+            let resolved_ref = m
+                .resolved_ref
+                .as_deref()
+                .ok_or_else(|| "git source missing resolved-ref".to_string())?;
+            if resolved_ref.len() != 40
+                || !resolved_ref.chars().all(|c| c.is_ascii_hexdigit())
+            {
+                return Err(format!("git resolved-ref not 40-char hex: {resolved_ref}"));
+            }
+            let url = m
+                .url
+                .as_deref()
+                .ok_or_else(|| "git source missing url".to_string())?;
+            let subpath = m
+                .path
+                .as_deref()
+                .filter(|p| !p.is_empty() && *p != ".")
+                .map(|p| format!("#{p}"))
+                .unwrap_or_default();
+            format!(
+                "pkg:pub/{name}@{resolved_ref}?vcs_url=git+{url}{subpath}",
+                url = minimal_qualifier_encode(url),
+            )
+        }
+        ("path", LockfileDescription::Map(_)) => {
+            format!("pkg:generic/{name}@{version}", version = sanitize_purl_version(&entry.version))
+        }
+        ("sdk", LockfileDescription::Sdk(_sdk_family)) => {
+            // Per FR-011 + purl-spec canonical example: literal @0.0.0
+            // (never derived from entry.version, though entry.version
+            // is itself "0.0.0" per pub convention).
+            format!("pkg:pub/{name}@0.0.0")
+        }
+        ("sdk", LockfileDescription::Map(_)) => {
+            // Tolerant: some lockfile generators may emit sdk source
+            // with a map-shaped description. Still emit per FR-011.
+            format!("pkg:pub/{name}@0.0.0")
+        }
+        (other, _) => {
+            return Err(format!(
+                "unknown source discriminator: {other} (expected hosted|git|path|sdk)"
+            ));
+        }
+    };
+    Purl::new(&purl_str).map_err(|e| format!("PURL construction failed for {purl_str}: {e:?}"))
+}
+
+/// PURL qualifier-value encoding per the PURL spec's `pchar` rule.
+/// Allows `:` / `/` / `@` / `=` (URL-readable); encodes only the chars
+/// that would break PURL parsing (`?`, `#`, `&`) plus whitespace.
+fn minimal_qualifier_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            ' ' => out.push_str("%20"),
+            '?' => out.push_str("%3F"),
+            '#' => out.push_str("%23"),
+            '&' => out.push_str("%26"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Per-source-type annotation bag (R3 + data-model.md).
+fn build_extra_annotations(
+    entry: &LockfileEntry,
+    source_type_value: &str,
+) -> BTreeMap<String, serde_json::Value> {
+    let mut out: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    out.insert(
+        "mikebom:source-type".to_string(),
+        serde_json::Value::String(source_type_value.to_string()),
+    );
+    match (&entry.source[..], &entry.description) {
+        ("git", LockfileDescription::Map(m)) => {
+            if let Some(r) = m.ref_.as_deref() {
+                out.insert(
+                    "mikebom:vcs-ref".to_string(),
+                    serde_json::Value::String(r.to_string()),
+                );
+            }
+        }
+        ("path", LockfileDescription::Map(m)) => {
+            if let Some(p) = m.path.as_deref() {
+                out.insert(
+                    "mikebom:path".to_string(),
+                    serde_json::Value::String(p.to_string()),
+                );
+            }
+        }
+        ("sdk", LockfileDescription::Sdk(family)) => {
+            out.insert(
+                "mikebom:sdk-name".to_string(),
+                serde_json::Value::String(family.to_string()),
+            );
+        }
+        _ => {}
+    }
+    out
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    fn hosted_map(url: &str, sha: &str) -> LockfileEntry {
+        LockfileEntry {
+            dependency: "direct main".into(),
+            description: LockfileDescription::Map(LockfileDescriptionMap {
+                name: Some("foo".into()),
+                sha256: Some(sha.into()),
+                url: Some(url.into()),
+                ..Default::default()
+            }),
+            source: "hosted".into(),
+            version: "1.2.3".into(),
+        }
+    }
+
+    fn git_map(url: &str, resolved: &str, path: Option<&str>, ref_: Option<&str>) -> LockfileEntry {
+        LockfileEntry {
+            dependency: "direct main".into(),
+            description: LockfileDescription::Map(LockfileDescriptionMap {
+                url: Some(url.into()),
+                resolved_ref: Some(resolved.into()),
+                path: path.map(String::from),
+                ref_: ref_.map(String::from),
+                ..Default::default()
+            }),
+            source: "git".into(),
+            version: "0.0.0".into(),
+        }
+    }
+
+    #[test]
+    fn hosted_default_pubdev_emits_bare_purl() {
+        let e = hosted_map("https://pub.dev", "a".repeat(64).as_str());
+        let p = build_purl_for_lockfile_entry("http", &e).unwrap();
+        assert_eq!(p.as_str(), "pkg:pub/http@1.2.3");
+    }
+
+    #[test]
+    fn hosted_legacy_dartlang_default_emits_bare_purl() {
+        let e = hosted_map("https://pub.dartlang.org", "a".repeat(64).as_str());
+        let p = build_purl_for_lockfile_entry("http", &e).unwrap();
+        assert_eq!(p.as_str(), "pkg:pub/http@1.2.3");
+    }
+
+    #[test]
+    fn hosted_self_hosted_emits_repository_url_qualifier() {
+        let e = hosted_map("https://pub.acme.example.com", "a".repeat(64).as_str());
+        let p = build_purl_for_lockfile_entry("internal_lib", &e).unwrap();
+        assert_eq!(
+            p.as_str(),
+            "pkg:pub/internal_lib@1.2.3?repository_url=https://pub.acme.example.com"
+        );
+    }
+
+    #[test]
+    fn git_source_emits_resolved_sha_plus_vcs_url_with_subpath() {
+        let resolved = "eb39649a76b87e8451baf75d10ce82ca3a3d5601";
+        let e = git_map(
+            "https://github.com/google/flutter-desktop-embedding.git",
+            resolved,
+            Some("plugins/window_size"),
+            Some("master"),
+        );
+        let p = build_purl_for_lockfile_entry("window_size", &e).unwrap();
+        assert_eq!(
+            p.as_str(),
+            format!(
+                "pkg:pub/window_size@{resolved}?vcs_url=git+https://github.com/google/flutter-desktop-embedding.git#plugins/window_size"
+            )
+        );
+    }
+
+    #[test]
+    fn git_source_omits_subpath_when_dot_or_empty() {
+        let resolved = "eb39649a76b87e8451baf75d10ce82ca3a3d5601";
+        let e_dot = git_map("https://example.com/r.git", resolved, Some("."), None);
+        let p_dot = build_purl_for_lockfile_entry("r", &e_dot).unwrap();
+        assert!(!p_dot.as_str().contains('#'), "got: {}", p_dot.as_str());
+
+        let e_empty = git_map("https://example.com/r.git", resolved, Some(""), None);
+        let p_empty = build_purl_for_lockfile_entry("r", &e_empty).unwrap();
+        assert!(!p_empty.as_str().contains('#'), "got: {}", p_empty.as_str());
+    }
+
+    #[test]
+    fn git_source_missing_resolved_ref_errors() {
+        let e = LockfileEntry {
+            dependency: "direct main".into(),
+            description: LockfileDescription::Map(LockfileDescriptionMap {
+                url: Some("https://example.com/r.git".into()),
+                resolved_ref: None,
+                ..Default::default()
+            }),
+            source: "git".into(),
+            version: "0.0.0".into(),
+        };
+        assert!(build_purl_for_lockfile_entry("r", &e).is_err());
+    }
+
+    #[test]
+    fn git_source_short_sha_errors() {
+        let e = git_map("https://example.com/r.git", "abc123", None, None);
+        assert!(build_purl_for_lockfile_entry("r", &e).is_err());
+    }
+
+    #[test]
+    fn path_source_emits_generic_placeholder() {
+        let e = LockfileEntry {
+            dependency: "direct main".into(),
+            description: LockfileDescription::Map(LockfileDescriptionMap {
+                path: Some("../packages/my_local_lib".into()),
+                relative: Some(true),
+                ..Default::default()
+            }),
+            source: "path".into(),
+            version: "0.1.0".into(),
+        };
+        let p = build_purl_for_lockfile_entry("my_local_lib", &e).unwrap();
+        assert_eq!(p.as_str(), "pkg:generic/my_local_lib@0.1.0");
+    }
+
+    #[test]
+    fn sdk_source_emits_zero_zero_zero_version() {
+        let e = LockfileEntry {
+            dependency: "direct main".into(),
+            description: LockfileDescription::Sdk("flutter".into()),
+            source: "sdk".into(),
+            version: "0.0.0".into(),
+        };
+        let p = build_purl_for_lockfile_entry("flutter", &e).unwrap();
+        assert_eq!(p.as_str(), "pkg:pub/flutter@0.0.0");
+
+        let e2 = LockfileEntry {
+            dependency: "direct main".into(),
+            description: LockfileDescription::Sdk("flutter".into()),
+            source: "sdk".into(),
+            version: "0.0.0".into(),
+        };
+        let p2 = build_purl_for_lockfile_entry("flutter_test", &e2).unwrap();
+        assert_eq!(p2.as_str(), "pkg:pub/flutter_test@0.0.0");
+    }
+
+    #[test]
+    fn unknown_source_discriminator_errors() {
+        let e = LockfileEntry {
+            dependency: "direct main".into(),
+            description: LockfileDescription::Map(LockfileDescriptionMap::default()),
+            source: "hg".into(),
+            version: "1.0.0".into(),
+        };
+        assert!(build_purl_for_lockfile_entry("foo", &e).is_err());
+    }
+
+    #[test]
+    fn extra_annotations_carry_source_type() {
+        let e = hosted_map("https://pub.dev", "a".repeat(64).as_str());
+        let ann = build_extra_annotations(&e, "pub-hosted");
+        assert_eq!(
+            ann.get("mikebom:source-type").and_then(|v| v.as_str()),
+            Some("pub-hosted")
+        );
+    }
+
+    #[test]
+    fn extra_annotations_git_carries_vcs_ref() {
+        let e = git_map(
+            "https://example.com/r.git",
+            &"a".repeat(40),
+            None,
+            Some("v1.0.0"),
+        );
+        let ann = build_extra_annotations(&e, "pub-git");
+        assert_eq!(
+            ann.get("mikebom:vcs-ref").and_then(|v| v.as_str()),
+            Some("v1.0.0")
+        );
+    }
+
+    #[test]
+    fn extra_annotations_sdk_carries_sdk_name() {
+        let e = LockfileEntry {
+            dependency: "direct main".into(),
+            description: LockfileDescription::Sdk("flutter".into()),
+            source: "sdk".into(),
+            version: "0.0.0".into(),
+        };
+        let ann = build_extra_annotations(&e, "pub-sdk");
+        assert_eq!(
+            ann.get("mikebom:sdk-name").and_then(|v| v.as_str()),
+            Some("flutter")
+        );
+    }
+
+    #[test]
+    fn minimal_qualifier_encode_passes_through_url_chars() {
+        assert_eq!(
+            minimal_qualifier_encode("https://pub.acme.example.com"),
+            "https://pub.acme.example.com"
+        );
+        assert_eq!(
+            minimal_qualifier_encode("with space"),
+            "with%20space"
+        );
+        assert_eq!(
+            minimal_qualifier_encode("with#hash&amp"),
+            "with%23hash%26amp"
+        );
+    }
+
+    #[test]
+    fn sanitize_purl_version_neutralizes_slashes() {
+        assert_eq!(sanitize_purl_version("^1.0.0"), "^1.0.0");
+        assert_eq!(sanitize_purl_version(">=1.0.0 <2.0.0"), ">=1.0.0_<2.0.0");
+        assert_eq!(sanitize_purl_version("git/foo"), "git_foo");
+    }
+}

--- a/mikebom-cli/src/scan_fs/package_db/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/mod.rs
@@ -17,6 +17,7 @@ pub mod brew;
 pub mod cargo;
 pub mod cmake;
 pub mod conan;
+pub mod dart;
 mod control_file;
 pub mod copyright;
 pub mod dpkg;
@@ -1509,6 +1510,13 @@ pub fn read_all(
     out.extend(cmake::read(rootfs, include_vendored));
     out.extend(vcpkg::read(rootfs));
     out.extend(conan::read(rootfs));
+
+    // Milestone 137: Dart/Flutter pub ecosystem reader. One
+    // main-module per `pubspec.yaml` (FR-012) + one component per
+    // lockfile entry when sibling `pubspec.lock` present (FR-002);
+    // design-tier fallback (FR-005) when lockfile absent. Pure-Rust
+    // YAML via `serde_yaml`; zero new Cargo deps.
+    out.extend(dart::read(rootfs, include_dev, exclude_set));
 
     // G3: when a scan produced BOTH `pkg:golang` source-tier entries
     // (from `golang.rs`'s go.sum parsing) AND `pkg:golang` analyzed-

--- a/mikebom-cli/tests/dart_design_tier.rs
+++ b/mikebom-cli/tests/dart_design_tier.rs
@@ -1,0 +1,217 @@
+//! Milestone 137 US3 — design-tier emission tests (no lockfile).
+//!
+//! Covers SC-003 + US3 acceptance scenarios 1/2/3: a Dart library
+//! project with `pubspec.yaml` only (no `pubspec.lock`) emits
+//! components for declared `dependencies:` + `dev_dependencies:` with
+//! `mikebom:sbom-tier = "design"` annotation + constraint preserved
+//! as `mikebom:requirement-range` evidence.
+
+#![cfg(test)]
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_mikebom")
+}
+
+fn run_scan(project_root: &Path) -> Value {
+    run_scan_with_flags(project_root, &[])
+}
+
+fn run_scan_with_flags(project_root: &Path, extra: &[&str]) -> Value {
+    // Top-level `--exclude-scope` MUST be passed BEFORE the `sbom`
+    // subcommand per main.rs:114; we splice it in before the
+    // subcommand args.
+    let mut top_level_extra: Vec<&str> = Vec::new();
+    let mut subcommand_extra: Vec<&str> = Vec::new();
+    let mut iter = extra.iter().peekable();
+    while let Some(a) = iter.next() {
+        if *a == "--exclude-scope" {
+            top_level_extra.push(a);
+            if let Some(v) = iter.next() {
+                top_level_extra.push(v);
+            }
+        } else {
+            subcommand_extra.push(a);
+        }
+    }
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("out.cdx.json");
+    let mut cmd = Command::new(binary_path());
+    cmd.arg("--offline");
+    for a in &top_level_extra {
+        cmd.arg(a);
+    }
+    cmd.arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(project_root)
+        .arg("--no-deep-hash")
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(format!("cyclonedx-json={}", out_path.display()));
+    for a in &subcommand_extra {
+        cmd.arg(a);
+    }
+    let result = cmd.output().unwrap();
+    assert!(
+        result.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&result.stderr),
+    );
+    let bytes = std::fs::read(&out_path).unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn dart_components(doc: &Value) -> Vec<&Value> {
+    doc.get("components")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter(|c| {
+                    let purl = c.get("purl").and_then(|v| v.as_str()).unwrap_or("");
+                    (purl.starts_with("pkg:pub/") || purl.starts_with("pkg:generic/"))
+                        && property_value(c, "mikebom:component-role") != Some("main-module")
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn property_value<'a>(component: &'a Value, name: &str) -> Option<&'a str> {
+    component
+        .get("properties")
+        .and_then(|v| v.as_array())?
+        .iter()
+        .find(|p| p.get("name").and_then(|v| v.as_str()) == Some(name))
+        .and_then(|p| p.get("value").and_then(|v| v.as_str()))
+}
+
+fn find_by_name<'a>(components: &'a [&'a Value], name: &str) -> Option<&'a Value> {
+    components
+        .iter()
+        .copied()
+        .find(|c| c.get("name").and_then(|v| v.as_str()) == Some(name))
+}
+
+#[test]
+fn design_tier_no_lockfile_emits_constraints() {
+    // SC-003: pubspec.yaml-only project emits components with
+    // sbom-tier=design + the constraint preserved as requirement-range.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("pubspec.yaml"),
+        "name: my_lib\nversion: 0.1.0\n\
+         environment:\n  sdk: '>=3.0.0 <4.0.0'\n\
+         dependencies:\n  http: ^1.0.0\n  provider: ^6.1.0\n",
+    )
+    .unwrap();
+
+    let doc = run_scan(tmp.path());
+    let dart = dart_components(&doc);
+    assert_eq!(
+        dart.len(),
+        2,
+        "design-tier scan must emit 2 deps; got {dart:#?}",
+    );
+    for &c in &dart {
+        assert_eq!(
+            property_value(c, "mikebom:sbom-tier"),
+            Some("design"),
+            "design-tier component {} missing sbom-tier=design",
+            c.get("name").and_then(|v| v.as_str()).unwrap_or("?"),
+        );
+    }
+    let http = find_by_name(&dart, "http").expect("http component must exist");
+    assert_eq!(
+        property_value(http, "mikebom:requirement-range"),
+        Some("^1.0.0"),
+        "http design-tier component must preserve constraint string verbatim",
+    );
+    let provider = find_by_name(&dart, "provider").expect("provider component must exist");
+    assert_eq!(
+        property_value(provider, "mikebom:requirement-range"),
+        Some("^6.1.0"),
+    );
+}
+
+#[test]
+fn design_tier_no_transitive_deps() {
+    // US3 acceptance scenario 2: design-tier emits ONLY declared
+    // direct deps; no transitives (no lockfile to resolve them).
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("pubspec.yaml"),
+        "name: my_lib\nversion: 0.1.0\n\
+         environment:\n  sdk: '>=3.0.0 <4.0.0'\n\
+         dependencies:\n  http: ^1.0.0\n",
+    )
+    .unwrap();
+
+    let doc = run_scan(tmp.path());
+    let dart = dart_components(&doc);
+    let names: Vec<&str> = dart
+        .iter()
+        .filter_map(|c| c.get("name").and_then(|v| v.as_str()))
+        .collect();
+    assert!(
+        names.contains(&"http"),
+        "declared direct dep http must emit; got {names:?}",
+    );
+    // No `http_parser` / `meta` / etc. — those would require lockfile resolution.
+    assert!(
+        !names.contains(&"http_parser"),
+        "design-tier must NOT emit transitive http_parser; got {names:?}",
+    );
+    assert!(
+        !names.contains(&"meta"),
+        "design-tier must NOT emit transitive meta; got {names:?}",
+    );
+}
+
+#[test]
+fn design_tier_dev_deps_carry_lifecycle_scope() {
+    // US3 acceptance scenario 3: dev_dependencies entries emit with
+    // mikebom:lifecycle-scope=development; --exclude-scope suppresses.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("pubspec.yaml"),
+        "name: my_lib\nversion: 0.1.0\n\
+         environment:\n  sdk: '>=3.0.0 <4.0.0'\n\
+         dependencies:\n  http: ^1.0.0\n\
+         dev_dependencies:\n  test: ^1.24.0\n",
+    )
+    .unwrap();
+
+    let doc_with_dev = run_scan(tmp.path());
+    let dart = dart_components(&doc_with_dev);
+    let test_c = find_by_name(&dart, "test").expect("dev dep `test` must emit");
+    let lifecycle = property_value(test_c, "mikebom:lifecycle-scope");
+    let cdx_scope = test_c.get("scope").and_then(|v| v.as_str());
+    assert!(
+        lifecycle == Some("development")
+            || matches!(cdx_scope, Some("excluded") | Some("optional")),
+        "dev dep `test` must carry development indicator; \
+         property={lifecycle:?} scope={cdx_scope:?}",
+    );
+
+    let doc_without_dev = run_scan_with_flags(tmp.path(), &["--exclude-scope", "dev"]);
+    let dart_prod = dart_components(&doc_without_dev);
+    let names_prod: Vec<&str> = dart_prod
+        .iter()
+        .filter_map(|c| c.get("name").and_then(|v| v.as_str()))
+        .collect();
+    assert!(
+        !names_prod.contains(&"test"),
+        "--exclude-scope must suppress dev dep `test`; got {names_prod:?}",
+    );
+    assert!(
+        names_prod.contains(&"http"),
+        "--exclude-scope must NOT suppress runtime `http`; got {names_prod:?}",
+    );
+}

--- a/mikebom-cli/tests/dart_edge_cases.rs
+++ b/mikebom-cli/tests/dart_edge_cases.rs
@@ -1,0 +1,369 @@
+//! Milestone 137 polish — edge-case coverage per spec Edge Cases +
+//! SC-005 + the v1 scope clarifications.
+
+#![cfg(test)]
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_mikebom")
+}
+
+fn run_scan(project_root: &Path) -> (Value, String) {
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("out.cdx.json");
+    let result = Command::new(binary_path())
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(project_root)
+        .arg("--no-deep-hash")
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(format!("cyclonedx-json={}", out_path.display()))
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&result.stderr),
+    );
+    let bytes = std::fs::read(&out_path).unwrap();
+    let doc: Value = serde_json::from_slice(&bytes).unwrap();
+    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+    (doc, stderr)
+}
+
+fn component_with_purl<'a>(doc: &'a Value, purl: &str) -> Option<&'a Value> {
+    if let Some(c) = doc.get("metadata").and_then(|m| m.get("component")) {
+        if c.get("purl").and_then(|v| v.as_str()) == Some(purl) {
+            return Some(c);
+        }
+    }
+    doc.get("components")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|c| {
+                c.get("purl").and_then(|v| v.as_str()) == Some(purl)
+            })
+        })
+}
+
+fn property_value<'a>(component: &'a Value, name: &str) -> Option<&'a str> {
+    component
+        .get("properties")
+        .and_then(|v| v.as_array())?
+        .iter()
+        .find(|p| p.get("name").and_then(|v| v.as_str()) == Some(name))
+        .and_then(|p| p.get("value").and_then(|v| v.as_str()))
+}
+
+fn dart_purls(doc: &Value) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut visit = |c: &Value| {
+        if let Some(p) = c.get("purl").and_then(|v| v.as_str()) {
+            if p.starts_with("pkg:pub/") || p.starts_with("pkg:generic/") {
+                out.push(p.to_string());
+            }
+        }
+    };
+    if let Some(arr) = doc.get("components").and_then(|v| v.as_array()) {
+        for c in arr {
+            visit(c);
+        }
+    }
+    if let Some(c) = doc.get("metadata").and_then(|m| m.get("component")) {
+        visit(c);
+    }
+    out
+}
+
+fn write_minimal_pubspec(dir: &Path, name: &str, version: Option<&str>) {
+    let body = match version {
+        Some(v) => format!("name: {name}\nversion: {v}\nenvironment:\n  sdk: '>=3.0.0 <4.0.0'\n"),
+        None => format!("name: {name}\nenvironment:\n  sdk: '>=3.0.0 <4.0.0'\n"),
+    };
+    std::fs::write(dir.join("pubspec.yaml"), body).unwrap();
+}
+
+#[test]
+fn malformed_lockfile_falls_back_to_design_tier() {
+    // SC-005: 1 valid + 1 corrupted lockfile across 2 sibling
+    // project dirs. The valid one emits per FR-002 (source-tier
+    // lockfile-driven). The corrupted one falls back to design-tier
+    // from pubspec.yaml. Scan exits 0 (no abort); a warning fires
+    // for the corrupted file.
+    let tmp = tempfile::tempdir().unwrap();
+    let valid = tmp.path().join("valid");
+    let bad = tmp.path().join("bad");
+    std::fs::create_dir_all(&valid).unwrap();
+    std::fs::create_dir_all(&bad).unwrap();
+
+    write_minimal_pubspec(&valid, "valid_app", Some("1.0.0"));
+    let sha = "a".repeat(64);
+    std::fs::write(
+        valid.join("pubspec.lock"),
+        format!(
+            "packages:\n\
+             \x20\x20http:\n\
+             \x20\x20\x20\x20dependency: \"direct main\"\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20name: http\n\
+             \x20\x20\x20\x20\x20\x20sha256: \"{sha}\"\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://pub.dev\"\n\
+             \x20\x20\x20\x20source: hosted\n\
+             \x20\x20\x20\x20version: \"1.1.0\"\n",
+        ),
+    )
+    .unwrap();
+
+    std::fs::write(
+        bad.join("pubspec.yaml"),
+        "name: bad_app\nversion: 0.2.0\n\
+         environment:\n  sdk: '>=3.0.0 <4.0.0'\n\
+         dependencies:\n  provider: ^6.1.0\n",
+    )
+    .unwrap();
+    std::fs::write(
+        bad.join("pubspec.lock"),
+        "this is not: : valid yaml\n\t\t\n[broken",
+    )
+    .unwrap();
+
+    let (doc, stderr) = run_scan(tmp.path());
+
+    // Valid project's lockfile emission MUST appear.
+    assert!(
+        component_with_purl(&doc, "pkg:pub/http@1.1.0").is_some(),
+        "valid project's lockfile-derived http MUST emit",
+    );
+    assert!(
+        component_with_purl(&doc, "pkg:pub/valid_app@1.0.0").is_some(),
+        "valid project's main-module MUST emit",
+    );
+
+    // Bad project's main-module + design-tier provider MUST emit
+    // (graceful degradation per FR-007 + R7).
+    assert!(
+        component_with_purl(&doc, "pkg:pub/bad_app@0.2.0").is_some(),
+        "bad project's main-module MUST emit even with malformed lockfile",
+    );
+    let provider = component_with_purl(&doc, "pkg:pub/provider@^6.1.0")
+        .expect("bad project's design-tier provider MUST emit from pubspec.yaml fallback");
+    assert_eq!(
+        property_value(provider, "mikebom:sbom-tier"),
+        Some("design"),
+    );
+
+    // Warn for the corrupted lockfile must fire to stderr.
+    assert!(
+        stderr.contains("failed to parse pubspec.lock"),
+        "expected warning for malformed lockfile in stderr; got: {stderr}",
+    );
+}
+
+#[test]
+fn workspace_monorepo_emits_one_main_module_per_pubspec() {
+    // FR-009 (Melos shape): a monorepo with multiple member packages,
+    // each with its own pubspec.yaml + pubspec.lock. One main-module
+    // per member; NO synthetic workspace-root component.
+    let tmp = tempfile::tempdir().unwrap();
+    for member in &["app", "lib_a", "lib_b"] {
+        let dir = tmp.path().join("packages").join(member);
+        std::fs::create_dir_all(&dir).unwrap();
+        let version = match *member {
+            "app" => "1.0.0",
+            "lib_a" => "0.5.0",
+            _ => "0.3.0",
+        };
+        write_minimal_pubspec(&dir, member, Some(version));
+    }
+
+    let (doc, _) = run_scan(tmp.path());
+    let purls = dart_purls(&doc);
+    for expected in &[
+        "pkg:pub/app@1.0.0",
+        "pkg:pub/lib_a@0.5.0",
+        "pkg:pub/lib_b@0.3.0",
+    ] {
+        assert!(
+            purls.contains(&expected.to_string()),
+            "expected workspace member {expected} not found; got {purls:?}",
+        );
+    }
+    // No synthetic workspace-root component (the tmpdir itself has no pubspec.yaml).
+    assert!(
+        !purls.iter().any(|p| p.contains("workspace-root")),
+        "no synthetic workspace-root component must emit; got {purls:?}",
+    );
+}
+
+#[test]
+fn missing_version_falls_back_to_unknown_placeholder() {
+    // FR-012: pubspec.yaml without `version:` field emits main-module
+    // with PURL `pkg:pub/<name>@0.0.0-unknown`.
+    let tmp = tempfile::tempdir().unwrap();
+    write_minimal_pubspec(tmp.path(), "library_in_development", None);
+
+    let (doc, _) = run_scan(tmp.path());
+    assert!(
+        component_with_purl(&doc, "pkg:pub/library_in_development@0.0.0-unknown").is_some(),
+        "missing-version main-module MUST emit with 0.0.0-unknown placeholder",
+    );
+}
+
+#[test]
+fn sdk_pseudo_deps_emit_zero_zero_zero() {
+    // FR-011: lockfile with `flutter` SDK pseudo-dep emits
+    // `pkg:pub/flutter@0.0.0` with `mikebom:source-type = pub-sdk`.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("pubspec.yaml"),
+        "name: my_app\nversion: 0.1.0\n\
+         environment:\n  sdk: '>=3.0.0 <4.0.0'\n",
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("pubspec.lock"),
+        "packages:\n  \
+         flutter:\n    \
+         dependency: \"direct main\"\n    \
+         description: flutter\n    \
+         source: sdk\n    \
+         version: \"0.0.0\"\n",
+    )
+    .unwrap();
+
+    let (doc, _) = run_scan(tmp.path());
+    let c = component_with_purl(&doc, "pkg:pub/flutter@0.0.0")
+        .expect("SDK pseudo-dep must emit at @0.0.0");
+    assert_eq!(property_value(c, "mikebom:source-type"), Some("pub-sdk"));
+}
+
+#[test]
+fn direct_overridden_treated_as_runtime() {
+    // R2 lifecycle mapping: lockfile entry with `dependency: "direct
+    // overridden"` emits as lifecycle-scope: Runtime (no development
+    // indicator).
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("pubspec.yaml"),
+        "name: my_app\nversion: 0.1.0\n\
+         environment:\n  sdk: '>=3.0.0 <4.0.0'\n",
+    )
+    .unwrap();
+    let sha = "a".repeat(64);
+    std::fs::write(
+        tmp.path().join("pubspec.lock"),
+        format!(
+            "packages:\n\
+             \x20\x20http:\n\
+             \x20\x20\x20\x20dependency: \"direct overridden\"\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20name: http\n\
+             \x20\x20\x20\x20\x20\x20sha256: \"{sha}\"\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://pub.dev\"\n\
+             \x20\x20\x20\x20source: hosted\n\
+             \x20\x20\x20\x20version: \"1.1.0\"\n",
+        ),
+    )
+    .unwrap();
+
+    let (doc, _) = run_scan(tmp.path());
+    let http = component_with_purl(&doc, "pkg:pub/http@1.1.0")
+        .expect("direct-overridden entry must still emit as a component");
+    // Must NOT carry the development lifecycle indicator.
+    let lifecycle = property_value(http, "mikebom:lifecycle-scope");
+    let cdx_scope = http.get("scope").and_then(|v| v.as_str());
+    assert!(
+        lifecycle != Some("development") && cdx_scope != Some("excluded"),
+        "direct-overridden must NOT be tagged as development; \
+         got property={lifecycle:?} scope={cdx_scope:?}",
+    );
+}
+
+#[test]
+fn empty_packages_block_emits_only_main_module() {
+    // Edge Cases: pubspec.lock with `packages: {}` emits just the
+    // main-module; no dep components; no warnings.
+    let tmp = tempfile::tempdir().unwrap();
+    write_minimal_pubspec(tmp.path(), "empty_app", Some("0.1.0"));
+    std::fs::write(
+        tmp.path().join("pubspec.lock"),
+        "packages: {}\nsdks:\n  dart: '>=3.0.0 <4.0.0'\n",
+    )
+    .unwrap();
+
+    let (doc, stderr) = run_scan(tmp.path());
+    let purls = dart_purls(&doc);
+    assert_eq!(
+        purls.len(),
+        1,
+        "only main-module must emit on empty packages block; got {purls:?}",
+    );
+    assert_eq!(purls[0], "pkg:pub/empty_app@0.1.0");
+    // No dart-specific warnings.
+    assert!(
+        !stderr.contains("dart: failed"),
+        "no dart warnings expected on empty packages block; got: {stderr}",
+    );
+}
+
+#[test]
+fn git_source_missing_resolved_ref_warns_and_skips() {
+    // Edge Cases: lockfile entry for a git source lacking
+    // `resolved-ref:` warns and skips that single entry; other valid
+    // lockfile entries still emit.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("pubspec.yaml"),
+        "name: my_app\nversion: 0.1.0\n\
+         environment:\n  sdk: '>=3.0.0 <4.0.0'\n",
+    )
+    .unwrap();
+    let sha = "a".repeat(64);
+    std::fs::write(
+        tmp.path().join("pubspec.lock"),
+        format!(
+            "packages:\n\
+             \x20\x20http:\n\
+             \x20\x20\x20\x20dependency: \"direct main\"\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20name: http\n\
+             \x20\x20\x20\x20\x20\x20sha256: \"{sha}\"\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://pub.dev\"\n\
+             \x20\x20\x20\x20source: hosted\n\
+             \x20\x20\x20\x20version: \"1.1.0\"\n\
+             \x20\x20broken_git:\n\
+             \x20\x20\x20\x20dependency: \"direct main\"\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://example.com/r.git\"\n\
+             \x20\x20\x20\x20\x20\x20ref: \"main\"\n\
+             \x20\x20\x20\x20source: git\n\
+             \x20\x20\x20\x20version: \"0.0.0\"\n",
+        ),
+    )
+    .unwrap();
+
+    let (doc, stderr) = run_scan(tmp.path());
+    assert!(
+        component_with_purl(&doc, "pkg:pub/http@1.1.0").is_some(),
+        "valid hosted entry must still emit when sibling git entry is malformed",
+    );
+    let purls = dart_purls(&doc);
+    assert!(
+        !purls.iter().any(|p| p.contains("broken_git")),
+        "malformed git entry must NOT emit; got {purls:?}",
+    );
+    assert!(
+        stderr.contains("skipping malformed lockfile entry")
+            || stderr.contains("git source missing resolved-ref"),
+        "expected skip warning in stderr; got: {stderr}",
+    );
+}

--- a/mikebom-cli/tests/dart_flutter_app_baseline.rs
+++ b/mikebom-cli/tests/dart_flutter_app_baseline.rs
@@ -1,0 +1,344 @@
+//! Milestone 137 US1 — end-to-end integration tests that a synthetic
+//! Flutter app project produces a CDX SBOM containing one main-module
+//! component plus one component per lockfile entry, with correct PURL
+//! identities and dep edges.
+//!
+//! Covers spec acceptance scenarios US1.1, US1.2, US1.4 plus SC-001
+//! (Flutter app baseline), SC-007 (dev-scope filterability), and SC-008
+//! (main-module emission).
+
+#![cfg(test)]
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_mikebom")
+}
+
+fn run_scan(project_root: &Path) -> Value {
+    run_scan_with_flags(project_root, &[])
+}
+
+fn run_scan_with_flags(project_root: &Path, extra: &[&str]) -> Value {
+    // Top-level `--exclude-scope` MUST be passed BEFORE the `sbom`
+    // subcommand per main.rs:114; splice it in before the subcommand.
+    let mut top_level_extra: Vec<&str> = Vec::new();
+    let mut subcommand_extra: Vec<&str> = Vec::new();
+    let mut iter = extra.iter().peekable();
+    while let Some(a) = iter.next() {
+        if *a == "--exclude-scope" {
+            top_level_extra.push(a);
+            if let Some(v) = iter.next() {
+                top_level_extra.push(v);
+            }
+        } else {
+            subcommand_extra.push(a);
+        }
+    }
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("out.cdx.json");
+    let mut cmd = Command::new(binary_path());
+    cmd.arg("--offline");
+    for a in &top_level_extra {
+        cmd.arg(a);
+    }
+    cmd.arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(project_root)
+        .arg("--no-deep-hash")
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(format!("cyclonedx-json={}", out_path.display()));
+    for a in &subcommand_extra {
+        cmd.arg(a);
+    }
+    let result = cmd.output().unwrap();
+    assert!(
+        result.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&result.stderr),
+    );
+    let bytes = std::fs::read(&out_path).unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn pub_purls(doc: &Value) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut visit = |c: &Value| {
+        if let Some(p) = c.get("purl").and_then(|v| v.as_str()) {
+            if p.starts_with("pkg:pub/") || p.starts_with("pkg:generic/") {
+                out.push(p.to_string());
+            }
+        }
+    };
+    if let Some(arr) = doc.get("components").and_then(|v| v.as_array()) {
+        for c in arr {
+            visit(c);
+        }
+    }
+    if let Some(c) = doc.get("metadata").and_then(|m| m.get("component")) {
+        visit(c);
+    }
+    out
+}
+
+fn component_with_purl<'a>(doc: &'a Value, purl: &str) -> Option<&'a Value> {
+    if let Some(c) = doc.get("metadata").and_then(|m| m.get("component")) {
+        if c.get("purl").and_then(|v| v.as_str()) == Some(purl) {
+            return Some(c);
+        }
+    }
+    doc.get("components")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|c| {
+                c.get("purl").and_then(|v| v.as_str()) == Some(purl)
+            })
+        })
+}
+
+fn property_value<'a>(component: &'a Value, name: &str) -> Option<&'a str> {
+    component
+        .get("properties")
+        .and_then(|v| v.as_array())?
+        .iter()
+        .find(|p| p.get("name").and_then(|v| v.as_str()) == Some(name))
+        .and_then(|p| p.get("value").and_then(|v| v.as_str()))
+}
+
+fn write_flutter_app_fixture(root: &Path) {
+    std::fs::write(
+        root.join("pubspec.yaml"),
+        "name: my_flutter_app\n\
+         version: 1.2.3\n\
+         description: Test fixture for milestone 137.\n\
+         environment:\n  sdk: '>=3.0.0 <4.0.0'\n\
+         dependencies:\n  http: ^1.1.0\n  provider: ^6.1.1\n  shared_preferences: ^2.2.2\n",
+    )
+    .unwrap();
+    // pubspec.lock with the 3 direct deps + 2 transitives = 5 packages.
+    let sha = "a".repeat(64);
+    std::fs::write(
+        root.join("pubspec.lock"),
+        format!(
+            "packages:\n\
+             \x20\x20http:\n\
+             \x20\x20\x20\x20dependency: \"direct main\"\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20name: http\n\
+             \x20\x20\x20\x20\x20\x20sha256: \"{sha}\"\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://pub.dev\"\n\
+             \x20\x20\x20\x20source: hosted\n\
+             \x20\x20\x20\x20version: \"1.1.0\"\n\
+             \x20\x20http_parser:\n\
+             \x20\x20\x20\x20dependency: transitive\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20name: http_parser\n\
+             \x20\x20\x20\x20\x20\x20sha256: \"{sha}\"\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://pub.dev\"\n\
+             \x20\x20\x20\x20source: hosted\n\
+             \x20\x20\x20\x20version: \"4.0.2\"\n\
+             \x20\x20provider:\n\
+             \x20\x20\x20\x20dependency: \"direct main\"\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20name: provider\n\
+             \x20\x20\x20\x20\x20\x20sha256: \"{sha}\"\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://pub.dev\"\n\
+             \x20\x20\x20\x20source: hosted\n\
+             \x20\x20\x20\x20version: \"6.1.1\"\n\
+             \x20\x20shared_preferences:\n\
+             \x20\x20\x20\x20dependency: \"direct main\"\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20name: shared_preferences\n\
+             \x20\x20\x20\x20\x20\x20sha256: \"{sha}\"\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://pub.dev\"\n\
+             \x20\x20\x20\x20source: hosted\n\
+             \x20\x20\x20\x20version: \"2.2.2\"\n\
+             \x20\x20meta:\n\
+             \x20\x20\x20\x20dependency: transitive\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20name: meta\n\
+             \x20\x20\x20\x20\x20\x20sha256: \"{sha}\"\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://pub.dev\"\n\
+             \x20\x20\x20\x20source: hosted\n\
+             \x20\x20\x20\x20version: \"1.10.0\"\n",
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn flutter_app_baseline_emits_lockfile_count_plus_main_module() {
+    // SC-001: 3 direct + 2 transitive + 1 main-module = 6 dart-derived
+    // components in the emitted CDX.
+    let tmp = tempfile::tempdir().unwrap();
+    write_flutter_app_fixture(tmp.path());
+
+    let doc = run_scan(tmp.path());
+    let purls = pub_purls(&doc);
+
+    // 5 lockfile entries + 1 main-module = 6.
+    let dart_purls: Vec<&String> = purls
+        .iter()
+        .filter(|p| p.starts_with("pkg:pub/"))
+        .collect();
+    assert_eq!(
+        dart_purls.len(),
+        6,
+        "expected 6 pkg:pub/* components (5 lockfile entries + 1 main-module), got {dart_purls:#?}"
+    );
+
+    // Each pinned dep emits with the expected PURL.
+    for expected in &[
+        "pkg:pub/http@1.1.0",
+        "pkg:pub/http_parser@4.0.2",
+        "pkg:pub/provider@6.1.1",
+        "pkg:pub/shared_preferences@2.2.2",
+        "pkg:pub/meta@1.10.0",
+        "pkg:pub/my_flutter_app@1.2.3",
+    ] {
+        assert!(
+            purls.contains(&expected.to_string()),
+            "expected PURL {expected} not found; got {purls:#?}"
+        );
+    }
+}
+
+#[test]
+fn main_module_emission() {
+    // SC-008: main-module component carries the expected PURL +
+    // component-role annotation.
+    let tmp = tempfile::tempdir().unwrap();
+    write_flutter_app_fixture(tmp.path());
+
+    let doc = run_scan(tmp.path());
+    let main = component_with_purl(&doc, "pkg:pub/my_flutter_app@1.2.3")
+        .expect("main-module component must exist");
+    assert_eq!(
+        property_value(main, "mikebom:component-role"),
+        Some("main-module"),
+        "main-module must carry the component-role annotation; got {main:#?}",
+    );
+}
+
+#[test]
+fn main_module_depends_lists_direct_deps() {
+    // US1 acceptance scenario 4 + SC-008: dependencies[] entry for
+    // main-module bom-ref targets each direct dep's bom-ref.
+    let tmp = tempfile::tempdir().unwrap();
+    write_flutter_app_fixture(tmp.path());
+
+    let doc = run_scan(tmp.path());
+    let main = component_with_purl(&doc, "pkg:pub/my_flutter_app@1.2.3").unwrap();
+    let main_ref = main
+        .get("bom-ref")
+        .and_then(|v| v.as_str())
+        .expect("main-module must have bom-ref");
+
+    let deps = doc
+        .get("dependencies")
+        .and_then(|v| v.as_array())
+        .expect("dependencies[] block must exist");
+    let main_deps = deps
+        .iter()
+        .find(|d| d.get("ref").and_then(|v| v.as_str()) == Some(main_ref))
+        .and_then(|d| d.get("dependsOn").and_then(|v| v.as_array()))
+        .expect("main-module must have a dependencies entry");
+    let main_dep_refs: Vec<&str> = main_deps
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+
+    // Each of the 3 direct deps' bom-refs MUST appear under main-module's dependsOn.
+    for direct_purl in &[
+        "pkg:pub/http@1.1.0",
+        "pkg:pub/provider@6.1.1",
+        "pkg:pub/shared_preferences@2.2.2",
+    ] {
+        let direct = component_with_purl(&doc, direct_purl)
+            .unwrap_or_else(|| panic!("direct dep {direct_purl} component missing"));
+        let direct_ref = direct.get("bom-ref").and_then(|v| v.as_str()).unwrap();
+        assert!(
+            main_dep_refs.contains(&direct_ref),
+            "main-module dependsOn must include {direct_purl}'s bom-ref {direct_ref}; got {main_dep_refs:?}",
+        );
+    }
+}
+
+#[test]
+fn dev_scope_filterability() {
+    // SC-007: a fixture with a `direct dev` entry produces a component
+    // with `mikebom:lifecycle-scope = development`; running with
+    // `--exclude-scope dev` suppresses it.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("pubspec.yaml"),
+        "name: my_app\nversion: 0.1.0\n\
+         environment:\n  sdk: '>=3.0.0 <4.0.0'\n\
+         dependencies:\n  http: ^1.1.0\n\
+         dev_dependencies:\n  test: ^1.24.0\n",
+    )
+    .unwrap();
+    let sha = "a".repeat(64);
+    std::fs::write(
+        tmp.path().join("pubspec.lock"),
+        format!(
+            "packages:\n\
+             \x20\x20http:\n\
+             \x20\x20\x20\x20dependency: \"direct main\"\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20name: http\n\
+             \x20\x20\x20\x20\x20\x20sha256: \"{sha}\"\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://pub.dev\"\n\
+             \x20\x20\x20\x20source: hosted\n\
+             \x20\x20\x20\x20version: \"1.1.0\"\n\
+             \x20\x20test:\n\
+             \x20\x20\x20\x20dependency: \"direct dev\"\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20name: test\n\
+             \x20\x20\x20\x20\x20\x20sha256: \"{sha}\"\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://pub.dev\"\n\
+             \x20\x20\x20\x20source: hosted\n\
+             \x20\x20\x20\x20version: \"1.24.0\"\n",
+        ),
+    )
+    .unwrap();
+
+    // With dev (default — flag varies; we rely on the default behavior
+    // of `mikebom sbom scan` which includes dev deps unless opted out).
+    let doc_with_dev = run_scan(tmp.path());
+    let test_component = component_with_purl(&doc_with_dev, "pkg:pub/test@1.24.0");
+    assert!(
+        test_component.is_some(),
+        "default scan must include dev-scope `test` component"
+    );
+    if let Some(c) = test_component {
+        // Property may be set via `lifecycle-scope` or `scope` (CDX native).
+        let lifecycle_property = property_value(c, "mikebom:lifecycle-scope");
+        let cdx_scope = c.get("scope").and_then(|v| v.as_str());
+        assert!(
+            lifecycle_property == Some("development")
+                || matches!(cdx_scope, Some("excluded") | Some("optional")),
+            "dev-scope `test` component should carry development indicator; \
+             property={lifecycle_property:?} scope={cdx_scope:?}",
+        );
+    }
+
+    // With --exclude-scope dev: the dev-scope `test` component must not appear.
+    let doc_without_dev = run_scan_with_flags(tmp.path(), &["--exclude-scope", "dev"]);
+    assert!(
+        component_with_purl(&doc_without_dev, "pkg:pub/test@1.24.0").is_none(),
+        "--exclude-scope dev must suppress dev-scope `test` component",
+    );
+    // Runtime dep MUST still appear.
+    assert!(
+        component_with_purl(&doc_without_dev, "pkg:pub/http@1.1.0").is_some(),
+        "--exclude-scope dev must NOT suppress runtime `http` component",
+    );
+}

--- a/mikebom-cli/tests/dart_source_discriminators.rs
+++ b/mikebom-cli/tests/dart_source_discriminators.rs
@@ -1,0 +1,233 @@
+//! Milestone 137 US2 — source-discriminator distinction tests.
+//!
+//! Covers SC-002: a fixture mixing hosted / git / path / sdk + the
+//! self-hosted hosted-source variant. Each entry must emit with the
+//! correct PURL shape per FR-003 + the correct `mikebom:source-type`
+//! annotation value (prefixed `pub-hosted` / `pub-git` / `pub-path` /
+//! `pub-sdk`).
+
+#![cfg(test)]
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_mikebom")
+}
+
+fn run_scan(project_root: &Path) -> Value {
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("out.cdx.json");
+    let result = Command::new(binary_path())
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(project_root)
+        .arg("--no-deep-hash")
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(format!("cyclonedx-json={}", out_path.display()))
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&result.stderr),
+    );
+    let bytes = std::fs::read(&out_path).unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn component_with_purl<'a>(doc: &'a Value, purl: &str) -> Option<&'a Value> {
+    if let Some(c) = doc.get("metadata").and_then(|m| m.get("component")) {
+        if c.get("purl").and_then(|v| v.as_str()) == Some(purl) {
+            return Some(c);
+        }
+    }
+    doc.get("components")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|c| {
+                c.get("purl").and_then(|v| v.as_str()) == Some(purl)
+            })
+        })
+}
+
+fn property_value<'a>(component: &'a Value, name: &str) -> Option<&'a str> {
+    component
+        .get("properties")
+        .and_then(|v| v.as_array())?
+        .iter()
+        .find(|p| p.get("name").and_then(|v| v.as_str()) == Some(name))
+        .and_then(|p| p.get("value").and_then(|v| v.as_str()))
+}
+
+fn write_mixed_fixture(root: &Path) {
+    std::fs::write(
+        root.join("pubspec.yaml"),
+        "name: my_app\nversion: 0.1.0\n\
+         environment:\n  sdk: '>=3.0.0 <4.0.0'\n\
+         dependencies:\n  http: ^1.1.0\n  window_size: any\n  my_local_lib: any\n",
+    )
+    .unwrap();
+    let sha = "a".repeat(64);
+    let resolved = "eb39649a76b87e8451baf75d10ce82ca3a3d5601";
+    std::fs::write(
+        root.join("pubspec.lock"),
+        format!(
+            "packages:\n\
+             \x20\x20http:\n\
+             \x20\x20\x20\x20dependency: \"direct main\"\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20name: http\n\
+             \x20\x20\x20\x20\x20\x20sha256: \"{sha}\"\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://pub.dev\"\n\
+             \x20\x20\x20\x20source: hosted\n\
+             \x20\x20\x20\x20version: \"1.1.0\"\n\
+             \x20\x20window_size:\n\
+             \x20\x20\x20\x20dependency: \"direct main\"\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20path: \"plugins/window_size\"\n\
+             \x20\x20\x20\x20\x20\x20ref: \"master\"\n\
+             \x20\x20\x20\x20\x20\x20resolved-ref: \"{resolved}\"\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://github.com/google/flutter-desktop-embedding.git\"\n\
+             \x20\x20\x20\x20source: git\n\
+             \x20\x20\x20\x20version: \"0.1.0\"\n\
+             \x20\x20my_local_lib:\n\
+             \x20\x20\x20\x20dependency: \"direct main\"\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20path: \"../packages/my_local_lib\"\n\
+             \x20\x20\x20\x20\x20\x20relative: true\n\
+             \x20\x20\x20\x20source: path\n\
+             \x20\x20\x20\x20version: \"0.1.0\"\n\
+             \x20\x20flutter:\n\
+             \x20\x20\x20\x20dependency: \"direct main\"\n\
+             \x20\x20\x20\x20description: flutter\n\
+             \x20\x20\x20\x20source: sdk\n\
+             \x20\x20\x20\x20version: \"0.0.0\"\n\
+             \x20\x20flutter_test:\n\
+             \x20\x20\x20\x20dependency: \"direct dev\"\n\
+             \x20\x20\x20\x20description: flutter\n\
+             \x20\x20\x20\x20source: sdk\n\
+             \x20\x20\x20\x20version: \"0.0.0\"\n",
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn hosted_default_pubdev_emits_bare_purl() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mixed_fixture(tmp.path());
+
+    let doc = run_scan(tmp.path());
+    let http = component_with_purl(&doc, "pkg:pub/http@1.1.0")
+        .expect("hosted-default http must emit as bare PURL");
+    assert_eq!(
+        property_value(http, "mikebom:source-type"),
+        Some("pub-hosted"),
+    );
+}
+
+#[test]
+fn hosted_self_hosted_emits_repository_url_qualifier() {
+    // Standalone fixture with a self-hosted url.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("pubspec.yaml"),
+        "name: my_app\nversion: 0.1.0\n\
+         environment:\n  sdk: '>=3.0.0 <4.0.0'\n\
+         dependencies:\n  internal_lib: ^2.0.0\n",
+    )
+    .unwrap();
+    let sha = "a".repeat(64);
+    std::fs::write(
+        tmp.path().join("pubspec.lock"),
+        format!(
+            "packages:\n\
+             \x20\x20internal_lib:\n\
+             \x20\x20\x20\x20dependency: \"direct main\"\n\
+             \x20\x20\x20\x20description:\n\
+             \x20\x20\x20\x20\x20\x20name: internal_lib\n\
+             \x20\x20\x20\x20\x20\x20sha256: \"{sha}\"\n\
+             \x20\x20\x20\x20\x20\x20url: \"https://pub.acme.example.com\"\n\
+             \x20\x20\x20\x20source: hosted\n\
+             \x20\x20\x20\x20version: \"2.0.0\"\n",
+        ),
+    )
+    .unwrap();
+
+    let doc = run_scan(tmp.path());
+    let expected = "pkg:pub/internal_lib@2.0.0?repository_url=https://pub.acme.example.com";
+    let internal = component_with_purl(&doc, expected)
+        .unwrap_or_else(|| panic!("self-hosted PURL {expected} not found"));
+    assert_eq!(
+        property_value(internal, "mikebom:source-type"),
+        Some("pub-hosted"),
+    );
+}
+
+#[test]
+fn git_source_emits_resolved_sha_plus_vcs_url() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mixed_fixture(tmp.path());
+
+    let doc = run_scan(tmp.path());
+    let expected = "pkg:pub/window_size@eb39649a76b87e8451baf75d10ce82ca3a3d5601?vcs_url=git+https://github.com/google/flutter-desktop-embedding.git#plugins/window_size";
+    let window = component_with_purl(&doc, expected)
+        .unwrap_or_else(|| panic!("git-source PURL {expected} not found"));
+    assert_eq!(
+        property_value(window, "mikebom:source-type"),
+        Some("pub-git"),
+    );
+    assert_eq!(
+        property_value(window, "mikebom:vcs-ref"),
+        Some("master"),
+        "git source must surface the user-supplied ref via mikebom:vcs-ref annotation",
+    );
+}
+
+#[test]
+fn path_source_emits_generic_placeholder() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mixed_fixture(tmp.path());
+
+    let doc = run_scan(tmp.path());
+    let my_local = component_with_purl(&doc, "pkg:generic/my_local_lib@0.1.0")
+        .expect("path-source PURL must use pkg:generic/ placeholder");
+    assert_eq!(
+        property_value(my_local, "mikebom:source-type"),
+        Some("pub-path"),
+    );
+    assert_eq!(
+        property_value(my_local, "mikebom:path"),
+        Some("../packages/my_local_lib"),
+    );
+}
+
+#[test]
+fn sdk_source_emits_zero_zero_zero_version() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mixed_fixture(tmp.path());
+
+    let doc = run_scan(tmp.path());
+    for sdk_purl in &["pkg:pub/flutter@0.0.0", "pkg:pub/flutter_test@0.0.0"] {
+        let c = component_with_purl(&doc, sdk_purl)
+            .unwrap_or_else(|| panic!("SDK pseudo-dep PURL {sdk_purl} not found"));
+        assert_eq!(
+            property_value(c, "mikebom:source-type"),
+            Some("pub-sdk"),
+            "SDK component {sdk_purl} must carry mikebom:source-type=pub-sdk",
+        );
+        assert_eq!(
+            property_value(c, "mikebom:sdk-name"),
+            Some("flutter"),
+            "SDK component {sdk_purl} must carry mikebom:sdk-name=flutter",
+        );
+    }
+}

--- a/specs/137-dart-pub-reader/checklists/requirements.md
+++ b/specs/137-dart-pub-reader/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Dart/Flutter pub ecosystem reader
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs) — spec talks about PURL shape, source-discriminator handling, SDK pseudo-deps; the `Dependencies and Constraints` section references mikebom milestones (architectural deps) which is permitted per the template
+- [X] Focused on user value and business needs — every user story names the operator outcome (Flutter app dev-machine inventory, source-discriminator distinction, library publisher design-tier scan)
+- [X] Written for non-technical stakeholders — terms like `pubspec.lock`, "hosted vs path vs git vs sdk", "SDK pseudo-dep" are explained inline where they appear
+- [X] All mandatory sections completed — User Scenarios, Requirements, Success Criteria all present and substantive
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain — informed defaults documented in Assumptions for: modern Dart 2.0+ scope, lockfile-first design, no live `dart` invocation, `pkg:generic/` placeholder for non-pub sources, license deferral (parallels milestone-135/136 deferrals)
+- [X] Requirements are testable and unambiguous — every FR-001..FR-011 has explicit MUST/MUST NOT semantics and a corresponding SC- gate or acceptance scenario
+- [X] Success criteria are measurable — SC-001..SC-007 are all concretely verifiable (component count match, source-type evidence presence, tier annotation, byte-identity preservation, exit-code-0 on corrupted-input fixture, jq-able PURL filter, dev-scope filterability)
+- [X] Success criteria are technology-agnostic — SC-006 explicitly requires the standard PURL filter to work without Dart-specific consumer code
+- [X] All acceptance scenarios are defined — US1×3, US2×3, US3×2
+- [X] Edge cases are identified — 8 entries (mixed source kinds, self-hosted registry, workspace projects, malformed git deps, pre-2.0 format, malformed lockfile, dev vs regular, empty lockfile)
+- [X] Scope is clearly bounded — explicit Out-of-Scope section listing 7 deferred concerns (live `dart` invocation, pre-2.0 format, package_config.json, constraint resolution, registry auth, future format migrations, license, package_graph.json)
+- [X] Dependencies and assumptions identified — both sections present and concrete
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria — FR-001/FR-006 → US1.3 + SC-004; FR-002/FR-003/FR-004 → US1.1+US1.2 + SC-001; FR-003 source-discrimination clauses → US2.1/2/3 + SC-002; FR-005 → US3 + SC-003; FR-007 → SC-005; FR-008 → SC-007; FR-009 → Edge Case (workspaces); FR-010 → Assumption; FR-011 → US2.3 + SC-002
+- [X] User scenarios cover primary flows — P1 Flutter app baseline, P2 source-discriminator distinction, P3 design-tier library scan; each independently testable per the spec template's MVP-slice discipline
+- [X] Feature meets measurable outcomes defined in Success Criteria — SC-001..SC-007 each tie back to a user story and a functional requirement
+- [X] No implementation details leak into specification — references to mikebom milestones (002, 122) in Dependencies / Assumptions refer to mikebom architectural milestones (template permits this); `serde_yaml` mentioned ONCE in Assumptions as a workspace-dep posture statement, not as an implementation prescription
+
+## Notes
+
+- The `pub` PURL type IS purl-spec-blessed (unlike `brew` in milestone 136 and `yocto` in milestone 128). No follow-up purl-spec extension issue needed.
+- Path-deps and SDK-deps deliberately use `pkg:generic/` placeholders rather than `pkg:pub/` — these don't have pub.dev provenance and emitting them under the pub namespace would be incorrect identity assertion. The `mikebom:source-type` evidence provides the discriminator downstream consumers need.
+- License extraction is deferred (parallels milestone-135 FR-012 URL, milestone-136 FR-011 license deferrals). Tracked as a cross-reader follow-up — extracting license info from `~/.pub-cache/hosted/pub.dev/<pkg>-<ver>/pubspec.yaml` requires walking the pub-cache, which is separate concern from the lockfile parse.
+- US2 has different code path semantics for each source type but doesn't require a separate reader module — all four (hosted/path/git/sdk) discriminate within the same `parse_lockfile_entry` function.
+- US3 (design-tier mode without lockfile) is an additive code path layered on top of US1's lockfile parser; the constraint-string preservation pattern matches the existing milestone-122 Kotlin DSL design-tier emission.

--- a/specs/137-dart-pub-reader/contracts/pub-component-purl.md
+++ b/specs/137-dart-pub-reader/contracts/pub-component-purl.md
@@ -1,0 +1,157 @@
+# Contract — `pkg:pub/*` and `pkg:generic/*` component PURL
+
+The only wire-format contract this feature introduces. Per Constitution Principle V audit (research §R1):
+
+- `pkg:pub/` is **purl-spec-blessed** ([pub-definition.md](https://github.com/package-url/purl-spec/blob/main/types-doc/pub-definition.md)) — used for hosted, git, and sdk source types.
+- `pkg:generic/` is the placeholder for path source type (purl-spec does not define a `pub-path` type).
+- The source-type discriminator surfaces via the existing parity-catalog C1 row (`mikebom:source-type` annotation) — no new C-row added; Dart contributes new VALUES (`pub-hosted` / `pub-git` / `pub-path` / `pub-sdk` / `pub-main-module`) to C1's value set.
+
+## Wire shapes per source
+
+### Hosted (default pub.dev)
+
+```text
+pkg:pub/<package-name>@<version>
+```
+
+### Hosted (self-hosted mirror)
+
+```text
+pkg:pub/<package-name>@<version>?repository_url=<base-url-with-scheme>
+```
+
+### Git
+
+```text
+pkg:pub/<package-name>@<resolved-40-char-sha>?vcs_url=git+<git-remote-url>[#<subpath>]
+```
+
+- `vcs_url` MUST carry the `git+` scheme prefix (cross-type purl-spec convention).
+- `#<subpath>` is the `description.path` from the lockfile when non-trivial (not `.` and not empty).
+
+### Path
+
+```text
+pkg:generic/<package-name>@<version>
+```
+
+(plus `mikebom:source-type = "pub-path"` annotation as discriminator)
+
+### SDK pseudo-deps
+
+```text
+pkg:pub/<sdk-name>@0.0.0
+```
+
+(the `0.0.0` is literal — purl-spec canonical example. Plus `mikebom:source-type = "pub-sdk"` annotation.)
+
+### Main-module (per FR-012)
+
+```text
+pkg:pub/<pubspec.yaml.name>@<pubspec.yaml.version-or-"0.0.0-unknown">
+```
+
+(plus `mikebom:component-role = "main-module"` + `mikebom:source-type = "pub-main-module"` annotations)
+
+## Examples
+
+| Scan input | Emitted PURL |
+|---|---|
+| `pubspec.yaml`: `name: my_flutter_app`, `version: 1.2.3` | `pkg:pub/my_flutter_app@1.2.3` (main-module) |
+| `pubspec.lock`: `http` from `pub.dev`, version `1.1.0` | `pkg:pub/http@1.1.0` |
+| `pubspec.lock`: `internal_lib` from `https://pub.acme.example.com`, version `2.0.0` | `pkg:pub/internal_lib@2.0.0?repository_url=https://pub.acme.example.com` |
+| `pubspec.lock`: `window_size`, git from `github.com/google/flutter-desktop-embedding.git`, `description.path = "plugins/window_size"`, resolved-ref `eb39649...3d5601` | `pkg:pub/window_size@eb39649...3d5601?vcs_url=git+https://github.com/google/flutter-desktop-embedding.git#plugins/window_size` |
+| `pubspec.lock`: `my_local_lib`, path `"../packages/my_local_lib"`, version `0.1.0` | `pkg:generic/my_local_lib@0.1.0` (with `mikebom:source-type = "pub-path"`) |
+| `pubspec.lock`: `flutter`, source sdk, version `"0.0.0"` | `pkg:pub/flutter@0.0.0` (with `mikebom:source-type = "pub-sdk"`) |
+| `pubspec.lock`: `flutter_test`, source sdk, version `"0.0.0"` | `pkg:pub/flutter_test@0.0.0` (with `mikebom:source-type = "pub-sdk"`) |
+
+## Per-format emission
+
+### CycloneDX 1.6
+
+Location: `.components[].purl` (native).
+
+```json
+{
+  "type": "library",
+  "name": "http",
+  "version": "1.1.0",
+  "purl": "pkg:pub/http@1.1.0",
+  "hashes": [
+    {"alg": "SHA-256", "content": "<lowercase-hex-from-lockfile-description.sha256>"}
+  ],
+  "properties": [
+    {"name": "mikebom:source-type", "value": "pub-hosted"},
+    {"name": "mikebom:evidence-kind", "value": "pubspec-lock"},
+    {"name": "mikebom:sbom-tier", "value": "source"}
+  ]
+}
+```
+
+The `mikebom:source-type` / `mikebom:evidence-kind` / `mikebom:sbom-tier` properties are existing per-component annotations (milestones 002 / 004 / 002 respectively). The PURL is the only new wire-format addition.
+
+For casks-style discrimination — git source ALSO includes `mikebom:vcs-ref` (preserves the lockfile's `ref:` field, distinct from `resolved-ref`). Path source includes `mikebom:path` (the relative path string). SDK source includes `mikebom:sdk-name`.
+
+### SPDX 2.3
+
+Location: `.packages[].externalRefs[]` with `referenceCategory: PACKAGE-MANAGER`.
+
+```json
+{
+  "name": "http",
+  "versionInfo": "1.1.0",
+  "externalRefs": [
+    {
+      "referenceCategory": "PACKAGE-MANAGER",
+      "referenceType": "purl",
+      "referenceLocator": "pkg:pub/http@1.1.0"
+    }
+  ],
+  "checksums": [
+    {"algorithm": "SHA256", "checksumValue": "<hex>"}
+  ],
+  "annotations": [
+    { /* mikebom:source-type / evidence-kind / sbom-tier envelopes via existing annotation pattern */ }
+  ]
+}
+```
+
+### SPDX 3.0.1
+
+Location: `software_Package.software_packageUrl` + `Element.externalIdentifier[]`.
+
+```json
+{
+  "type": "software_Package",
+  "spdxId": "...",
+  "name": "http",
+  "software_packageVersion": "1.1.0",
+  "software_packageUrl": "pkg:pub/http@1.1.0",
+  "externalIdentifier": [
+    {
+      "type": "ExternalIdentifier",
+      "externalIdentifierType": "packageUrl",
+      "identifier": "pkg:pub/http@1.1.0"
+    }
+  ]
+}
+```
+
+## Determinism
+
+For a given `pubspec.lock` / `pubspec.yaml`, the emitted PURL set MUST be identical across runs:
+
+- Lockfile entries processed in `BTreeMap` insertion order (lex-sorted by package name — `serde_yaml`'s default).
+- Main-module components processed in walker discovery order (sorted directory entries per `safe_walk` convention from milestone 114).
+
+## Absence semantics
+
+When the scanned root contains no `pubspec.yaml` AND no `pubspec.lock`:
+
+- Zero `pkg:pub/*` and zero `pkg:generic/*` Dart-derived components emit.
+- No warnings fire (per FR-006).
+- SBOM bytes are identical (modulo timestamps + serial numbers) to a pre-feature scan (SC-004 invariant).
+
+## Parity-catalog note
+
+Because the wire-format addition is the native PURL field (not a new `mikebom:*` annotation), no new C-row is added to `docs/reference/sbom-format-mapping.md`. The PURL surfaces via the existing A1 row ("PURL"). The `mikebom:source-type` annotation reuses C1 (introduced in milestone 002 for cargo's path/git/registry discrimination); Dart contributes new VALUES (`pub-hosted` / `pub-git` / `pub-path` / `pub-sdk` / `pub-main-module`) to C1's value set without altering wire shape.

--- a/specs/137-dart-pub-reader/data-model.md
+++ b/specs/137-dart-pub-reader/data-model.md
@@ -1,0 +1,210 @@
+# Data Model — milestone 137
+
+The Dart reader does NOT introduce any new types in `mikebom-common`. Every Dart-derived component flows through the existing `PackageDbEntry` → `ResolvedComponent` pipeline. The new types are reader-private serde-deserializing structs that mirror the subset of `pubspec.yaml` + `pubspec.lock` the reader consumes.
+
+## PubspecYaml (reader-private, manifest)
+
+The manifest parser's per-project intermediate representation. Lives inside `mikebom-cli/src/scan_fs/package_db/dart.rs` only.
+
+```rust
+// Lives in mikebom-cli/src/scan_fs/package_db/dart.rs only.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[allow(dead_code)]
+struct PubspecYaml {
+    /// `name:` — required for any valid pubspec. PURL-segment source.
+    name: String,
+    /// `version:` — optional (libraries-in-development may omit).
+    /// Falls back to `"0.0.0-unknown"` per the cargo (milestone 064)
+    /// main-module convention when absent.
+    #[serde(default)]
+    version: Option<String>,
+    /// `description:` — informational; not consumed for emission.
+    #[serde(default)]
+    description: Option<String>,
+    /// `dependencies:` — declared direct runtime deps (constraint
+    /// strings). Used in design-tier mode (no lockfile) per FR-005.
+    #[serde(default)]
+    dependencies: std::collections::BTreeMap<String, serde_yaml::Value>,
+    /// `dev_dependencies:` — declared dev-only deps. Used in
+    /// design-tier mode + tagged with lifecycle-scope=development
+    /// per FR-005's analysis-clarified behavior.
+    #[serde(default)]
+    dev_dependencies: std::collections::BTreeMap<String, serde_yaml::Value>,
+    /// `dependency_overrides:` — informational v1. The lockfile's
+    /// `direct overridden` entry classification (when present) is the
+    /// authoritative discriminator; pubspec.yaml's override block is
+    /// not separately consumed in design-tier mode.
+    #[serde(default)]
+    dependency_overrides: std::collections::BTreeMap<String, serde_yaml::Value>,
+    /// `environment:` — SDK constraints; informational only (not
+    /// consumed v1).
+    #[serde(default)]
+    environment: Option<serde_yaml::Value>,
+}
+```
+
+### Validation rules
+
+- `name` MUST be non-empty for the project to emit a main-module component.
+- `version` MAY be absent (libraries-in-development); falls back to `"0.0.0-unknown"`.
+- Dep-constraint values (`dependencies[key]`) are heterogeneous YAML scalars or maps (string for simple constraint, map for `path: ...` / `git: ...` / `sdk:` directives). Stored as `serde_yaml::Value` for permissive design-tier extraction; the dep NAME (key) is what matters for the design-tier emission.
+
+## PubspecLock + LockfileEntry (reader-private, lockfile)
+
+```rust
+#[derive(Debug, Clone, serde::Deserialize)]
+#[allow(dead_code)]
+struct PubspecLock {
+    /// `packages:` — every direct + transitive dep keyed by name.
+    #[serde(default)]
+    packages: std::collections::BTreeMap<String, LockfileEntry>,
+    /// `sdks:` — host SDK constraint strings; informational only
+    /// (not consumed v1 per research §R2).
+    #[serde(default)]
+    sdks: Option<serde_yaml::Value>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[allow(dead_code)]
+struct LockfileEntry {
+    /// `dependency:` — required. One of: "direct main" | "direct dev"
+    /// | "transitive" | "direct overridden".
+    dependency: String,
+    /// `description:` — polymorphic per `source:`. String for
+    /// `source: sdk` entries (the SDK name); map for hosted/git/path.
+    /// Use `#[serde(untagged)]` to handle both shapes.
+    description: LockfileDescription,
+    /// `source:` — discriminator. Required. One of: hosted | git |
+    /// path | sdk.
+    source: String,
+    /// `version:` — required. For hosted: upstream version string.
+    /// For git: typically `"0.0.0"` or upstream-recorded version.
+    /// For path: the local package's declared version. For sdk:
+    /// always literal `"0.0.0"` per pub convention.
+    version: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(untagged)]
+#[allow(dead_code)]
+enum LockfileDescription {
+    /// `source: sdk` entries — `description: flutter` (bare scalar).
+    /// The scalar IS the SDK name.
+    Sdk(String),
+    /// All other source types — a map of source-specific fields.
+    Map(LockfileDescriptionMap),
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[allow(dead_code)]
+struct LockfileDescriptionMap {
+    /// hosted: package name (typically matches top-level key but
+    /// preserved for safety). git: not present.
+    /// path: not present.
+    #[serde(default)]
+    name: Option<String>,
+    /// hosted: download SHA-256 (lowercase hex, no prefix).
+    /// Universally present for Dart 2.19+ lockfiles per research §R2.
+    #[serde(default)]
+    sha256: Option<String>,
+    /// hosted: bare base URL with scheme (e.g., "https://pub.dev").
+    /// git: git remote URL.
+    #[serde(default)]
+    url: Option<String>,
+    /// git: user-supplied ref (branch name, tag, or "HEAD").
+    #[serde(default)]
+    ref_: Option<String>,
+    /// git: resolved 40-char SHA. Required for git PURL construction.
+    #[serde(default, rename = "resolved-ref")]
+    resolved_ref: Option<String>,
+    /// git: subdirectory inside the repo where the package lives.
+    /// "." when at repo root; always present for git source.
+    /// path: filesystem path (relative if `relative: true`).
+    #[serde(default)]
+    path: Option<String>,
+    /// path: whether `path` is workspace-relative.
+    #[serde(default)]
+    relative: Option<bool>,
+}
+```
+
+### Validation rules
+
+- `dependency` MUST be one of the four documented values; unknown values trigger warn-and-skip per FR-007.
+- `source` MUST be one of `hosted` / `git` / `path` / `sdk`; unknown values trigger warn-and-skip per research §R7.
+- For `source: hosted`, `description.url` defaults to `"https://pub.dev"` if absent (matches pub's own fallback).
+- For `source: git`, `description.resolved-ref` MUST be present + 40 hex chars; absent triggers warn-and-skip per spec Edge Cases ("Git deps without a resolved SHA").
+- For `source: sdk`, `description` is a bare string; the parser must NOT fail when it's not a map. The `version` field is always literal `"0.0.0"` per purl-spec example (preserved verbatim).
+
+## PackageDbEntry field mapping (per source type)
+
+### Common fields (all source types)
+
+| Field | Source | Notes |
+|---|---|---|
+| `name` | Lockfile entry's top-level key (== `description.name` for hosted) | Verbatim |
+| `version` | `LockfileEntry.version` | Verbatim per source-type semantics |
+| `arch` | `None` | Dart components are architecture-independent at the lockfile layer |
+| `source_path` | Absolute path to the owning `pubspec.lock` (or `pubspec.yaml` for design-tier) | Drives `ResolutionEvidence.source_file_paths` |
+| `maintainer` | `None` | Not in lockfile |
+| `lifecycle_scope` | `Runtime` for `direct main` / `transitive` / `direct overridden`; `Development` for `direct dev` | Per FR-008 |
+| `requirement_range` | `None` for lockfile entries; `Some(constraint-string)` for design-tier per FR-005 | |
+| `evidence_kind` | `Some("pubspec-lock")` for lockfile-derived; `Some("pubspec-yaml")` for design-tier | NEW values added to cyclonedx/builder.rs enum |
+| `sbom_tier` | `Some("source")` for lockfile-derived; `Some("design")` for design-tier (FR-005) | |
+| `binary_class` / `binary_stripped` / `linkage_kind` / `detected_go` / `confidence` / `binary_packed` | `None` | N/A for source-tree language reader |
+| `raw_version` | `None` | |
+| `parent_purl` | `None` | Top-level (lockfile entries are flat) |
+| `npm_role` | `None` | N/A |
+| `co_owned_by` | `None` | N/A |
+| `shade_relocation` | `None` | N/A |
+| `binary_role` | `None` | N/A |
+| `build_inclusion` | `None` | N/A |
+| `licenses` | `Vec::new()` | License NOT in lockfile per spec Out-of-Scope (mirrors milestone-135 FR-012 + milestone-136 FR-011 deferrals) |
+| `extra_annotations` | Source-type discriminator (see per-source-type rows) | See below |
+
+### Per-source-type fields
+
+| Source | `purl` | `source_type` (in `PackageDbEntry.source_type`) | `extra_annotations` extras | `hashes` |
+|---|---|---|---|---|
+| **hosted** | `pkg:pub/<name>@<version>[?repository_url=<url>]` (qualifier omitted when url is `pub.dev` or `pub.dartlang.org`) | `Some("pub-hosted")` | `mikebom:source-type = "pub-hosted"` | When `description.sha256` present: `vec![ContentHash::sha256(<hex>)]`; else empty |
+| **git** | `pkg:pub/<name>@<resolved-sha>?vcs_url=git+<url>[#<subpath>]` (subpath omitted when path is `"."` or empty) | `Some("pub-git")` | `mikebom:source-type = "pub-git"`; `mikebom:vcs-ref = "<user-ref>"` (preserves the `ref:` field for evidence) | Empty (git source has no download hash) |
+| **path** | `pkg:generic/<name>@<version>` (placeholder per R1) | `Some("pub-path")` | `mikebom:source-type = "pub-path"`; `mikebom:path = "<lockfile-relative-path>"` | Empty |
+| **sdk** | `pkg:pub/<sdk-name>@0.0.0` (purl-spec canonical example) | `Some("pub-sdk")` | `mikebom:source-type = "pub-sdk"`; `mikebom:sdk-name = "<sdk>"` (the SDK family — `flutter`, `dart`, etc.) | Empty |
+
+### Main-module field mapping (per FR-012)
+
+For each scanned `pubspec.yaml`, one additional `PackageDbEntry` emits with:
+
+| Field | Value |
+|---|---|
+| `purl` | `pkg:pub/<pubspec.yaml.name>@<pubspec.yaml.version-or-"0.0.0-unknown">` |
+| `name` | `pubspec.yaml.name` |
+| `version` | `pubspec.yaml.version` (or `"0.0.0-unknown"` fallback) |
+| `source_path` | Absolute path to `pubspec.yaml` |
+| `evidence_kind` | `Some("pubspec-yaml")` |
+| `sbom_tier` | `Some("source")` |
+| `source_type` | `Some("pub-main-module")` |
+| `extra_annotations` | `mikebom:component-role = "main-module"` + `mikebom:source-type = "pub-main-module"` |
+| `depends` | Names of direct deps from the project's lockfile (or pubspec.yaml `dependencies:` + `dev_dependencies:` in design-tier mode) |
+
+### Dep edges
+
+- **Lockfile mode**: each `LockfileEntry`'s dependencies come from the lockfile's per-entry `dependencies:` sub-array (not modeled in the struct above for v1 — extracted via post-parse pass through the raw `serde_yaml::Value` map). When absent in v1's typed parse, dep edges are derived from the project main-module → lockfile entries where `dependency == "direct main" | "direct dev" | "direct overridden"`. Transitive edges deferred to v1.1.
+- **Design-tier mode**: main-module → each top-level key in `dependencies:` + `dev_dependencies:`. No transitive edges (no lockfile available).
+
+## Validation invariants (per spec FR-* + Constitution)
+
+- `purl.as_str().starts_with("pkg:pub/")` OR `purl.as_str().starts_with("pkg:generic/")` for every emitted Dart entry.
+- `source_type` value MUST be one of `pub-hosted` / `pub-git` / `pub-path` / `pub-sdk` / `pub-main-module`.
+- `evidence_kind` MUST be one of `pubspec-lock` / `pubspec-yaml` (the cyclonedx/builder.rs enum extension).
+- For SDK entries: `purl.as_str().ends_with("@0.0.0")` (literal placeholder per purl-spec).
+- For git entries: `purl.as_str().contains("?vcs_url=git+")`.
+
+## Out-of-scope data shapes
+
+- License extraction from `~/.pub-cache/hosted/pub.dev/<pkg>-<ver>/pubspec.yaml` (cross-reader follow-up; mirrors milestone-135 FR-012 + milestone-136 FR-011 deferrals).
+- Per-package homepage / VCS URL from the upstream `pubspec.yaml` (same deferral).
+- Pre-Dart-2.0 lockfile format (rare in 2026; explicitly out of spec scope).
+- `.dart_tool/package_config.json` parsing (file-claim follow-up).
+- Transitive dep edges from individual lockfile entries' `dependencies:` arrays — v1 emits main-module → direct deps only; transitive components surface but their inter-edges are deferred to v1.1.
+- pub-workspace single-lockfile per-member attribution (operators in pub-workspace mode see unified view in v1).

--- a/specs/137-dart-pub-reader/plan.md
+++ b/specs/137-dart-pub-reader/plan.md
@@ -1,0 +1,116 @@
+# Implementation Plan: Dart/Flutter pub ecosystem reader
+
+**Branch**: `137-dart-pub-reader` | **Date**: 2026-06-23 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/137-dart-pub-reader/spec.md`
+
+## Summary
+
+First **language-ecosystem reader** added to mikebom since milestone 122 (Kotlin DSL) — joins cargo, npm, pip, gem, maven, golang, nuget, swift, kotlin, conan, vcpkg, bazel, cmake in the language-reader family. Parses Dart's `pubspec.lock` (YAML) and `pubspec.yaml` (for design-tier scans without a lockfile); emits one main-module component per `pubspec.yaml` (`name:` + `version:` → `pkg:pub/<name>@<version>` per the milestone-064 cargo precedent confirmed in Clarifications Q1+Q2) plus one component per lockfile entry. Source-discriminator handling per FR-003 — hosted gets `pkg:pub/...?repository_url=`, git gets `pkg:pub/...@<sha>?vcs_url=git+...`, path falls back to `pkg:generic/` placeholder, sdk emits as `pkg:pub/<sdk>@0.0.0` per purl-spec canonical example. Direct-dev deps tagged with `mikebom:lifecycle-scope = "development"` per existing language-reader precedent. Integrates into the existing `read_all` dispatcher; `serde_yaml = "0.9"` is already a workspace dep (per `npm/yarn_lock.rs` + `npm/pnpm_lock.rs`); zero new Cargo dependencies.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–136; no nightly required for this user-space-only work).
+
+**Primary Dependencies**: Existing only — `serde`/`serde_yaml = "0.9"` (workspace; already used by `npm/yarn_lock.rs` + `npm/pnpm_lock.rs`), `serde_json` for evidence-annotation construction, `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror` (error propagation), `mikebom_common::types::purl::Purl` (PURL construction + validation; the `pub` type is purl-spec-blessed). **No new Cargo dependencies.**
+
+**Storage**: N/A — all state is in-process for the duration of a single scan. Mirrors every language-reader since milestone 002.
+
+**Testing**: `cargo +stable test --workspace`. Synthetic-fixture pattern via `tempfile::tempdir()` constructing minimal `pubspec.yaml` + `pubspec.lock` trees. Four new integration test files at `mikebom-cli/tests/dart_*.rs` mirroring the milestone-135/136 OS-reader test families. SC-004 byte-identity preservation guarded by the existing 11-ecosystem golden suite (no Dart project present → those goldens stay unchanged).
+
+**Target Platform**: Cross-platform reader. Same cargo/maven/npm precedent applies — mikebom's host portability is independent of the scanned target's OS. The reader is pure-Rust YAML parsing.
+
+**Project Type**: CLI tool — extends the `mikebom sbom scan` pipeline via the `read_all` dispatcher.
+
+**Performance Goals**: ≤2 ms overhead per lockfile entry on the read path; ≤300 ms for a heavy Flutter app (~150 deps in a typical Material-Design Flutter project). The no-Dart-detected fast path (walker doesn't find any `pubspec.yaml` or `pubspec.lock`) MUST add ≤5 µs per non-Dart scan.
+
+**Constraints**:
+- Byte-identical SBOM goldens when no Dart project present (SC-004).
+- Zero new Cargo deps (matches the milestone-002/064/066/068/069/070/135/136 OS-and-language-reader posture).
+- Per-lockfile YAML parse failures MUST warn-and-skip, not fail the scan (FR-007).
+- The `pub` PURL type IS purl-spec-blessed — no informal-type follow-up needed (unlike `brew` in milestone 136 and `yocto` in milestone 128).
+- Workspace structure NOT represented in SBOM — one main-module per `pubspec.yaml`, no synthetic workspace-root (per Clarifications Q2).
+
+**Scale/Scope**: Typical Flutter app: 30–80 direct + transitive deps. Heavy app (Material gallery): ~200. Monorepo with 5 members × 50 deps each: ~250 components total. Per-lockfile YAML parse: ~500 µs warm-cache.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Verdict | Justification |
+|---|---|---|
+| I. Pure Rust, Zero C | ✓ | All new code is user-space Rust; no FFI, no C. YAML parsing via `serde_yaml` (pure-Rust crate already in the workspace per `npm/yarn_lock.rs` precedent). |
+| II. eBPF-Only Observation | N/A | This reader processes manifest/lockfile metadata for components ALREADY declared in source-tree files; no new dependency-discovery surface. Matches every language reader (cargo/npm/pip/gem/maven/golang/etc.) — language readers parse source-tree manifests, OS readers parse system-DB files; both are pre-existing "discovery surface" categories. |
+| III. Fail Closed | ✓ | A source tree without `pubspec.yaml` AND without `pubspec.lock` is a clean no-op (FR-006), NOT a fail-closed condition. Per-lockfile parse failures warn-and-skip (FR-007). |
+| IV. Type-Driven Correctness | ✓ | Uses the existing `Purl` newtype for PURL construction; no stringly-typed identifiers. `description:` field is polymorphic (string for sdk, map for others) — handled via `#[serde(untagged)]` enum in `LockfileDescription`. Production code MUST NOT call `.unwrap()` — error propagation via `Result`. |
+| V. Specification Compliance | ✓ | **`pub` IS a purl-spec-defined type** ([purl-spec PURL-TYPES.rst pub-definition.md](https://github.com/package-url/purl-spec/blob/main/types-doc/pub-definition.md)). Path-sourced placeholder uses `pkg:generic/` (well-defined purl-spec type) with `mikebom:source-type = "path"` annotation as the discriminator — the annotation is a PARITY-BRIDGE per Principle V (path identity has no standards-native type-name; `pkg:generic/` + annotation surfaces what the standard doesn't express). The `mikebom:source-type` reuses the existing C1 parity-catalog row (introduced in milestone 002); no new C-row added. Documented in research §R1. |
+| VI. Three-Crate Architecture | ✓ | All new code lives in `mikebom-cli`. No new workspace crate. Reader is a peer of `cargo.rs` / `gem.rs` / `maven.rs` / `golang.rs` under `mikebom-cli/src/scan_fs/package_db/`. |
+| VII. Test Isolation | ✓ | Synthetic tempfile fixtures only; no host-state dependency. Pure-Rust YAML parsing — runs on any host. |
+| VIII. Completeness | ✓ | This feature IS a completeness improvement — eliminates the false-negative gap where every Dart/Flutter dep was invisible to the scan. Mobile + cross-platform projects gain SBOM coverage. |
+| IX. Accuracy | ✓ | PURL identity comes directly from the on-disk lockfile / manifest; no heuristic guesses. Dep-name extraction uses the lockfile's `dependencies:` array verbatim. SDK pseudo-deps emit with the purl-spec-blessed `0.0.0` placeholder — explicit per purl-spec example, not a heuristic guess. |
+| X. Transparency | ✓ | Per-lockfile parse failures (FR-007) emit `tracing::warn!` with the affected lockfile path. Source-type discriminator surfaces via the standard `mikebom:source-type` evidence property — operators see exactly what discrimination class each dep falls into. No silent drops. |
+| XII. External Data Source Enrichment | ✓ | The lockfile + manifest ARE the discovery sources — same posture as cargo/npm/pip/gem/maven. No external enrichment in this feature (license extraction explicitly out of scope per spec). |
+
+**Verdict: PASS.** No violations, no justifications required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/137-dart-pub-reader/
+├── plan.md              # This file
+├── spec.md              # Feature spec (already written; corrected post-Phase-0)
+├── research.md          # Phase 0 output — Principle V audit + pubspec.lock schema + purl-spec pub canonical form
+├── data-model.md        # Phase 1 output — PubspecLock + LockfileEntry + PackageDbEntry field mapping
+├── quickstart.md        # Phase 1 output — operator-facing walkthrough
+├── contracts/           # Phase 1 output — wire-format contracts
+│   └── pub-component-purl.md
+├── checklists/
+│   └── requirements.md  # Spec-quality checklist (already written)
+└── tasks.md             # Phase 2 output (via /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/src/
+├── scan_fs/
+│   ├── package_db/
+│   │   ├── mod.rs                     # MODIFY: register dart in read_all dispatcher
+│   │   │                              # (language-reader pattern; no claim_paths)
+│   │   ├── dart.rs                    # NEW: pubspec.yaml + pubspec.lock parsing,
+│   │   │                              # main-module emission, source-type
+│   │   │                              # discrimination, design-tier fallback
+│   │   ├── cargo.rs                   # REFERENCE: milestone 064 main-module + workspace pattern
+│   │   ├── npm/yarn_lock.rs           # REFERENCE: serde_yaml YAML lockfile parsing precedent
+│   │   ├── npm/pnpm_lock.rs           # REFERENCE: same
+│   │   └── maven.rs                   # REFERENCE: language-reader source-tree walk pattern
+│   └── (no other scan_fs changes — dart is purely additive)
+├── generate/cyclonedx/builder.rs       # MODIFY: extend mikebom:evidence-kind enum to
+│                                       # include "pubspec-lock" + "pubspec-yaml"
+│                                       # (mirrors milestone-135 T002b + 136 T002b pattern)
+└── (no changes to other generate/, parity/, common/)
+
+mikebom-cli/tests/
+├── dart_flutter_app_baseline.rs       # NEW: US1 — pubspec.yaml + pubspec.lock fixture
+├── dart_source_discriminators.rs      # NEW: US2 — hosted + git + path + sdk fixture
+├── dart_design_tier.rs                # NEW: US3 — pubspec.yaml only (no lockfile)
+└── dart_edge_cases.rs                 # NEW: malformed lockfile + workspace + dev-deps +
+                                       # SDK 0.0.0 + self-hosted registry
+
+docs/reference/
+└── (no changes — pkg:pub is purl-spec-blessed; no new mikebom:* annotation introduced for
+   identity. The `mikebom:source-type` annotation reuses existing C1 row per parity catalog;
+   dart components contribute new VALUES (`pub-hosted`/`pub-git`/`pub-path`/`pub-sdk`) to
+   that row's value set but do not alter wire shape.)
+```
+
+**Structure Decision**: Extends the existing `mikebom-cli/src/scan_fs/package_db/` reader family with a new language-ecosystem reader. New file `dart.rs` is a peer of cargo/npm/pip/gem/maven/golang/nuget/swift/kotlin/conan/vcpkg/bazel/cmake. Integration site is the existing `read_all` dispatcher; no file-claim tracker integration (language readers don't claim binary paths). Test files follow the existing `<reader>_<scenario>.rs` integration-test naming convention. **No new workspace crate per Principle VI; no new Cargo deps; no new annotation in the parity catalog for identity (source-type discriminator reuses existing C1 row).**
+
+## Complexity Tracking
+
+> No Constitution Check violations — no justifications required.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none)    | n/a        | n/a                                  |

--- a/specs/137-dart-pub-reader/quickstart.md
+++ b/specs/137-dart-pub-reader/quickstart.md
@@ -1,0 +1,249 @@
+# Quickstart — milestone 137 Dart/Flutter pub reader
+
+Operator-facing walkthrough of the scenarios this milestone surfaces.
+
+## Scenario 1 — Scan a Flutter app project (US1 / SC-001)
+
+A mobile developer's Flutter app source tree with `pubspec.yaml` + `pubspec.lock`:
+
+```bash
+mikebom --offline sbom scan --path . --output /tmp/app.cdx.json
+```
+
+Inspect main-module + deps:
+
+```bash
+# Main-module (the app itself):
+jq '.metadata.component' /tmp/app.cdx.json
+# {"bom-ref": "pkg:pub/my_flutter_app@1.2.3",
+#  "name": "my_flutter_app", "version": "1.2.3",
+#  "purl": "pkg:pub/my_flutter_app@1.2.3", ...
+#  "properties": [
+#    {"name": "mikebom:component-role", "value": "main-module"},
+#    {"name": "mikebom:source-type", "value": "pub-main-module"}
+#  ]}
+
+# Direct + transitive deps:
+jq '.components[] | select(.purl | startswith("pkg:pub/")) | .purl' /tmp/app.cdx.json | sort | head -10
+# "pkg:pub/async@2.11.0"
+# "pkg:pub/collection@1.18.0"
+# "pkg:pub/http@1.1.0"
+# "pkg:pub/http_parser@4.0.2"
+# "pkg:pub/meta@1.10.0"
+# "pkg:pub/provider@6.1.1"
+# "pkg:pub/shared_preferences@2.2.2"
+# ...
+```
+
+Count check against `dart pub deps`:
+
+```bash
+dart pub deps --json | jq '[.packages[] | select(.kind != "root")] | length'
+# 47
+
+jq '[.components[] | select(.purl | startswith("pkg:pub/")) | select(.properties[]? | .name == "mikebom:source-type" and .value != "pub-main-module")] | length' /tmp/app.cdx.json
+# 47  ✓
+```
+
+## Scenario 2 — Source discriminator distinction (US2 / SC-002)
+
+A Flutter app whose lockfile mixes hosted + git + path + sdk:
+
+```bash
+mikebom --offline sbom scan --path . --output /tmp/mixed.cdx.json
+```
+
+Filter by source type:
+
+```bash
+# Hosted deps only:
+jq '.components[] | select(.properties[]? | .name == "mikebom:source-type" and .value == "pub-hosted") | .purl' /tmp/mixed.cdx.json
+# "pkg:pub/http@1.1.0"
+# "pkg:pub/provider@6.1.1"
+
+# Git deps only:
+jq '.components[] | select(.properties[]? | .name == "mikebom:source-type" and .value == "pub-git") | .purl' /tmp/mixed.cdx.json
+# "pkg:pub/window_size@eb39649...3d5601?vcs_url=git+https://github.com/google/flutter-desktop-embedding.git#plugins/window_size"
+
+# Path deps (operator's monorepo-local libs):
+jq '.components[] | select(.properties[]? | .name == "mikebom:source-type" and .value == "pub-path") | .purl' /tmp/mixed.cdx.json
+# "pkg:generic/my_local_lib@0.1.0"
+
+# SDK pseudo-deps (Flutter framework + tooling):
+jq '.components[] | select(.properties[]? | .name == "mikebom:source-type" and .value == "pub-sdk") | .purl' /tmp/mixed.cdx.json
+# "pkg:pub/flutter@0.0.0"
+# "pkg:pub/flutter_test@0.0.0"
+```
+
+## Scenario 3 — Self-hosted pub registry
+
+A project pulling from a private pub mirror at `https://pub.acme.example.com`:
+
+```bash
+jq '.components[] | select(.purl | contains("repository_url=")) | .purl' /tmp/private.cdx.json
+# "pkg:pub/internal_widget@2.0.0?repository_url=https://pub.acme.example.com"
+```
+
+Default-tap deps (from `pub.dev`) MUST NOT carry the qualifier:
+
+```bash
+jq '.components[] | select(.purl | startswith("pkg:pub/http@")) | .purl' /tmp/private.cdx.json
+# "pkg:pub/http@1.1.0"     ← no ?repository_url= qualifier
+```
+
+## Scenario 4 — Library project, design-tier mode (US3 / SC-003)
+
+A Dart library with `pubspec.yaml` but no `pubspec.lock`:
+
+```bash
+mikebom --offline sbom scan --path . --output /tmp/lib.cdx.json
+
+# Components are design-tier (constraint preserved, not pinned):
+jq '.components[] | {name, purl, props: .properties}' /tmp/lib.cdx.json | head -30
+# {
+#   "name": "http",
+#   "purl": "pkg:pub/http@^1.0.0",                ← constraint not pinned
+#   "props": [
+#     {"name": "mikebom:sbom-tier", "value": "design"},
+#     {"name": "mikebom:requirement-range", "value": "^1.0.0"},
+#     {"name": "mikebom:evidence-kind", "value": "pubspec-yaml"},
+#     {"name": "mikebom:source-type", "value": "pub-hosted"}
+#   ]
+# }
+```
+
+Dev deps tagged with lifecycle-scope (US3 acceptance scenario 3):
+
+```bash
+jq '.components[] | select(.properties[]? | .name == "mikebom:lifecycle-scope" and .value == "development") | .name' /tmp/lib.cdx.json
+# "test"
+# "build_runner"
+# "lints"
+```
+
+`--include-dev=off` filtering works:
+
+```bash
+mikebom --offline sbom scan --path . --no-include-dev --output /tmp/lib-prod.cdx.json
+jq '.components[] | select(.properties[]? | .name == "mikebom:lifecycle-scope" and .value == "development")' /tmp/lib-prod.cdx.json
+# (empty — dev deps filtered)
+```
+
+## Scenario 5 — Workspace / monorepo (FR-009)
+
+A Melos monorepo with multiple packages, each with its own `pubspec.yaml`:
+
+```text
+my_workspace/
+├── packages/
+│   ├── app/pubspec.yaml + pubspec.lock
+│   ├── lib_a/pubspec.yaml + pubspec.lock
+│   └── lib_b/pubspec.yaml + pubspec.lock
+└── melos.yaml
+```
+
+```bash
+mikebom --offline sbom scan --path my_workspace --output /tmp/workspace.cdx.json
+
+# One main-module per pubspec.yaml — workspace structure is invisible:
+jq '.components[] | select(.properties[]? | .name == "mikebom:component-role" and .value == "main-module") | .purl' /tmp/workspace.cdx.json
+# "pkg:pub/app@1.0.0"
+# "pkg:pub/lib_a@0.5.0"
+# "pkg:pub/lib_b@0.3.0"
+```
+
+No synthetic workspace-root component emits (per Clarifications Q2). Same-PURL deps across the three lockfiles collapse via standard dedup.
+
+## Scenario 6 — No-op on non-Dart rootfs (SC-004 regression invariant)
+
+A pure Linux server rootfs (no `pubspec.yaml`, no `pubspec.lock`):
+
+```bash
+mikebom --offline sbom scan --path /mnt/server-rootfs --output /tmp/server.cdx.json 2>/tmp/scan.log
+
+jq '[.components[] | select(.purl | startswith("pkg:pub/") or startswith("pkg:generic/"))] | length' /tmp/server.cdx.json
+# (matches pre-feature baseline — Dart contributes zero)
+
+grep -c 'dart\|pubspec' /tmp/scan.log
+# 0
+```
+
+SBOM bytes are identical (modulo timestamps + serial numbers) to a pre-milestone-137 baseline for the same rootfs.
+
+## Scenario 7 — Malformed lockfile graceful degradation (SC-005)
+
+A monorepo where one `pubspec.lock` has corrupted YAML alongside three valid project subdirs:
+
+```bash
+mikebom --offline sbom scan --path /tmp/corrupted-dart --output /tmp/corrupted.cdx.json 2>/tmp/scan.log
+
+# Scan exit code:
+echo $?
+# 0  (scan succeeded — partial output preserved)
+
+# Components from the three valid projects emit:
+jq '[.components[] | select(.purl | startswith("pkg:pub/"))] | length' /tmp/corrupted.cdx.json
+# (sum of three valid projects' deps)
+
+# Warn for the broken lockfile:
+grep 'dart:.*parse failed\|pubspec' /tmp/scan.log
+# WARN mikebom::scan_fs::package_db::dart: dart: failed to parse pubspec.lock, falling back to design-tier from pubspec.yaml path=/tmp/corrupted-dart/broken/pubspec.lock
+```
+
+## Verification commands
+
+End-to-end SC validations:
+
+```bash
+# SC-001 — Flutter app baseline + dep edges
+cargo test -p mikebom --test dart_flutter_app_baseline
+
+# SC-002 — Source discriminator distinction
+cargo test -p mikebom --test dart_source_discriminators
+
+# SC-003 — Design-tier emission (no lockfile)
+cargo test -p mikebom --test dart_design_tier
+
+# SC-004 — Non-Dart byte-identity invariant
+cargo test -p mikebom --test cdx_regression --test spdx_regression --test spdx3_regression
+
+# SC-005 — Malformed-lockfile graceful degradation
+cargo test -p mikebom --test dart_edge_cases -- malformed_lockfile
+
+# SC-006 — Standard PURL filter usability
+mikebom --offline sbom scan --path <project> --format cyclonedx-json --output /tmp/out.cdx.json
+jq '.components[] | select(.purl | startswith("pkg:pub/"))' /tmp/out.cdx.json
+
+# SC-007 — Dev-scope filterability
+cargo test -p mikebom --test dart_flutter_app_baseline -- dev_scope
+
+# SC-008 — Main-module emission
+cargo test -p mikebom --test dart_flutter_app_baseline -- main_module
+```
+
+## Cross-format byte-equivalence check
+
+Same scan, all three formats — Dart components must agree:
+
+```bash
+mikebom --offline sbom scan --path my_flutter_app \
+  --format cyclonedx-json --format spdx-2.3-json --format spdx-3-json \
+  --output cyclonedx-json=/tmp/dart.cdx.json \
+  --output spdx-2.3-json=/tmp/dart.spdx.json \
+  --output spdx-3-json=/tmp/dart.spdx3.json
+
+jq '[.components[] | select(.purl | startswith("pkg:pub/")) | .purl] | sort' /tmp/dart.cdx.json > /tmp/cdx-pub.txt
+jq '[.packages[].externalRefs[]? | select(.referenceType == "purl") | .referenceLocator | select(startswith("pkg:pub/"))] | sort' /tmp/dart.spdx.json > /tmp/spdx-pub.txt
+jq '[.["@graph"][] | select(.software_packageUrl? | tostring | startswith("pkg:pub/")) | .software_packageUrl] | sort' /tmp/dart.spdx3.json > /tmp/spdx3-pub.txt
+
+diff /tmp/cdx-pub.txt /tmp/spdx-pub.txt
+diff /tmp/cdx-pub.txt /tmp/spdx3-pub.txt
+# (no output = success)
+```
+
+## Known deferrals (documented in spec Out-of-Scope)
+
+- **License emission**: `pubspec.lock` carries no license; extracting requires reading per-package `~/.pub-cache/hosted/pub.dev/<pkg>-<ver>/pubspec.yaml`. Cross-reader follow-up (parallels milestone-135 FR-012 + milestone-136 FR-011 deferrals).
+- **Transitive dep edges**: v1 emits main-module → direct deps; transitive components surface but their inter-edges are deferred to v1.1.
+- **`.dart_tool/package_config.json`** integration: lockfile-first design for v1; file-claim wiring is a separate spec.
+- **Pre-Dart-2.0 lockfile format**: deferred indefinitely (rare in 2026).

--- a/specs/137-dart-pub-reader/research.md
+++ b/specs/137-dart-pub-reader/research.md
@@ -1,0 +1,214 @@
+# Research — milestone 137 Dart/Flutter pub reader
+
+Resolves the Phase 0 open items from `plan.md`'s Technical Context: Constitution Principle V audit, on-disk `pubspec.lock` schema, purl-spec `pub` canonical form, integration site within `read_all`, the language-reader pattern selection, and per-source error posture.
+
+## R1: Constitution Principle V audit — `pub` PURL type is purl-spec-blessed
+
+**Decision**: Emit `pkg:pub/<name>@<version>` per [purl-spec PURL-TYPES.rst `pub-definition.md`](https://github.com/package-url/purl-spec/blob/main/types-doc/pub-definition.md). No `mikebom:*` annotation introduced for identity. Source-discriminator surfaces via the existing `mikebom:source-type` annotation (parity-catalog C1, introduced in milestone 002) — same wire shape as cargo's `path` / `git` / `registry` discrimination.
+
+**Rationale**:
+
+The purl-spec defines `pub` explicitly:
+
+- **Namespace**: prohibited (no `pkg:pub/<vendor>/<name>` form).
+- **Default repository URL**: `https://pub.dartlang.org` (legacy; `pub.dev` redirects).
+- **Name normalization**: lowercase-snake-case enforced by pub.dev's publishing rules; canonical form is no-op for any modern package.
+- **Canonical example**: `pkg:pub/characters@1.2.0` AND `pkg:pub/flutter@0.0.0` (the spec explicitly blesses the `0.0.0` placeholder for Flutter SDK pseudo-deps).
+
+This is fundamentally different from milestone 136's `brew` situation — `pub` is upstream-blessed, no follow-up purl-spec extension needed.
+
+**Source-discriminator handling**:
+
+For hosted / git / sdk: emit under `pkg:pub/` per spec. The `mikebom:source-type` annotation reuses the existing C1 parity-catalog row (milestone 002 introduced it for cargo's path/git/registry discrimination). Dart contributes new VALUES to that row's value set (`pub-hosted`, `pub-git`, `pub-sdk`) but does NOT alter wire shape — same as how cargo, npm, pip etc. already populate it.
+
+For path-sourced deps: the purl-spec doesn't define an addressable PURL for filesystem-local packages (path identity has no globally-unique resolvable form). The reader emits `pkg:generic/<name>@<version>` as a placeholder + `mikebom:source-type = "pub-path"` annotation as the discriminator. This is a **parity-bridge** per Principle V's escape clause (annotation surfaces information the standard doesn't express). No new C-row in the parity catalog because the annotation reuses C1.
+
+**Alternatives considered**:
+
+- **`pkg:pub/<name>?host=<bare-hostname>` for self-hosted**. Rejected: purl-spec uses `repository_url=` as the cross-type qualifier name (with full scheme), not `host=`. Wrong qualifier name vs spec authority.
+- **Skip path deps entirely**. Rejected: they're real source-tree deps the operator's project relies on. Surfacing them with an annotated placeholder is more transparent than silently dropping.
+- **Custom `pkg:pub-path/` informal type**. Rejected: violates Principle V (don't invent type-names; the `pkg:generic/` + annotation pattern is the established mikebom convention for non-addressable identities).
+- **Emit SDK deps as `pkg:generic/flutter-sdk`**. Rejected: the purl-spec EXPLICITLY uses `pkg:pub/flutter@0.0.0` as a canonical example. Honor upstream spec rather than invent a placeholder.
+
+## R2: `pubspec.lock` v2 schema (Dart 2.0+, current as of Dart 3.x)
+
+**Decision**: Parse a small typed subset; treat every per-package field as `Option<T>` except `dependency`, `description`, `source`, `version` (universally present in modern lockfiles). Use `#[serde(untagged)]` for `description` to handle string-vs-map polymorphism.
+
+**Schema** (per [`dart-lang/pub` source](https://github.com/dart-lang/pub) + real-world `flutter/gallery/pubspec.lock`):
+
+Top-level keys (only two):
+
+```yaml
+packages:
+  <package_name>: <LockfileEntry>
+  ...
+sdks:
+  dart: ">=3.11.0 <3.999.0"   # informational; not consumed v1
+  flutter: ">=3.41.2"
+```
+
+The `sdks:` block carries **constraint strings** (not resolved versions). Out of scope for v1 — describes host toolchain requirement, not a runtime/build component. Skip.
+
+**Per-package entry** (always 4 fields):
+
+```yaml
+<name>:
+  dependency: "direct main"      # | "direct dev" | "transitive" | "direct overridden"
+  description: <see below>
+  source: hosted                  # | git | path | sdk
+  version: "<string>"
+```
+
+**`description:` polymorphism** — varies by `source:`:
+
+| `source:` | `description:` shape | Fields |
+|---|---|---|
+| `hosted` | Map | `name`, `sha256` (lowercase hex, no prefix), `url` (bare base URL with scheme, no trailing slash) |
+| `git` | Map | `url` (git remote), `ref` (user-supplied — branch/tag/`HEAD`), `resolved-ref` (40-char SHA), `path` (subdir; `"."` when package is at repo root — always present) |
+| `path` | Map | `path` (string — absolute or relative), `relative` (bool) |
+| `sdk` | **Scalar string** (e.g., `"flutter"`) | SDK name; same scalar shared across multiple entries from same SDK |
+
+**`dependency:` enum** (four values per [`dart-lang/pub#4047`](https://github.com/dart-lang/pub/issues/4047)):
+
+- `"direct main"` — `dependencies:` in pubspec.yaml
+- `"direct dev"` — `dev_dependencies:`
+- `"transitive"` — pulled in by another package
+- `"direct overridden"` — `dependency_overrides:` in pubspec.yaml (rare but real)
+
+Lifecycle mapping per FR-008:
+- `direct main` → `Runtime`
+- `direct dev` → `Development`
+- `direct overridden` → treat as `Runtime` (overrides preserve runtime semantics; the override fact is annotation-worthy but doesn't change scope)
+- `transitive` → `Runtime` (lockfile doesn't distinguish transitive-from-runtime vs transitive-from-dev; mikebom's existing language-reader convention treats transitives uniformly)
+
+**Pre-Dart-2.0 lockfile format**: per spec Out-of-Scope. Modern Dart 2.0+ (2018) is universal in 2026 production.
+
+**Alternatives considered**:
+
+- **Shell out to `dart pub deps`**. Rejected: `dart` not guaranteed on scan host; cross-platform reader principle. Matches cargo/npm/pip posture.
+- **Parse `.dart_tool/package_config.json` instead of `pubspec.lock`**. Rejected: package_config.json is post-`dart pub get` evidence, lockfile is the input authority. Out of scope per spec.
+- **Strongly-typed `LockfileDescription` enum with `tag: source`**. Rejected: the YAML doesn't carry a typed discriminator inside `description`; only the sibling `source:` field acts as the tag. Use `#[serde(untagged)]` with explicit variant probing or post-parse re-interpretation.
+
+## R3: purl-spec `pub` canonical form
+
+**Decision**: Honor purl-spec verbatim. Specifically:
+
+- **Base form**: `pkg:pub/<name>@<version>` (no namespace).
+- **Self-hosted registry**: `?repository_url=<base-url-with-scheme>` (NOT `host=`). Value preserves scheme (e.g., `https://pub.acme.example.com`). Omitted when `description.url == "https://pub.dev"` or `https://pub.dartlang.org`.
+- **SHA-256 download hash**: surfaced via the `PackageDbEntry.hashes` field (existing milestone-002 convention), NOT as a PURL `checksums=` qualifier. PackageDbEntry.hashes flows to `components[].hashes[]` in CDX / `Package.checksums[]` in SPDX — the standards-native field. Bypassing it for a PURL qualifier would be Principle V regression.
+- **Git source**: `pkg:pub/<name>@<resolved-sha>?vcs_url=git+<git-url>[#<subpath>]`. The `git+` scheme prefix on `vcs_url` is the purl-spec git-source cross-type convention. `description.path` (subdir) becomes the PURL `#<subpath>` fragment when not `.` or empty. The user-supplied `ref` (branch/tag) is preserved as a `mikebom:source-type` evidence sub-field, not in the PURL.
+- **Path source**: `pkg:generic/<name>@<version>` placeholder + `mikebom:source-type = "pub-path"` annotation (see R1).
+- **SDK source**: `pkg:pub/<sdk-name>@0.0.0` + `mikebom:source-type = "pub-sdk"` annotation. The `0.0.0` is the literal placeholder pub writes; preserve verbatim per purl-spec canonical example.
+
+**`mikebom:source-type` value set extension** (reuses parity-catalog C1):
+
+| Source kind | `mikebom:source-type` value |
+|---|---|
+| Hosted (default `pub.dev`) | `pub-hosted` |
+| Hosted (self-hosted mirror) | `pub-hosted` (the `repository_url=` PURL qualifier carries the distinguishing URL) |
+| Git | `pub-git` |
+| Path | `pub-path` |
+| SDK | `pub-sdk` |
+
+(The `pub-` prefix avoids collision with existing C1 values like cargo's `git`/`path`/`registry`. Per milestone-122 Kotlin DSL's `kmp-` prefix convention.)
+
+## R4: Integration site within `read_all`
+
+**Decision**: register `pub mod dart;` in `mikebom-cli/src/scan_fs/package_db/mod.rs` and add a call site in `read_all` alongside the existing language readers (cargo / gem / npm / pip / golang / maven / nuget / swift / kotlin_dsl).
+
+Existing pattern (cargo example, line ~1436):
+
+```rust
+let cargo_out = cargo::read(rootfs, include_dev, exclude_set)?;
+out.extend(cargo_out.entries);
+diagnostics.divergence_records.extend(cargo_out.divergences);
+```
+
+Dart adds (placed alphabetically between `conan::read` and `gem::read`):
+
+```rust
+out.extend(dart::read(rootfs, include_dev, exclude_set));
+```
+
+No `collect_claimed_paths` integration — language readers don't claim binary paths (file-claim is an OS-reader concern; the binary walker classifies non-OS-claimed binaries as `pkg:generic/*` regardless of source-tree language-reader output).
+
+**`include_dev` flag**: existing language-reader convention is to accept `include_dev: bool` and filter out dev-scope components before returning. Dart respects this (FR-008): when `include_dev == false`, components with `dependency: direct dev` are dropped at the reader level.
+
+**`exclude_set`**: existing `ExclusionSet` (milestone 113) for the safe-walk filter. Standard plumbing.
+
+## R5: Language-reader pattern selection
+
+**Decision**: Use **cargo.rs** (milestone 002 + 064) as the architectural template. Closest semantic match:
+
+- Both parse a YAML/TOML lockfile in a source-tree project directory
+- Both emit a main-module component per workspace member's manifest (`Cargo.toml` ↔ `pubspec.yaml`)
+- Both handle multi-source dep classification (cargo: registry/path/git; dart: hosted/path/git/sdk)
+- Both support multi-version-of-same-package coexistence
+- Both use lifecycle-scope annotation for dev vs runtime distinction
+
+**`serde_yaml` precedent**: `npm/yarn_lock.rs` + `npm/pnpm_lock.rs` already use `serde_yaml = "0.9"` from the workspace dep tree. Confirms the dep is available and battle-tested for lockfile parsing.
+
+**Source-tree walker**: reuse `scan_fs::walk::safe_walk` (milestone 114). Pattern: walk for `pubspec.yaml` files; for each, look for sibling `pubspec.lock`; emit per-project components keyed off the manifest's `name:`+`version:`.
+
+**Alternatives considered**:
+
+- **Use maven.rs as template**. Rejected: maven is more complex (BOM imports, parent-POM walking, JAR archive descent). Cargo is simpler and closer.
+- **Custom YAML parser via line-format extraction**. Rejected: `serde_yaml` is in the workspace; no reason to hand-roll.
+
+## R6: Multi-project / workspace handling
+
+**Decision**: per Clarifications Q2, one main-module per `pubspec.yaml`. No synthetic workspace-root component.
+
+Implementation: the source-tree walker finds every `pubspec.yaml` under the scan root. For each, the reader:
+
+1. Parses the manifest's `name:` + `version:` for the main-module emission.
+2. Looks for a sibling `pubspec.lock` in the same directory.
+3. If lockfile present → emit `source`-tier components per FR-002 (lockfile-driven, all transitive deps).
+4. If lockfile absent → emit `design`-tier components per FR-005 (manifest-only, direct + dev deps).
+5. Attribute dep edges to THAT manifest's main-module bom-ref.
+
+Same-PURL dep collisions across multiple lockfiles (e.g., monorepo where two members both pin `http 1.1.0`) collapse via the standard cross-component `seen_purls` dedup at the orchestrator level — milestone-002 pattern, no special handling needed.
+
+**Pub-workspace (Dart 3.6+ `workspace:` field in root `pubspec.yaml`, single lockfile at root)** — **DEFERRED TO v1.1**: walker finds each member's `pubspec.yaml` and emits one main-module per member per FR-009; member dep edges from `pubspec.yaml`'s `dependencies:` / `dev_dependencies:` (design-tier fallback per FR-005) are emitted in v1, but inheriting pinned versions from an enclosing root-level lockfile via parent-directory walk is **out of scope for v1** to keep the implementation small and the test surface tractable. In v1, members without their own sibling `pubspec.lock` use design-tier emission from `pubspec.yaml` only — even when a root lockfile is present. This is a v1.1 follow-up: extend the walker to discover root-level lockfiles and attribute their entries to each member's main-module via the lockfile's per-entry `dependency:` classification. The unified-view behavior (single SBOM containing all members + their deps) STILL works in v1 because each member's pubspec.yaml carries the same dep names — only the version-pinning fidelity differs (design-tier constraint vs source-tier pinned version).
+
+## R7: Per-lockfile error posture
+
+**Decision**: warn-and-skip per FR-007.
+
+| Condition | Behavior | Justification |
+|---|---|---|
+| Source tree has no `pubspec.yaml` and no `pubspec.lock` | Return `Vec::new()` immediately | Clean no-op (FR-006) |
+| `pubspec.yaml` exists, no `pubspec.lock` | Emit design-tier components per FR-005 | Library publishers / pre-`pub get` workflows |
+| `pubspec.yaml` malformed YAML | `tracing::warn!`, skip the project, continue walking other projects | FR-007 |
+| `pubspec.yaml` missing `name:` field | `tracing::warn!`, skip main-module emission for that project | Cannot synthesize PURL |
+| `pubspec.lock` malformed YAML | `tracing::warn!`, fall back to design-tier emission from `pubspec.yaml` | Best-effort preservation |
+| Per-entry `version:` missing or empty | `tracing::warn!`, skip that single entry | Cannot synthesize PURL |
+| Per-entry `source:` discriminator unknown (not hosted/git/path/sdk) | `tracing::warn!`, skip that single entry | Future pub format changes — warn-and-skip preserves forward compat |
+| Empty `packages:` block | Emit just the main-module; no dep components; no warning | Fresh `pub get` failure or library with zero deps |
+
+## R8: Performance considerations
+
+**Decision**: no performance budget violations expected; per-scan cost is bounded by lockfile size.
+
+- Per-project: read `pubspec.yaml` (~500 bytes) + `pubspec.lock` (5–20 KB typical), parse via `serde_yaml`, build N `PackageDbEntry` instances. Estimated 1–3 ms per project on warm cache.
+- Typical Flutter app (~50 deps): ~3 ms total. Heavy app (~200 deps): ~10 ms. Monorepo with 5 members (~250 deps): ~15 ms.
+- Source-tree walker discovery cost (find all `pubspec.yaml` under scan root): same as cargo's existing `find_cargo_manifests` walker — sub-millisecond on typical repos.
+
+The no-Dart-detected fast path: walker finds no `pubspec.yaml`; reader returns empty Vec; statistically free.
+
+---
+
+## Summary of Phase 0 resolutions
+
+| Unknown | Decision | Reference |
+|---|---|---|
+| Principle V audit | `pub` is purl-spec-blessed; reuse C1 for source-type discriminator | R1 |
+| `pubspec.lock` schema | Parse 4-field subset; `serde(untagged)` for description polymorphism | R2 |
+| purl-spec `pub` canonical form | `repository_url=`, `vcs_url=git+...#<subpath>`, `0.0.0` for SDK per spec example | R3 |
+| Integration site | `read_all` dispatcher alongside other language readers | R4 |
+| Reader pattern template | cargo.rs (milestone 002 + 064) — closest semantic match | R5 |
+| Multi-project handling | One main-module per `pubspec.yaml`; no synthetic root | R6 |
+| Per-lockfile error posture | Warn-and-skip; never fail-the-scan | R7 |
+| Performance | ~15 ms on heavy monorepo; no budget concerns | R8 |
+
+All Phase 0 unknowns resolved. Ready for Phase 1 (data-model + contracts + quickstart).

--- a/specs/137-dart-pub-reader/spec.md
+++ b/specs/137-dart-pub-reader/spec.md
@@ -1,0 +1,185 @@
+# Feature Specification: Dart/Flutter pub ecosystem reader
+
+**Feature Branch**: `137-dart-pub-reader`
+**Created**: 2026-06-22
+**Status**: Draft
+**Input**: User description: "let's now move to dart"
+
+## Background
+
+Dart/Flutter is the dominant cross-platform mobile framework — Flutter powers production apps at Google (Google Pay, Google Ads, Stadia), Alibaba, BMW, Tencent, and an increasingly visible portion of the indie/startup mobile market. Server-side Dart is also growing (Shelf, Serverpod) for backend services that share code with the Flutter client.
+
+mikebom currently emits **zero** Dart/Flutter components when scanning a Flutter app, a Dart server project, or any source tree containing `pubspec.lock`. Every dep pulled from pub.dev — and the often-larger graph of transitive deps — is invisible to the scan.
+
+The Dart ecosystem has four discrimination surfaces a reader must handle:
+
+- **Hosted deps** (the common case): from `pub.dev` or a self-hosted pub server. PURL: `pkg:pub/<package>@<version>`.
+- **Path deps**: local-filesystem deps (`path: ../my-lib`) typically used for monorepos. Identity is the path; the dep doesn't carry a pub.dev version.
+- **Git deps**: directly-pinned git URLs (`git: https://github.com/foo/bar.git`). Identity is the resolved Git SHA.
+- **SDK pseudo-deps**: `flutter`, `flutter_test`, `flutter_localizations` etc. resolve to the Flutter SDK shipped with the project's Flutter version, NOT to pub.dev. Surfacing these as `pkg:pub/flutter` is wrong — they have no pub.dev provenance.
+
+This feature closes the gap so an operator scanning any Dart/Flutter project gets a complete SBOM with every pub-managed dep represented, the right provenance distinction surfaced, and SDK pseudo-deps handled correctly.
+
+## Clarifications
+
+### Session 2026-06-22
+
+- Q: Should the Dart reader emit a `pkg:pub/<project-name>@<version>` component for each scanned `pubspec.yaml` with a `name:` field (matching the main-module emission pattern established by cargo / npm / pip / gem / maven)? → A: Yes — emit main-module per `pubspec.yaml`. The component is tagged `mikebom:component-role = "main-module"` and `mikebom:sbom-tier = "source"` per the milestone-064-through-070 pattern. Dep edges flow from the main-module to its declared direct deps; without this anchor the dep graph would have no root.
+- Q: How should the reader treat multi-`pubspec.yaml` projects (Melos monorepos with N member packages, or pub workspaces with single root lockfile)? → A: One main-module per `pubspec.yaml` (Option A). Each member emits a `pkg:pub/<name>@<version>` regardless of monorepo membership. Workspace structure is invisible in the SBOM (no synthetic workspace-root); consumers see N independent packages. Matches cargo's milestone-064 + maven's milestone-070 pattern. For pub-workspace single-lockfile installs (Dart 3.6+), dep edges are attributed to each member's main-module via the `pubspec.yaml`'s declared direct deps.
+- Q: In design-tier mode (no `pubspec.lock`, only `pubspec.yaml`), should the reader emit components for `dev_dependencies:` entries, and if so, tagged how? → A: Both, tagged (Option A). Emit components for BOTH `dependencies:` and `dev_dependencies:` entries; tag dev ones with `mikebom:lifecycle-scope = "development"` so `--include-dev=off` filters them out. Symmetric with FR-008's lockfile-mode behavior — operators get consistent results whether or not a lockfile is present.
+
+#### Phase 0 research corrections (post-clarification)
+
+Plan-phase research against the [purl-spec `pub` definition](https://github.com/package-url/purl-spec/blob/main/types-doc/pub-definition.md) surfaced three corrections to the initial PURL-shape guesses in FR-003 + FR-011. These are CORRECTIONS to align with the purl-spec authority, not scope changes:
+
+- **Hosted qualifier name**: the canonical qualifier is `repository_url=<base-url-with-scheme>`, NOT `host=<bare-hostname>`. Omitted when `description.url` is `"https://pub.dev"` OR `"https://pub.dartlang.org"` (both default URLs; the latter is the legacy purl-spec-recorded default that redirects to `pub.dev`).
+- **Git source PURL form**: per the purl-spec git-source cross-type convention, the `vcs_url` qualifier value carries a `git+` scheme prefix (e.g., `?vcs_url=git+https://github.com/foo/bar.git`), and `description.path` (subdirectory inside the repo) is preserved as a `#<subpath>` PURL fragment.
+- **SDK pseudo-deps**: the purl-spec EXPLICITLY blesses `pkg:pub/flutter@0.0.0` as a canonical example. The initial FR-011 instruction to use `pkg:generic/<sdk-name>-sdk` instead was incorrect — SDK pseudo-deps MUST emit as `pkg:pub/<sdk-name>@0.0.0` per purl-spec, with `mikebom:source-type = "pub-sdk"` annotation surfacing the discriminator (the `pub-` prefix on all source-type values avoids collision with cargo's bare C1 values per research R3). The `0.0.0` version is the literal placeholder `pub` writes into the lockfile for SDK entries; preserving it matches purl-spec example output.
+
+FR-003 + FR-011 are updated below to reflect these corrections.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Operator scans a Flutter app project (Priority: P1) 🎯 MVP
+
+A mobile developer runs `mikebom sbom scan --path .` on their Flutter app source tree. They receive an SBOM containing one component per package pinned in `pubspec.lock`. Each component carries a `pkg:pub/<package>@<version>` PURL identity and a dependsOn edge from the app's root component to each of its direct deps.
+
+**Why this priority**: The headline use case. Without it, the entire feature has no operator value — every Flutter app is the canonical target, and pubspec.lock is the universal artifact.
+
+**Independent Test** (SC-001): Synthetic fixture with `pubspec.yaml` declaring 3 direct deps + `pubspec.lock` pinning those + their 2 transitive deps (5 total). Run `mikebom sbom scan --path <tmp>`. Assert exactly 5 `pkg:pub/*` components emit with correct versions and the project's direct-dep edges target the correct bom-refs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Flutter app project with `pubspec.lock` pinning `http 1.1.0`, `provider 6.1.1`, `shared_preferences 2.2.2`, **When** the operator runs `mikebom sbom scan --path <project>`, **Then** the emitted SBOM contains components for each pinned dep with PURL `pkg:pub/<name>@<version>`.
+2. **Given** the same project, **When** the operator inspects the emitted SBOM, **Then** transitive deps pinned in `pubspec.lock` (e.g., `http_parser`, `meta`) also appear as components — the lockfile is the authoritative dep set, not just direct deps.
+3. **Given** a source tree WITHOUT `pubspec.lock` or `pubspec.yaml`, **When** the operator scans, **Then** no Dart components or annotations appear AND no warning fires (clean no-op).
+4. **Given** a project whose `pubspec.yaml` declares `name: my_flutter_app` and `version: 1.2.3`, **When** the operator scans, **Then** a main-module component emits with PURL `pkg:pub/my_flutter_app@1.2.3`, `mikebom:component-role = "main-module"`, and `mikebom:sbom-tier = "source"` annotations; dep edges flow from this main-module bom-ref to each direct dep's bom-ref.
+
+---
+
+### User Story 2 — Operator distinguishes hosted vs git/path/SDK deps (Priority: P2)
+
+The operator's Flutter app's `pubspec.lock` mixes hosted deps (from pub.dev), a `path:` dep pointing to a shared in-monorepo package, a `git:` dep pinning a fork, and the standard Flutter SDK pseudo-deps. The SBOM must distinguish these sources so downstream supply-chain risk tooling can correctly assess each (path deps + git deps + SDK deps have meaningfully different risk profiles than hosted deps).
+
+**Why this priority**: Important for supply-chain risk assessment but the headline value (US1) ships independently. Path/git/SDK handling is a refinement layered on top of the baseline hosted-dep extraction.
+
+**Independent Test** (SC-002): Synthetic fixture with one each of hosted/path/git/sdk dep in `pubspec.lock`. Scan. Assert that:
+- The hosted dep emits as `pkg:pub/<name>@<version>` (standard) with `mikebom:source-type = "pub-hosted"` evidence.
+- The path dep emits with `mikebom:source-type = "pub-path"` evidence and a `pkg:generic/` PURL (not pub.dev's namespace).
+- The git dep emits with `mikebom:source-type = "pub-git"` evidence; PURL carries the resolved git SHA per the purl-spec git-source convention.
+- The SDK pseudo-dep (`flutter`) emits as `pkg:pub/flutter@0.0.0` per purl-spec canonical example; the `mikebom:source-type = "pub-sdk"` annotation distinguishes it from pub.dev-hosted deps via the standard property filter.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `pubspec.lock` containing a `path:` dep entry, **When** the operator scans, **Then** that dep emits with `mikebom:source-type = "pub-path"` evidence; downstream filtering on the property surfaces only path-sourced deps.
+2. **Given** a `pubspec.lock` containing a `git:` dep with a `resolved-ref:` SHA, **When** the operator scans, **Then** the emitted PURL embeds the resolved SHA as the version segment (per purl-spec's git-source convention) AND carries `mikebom:source-type = "pub-git"` evidence.
+3. **Given** a `pubspec.lock` containing the `flutter` SDK pseudo-dep (`source: sdk`, `version: "0.0.0"`), **When** the operator scans, **Then** the emitted component carries PURL `pkg:pub/flutter@0.0.0` per purl-spec canonical example AND `mikebom:source-type = "pub-sdk"` annotation so downstream consumers can distinguish SDK pseudo-deps from pub.dev-hosted deps via the standard property filter.
+
+---
+
+### User Story 3 — Operator scans a Dart project WITHOUT a committed lockfile (Priority: P3)
+
+Some Dart projects (especially libraries published to pub.dev) deliberately do NOT commit `pubspec.lock` — only `pubspec.yaml` with version constraints. Scanning such a project should produce SOME inventory (the declared direct deps with their constraint expressions) rather than empty output, marked as `design`-tier (not `source`-tier) to reflect the lower fidelity.
+
+**Why this priority**: Important for libraries-and-packages publishers (smaller user base than app authors) but not blocking. The lockfile-driven slice in US1 is the headline.
+
+**Independent Test** (SC-003): Synthetic fixture with `pubspec.yaml` declaring 2 direct deps but NO `pubspec.lock`. Scan. Assert: (a) 2 components emit with `mikebom:sbom-tier = "design"` annotation, (b) each carries the declared constraint string as a `mikebom:requirement-range` annotation so consumers see "what was declared" not "what was resolved".
+
+**Acceptance Scenarios**:
+
+1. **Given** a Dart library project with `pubspec.yaml` only (no `pubspec.lock`), **When** the operator scans, **Then** components emit for declared direct deps from BOTH `dependencies:` and `dev_dependencies:` blocks, each with `mikebom:sbom-tier = "design"` and the original version constraint preserved as evidence.
+2. **Given** the same project, **When** the operator inspects the emitted SBOM, **Then** NO transitive deps appear (lockfile is required for transitive resolution; design-tier captures only what's explicitly declared).
+3. **Given** a project with `dev_dependencies:` declaring `test: ^1.24.0`, **When** the operator scans in design-tier mode, **Then** the emitted `test` component carries `mikebom:lifecycle-scope = "development"` annotation; downstream `--include-dev=off` filtering on that property successfully suppresses it.
+
+---
+
+### Edge Cases
+
+- **Mixed hosted/path/git/SDK in one project**: a Flutter app commonly has all four source kinds in one `pubspec.lock`. Each MUST surface with the correct `source-type` evidence; none MUST silently masquerade as a pub.dev hosted dep.
+- **Self-hosted pub registry**: some organizations run an internal pub mirror. The `hosted` source-description in `pubspec.lock` carries a `url:` field. When `url` != `https://pub.dev` AND `url` != `https://pub.dartlang.org` (the two defaults), emit a `repository_url=<full-url-with-scheme>` qualifier on the PURL per the purl-spec authority (`pkg:pub/foo@1.0.0?repository_url=https://pub.acme.example.com`). See FR-003 + research R3 for the canonical form.
+- **Workspace projects (Melos)**: a monorepo with multiple `pubspec.yaml` files (one per workspace member), each with its own sibling `pubspec.lock`. Each member's lockfile is parsed independently; same-PURL deps across multiple lockfiles collapse via the standard `seen_purls` dedup.
+- **Pub-workspace (Dart 3.6+ single root lockfile)**: a workspace where the root `pubspec.yaml` declares `workspace:` field listing member packages, and ONE `pubspec.lock` lives at the root (members lack sibling lockfiles). v1 emits each member as a main-module + design-tier deps from THAT member's `pubspec.yaml`; the root-level lockfile is NOT walked to inherit pinned versions to each member. **Pub-workspace pinned-version inheritance is deferred to v1.1** — see research R6 for the v1.1 design sketch. v1 still produces a usable SBOM (unified-view: all member deps surface; only version-pinning fidelity is design-tier instead of source-tier).
+- **Git deps without a resolved SHA**: malformed lockfile or interrupted `pub get`. Skip the dep with `tracing::warn!` rather than emit a placeholder PURL (would create a non-identifying component).
+- **Pre-pub-2.0 lockfile format**: very old Dart projects use a different lockfile shape. Out of scope for v1 — modern Dart 2.0+ (released 2018) is universal in 2026 production.
+- **Malformed `pubspec.lock`**: skip-the-file with `tracing::warn!`; downstream emission produces zero Dart components for that project rather than aborting the whole scan.
+- **Dev dependencies vs regular dependencies**: `pubspec.lock` carries a `dependency: direct main|direct dev|transitive` field. Direct-dev deps SHOULD be tagged with `mikebom:lifecycle-scope = "development"` so the standard `--include-dev=off` filtering works (matches dpkg/maven/npm precedent).
+- **Empty `pubspec.lock`**: a project with `pubspec.lock` but zero packages section (fresh `pub get` failure). Skip silently — no components emit, no warnings.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST detect Dart/Flutter projects by the presence of `pubspec.lock` or `pubspec.yaml` files anywhere under the scan root. Both file names participate; presence of either triggers reader activation.
+- **FR-002**: System MUST parse `pubspec.lock` (YAML format) and extract: each package's name (top-level key under `packages:`), version, source discriminator (`hosted` / `path` / `git` / `sdk`), the source-specific identity payload (URL for hosted, path for path, repo + ref for git), and `dependency:` classification (`direct main`, `direct dev`, or `transitive`).
+- **FR-003**: System MUST emit one component per parsed lockfile entry with PURL according to the source type (shapes confirmed against the [purl-spec `pub` definition](https://github.com/package-url/purl-spec/blob/main/types-doc/pub-definition.md)):
+  - **hosted**: `pkg:pub/<package>@<version>[?repository_url=<base-url-with-scheme>]` (`repository_url=` qualifier omitted when `description.url` is `"https://pub.dev"` OR `"https://pub.dartlang.org"` — both default URLs; the latter is the legacy purl-spec-recorded default that redirects to `pub.dev`. Present for self-hosted mirrors.)
+  - **git**: `pkg:pub/<package>@<resolved-sha>?vcs_url=git+<git-url>[#<subpath>]` per purl-spec git-source convention (`git+` scheme prefix MUST appear in the `vcs_url` value; `description.path` carries as the PURL `#<subpath>` fragment when non-trivial)
+  - **path**: `pkg:generic/<package>@<version>` with `mikebom:source-type = "pub-path"` evidence — path-deps have no purl-spec-addressable identity, so the `pkg:generic/` placeholder + annotation surface the discriminator while preserving a usable bom-ref for dep-graph wiring
+  - **sdk**: `pkg:pub/<sdk-name>@0.0.0` (the literal placeholder version `pub` writes for SDK entries) with `mikebom:source-type = "pub-sdk"` evidence. Per purl-spec canonical example (`pkg:pub/flutter@0.0.0`) — SDK pseudo-deps ARE addressable via the pub-type PURL; the annotation distinguishes them from pub.dev-hosted deps
+- **FR-004**: System MUST emit dependency edges from each project's main-module (per FR-012) to each direct dep declared in `pubspec.yaml` (`dependencies:` + `dev_dependencies:` when `--include-dev=on`) OR — when a `pubspec.lock` is present — to each `dependency: direct main` / `direct dev` / `direct overridden` entry. Transitive components (lockfile `dependency: transitive`) surface as standalone components but their inter-package dependency edges (per-`LockfileEntry` `dependencies:` arrays) are deferred to v1.1 — scope-aligned with the milestone-064 / 066 / 068 / 069 / 070 v1 convention (main-module → direct deps in v1; full transitive edge graph in a follow-up).
+- **FR-005**: When `pubspec.lock` is absent but `pubspec.yaml` is present, system MUST emit components for direct deps declared in BOTH `dependencies:` and `dev_dependencies:` blocks, with `mikebom:sbom-tier = "design"` annotation and the original constraint string as `mikebom:requirement-range` evidence. Components from `dev_dependencies:` MUST additionally carry `mikebom:lifecycle-scope = "development"` annotation so `--include-dev=off` filtering applies uniformly (symmetric with FR-008's lockfile-mode behavior). No transitive deps emit in this design-tier mode.
+- **FR-006**: System MUST treat a source tree containing no `pubspec.lock` AND no `pubspec.yaml` as a clean no-op — no components emitted, no warnings logged. Existing scans on non-Dart projects MUST stay byte-identical pre/post this feature.
+- **FR-007**: System MUST tolerate per-lockfile parse errors (malformed YAML, missing required fields, encoding issues) without aborting the whole scan — log a structured warning naming the affected lockfile path and continue.
+- **FR-008**: System MUST tag direct-dev deps (lockfile `dependency: direct dev`) with `mikebom:lifecycle-scope = "development"` so the standard `--include-dev=off` filtering works (matches dpkg/maven/npm precedent).
+- **FR-009**: System MUST handle Dart workspace projects (Melos monorepos with multiple `pubspec.yaml`/`pubspec.lock` files, OR pub workspaces with a single root lockfile per Dart 3.6+) by emitting **one main-module component per `pubspec.yaml`** regardless of monorepo membership. Each member's lockfile (when present) is parsed independently for the dep edges attributed to that member's main-module. Same-PURL deps across multiple lockfiles collapse via the standard cross-component `seen_purls` dedup at the orchestrator level. No synthetic workspace-root component is emitted — workspace structure is invisible at the SBOM level; consumers see N independent packages. Mirrors the cargo (milestone 064) + maven (milestone 070) workspace-member pattern.
+- **FR-010**: System MUST NOT make any network calls during the scan — `pubspec.lock` is fully self-contained. Resolving a hosted-dep's registry URL via a remote query is out of scope.
+- **FR-011**: For Flutter SDK pseudo-deps (`flutter`, `flutter_test`, `flutter_localizations`, `flutter_web_plugins`, etc. — detectable via the `source: sdk` discriminator in the lockfile), system MUST emit one component per entry with PURL `pkg:pub/<sdk-name>@0.0.0` (the `0.0.0` is the literal placeholder version `pub` writes for SDK entries; preserving it matches the purl-spec canonical example `pkg:pub/flutter@0.0.0`). The component MUST carry `mikebom:source-type = "pub-sdk"` annotation so consumers can distinguish toolchain-bundled deps from pub.dev-hosted ones via the standard property filter. (The `pub-` prefix on all `mikebom:source-type` values avoids collision with existing C1 parity-catalog row values like cargo's bare `git` / `path` / `registry`; per the milestone-122 Kotlin DSL `kmp-` precedent — see research R3.)
+- **FR-012**: For each `pubspec.yaml` encountered under the scan root, system MUST emit one **main-module component** with PURL `pkg:pub/<name>@<version>` (where `<name>` and `<version>` come from the `pubspec.yaml`'s `name:` and `version:` fields). The component MUST carry `mikebom:component-role = "main-module"` and `mikebom:sbom-tier = "source"` annotations. Dep edges MUST flow from this main-module to each direct dep declared in `pubspec.yaml` (or, when a `pubspec.lock` is present, to each `dependency: direct main`/`direct dev` entry per FR-008). When the `pubspec.yaml` lacks a `version:` field (libraries-in-development), use `0.0.0-unknown` as the version placeholder per the existing cargo main-module convention (milestone 064). Mirrors the established milestone-064 (cargo) / 066 (npm) / 068 (pip) / 069 (gem) / 070 (maven) main-module emission pattern.
+
+### Key Entities
+
+- **pubspec.lock**: YAML lockfile pinning each direct + transitive dep of a Dart project to a specific version. Each `packages:` entry carries name (key), description (source-specific payload), `source:` discriminator (hosted / path / git / sdk), version, and a `dependency:` classification.
+- **pubspec.yaml**: Declared dep manifest in the project root. Required for any Dart project; `pubspec.lock` is optional (libraries often omit it). Lower fidelity than lockfile (constraints not pinned versions).
+- **`.dart_tool/package_config.json`**: Resolved package-path map written by `dart pub get` post-resolution. Not consumed by milestone 137 — the lockfile is the canonical source.
+- **Package source**: Discriminator for where a dep came from. Four values: `hosted` (pub.dev or self-hosted mirror), `path` (filesystem-local), `git` (git repo + ref), `sdk` (Flutter / Dart SDK pseudo-deps).
+- **Flutter SDK pseudo-dep**: A dep name like `flutter` that resolves to the Flutter framework shipped with the project's installed Flutter version, NOT to pub.dev. Has no pub.dev provenance; must NOT emit as `pkg:pub/flutter@...`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A scan of a synthetic Flutter app project with `pubspec.yaml` (3 direct deps) + `pubspec.lock` (those 3 plus 2 transitives = 5 total) produces a CDX SBOM whose Dart component count matches the lockfile package count exactly (5) and direct-dep edges target real bom-refs.
+- **SC-002**: A scan of a fixture mixing one hosted, one path, one git, and one SDK dep produces correct PURLs for each per FR-003: hosted as `pkg:pub/<name>@<version>` (or with `?repository_url=` for self-hosted), git as `pkg:pub/<name>@<resolved-sha>?vcs_url=git+<url>` (with `#<subpath>` when applicable), path as `pkg:generic/<name>@<version>` (placeholder), sdk as `pkg:pub/<sdk-name>@0.0.0` (per purl-spec canonical example). Each carries the correct `mikebom:source-type` evidence (`pub-hosted` / `pub-git` / `pub-path` / `pub-sdk`).
+- **SC-003**: A scan of a Dart library project with `pubspec.yaml` only (no `pubspec.lock`) produces components for declared direct deps with `mikebom:sbom-tier = "design"` annotation and the constraint string preserved as `mikebom:requirement-range` evidence.
+- **SC-004**: A source tree containing no Dart files produces an SBOM byte-identical (modulo timestamps + serial numbers) to a pre-feature baseline scan. (No-op preservation invariant — protects every non-Dart scan.)
+- **SC-005**: A scan completes successfully (exit code 0, valid SBOM) on a fixture where one `pubspec.lock` has corrupted YAML alongside three valid Dart project subdirectories. The output contains components from the three valid projects plus a warning naming the corrupted lockfile path; the corrupted project is silently dropped.
+- **SC-006**: An external SBOM consumer reading the emitted CDX JSON can enumerate every Dart/Flutter dep via the standard `components[]` array filtered on `purl =~ "^pkg:pub/"`. No Dart-specific consumer code is required — the standard PURL filter works.
+- **SC-007**: A scan of a fixture with one direct-dev dep (lockfile `dependency: direct dev`) produces a component carrying `mikebom:lifecycle-scope = "development"` annotation; downstream `--include-dev=off` filtering on that property successfully suppresses the component.
+- **SC-008**: A scan of a project whose `pubspec.yaml` declares `name: my_flutter_app` and `version: 1.2.3` produces a main-module component with PURL `pkg:pub/my_flutter_app@1.2.3` carrying `mikebom:component-role = "main-module"` annotation; the SBOM's `dependencies[]` block contains an entry for the main-module's bom-ref with `dependsOn` targeting every direct dep's bom-ref.
+
+## Assumptions
+
+- **Modern Dart 2.0+ lockfile format only**: pre-2.0 (2018) lockfiles are out of scope. Modern Dart is universal in 2026 production.
+- **`pubspec.lock` is the authoritative source when present**: the reader does NOT consult `.dart_tool/package_config.json` for v1. The lockfile is what `dart pub get` produces and is the build's source of truth.
+- **No live `dart pub` invocation**: the reader parses on-disk metadata directly. It does NOT shell out to `dart pub deps` or `dart pub get` — the `dart` binary isn't guaranteed to exist on the scan host (mikebom is host-portable; scanned target may be a Dart project on a Linux server scanned from a macOS host).
+- **The `pub` PURL type IS purl-spec-blessed**: the [purl-spec PURL-TYPES.rst](https://github.com/package-url/purl-spec/blob/main/PURL-TYPES.rst) defines the `pub` type explicitly. mikebom emits per the spec — no informal-type follow-up needed (unlike `brew` in milestone 136 and `yocto` in milestone 128).
+- **Existing milestone-002 language-reader pattern is the template**: the reader will share architectural shape with `cargo.rs` / `npm/` (closest siblings — both parse lockfiles in source-tree-walked project directories). NOT the milestones-002/004/107/135/136 OS-reader pattern (those parse system-installed package DBs).
+- **YAML parsing**: `serde_yaml` is already a workspace dep (per milestone 122's Kotlin DSL reader use); zero new Cargo deps.
+- **Git-source PURL convention**: per purl-spec, git-sourced packages use the resolved Git SHA as the version segment + `vcs_url=<repo>` qualifier. Aligned with how the existing cargo reader handles `git+https://...` source-kind cargo deps (milestone 002).
+- **Path-deps and SDK-deps use `pkg:generic/` placeholders**: these don't have pub.dev provenance so emitting under `pkg:pub/` would be wrong. The `pkg:generic/` placeholder + `mikebom:source-type` evidence properly signals their non-pub nature.
+
+## Out of Scope
+
+- **Live invocation of `dart pub` or any Dart toolchain binary**: read-only metadata parse only.
+- **Pre-Dart-2.0 lockfile format**: deferred indefinitely (these are exceptionally rare in 2026).
+- **`.dart_tool/package_config.json` parsing**: lockfile-first design; the resolved package-config is post-`dart pub get` evidence and out of scope for v1. File-claim integration (tracking which on-disk paths under `~/.pub-cache/` a project uses) is a separate concern.
+- **Constraint-resolution simulation**: when only `pubspec.yaml` is present (no lockfile), we emit at design-tier with the raw constraints preserved. We do NOT attempt to resolve constraints (`^1.0.0`, `>=1.2.0 <2.0.0`, etc.) into pinned versions ourselves.
+- **Self-hosted pub registry authentication**: scanning a project whose lockfile points at a private pub registry that requires auth is out of scope — we read the registry URL from the lockfile but never contact the registry.
+- **Dart Hosted Pub format v2 future migrations**: the spec targets the current pubspec.lock v2 format (per Dart 3.x). Future Dart format changes would be addressed in follow-up milestones.
+- **License extraction**: `pubspec.lock` does NOT carry license information — license lives in each package's own `pubspec.yaml` shipped under `~/.pub-cache/hosted/pub.dev/<pkg>-<ver>/pubspec.yaml`. Same shape as milestone-135 FR-012 (URL) and milestone-136 FR-011 (license) deferrals — out of scope for v1; tracked as cross-reader follow-up.
+- **`.dart_tool/package_graph.json`** (Dart 3.6+): newer alternative to package_config.json; same out-of-scope rationale.
+
+## Dependencies and Constraints
+
+- **Builds on milestone 002** (initial language-reader architecture — cargo, npm, pip, etc.).
+- **Builds on milestone 122** (Kotlin DSL reader — most recent YAML-parsing precedent using `serde_yaml`).
+- **Reuses the existing source-tree walker** (`scan_fs::walk::safe_walk`) — no new walker logic.
+- **Does NOT touch existing language readers** — Dart support is strictly additive.
+- **Does NOT introduce new external dependencies** — `serde_yaml = "0.9"` is already a direct workspace dep.
+
+## Related
+
+- Closes: #420 (Add Dart/Flutter ecosystem support (pubspec.lock))
+- Adjacent: #424 (CocoaPods reader — sibling mobile ecosystem)
+- Adjacent: #422 (Elixir/Mix reader — another lockfile language ecosystem)
+- Foundational reference: milestone 002 (cargo + npm + pip lockfile readers), milestone 122 (Kotlin DSL — `serde_yaml` precedent)

--- a/specs/137-dart-pub-reader/tasks.md
+++ b/specs/137-dart-pub-reader/tasks.md
@@ -1,0 +1,253 @@
+---
+
+description: "Task list for milestone 137 — Dart/Flutter pub ecosystem reader"
+---
+
+# Tasks: Dart/Flutter pub ecosystem reader
+
+**Input**: Design documents from `/specs/137-dart-pub-reader/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/pub-component-purl.md ✓, quickstart.md ✓
+
+**Tests**: Integration tests included — established convention for milestones 064 / 066 / 068 / 069 / 070 / 122 / 135 / 136 main-module-reader work. Synthetic-fixture pattern via `tempfile::tempdir()`.
+
+**Organization**: Tasks grouped by user story (US1 = P1 MVP; US2 = P2 source-discriminator distinction; US3 = P3 design-tier mode). Setup + Foundational phases are blocking prerequisites for ALL user stories.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Maps task to user story phase (US1 / US2 / US3)
+- Setup / Foundational / Polish phases: no story label
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Module skeleton + cyclonedx evidence-kind enum extension before any logic lands.
+
+- [X] T001 Create `mikebom-cli/src/scan_fs/package_db/dart.rs` with module-level docstring (mirrors cargo.rs:1–30 + maven.rs:1–25 preamble: milestone reference, FR list, PURL shape summary), `use` block (`anyhow`, `serde`, `serde_yaml`, `tracing`, `std::collections::BTreeMap`, `std::path::{Path, PathBuf}`, `mikebom_common::types::purl::Purl`, the existing `PackageDbEntry`/`SourceType`/`LifecycleScope` types from `super`), and `pub fn read(rootfs: &Path, include_dev: bool, exclude_set: &ExclusionSet) -> Vec<PackageDbEntry>` stub returning `Vec::new()`.
+
+- [X] T002 Add `pub mod dart;` declaration to `mikebom-cli/src/scan_fs/package_db/mod.rs` (placed alphabetically between `pub mod conan;` and `pub mod gem;`). No `read_all` integration yet — that lands in T008.
+
+- [X] T002b Extend the cyclonedx evidence-kind allowlist in `mikebom-cli/src/generate/cyclonedx/builder.rs` to accept `"pubspec-lock"` and `"pubspec-yaml"`. The `debug_assert!` gate currently enumerates {rpm-file, rpmdb-sqlite, rpmdb-bdb, dynamic-linkage, elf-note-package, embedded-version-string, symbol-fingerprint, python-stdlib-collapsed, jdk-runtime-collapsed, alpm-local-db, brew-install-receipt, brew-cask-metadata} — add the two new values per the milestone-135 + milestone-136 T002b pattern. Without this, the implementation in T010 + T018 would panic in debug builds.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Reader-private types + parsing + PURL helpers + dispatcher integration. MUST complete before ANY user story phase.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 Define reader-private serde structs in `mikebom-cli/src/scan_fs/package_db/dart.rs` per `data-model.md`: `PubspecYaml` (name, version, description, dependencies, dev_dependencies, dependency_overrides, environment), `PubspecLock` (packages, sdks), `LockfileEntry` (dependency, description, source, version), `LockfileDescription` enum with `#[serde(untagged)]` covering `Sdk(String)` and `Map(LockfileDescriptionMap)` variants, and `LockfileDescriptionMap` (name, sha256, url, ref_, resolved_ref, path, relative). All fields use `#[serde(default)]` except the universally-present-in-modern-Dart-2.0+ four (`dependency`, `description`, `source`, `version` on `LockfileEntry`). `#[allow(dead_code)]` on each struct.
+
+- [X] T004 Implement `fn find_dart_projects(rootfs: &Path, exclude_set: &ExclusionSet) -> Vec<PathBuf>` in `dart.rs` that walks via `scan_fs::walk::safe_walk` (milestone 114) returning every absolute path containing a `pubspec.yaml` (one per directory). For each `pubspec.yaml`, the caller will look for a sibling `pubspec.lock`. Skip directories matching `exclude_set`.
+
+- [X] T005 Implement `fn parse_pubspec_yaml(path: &Path) -> Result<PubspecYaml>` and `fn parse_pubspec_lock(path: &Path) -> Result<PubspecLock>` in `dart.rs` using `serde_yaml::from_slice` over `std::fs::read`. Errors propagate via `anyhow::Result` so callers can warn-and-skip per FR-007. Use `?` operator — no `.unwrap()` per Constitution Principle IV.
+
+- [X] T006 Implement `fn build_purl_for_lockfile_entry(name: &str, entry: &LockfileEntry) -> Result<Purl>` in `dart.rs` per FR-003 + contracts/pub-component-purl.md:
+  - `source: "hosted"` → `pkg:pub/<name>@<version>`; if `description.url.as_deref()` is `Some(u)` AND `u != "https://pub.dev"` AND `u != "https://pub.dartlang.org"`, append `?repository_url=<u>` qualifier. URL-encode per the minimal-encoding rule defined in T016 (PURL `pchar` rule allows `:` / `/` / `?` / `@` in qualifier values; encode only ` `, `?`, `#`, `&`). Do NOT use `url::form_urlencoded` — that would over-escape `:`/`/` and break URL readability.
+  - `source: "git"` → require `description.resolved_ref` present + 40 hex chars; produce `pkg:pub/<name>@<resolved-sha>?vcs_url=git+<url>` with `#<subpath>` fragment when `description.path` is `Some(p)` AND `p != "."` AND `!p.is_empty()`.
+  - `source: "path"` → `pkg:generic/<name>@<version>` (placeholder per R1; discriminator surfaces via annotation, not PURL).
+  - `source: "sdk"` → `pkg:pub/<sdk-name>@0.0.0` where `<sdk-name>` is from `LockfileDescription::Sdk(s)`; preserve `0.0.0` verbatim per purl-spec canonical example.
+  - Unknown `source:` value → `Err(...)` so caller warns-and-skips per FR-007.
+
+- [X] T007 Implement `fn build_extra_annotations(name: &str, entry: &LockfileEntry) -> BTreeMap<String, serde_json::Value>` in `dart.rs` per data-model.md per-source-type fields. Always sets `"mikebom:source-type"` to one of `pub-hosted` / `pub-git` / `pub-path` / `pub-sdk`. Source-specific extras: git → `"mikebom:vcs-ref": <ref_>`; path → `"mikebom:path": <path>`; sdk → `"mikebom:sdk-name": <sdk-family>` (from the `LockfileDescription::Sdk` payload, which IS the sdk-family per R2).
+
+- [X] T008 Wire `dart::read(rootfs, include_dev, exclude_set)` into `read_all` in `mikebom-cli/src/scan_fs/package_db/mod.rs`. Place the call alphabetically between `conan::read(...)` and `gem::read(...)` calls. Mirror the cargo pattern (`out.extend(cargo_out.entries);`) — Dart's signature is simpler (returns `Vec<PackageDbEntry>` directly, no separate divergence record set per R4). NO `collect_claimed_paths` integration — language readers don't claim binary paths.
+
+**Checkpoint**: Foundation ready — `dart::read` is callable from the dispatcher, returns empty Vec, and the cyclonedx evidence-kind gate accepts the new values. User story phases (US1 / US2 / US3) can now proceed in parallel.
+
+---
+
+## Phase 3: User Story 1 — Operator scans a Flutter app project (Priority: P1) 🎯 MVP
+
+**Goal**: Lockfile-driven SBOM emission for the canonical Flutter-app case — one main-module per `pubspec.yaml` + one component per lockfile entry + dep edges from the main-module to its direct deps.
+
+**Independent Test (SC-001)**: Synthetic fixture with `pubspec.yaml` (name=my_flutter_app, version=1.2.3, 3 direct deps) + `pubspec.lock` (5 packages — 3 direct + 2 transitives). Scan produces exactly 5 `pkg:pub/*` components + 1 main-module + main-module's `depends` lists the 3 direct deps by name.
+
+### Implementation for User Story 1
+
+- [X] T009 [US1] Implement `fn emit_main_module(pubspec_path: &Path, pubspec_yaml: &PubspecYaml) -> Option<PackageDbEntry>` in `dart.rs` per FR-012. Returns `None` when `pubspec_yaml.name.is_empty()` (warn-and-skip per R7). Builds a `PackageDbEntry` with: `purl = Purl::new(format!("pkg:pub/{name}@{version}", version = pubspec_yaml.version.as_deref().unwrap_or("0.0.0-unknown")))?`, `name = pubspec_yaml.name.clone()`, `version = pubspec_yaml.version.clone().unwrap_or_else(|| "0.0.0-unknown".into())`, `source_path = Some(pubspec_path.to_path_buf())`, `evidence_kind = Some("pubspec-yaml".into())`, `sbom_tier = Some("source".into())`, `source_type = Some("pub-main-module".into())`, `extra_annotations` containing `"mikebom:component-role": "main-module"` + `"mikebom:source-type": "pub-main-module"`. `depends` populated in T011.
+
+- [X] T010 [US1] Implement `fn emit_lockfile_entries(lockfile_path: &Path, pubspec_lock: &PubspecLock, include_dev: bool) -> Vec<PackageDbEntry>` in `dart.rs` per FR-002 + FR-003 + FR-008. For each `(name, entry)` in `pubspec_lock.packages`:
+  - If `entry.dependency == "direct dev"` AND `!include_dev`, skip (per FR-008 + language-reader convention).
+  - Call `build_purl_for_lockfile_entry(name, entry)` — on `Err`, `tracing::warn!` with the package name + lockfile path and `continue`.
+  - Construct `PackageDbEntry` with: `purl`, `name = name.clone()`, `version = entry.version.clone()`, `source_path = Some(lockfile_path.to_path_buf())`, `lifecycle_scope = if entry.dependency == "direct dev" { Some(LifecycleScope::Development) } else { Some(LifecycleScope::Runtime) }`, `evidence_kind = Some("pubspec-lock".into())`, `sbom_tier = Some("source".into())`, `source_type = Some(source_type_string)` (where source_type_string is the `pub-hosted`/`pub-git`/`pub-path`/`pub-sdk` value matching the source), `extra_annotations = build_extra_annotations(name, entry)`, `hashes = ...` (for hosted with sha256 present, build `ContentHash::sha256(hex)`; else empty).
+
+- [X] T011 [US1] Implement the `dart::read` orchestrator body in `dart.rs`: walk for `pubspec.yaml` files via `find_dart_projects`; for each `pubspec_path`, attempt `parse_pubspec_yaml`; on error → `tracing::warn!` + skip. Compute sibling `pubspec.lock` path (same directory). If lockfile present and parses → emit main-module via T009 (with `depends` populated from `pubspec_lock.packages` keys filtered to `direct main` + (if include_dev) `direct dev`) + emit lockfile entries via T010. If lockfile absent → defer to design-tier path (T019). Append all `PackageDbEntry`s to the output Vec.
+
+- [X] T012 [US1] Write integration test file `mikebom-cli/tests/dart_flutter_app_baseline.rs` with `#[test]` functions covering:
+  - `flutter_app_baseline_emits_lockfile_count_plus_main_module` — SC-001 5-component count assertion (3 direct + 2 transitive + 1 main-module = 6 dart components total in the emitted CDX).
+  - `main_module_emission` — SC-008 PURL `pkg:pub/my_flutter_app@1.2.3` exists in `components[]` with `mikebom:component-role = main-module` property.
+  - `main_module_depends_lists_direct_deps` — US1 acceptance scenario 4: the SBOM's `dependencies[]` entry for the main-module's `bom-ref` carries `dependsOn` targeting each direct dep's bom-ref.
+  - `dev_scope_filterability` — SC-007: a fixture with a `direct dev` entry produces a component with `mikebom:lifecycle-scope = development`; running with `--no-include-dev` suppresses it.
+  
+  Use `tempfile::tempdir()` + helper functions to write synthetic `pubspec.yaml` + `pubspec.lock` files; invoke via `std::process::Command::new(env!("CARGO_BIN_EXE_mikebom"))`. Pattern matches `mikebom-cli/tests/arch_alpm_baseline.rs` (milestone 135) and `mikebom-cli/tests/homebrew_baseline.rs` (milestone 136). Guard `.unwrap()` calls with `#[cfg_attr(test, allow(clippy::unwrap_used))]` per CLAUDE.md convention.
+
+**Checkpoint**: At this point, US1 (the headline MVP — Flutter app scan with main-module + lockfile-driven components + dep edges) is fully functional and SC-001, SC-007, SC-008 all pass independently.
+
+---
+
+## Phase 4: User Story 2 — Operator distinguishes hosted vs git/path/SDK deps (Priority: P2)
+
+**Goal**: Surface the four-way source-type discriminator so downstream supply-chain tooling can correctly classify each dep's risk profile.
+
+**Independent Test (SC-002)**: Synthetic fixture with one each of hosted / git / path / sdk in `pubspec.lock`. Scan. Assert correct PURL shape per FR-003 for each + correct `mikebom:source-type` annotation value.
+
+### Implementation for User Story 2
+
+US2's source-discriminator helpers (`build_purl_for_lockfile_entry` + `build_extra_annotations`) are already implemented in foundational phase (T006 + T007). This phase adds end-to-end correctness validation + the self-hosted hosted-source qualifier branch.
+
+- [X] T013 [US2] Augment `build_purl_for_lockfile_entry` (T006) with the inline correctness invariants for git source: `Err` when `description.resolved_ref` is absent or not 40 hex chars (per spec Edge Cases "Git deps without a resolved SHA"). Strip `#<subpath>` when `path == "."` or empty per R3. Use `.chars().all(|c| c.is_ascii_hexdigit())` for SHA validation.
+
+- [X] T014 [US2] Augment `build_purl_for_lockfile_entry` (T006) with the path-source variant: `pkg:generic/<name>@<version>`. No URL encoding needed on `<name>` (dart package names are lowercase-snake-case per pub.dev publish rules); use the verbatim lockfile key.
+
+- [X] T015 [US2] Augment `build_purl_for_lockfile_entry` (T006) with the SDK-source variant: match `entry.description` against `LockfileDescription::Sdk(sdk_name)` (NOT `Map`) — preserving the polymorphism per R2; produce `pkg:pub/{sdk_name}@0.0.0` (the `0.0.0` is literal, never read from `entry.version` which itself is `"0.0.0"` per pub convention).
+
+- [X] T016 [US2] Augment `build_purl_for_lockfile_entry` (T006) with the self-hosted hosted-source qualifier branch: when `description.url.as_deref() == Some(u)` AND `u != "https://pub.dev"` AND `u != "https://pub.dartlang.org"`, append `?repository_url=<u>` qualifier. Apply minimal URL-encoding for qualifier-value safety (PURL spec allows `:`/`/` in qualifier values; encode only ` `, `?`, `#`, `&`).
+
+- [X] T017 [US2] Write integration test file `mikebom-cli/tests/dart_source_discriminators.rs` with `#[test]` functions covering SC-002 per the contracts/pub-component-purl.md example table:
+  - `hosted_default_pubdev_emits_bare_purl` — `pkg:pub/http@1.1.0` (no qualifier).
+  - `hosted_self_hosted_emits_repository_url_qualifier` — `pkg:pub/internal_lib@2.0.0?repository_url=https://pub.acme.example.com`.
+  - `git_source_emits_resolved_sha_plus_vcs_url` — `pkg:pub/window_size@eb39649...3d5601?vcs_url=git+https://github.com/google/flutter-desktop-embedding.git#plugins/window_size`.
+  - `path_source_emits_generic_placeholder` — `pkg:generic/my_local_lib@0.1.0` with `mikebom:source-type = pub-path` property.
+  - `sdk_source_emits_zero_zero_zero_version` — `pkg:pub/flutter@0.0.0` and `pkg:pub/flutter_test@0.0.0` with `mikebom:source-type = pub-sdk`.
+
+**Checkpoint**: US1 + US2 both functional. The full lockfile-driven SBOM (hosted + git + path + sdk) is correctly classified, addressable via standard `purl` and `properties[].name = mikebom:source-type` filters.
+
+---
+
+## Phase 5: User Story 3 — Operator scans a Dart project WITHOUT a committed lockfile (Priority: P3)
+
+**Goal**: Design-tier emission for library projects + pre-`pub get` workflows — `pubspec.yaml`-only scans surface declared direct deps (runtime + dev) with the constraint string preserved as evidence.
+
+**Independent Test (SC-003)**: Synthetic fixture with `pubspec.yaml` declaring 2 direct deps but NO `pubspec.lock`. Scan. Assert 2 components emit with `mikebom:sbom-tier = "design"` annotation + `mikebom:requirement-range = <constraint-str>` evidence.
+
+### Implementation for User Story 3
+
+- [X] T018 [US3] Implement `fn emit_design_tier_components(pubspec_path: &Path, pubspec_yaml: &PubspecYaml, include_dev: bool) -> Vec<PackageDbEntry>` in `dart.rs` per FR-005. For each `(name, value)` in `pubspec_yaml.dependencies` (always) and `pubspec_yaml.dev_dependencies` (only when `include_dev`):
+  - Extract constraint string from `value` — if scalar string, use verbatim; if map (e.g., `path:` / `git:` / `sdk:` directive), use placeholder string `"unspecified"` (lockfile is the only place where constraints get resolved for non-hosted sources).
+  - Build PURL `pkg:pub/<name>@<constraint-str>` for hosted-shaped declarations; for non-scalar values, emit `pkg:pub/<name>@unspecified`.
+  - Construct `PackageDbEntry` with: `purl`, `name = name.clone()`, `version = constraint-str.clone()`, `source_path = Some(pubspec_path.to_path_buf())`, `lifecycle_scope = if is_dev_block { Some(LifecycleScope::Development) } else { Some(LifecycleScope::Runtime) }`, `evidence_kind = Some("pubspec-yaml".into())`, `sbom_tier = Some("design".into())`, `requirement_range = Some(constraint-str.clone())`, `source_type = Some("pub-hosted".into())` (design-tier is best-effort), `extra_annotations = { "mikebom:source-type": "pub-hosted" }`.
+
+- [X] T019 [US3] Wire design-tier path into the `dart::read` orchestrator (T011): when sibling `pubspec.lock` does NOT exist OR fails to parse, fall back to `emit_design_tier_components(pubspec_path, &pubspec_yaml, include_dev)` per R7. The main-module STILL emits via T009 (with `depends` populated from `pubspec_yaml.dependencies` keys + (if include_dev) `dev_dependencies` keys).
+
+- [X] T020 [US3] Write integration test file `mikebom-cli/tests/dart_design_tier.rs` with `#[test]` functions covering:
+  - `design_tier_no_lockfile_emits_constraints` — SC-003: fixture with `pubspec.yaml` declaring `http: ^1.0.0` + `provider: ^6.1.0`; assert 2 components emit each with `mikebom:sbom-tier = design` and `mikebom:requirement-range = ^1.0.0` (and `^6.1.0`).
+  - `design_tier_no_transitive_deps` — US3 acceptance scenario 2: assert NO components emit for packages not declared in pubspec.yaml (transitive deps require lockfile per spec).
+  - `design_tier_dev_deps_carry_lifecycle_scope` — US3 acceptance scenario 3: fixture with `dev_dependencies: { test: ^1.24.0 }` → emitted `test` component carries `mikebom:lifecycle-scope = development`; rerun with `--no-include-dev` suppresses it.
+
+**Checkpoint**: All three user stories independently functional. US3 enables the library-publisher scan workflow without requiring a committed lockfile.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Edge-case coverage + invariant validation + pre-PR gate.
+
+- [X] T021 [P] Write integration test file `mikebom-cli/tests/dart_edge_cases.rs` covering the spec Edge Cases section + SC-005:
+  - `malformed_lockfile_falls_back_to_design_tier` — SC-005: 4-project fixture where one lockfile has corrupted YAML; scan succeeds (exit 0); the 3 valid projects emit normally + the 4th falls back to design-tier from its pubspec.yaml; `tracing::warn!` fires.
+  - `workspace_monorepo_emits_one_main_module_per_pubspec` — FR-009: Melos-shaped fixture with 3 packages under `packages/` each with own `pubspec.yaml` + `pubspec.lock`; assert 3 main-module components emit; assert NO synthetic workspace-root component.
+  - `missing_version_falls_back_to_unknown_placeholder` — FR-012: `pubspec.yaml` without `version:` field emits main-module with PURL `pkg:pub/<name>@0.0.0-unknown`.
+  - `self_hosted_registry_emits_repository_url_qualifier` — spec Edge Cases: a lockfile entry from `https://pub.acme.example.com` emits PURL with `?repository_url=https://pub.acme.example.com` qualifier.
+  - `sdk_pseudo_deps_emit_zero_zero_zero` — FR-011: lockfile with `flutter` SDK pseudo-dep emits `pkg:pub/flutter@0.0.0` with `mikebom:source-type = pub-sdk` annotation.
+  - `direct_overridden_treated_as_runtime` — R2 lifecycle mapping: lockfile entry with `dependency: "direct overridden"` emits as `lifecycle-scope: Runtime` (no `mikebom:lifecycle-scope = development` annotation).
+  - `empty_packages_block_emits_only_main_module` — Edge Cases: `pubspec.lock` with `packages: {}` emits just the main-module; no warnings; no dep components.
+  - `git_source_missing_resolved_ref_warns_and_skips` — Edge Cases: lockfile with git entry lacking `resolved-ref:` triggers `tracing::warn!` + skips that single entry (other lockfile entries still emit).
+
+- [X] T022 [P] Verify SC-004 no-Dart-rootfs byte-identity invariant by running the existing CDX/SPDX 2.3/SPDX 3 regression test suites against a synthetic fixture containing zero Dart files. Confirm the emitted SBOMs are byte-identical (modulo timestamps + serial numbers) to a pre-feature baseline. Command: `cargo +stable test -p mikebom --test cdx_regression --test spdx_regression --test spdx3_regression`. Document the invariant validation in the test file comments.
+
+- [X] T023 Run `./scripts/pre-pr.sh` from repo root to confirm clippy + workspace test gates pass per CLAUDE.md MANDATORY pre-PR gate. Fix any clippy warnings (especially `unwrap_used` in test files — guard with `#[cfg_attr(test, allow(clippy::unwrap_used))]` per convention) and any failing tests. Re-run until both lanes show `0 errors` / `N passed; 0 failed`.
+
+- [X] T024 Run the quickstart.md SC-006 standard-PURL-filter check + the cross-format byte-equivalence diff (CDX vs SPDX 2.3 vs SPDX 3) on a synthetic Flutter-app fixture. The three formats' Dart-component PURL sets MUST be identical when sorted. Document any divergences (none expected — Dart components flow through the standard PackageDbEntry pipeline).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: T001 → T002 (T002 imports the module declared in T001); T002b independent. T002b BLOCKS T010 (cyclonedx gate would panic in debug builds without T002b).
+- **Foundational (Phase 2)**: All foundational tasks depend on Phase 1 completion. Within Phase 2: T003 → T005 (parser needs struct definitions); T003 → T006 → T007 (PURL helper needs structs; annotation helper has no logical dep on PURL helper but lives in same file); T004 independent; T008 depends on `dart::read` stub existing (T001) — but `read_all` integration in T008 can land before T011 fills in the orchestrator body (intermediate state: dispatcher calls `dart::read` which returns empty Vec).
+- **User Story phases (Phase 3 / 4 / 5)**: ALL depend on Foundational completion. Within each phase, tasks are sequential by default unless marked `[P]`.
+- **Polish (Phase 6)**: T021 + T022 marked `[P]` — independent files. T023 + T024 depend on all preceding phases.
+
+### User Story Dependencies
+
+- **US1 (P1) MVP**: Depends on Foundational. T012 (integration test) depends on T009 + T010 + T011. T009 / T010 / T011 can be implemented in sequence (T009 first since main-module is the simplest, then T010 for lockfile entries, then T011 for orchestration + dep edges).
+- **US2 (P2)**: Depends on Foundational (T006 + T007 already exist after Foundational). T013–T016 augment T006/T007 in-place. T017 (integration test) depends on T013–T016 + T010 (US2 builds atop US1's emit_lockfile_entries).
+- **US3 (P3)**: Depends on Foundational + T009 (main-module emission is shared between lockfile + design-tier paths). T018 → T019 → T020.
+
+### Within Each User Story
+
+- Models → services → integration tests (standard ordering).
+- No TDD ordering imposed for this milestone — tests follow implementation per the milestone-135/136 precedent (tests are integration-test-shaped, not unit-test-shaped; they validate end-to-end CDX emission against the running binary).
+
+### Parallel Opportunities
+
+- **Phase 1**: T001 + T002b can run in parallel (different files). T002 sequential after T001.
+- **Phase 2**: T004 independent of T003/T005/T006/T007 (walker logic doesn't need struct definitions).
+- **Phase 3**: T009 + T010 can run in parallel only if developer is careful — both modify `dart.rs`. In practice, sequentialize: T009 → T010 → T011 → T012.
+- **Phase 4**: T013/T014/T015/T016 all modify `build_purl_for_lockfile_entry` in `dart.rs` — sequential.
+- **Phase 5**: T018 → T019 → T020 sequential.
+- **Phase 6**: T021 + T022 in parallel (different test files); T023 + T024 sequential after.
+
+---
+
+## Parallel Example: Phase 1 + Foundational kickoff
+
+```bash
+# Phase 1 — module + cyclonedx gate extension in parallel:
+Task: "T001 Create mikebom-cli/src/scan_fs/package_db/dart.rs skeleton"
+Task: "T002b Extend evidence-kind enum in mikebom-cli/src/generate/cyclonedx/builder.rs"
+
+# Then T002 (depends on T001):
+Task: "T002 Add `pub mod dart;` to mikebom-cli/src/scan_fs/package_db/mod.rs"
+
+# Phase 2 — walker + struct definitions in parallel:
+Task: "T003 Define PubspecYaml/PubspecLock/LockfileEntry/LockfileDescription structs"
+Task: "T004 Implement find_dart_projects walker"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 — P1)
+
+1. Complete Phase 1: Setup (T001, T002, T002b — module skeleton + cyclonedx gate extension).
+2. Complete Phase 2: Foundational (T003–T008 — structs, parsers, PURL+annotation helpers, dispatcher integration).
+3. Complete Phase 3: US1 (T009–T012 — main-module + lockfile-driven emission + dep edges + integration test).
+4. **STOP and VALIDATE**: Run `cargo +stable test -p mikebom --test dart_flutter_app_baseline` and confirm SC-001 + SC-007 + SC-008 pass.
+5. Deploy/demo if ready — the headline use case (Flutter app scan with PURLs + dep edges) ships independently.
+
+### Incremental Delivery
+
+1. Setup + Foundational → dispatch wired, empty Vec.
+2. + US1 → MVP shippable: Flutter app scans emit full pinned dep graph + main-module.
+3. + US2 → adds source-discriminator filterability (hosted vs git vs path vs sdk).
+4. + US3 → adds library-project / pre-`pub get` workflow support (design-tier from pubspec.yaml only).
+5. + Polish → edge-case coverage + invariant validation + pre-PR gate green.
+
+### Single-PR Pattern (per milestone-135/136 convention)
+
+All phases land in ONE PR per the established Dart-reader milestone pattern. The single PR includes:
+- Module: `mikebom-cli/src/scan_fs/package_db/dart.rs` (~500–800 LOC including doc-comments)
+- Dispatcher integration: `mikebom-cli/src/scan_fs/package_db/mod.rs` (≤10 LOC)
+- Cyclonedx evidence-kind extension: `mikebom-cli/src/generate/cyclonedx/builder.rs` (≤5 LOC)
+- Four integration test files: `mikebom-cli/tests/dart_*.rs` (~600–900 LOC total)
+- Closes #420.
+
+---
+
+## Notes
+
+- `[P]` tasks = different files, no dependencies on incomplete tasks.
+- `[Story]` label maps task to specific user story for traceability.
+- Each user story independently completable and testable.
+- Commit after each logical group (e.g., T001–T002b together; T003–T008 together; T009–T012 together; etc.).
+- Stop at any checkpoint to validate independently.
+- Avoid: cross-story dependencies that break independence (US2 + US3 can ship after US1 in either order).
+- **Pre-PR gate (CLAUDE.md MANDATORY)**: `./scripts/pre-pr.sh` MUST pass before opening PR; per-crate `cargo test -p mikebom` is insufficient (clippy `--all-targets` enforces `unwrap_used` inside test mods).
+- **No-op invariant (SC-004)**: every change MUST preserve byte-identical SBOM output on non-Dart source trees. T022 is the validation.
+- **Per-PR PR-friendly diff size estimate**: ~1,500–2,000 LOC total (matches milestone-135 + milestone-136 PR sizes).


### PR DESCRIPTION
## Summary

- New language reader for Dart/Flutter projects under `mikebom-cli/src/scan_fs/package_db/dart.rs`. Parses `pubspec.yaml` + `pubspec.lock` and emits one main-module component per project plus one component per pinned lockfile entry, with per-source-type PURL shapes confirmed against the purl-spec `pub` definition.
- Source-discriminator surfaces via the existing `mikebom:source-type` annotation (parity-catalog C1 row) with prefixed values (`pub-hosted` / `pub-git` / `pub-path` / `pub-sdk` / `pub-main-module`) to avoid collision with cargo's existing bare values.
- Design-tier fallback (FR-005) when no lockfile is present — emits `dependencies:` + `dev_dependencies:` with the constraint string preserved as `mikebom:requirement-range` evidence so library publishers and pre-`pub get` workflows still get coverage.
- **Zero new Cargo dependencies** — `serde_yaml = 0.9` is already a workspace dep (per `npm/yarn_lock.rs` + `npm/pnpm_lock.rs`).

## PURL shapes (per FR-003 + purl-spec)

| Source | PURL |
|---|---|
| hosted (pub.dev) | `pkg:pub/<name>@<version>` |
| hosted (self-hosted) | `pkg:pub/<name>@<version>?repository_url=<url>` |
| git | `pkg:pub/<name>@<resolved-sha>?vcs_url=git+<url>[#<subpath>]` |
| path | `pkg:generic/<name>@<version>` + `mikebom:source-type=pub-path` |
| sdk | `pkg:pub/<sdk-name>@0.0.0` per purl-spec canonical example |
| main-module | `pkg:pub/<pubspec.yaml.name>@<version>` |

## v1 scope notes

- Transitive inter-package dependency edges are deferred to v1.1 (main-module → direct deps in v1; matches the milestone-064 / 066 / 068 / 069 / 070 v1 convention).
- Pub-workspace (Dart 3.6+ single root lockfile) member-attribution from a root lockfile is deferred to v1.1; v1 emits design-tier deps from each member's own `pubspec.yaml`.
- License extraction is deferred (parallels milestone-135 FR-012 + milestone-136 FR-011 deferrals — license lives in per-package cached pubspec.yaml under `~/.pub-cache/`, cross-reader follow-up).

## Test plan

- [x] 15 dart unit tests pass (PURL construction + annotation building + encoding helpers)
- [x] 19 dart integration tests pass across 4 test files (US1 baseline + US2 source discriminators + US3 design-tier + edge cases)
- [x] 22 byte-identity regression tests preserved (cdx + spdx 2.3 + spdx 3) — SC-004 no-Dart-rootfs invariant
- [x] `./scripts/pre-pr.sh` clean (clippy `--workspace --all-targets -D warnings` + `cargo test --workspace`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)