### PR TITLE
feat(scan_fs/package_db): Elixir/Mix ecosystem reader (closes #422)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-23
+Auto-generated from all feature plans. Last updated: 2026-06-24
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -158,6 +158,7 @@ Auto-generated from all feature plans. Last updated: 2026-06-23
 - N/A — all state is in-process for the duration of a single scan. Mirrors every language-reader since milestone 002. (137-dart-pub-reader)
 - Rust stable (workspace toolchain inherited from milestones 001–137; no nightly required for this user-space-only work). + Existing only — `serde`/`serde_json` (Composer artifacts are JSON; pervasive workspace dep), `mikebom_common::types::hash::ContentHash` (FR-013 SHA-1 emission; already uses `sha2` + `data-encoding` transitively), `tracing` (warn-and-skip per FR-008), `anyhow`/`thiserror` (error propagation), `mikebom_common::types::purl::Purl` (PURL construction + validation; the `composer` type is purl-spec-blessed). **No new Cargo dependencies.** (138-php-composer-reader)
 - Rust stable (workspace toolchain inherited from milestones 001–138; no nightly required for this user-space-only work). + Existing only — `serde`/`serde_yaml = "0.9"` (Podfile.lock + Manifest.lock are YAML; workspace dep per dart.rs + npm/yarn_lock.rs precedent), `serde_json` (annotation construction), `mikebom_common::types::hash::ContentHash` + `HashAlgorithm::Sha1` (FR-008 SHA-1 emission per milestone-138 precedent), `regex` (Podfile line-by-line `pod` / `target` extraction — workspace dep, already used by alpm + brew + yocto), `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror` (error propagation), `mikebom_common::types::purl::Purl` (PURL construction + validation; the `cocoapods` type is purl-spec-blessed). **No new Cargo dependencies.** (139-cocoapods-reader)
+- Rust stable (workspace toolchain inherited from milestones 001–139; no nightly required). + Existing only — `regex` (workspace dep, used by alpm/brew/yocto/cocoapods for line-format and DSL extraction), `mikebom_common::types::hash::{ContentHash, HashAlgorithm}` (FR-011 SHA-256 emission), `mikebom_common::types::purl::Purl` (PURL construction), `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror`, `serde_json` (annotation values), `std::sync::OnceLock` (regex compile-once). **No new Cargo dependencies.** (140-elixir-mix-reader)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -220,9 +221,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 140-elixir-mix-reader: Added Rust stable (workspace toolchain inherited from milestones 001–139; no nightly required). + Existing only — `regex` (workspace dep, used by alpm/brew/yocto/cocoapods for line-format and DSL extraction), `mikebom_common::types::hash::{ContentHash, HashAlgorithm}` (FR-011 SHA-256 emission), `mikebom_common::types::purl::Purl` (PURL construction), `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror`, `serde_json` (annotation values), `std::sync::OnceLock` (regex compile-once). **No new Cargo dependencies.**
 - 139-cocoapods-reader: Added Rust stable (workspace toolchain inherited from milestones 001–138; no nightly required for this user-space-only work). + Existing only — `serde`/`serde_yaml = "0.9"` (Podfile.lock + Manifest.lock are YAML; workspace dep per dart.rs + npm/yarn_lock.rs precedent), `serde_json` (annotation construction), `mikebom_common::types::hash::ContentHash` + `HashAlgorithm::Sha1` (FR-008 SHA-1 emission per milestone-138 precedent), `regex` (Podfile line-by-line `pod` / `target` extraction — workspace dep, already used by alpm + brew + yocto), `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror` (error propagation), `mikebom_common::types::purl::Purl` (PURL construction + validation; the `cocoapods` type is purl-spec-blessed). **No new Cargo dependencies.**
 - 138-php-composer-reader: Added Rust stable (workspace toolchain inherited from milestones 001–137; no nightly required for this user-space-only work). + Existing only — `serde`/`serde_json` (Composer artifacts are JSON; pervasive workspace dep), `mikebom_common::types::hash::ContentHash` (FR-013 SHA-1 emission; already uses `sha2` + `data-encoding` transitively), `tracing` (warn-and-skip per FR-008), `anyhow`/`thiserror` (error propagation), `mikebom_common::types::purl::Purl` (PURL construction + validation; the `composer` type is purl-spec-blessed). **No new Cargo dependencies.**
-- 137-dart-pub-reader: Added Rust stable (workspace toolchain inherited from milestones 001–136; no nightly required for this user-space-only work). + Existing only — `serde`/`serde_yaml = "0.9"` (workspace; already used by `npm/yarn_lock.rs` + `npm/pnpm_lock.rs`), `serde_json` for evidence-annotation construction, `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror` (error propagation), `mikebom_common::types::purl::Purl` (PURL construction + validation; the `pub` type is purl-spec-blessed). **No new Cargo dependencies.**
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/generate/cyclonedx/builder.rs
+++ b/mikebom-cli/src/generate/cyclonedx/builder.rs
@@ -981,6 +981,8 @@ impl CycloneDxBuilder {
                             | "cocoapods-podfile-lock"
                             | "cocoapods-podfile"
                             | "cocoapods-manifest-lock"
+                            | "mix-lock"
+                            | "mix-exs"
                     ),
                     "mikebom:evidence-kind value '{kind}' is not in the canonical \
                      enum (rpm-file | rpmdb-sqlite | rpmdb-bdb | \
@@ -990,7 +992,7 @@ impl CycloneDxBuilder {
                      alpm-local-db | brew-install-receipt | brew-cask-metadata | \
                      pubspec-lock | pubspec-yaml | composer-lock | composer-json | \
                      composer-installed-json | cocoapods-podfile-lock | \
-                     cocoapods-podfile | cocoapods-manifest-lock)"
+                     cocoapods-podfile | cocoapods-manifest-lock | mix-lock | mix-exs)"
                 );
                 properties.push(json!({
                     "name": "mikebom:evidence-kind",

--- a/mikebom-cli/src/generate/cyclonedx/metadata.rs
+++ b/mikebom-cli/src/generate/cyclonedx/metadata.rs
@@ -713,6 +713,23 @@ pub fn build_metadata(
                 "value": value_str,
             }));
         }
+        // Milestone 140 — propagate `mikebom:umbrella-root` when the
+        // Elixir umbrella root main-module is promoted to
+        // `metadata.component` (small umbrella scans with the root as
+        // the dominant project). Multi-member umbrellas emit via
+        // components[] and pick up the property automatically.
+        // Mirrors the milestone-116 + milestone-134 propagation
+        // patterns above.
+        if let Some(value) = c.extra_annotations.get("mikebom:umbrella-root") {
+            let value_str = match value {
+                serde_json::Value::String(s) => s.clone(),
+                other => serde_json::to_string(other).unwrap_or_default(),
+            };
+            comp_props.push(json!({
+                "name": "mikebom:umbrella-root",
+                "value": value_str,
+            }));
+        }
         metadata["component"]["properties"] = json!(comp_props);
 
         // Propagate the supplier so the parity Section A `cdx_supplier`

--- a/mikebom-cli/src/scan_fs/package_db/elixir.rs
+++ b/mikebom-cli/src/scan_fs/package_db/elixir.rs
@@ -1,0 +1,1685 @@
+//! Milestone 140 — Elixir/Mix ecosystem reader.
+//!
+//! Discovers Elixir 1.4+ Mix projects under the scan root via two
+//! input artifacts:
+//!
+//! - `mix.lock` (Elixir-syntax tuple map literal) — source-tier per
+//!   FR-002. Regex-tokenized with brace-counted multi-line tuple
+//!   handling (the lockfile IS stable Elixir source, not standardized
+//!   data — but every prominent SBOM tool regex-parses it).
+//! - `mix.exs` (Elixir source) — design-tier fallback per FR-005 +
+//!   main-module name/version source per FR-012 + dev-scope cross-
+//!   reference source per FR-008. Regex-extracted, no Elixir runtime.
+//!
+//! Three source discriminators with per-source PURL shapes:
+//!
+//! - **hex** (`:hex` tuple, default `"hexpm"` repo): `pkg:hex/<lc-name>@<version>`.
+//! - **hex (private org `"hexpm:<org>"`)**: `pkg:hex/<org>/<lc-name>@<version>?repository_url=https://repo.hex.pm`
+//!   per Phase 0 research correction — purl-spec hex-definition
+//!   blesses the namespace-as-org form + `repository_url=` qualifier.
+//! - **git** (`:git` tuple): `pkg:generic/<name>@<resolved-sha>?vcs_url=git+<url>`
+//!   per Phase 0 — purl-spec doesn't bless `vcs_url=` for hex, so
+//!   git-source emits via `pkg:generic/` (honest about loss of Hex.pm
+//!   provenance once git-swapped).
+//! - **path** (`:path` tuple): `pkg:generic/<name>@unspecified`
+//!   placeholder + `mikebom:source-type = "hex-path"` annotation.
+//!
+//! Inner SHA-256 (4th tuple element) always emits; outer SHA-256 (8th,
+//! optional) emits only when present + non-empty per Q3 best-effort.
+//!
+//! Umbrella projects (root `mix.exs` with `apps_path:` key) emit one
+//! main-module per `mix.exs` (root + each sub-app under `apps/`);
+//! root's `depends` lists each sub-app's main-module NAME per Q2.
+//!
+//! Design-tier `deps/0` extraction is conditional-flattened per Q1 —
+//! every dep tuple in the file emits regardless of `if Mix.env() ...`
+//! / `unless ...` / multi-clause `def deps(env)` nesting; components
+//! inside any conditional carry `mikebom:elixir-extraction-mode =
+//! "conditional-flattened"` annotation as a precision-loss signal.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use mikebom_common::resolution::LifecycleScope;
+use mikebom_common::types::hash::{ContentHash, HashAlgorithm};
+use mikebom_common::types::purl::Purl;
+
+use super::exclude_path::ExclusionSet;
+use super::PackageDbEntry;
+
+const MAX_ELIXIR_WALK_DEPTH: usize = 12;
+
+fn should_skip_descent(name: &str) -> bool {
+    matches!(
+        name,
+        ".git"
+            | ".svn"
+            | ".hg"
+            | "_build"
+            | "deps"
+            | "node_modules"
+            | "priv"
+            | "cover"
+    )
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+enum LockEntry {
+    Hex {
+        name: String,
+        version: String,
+        inner_sha256: String,
+        repo: String,
+        outer_sha256: Option<String>,
+    },
+    Git {
+        name: String,
+        url: String,
+        resolved_sha: String,
+        declared_ref: Option<String>,
+    },
+    Path {
+        name: String,
+        path: String,
+        in_umbrella: bool,
+    },
+}
+
+impl LockEntry {
+    fn name(&self) -> &str {
+        match self {
+            LockEntry::Hex { name, .. } => name,
+            LockEntry::Git { name, .. } => name,
+            LockEntry::Path { name, .. } => name,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
+struct MixExsInfo {
+    app_name: Option<String>,
+    version: Option<String>,
+    is_umbrella: bool,
+    deps: Vec<DeclaredDep>,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct DeclaredDep {
+    name: String,
+    constraint: Option<String>,
+    dev_scope: bool,
+    in_conditional: bool,
+    source_kind: DeclaredDepSource,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+enum DeclaredDepSource {
+    Hex,
+    Git {
+        url: String,
+        declared_ref: Option<String>,
+    },
+    Path {
+        path: String,
+        in_umbrella: bool,
+    },
+}
+
+pub fn read(
+    rootfs: &Path,
+    _include_dev: bool,
+    exclude_set: &ExclusionSet,
+) -> Vec<PackageDbEntry> {
+    let mut out: Vec<PackageDbEntry> = Vec::new();
+    let mut seen_purls: HashSet<String> = HashSet::new();
+    let mut lockfile_dirs: HashSet<PathBuf> = HashSet::new();
+    let mut warned = 0usize;
+    let mut emitted_lockfile = 0usize;
+    let mut emitted_design = 0usize;
+
+    // Pass A — mix.lock walker.
+    for lockfile_path in find_mix_locks(rootfs, exclude_set) {
+        let Some(project_dir) = lockfile_path.parent() else {
+            continue;
+        };
+
+        let text = match std::fs::read_to_string(&lockfile_path) {
+            Ok(t) => t,
+            Err(err) => {
+                warned += 1;
+                tracing::warn!(
+                    path = %lockfile_path.display(),
+                    error = %err,
+                    "elixir: failed to read mix.lock; skipping",
+                );
+                continue;
+            }
+        };
+
+        let tokens = tokenize_mix_lock(&text);
+        if tokens.is_empty() && !text.trim().is_empty() && !text.trim().starts_with("%{}") {
+            warned += 1;
+            tracing::warn!(
+                path = %lockfile_path.display(),
+                "elixir: mix.lock parse yielded zero entries; falling back to sibling mix.exs design-tier if present",
+            );
+            // Fall through — pass B handles the design-tier fallback
+            // for this project dir (project_dir NOT marked in
+            // lockfile_dirs).
+            continue;
+        }
+
+        let mut entries: Vec<LockEntry> = Vec::new();
+        for (name, body) in &tokens {
+            if let Some(e) = parse_lock_entry(name, body) {
+                entries.push(e);
+            } else {
+                tracing::debug!(
+                    path = %lockfile_path.display(),
+                    name = %name,
+                    "elixir: skipping unparseable lockfile entry",
+                );
+            }
+        }
+
+        lockfile_dirs.insert(project_dir.to_path_buf());
+
+        let mix_exs_path = project_dir.join("mix.exs");
+        let mix_exs_info: Option<MixExsInfo> = if mix_exs_path.is_file() {
+            parse_mix_exs(&mix_exs_path).ok()
+        } else {
+            None
+        };
+
+        let declared_dep_names: Vec<String> = mix_exs_info
+            .as_ref()
+            .map(|i| i.deps.iter().map(|d| d.name.clone()).collect())
+            .unwrap_or_default();
+
+        if let Some(main_module) = emit_main_module(
+            project_dir,
+            mix_exs_path.is_file().then_some(mix_exs_path.as_path()),
+            Some(&lockfile_path),
+            mix_exs_info.as_ref(),
+            true,
+            &declared_dep_names,
+        ) {
+            let purl_key = main_module.purl.as_str().to_string();
+            if seen_purls.insert(purl_key) {
+                out.push(main_module);
+            }
+        }
+
+        let lock_entries =
+            emit_lockfile_components(&lockfile_path, &entries, mix_exs_info.as_ref());
+        emitted_lockfile += lock_entries.len();
+        for entry in lock_entries {
+            let purl_key = entry.purl.as_str().to_string();
+            if seen_purls.insert(purl_key) {
+                out.push(entry);
+            }
+        }
+    }
+
+    // Pass B — mix.exs design-tier walker (only for projects without
+    // a sibling mix.lock that Pass A processed).
+    let mut umbrella_roots: Vec<(PathBuf, String)> = Vec::new(); // (project_dir, root_app_name)
+    for mix_exs_path in find_mix_exs(rootfs, exclude_set) {
+        let Some(project_dir) = mix_exs_path.parent() else {
+            continue;
+        };
+        let info = match parse_mix_exs(&mix_exs_path) {
+            Ok(info) => info,
+            Err(err) => {
+                warned += 1;
+                tracing::warn!(
+                    path = %mix_exs_path.display(),
+                    error = %err,
+                    "elixir: failed to parse mix.exs; skipping",
+                );
+                continue;
+            }
+        };
+
+        // Track umbrella roots for Pass C aggregation regardless of
+        // tier — applies to lockfile-mode projects too if root has
+        // apps_path.
+        if info.is_umbrella {
+            if let Some(app_name) = info.app_name.clone() {
+                umbrella_roots.push((project_dir.to_path_buf(), app_name));
+            }
+        }
+
+        // If this project dir was Pass A processed, skip design-tier
+        // emission (lockfile already won) but still need to track
+        // umbrella status (handled above).
+        if lockfile_dirs.contains(project_dir) {
+            continue;
+        }
+
+        let declared_dep_names: Vec<String> =
+            info.deps.iter().map(|d| d.name.clone()).collect();
+        if let Some(main_module) = emit_main_module(
+            project_dir,
+            Some(&mix_exs_path),
+            None,
+            Some(&info),
+            false,
+            &declared_dep_names,
+        ) {
+            let purl_key = main_module.purl.as_str().to_string();
+            if seen_purls.insert(purl_key) {
+                out.push(main_module);
+            }
+        }
+
+        let design_entries = emit_design_tier_components(&mix_exs_path, &info);
+        emitted_design += design_entries.len();
+        for entry in design_entries {
+            let purl_key = entry.purl.as_str().to_string();
+            if seen_purls.insert(purl_key) {
+                out.push(entry);
+            }
+        }
+    }
+
+    // Pass C — umbrella root aggregation per Q2 + I1 remediation.
+    // For each umbrella root, append each sub-app's main-module NAME
+    // (not bom-ref — orchestrator handles name→bom-ref translation at
+    // dep-edge wiring) to the root's `depends` list.
+    for (root_dir, root_app_name) in &umbrella_roots {
+        let sub_app_names: Vec<String> = collect_apps_subdirs(root_dir)
+            .into_iter()
+            .filter_map(|sub_mix_exs| {
+                parse_mix_exs(&sub_mix_exs)
+                    .ok()
+                    .and_then(|info| info.app_name)
+            })
+            .collect();
+        if sub_app_names.is_empty() {
+            continue;
+        }
+        // Find the root main-module in `out` and append sub-app names.
+        for entry in out.iter_mut() {
+            if entry.name == *root_app_name
+                && entry
+                    .extra_annotations
+                    .get("mikebom:umbrella-root")
+                    .and_then(|v| v.as_str())
+                    == Some("true")
+            {
+                for sub in &sub_app_names {
+                    if !entry.depends.contains(sub) {
+                        entry.depends.push(sub.clone());
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    if !out.is_empty() || warned > 0 {
+        tracing::info!(
+            rootfs = %rootfs.display(),
+            entries = out.len(),
+            emitted_lockfile,
+            emitted_design,
+            umbrella_roots = umbrella_roots.len(),
+            warned,
+            "parsed mix.lock + mix.exs entries",
+        );
+    }
+    out
+}
+
+fn find_mix_locks(rootfs: &Path, exclude_set: &ExclusionSet) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let cfg = crate::scan_fs::walk::WalkConfig {
+        max_depth: MAX_ELIXIR_WALK_DEPTH,
+        should_skip: &|candidate: &Path, _rootfs: &Path| -> bool {
+            let Some(name) = candidate.file_name().and_then(|s| s.to_str()) else {
+                return true;
+            };
+            should_skip_descent(name)
+        },
+        exclude_set,
+    };
+    crate::scan_fs::walk::safe_walk(rootfs, &cfg, |path| {
+        if path.is_file() && path.file_name().and_then(|s| s.to_str()) == Some("mix.lock") {
+            out.push(path.to_path_buf());
+        }
+    });
+    out.sort();
+    out
+}
+
+fn find_mix_exs(rootfs: &Path, exclude_set: &ExclusionSet) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let cfg = crate::scan_fs::walk::WalkConfig {
+        max_depth: MAX_ELIXIR_WALK_DEPTH,
+        should_skip: &|candidate: &Path, _rootfs: &Path| -> bool {
+            let Some(name) = candidate.file_name().and_then(|s| s.to_str()) else {
+                return true;
+            };
+            should_skip_descent(name)
+        },
+        exclude_set,
+    };
+    crate::scan_fs::walk::safe_walk(rootfs, &cfg, |path| {
+        if path.is_file() && path.file_name().and_then(|s| s.to_str()) == Some("mix.exs") {
+            out.push(path.to_path_buf());
+        }
+    });
+    out.sort();
+    out
+}
+
+/// Tokenize `mix.lock` into `(name, tuple_body)` pairs via brace
+/// counting. Each entry shape: `"<name>": {...},` where the value's
+/// `{...}` may contain nested `[...]` and quoted strings.
+fn tokenize_mix_lock(text: &str) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    let bytes = text.as_bytes();
+    let mut i = 0usize;
+    let len = bytes.len();
+
+    // Skip past the opening `%{`.
+    while i < len && bytes[i] != b'{' {
+        i += 1;
+    }
+    if i >= len {
+        return out;
+    }
+    i += 1; // past `{`
+
+    loop {
+        // Skip whitespace and commas.
+        while i < len
+            && (bytes[i] == b' '
+                || bytes[i] == b'\n'
+                || bytes[i] == b'\r'
+                || bytes[i] == b'\t'
+                || bytes[i] == b',')
+        {
+            i += 1;
+        }
+        if i >= len || bytes[i] == b'}' {
+            break;
+        }
+        // Expect `"<name>"`.
+        if bytes[i] != b'"' {
+            // Unexpected byte — skip
+            i += 1;
+            continue;
+        }
+        let name_start = i + 1;
+        i += 1;
+        while i < len && bytes[i] != b'"' {
+            i += 1;
+        }
+        if i >= len {
+            break;
+        }
+        let name_end = i;
+        i += 1; // past closing `"`
+        let name = String::from_utf8_lossy(&bytes[name_start..name_end]).into_owned();
+
+        // Skip `:` + whitespace.
+        while i < len && (bytes[i] == b':' || bytes[i] == b' ' || bytes[i] == b'\t') {
+            i += 1;
+        }
+        if i >= len || bytes[i] != b'{' {
+            // Unexpected — skip to next entry by scanning to next `"`
+            // at indent.
+            continue;
+        }
+        let body_start = i;
+        // Brace-counted scan to find matching `}`. Quoted strings +
+        // bracketed lists pass through transparently — we only need
+        // to track brace depth to find the entry's terminator.
+        let mut depth_brace = 0i32;
+        let mut in_str = false;
+        let mut escape = false;
+        while i < len {
+            let c = bytes[i];
+            if escape {
+                escape = false;
+            } else if in_str {
+                if c == b'\\' {
+                    escape = true;
+                } else if c == b'"' {
+                    in_str = false;
+                }
+            } else {
+                match c {
+                    b'"' => in_str = true,
+                    b'{' => depth_brace += 1,
+                    b'}' => {
+                        depth_brace -= 1;
+                        if depth_brace == 0 {
+                            i += 1;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            i += 1;
+        }
+        if depth_brace > 0 {
+            // Unterminated — bail.
+            break;
+        }
+        let body_end = i;
+        let body = String::from_utf8_lossy(&bytes[body_start..body_end]).into_owned();
+        out.push((name, body));
+    }
+    out
+}
+
+fn parse_lock_entry(name: &str, tuple_body: &str) -> Option<LockEntry> {
+    let trimmed = tuple_body.trim();
+    if !trimmed.starts_with('{') || !trimmed.ends_with('}') {
+        return None;
+    }
+    let inner = &trimmed[1..trimmed.len() - 1];
+    let inner_trimmed = inner.trim_start();
+
+    if let Some(rest) = inner_trimmed.strip_prefix(":hex") {
+        return parse_hex_entry(name, rest);
+    }
+    if let Some(rest) = inner_trimmed.strip_prefix(":git") {
+        return parse_git_entry(name, rest);
+    }
+    if let Some(rest) = inner_trimmed.strip_prefix(":path") {
+        return parse_path_entry(name, rest);
+    }
+    None
+}
+
+fn parse_hex_entry(name: &str, rest: &str) -> Option<LockEntry> {
+    // After `:hex`, the comma-separated parts are:
+    //   :<atom_name>, "<version>", "<inner_sha256>", [<managers>],
+    //   [<deps>], "<repo>", "<outer_sha256>"?
+    // We use a forgiving extraction: pull the first 3 quoted strings
+    // (version, inner_sha, then later repo + outer_sha), with skip
+    // logic for the bracketed lists.
+    let s = rest.trim_start_matches(',').trim_start();
+    // Skip the atom name.
+    if !s.starts_with(':') {
+        return None;
+    }
+    let atom_end = s
+        .char_indices()
+        .find(|(_, c)| !c.is_ascii_alphanumeric() && *c != '_' && *c != ':')
+        .map(|(i, _)| i)
+        .unwrap_or(s.len());
+    let after_atom = &s[atom_end..];
+
+    // Extract quoted strings sequentially, skipping bracketed lists
+    // (managers + deps).
+    let strings = extract_quoted_strings_skipping_brackets(after_atom);
+    // Position 0: version, Position 1: inner_sha256, Position 2: repo,
+    // Position 3 (optional): outer_sha256.
+    let version = strings.first()?.clone();
+    let inner_sha256 = strings.get(1)?.clone();
+    if inner_sha256.len() != 64 || !inner_sha256.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let repo = strings.get(2).cloned().unwrap_or_else(|| "hexpm".to_string());
+    let outer_sha256 = strings.get(3).cloned().filter(|s| !s.is_empty()
+        && s.len() == 64
+        && s.chars().all(|c| c.is_ascii_hexdigit()));
+    Some(LockEntry::Hex {
+        name: name.to_string(),
+        version,
+        inner_sha256,
+        repo,
+        outer_sha256,
+    })
+}
+
+fn parse_git_entry(name: &str, rest: &str) -> Option<LockEntry> {
+    let s = rest.trim_start_matches(',').trim_start();
+    let strings = extract_quoted_strings_skipping_brackets(s);
+    let url = strings.first()?.clone();
+    let resolved_sha = strings.get(1)?.clone();
+    if resolved_sha.len() != 40 || !resolved_sha.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    // Find opts bracket — last `[...]` in the body.
+    let declared_ref = extract_first_kw_from_brackets(s);
+    Some(LockEntry::Git {
+        name: name.to_string(),
+        url,
+        resolved_sha,
+        declared_ref,
+    })
+}
+
+fn parse_path_entry(name: &str, rest: &str) -> Option<LockEntry> {
+    let s = rest.trim_start_matches(',').trim_start();
+    let strings = extract_quoted_strings_skipping_brackets(s);
+    let path = strings.first()?.clone();
+    let in_umbrella = s.contains("in_umbrella: true") || s.contains("in_umbrella: :true");
+    Some(LockEntry::Path {
+        name: name.to_string(),
+        path,
+        in_umbrella,
+    })
+}
+
+/// Extract top-level quoted strings, skipping content inside `[...]`
+/// brackets (which contain managers / deps lists with their own
+/// quoted strings).
+fn extract_quoted_strings_skipping_brackets(s: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let bytes = s.as_bytes();
+    let mut i = 0usize;
+    let mut in_str = false;
+    let mut escape = false;
+    let mut bracket_depth = 0i32;
+    let mut current = String::new();
+    while i < bytes.len() {
+        let c = bytes[i];
+        if escape {
+            current.push(c as char);
+            escape = false;
+        } else if in_str {
+            if c == b'\\' {
+                escape = true;
+            } else if c == b'"' {
+                in_str = false;
+                if bracket_depth == 0 {
+                    out.push(std::mem::take(&mut current));
+                }
+            } else if bracket_depth == 0 {
+                current.push(c as char);
+            }
+        } else {
+            match c {
+                b'[' => bracket_depth += 1,
+                b']' => bracket_depth -= 1,
+                b'"' if bracket_depth == 0 => in_str = true,
+                b'"' => in_str = true, // inside brackets — skip but track string
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Extract the first keyword from the LAST `[...]` block in the body
+/// (the opts list for `:git` / `:path` entries). Returns e.g.
+/// `"ref: main"` for `[ref: "main"]`.
+fn extract_first_kw_from_brackets(s: &str) -> Option<String> {
+    // Find the last `[` and matching `]`.
+    let open = s.rfind('[')?;
+    let close = s[open..].find(']').map(|p| open + p)?;
+    let inner = &s[open + 1..close].trim();
+    if inner.is_empty() {
+        return None;
+    }
+    // Match `<kw>: "<value>"` or `<kw>: :<atom>` or `<kw>: <atom>`.
+    static KW_RE: OnceLock<Regex> = OnceLock::new();
+    let re = KW_RE.get_or_init(|| {
+        Regex::new(r#"^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(?:"([^"]+)"|:?([a-zA-Z_][a-zA-Z0-9_.]*))"#)
+            .expect("static kw regex")
+    });
+    let captures = re.captures(inner)?;
+    let key = captures.get(1)?.as_str();
+    let value = captures
+        .get(2)
+        .or_else(|| captures.get(3))?
+        .as_str();
+    Some(format!("{key}: {value}"))
+}
+
+fn parse_mix_exs(path: &Path) -> anyhow::Result<MixExsInfo> {
+    static APP_RE: OnceLock<Regex> = OnceLock::new();
+    static VERSION_RE: OnceLock<Regex> = OnceLock::new();
+    static APPS_PATH_RE: OnceLock<Regex> = OnceLock::new();
+    static DEP_RE: OnceLock<Regex> = OnceLock::new();
+    // Regexes match either start-of-line (multi-line `do ... end` form)
+    // OR after `[` / `,` (single-line `do: [app: :x, version: "...", ...]`
+    // shorthand). The dep_re false-positive filter (T008) drops `app` /
+    // `version` / `deps` / `elixir` as dep names so a stray match in a
+    // dep tuple's opts doesn't pollute the `deps` list.
+    let app_re = APP_RE.get_or_init(|| {
+        Regex::new(r"(?m)(?:^\s*|[\[,]\s*)app:\s*:([a-zA-Z_][a-zA-Z0-9_]*)\b")
+            .expect("static app regex")
+    });
+    let version_re = VERSION_RE.get_or_init(|| {
+        Regex::new(r#"(?m)(?:^\s*|[\[,]\s*)version:\s*"([^"]+)""#)
+            .expect("static version regex")
+    });
+    let apps_path_re = APPS_PATH_RE.get_or_init(|| {
+        Regex::new(r"(?m)(?:^\s*|[\[,]\s*)apps_path:\s*").expect("static apps_path regex")
+    });
+    let dep_re = DEP_RE.get_or_init(|| {
+        // Capture: 1 = name, 2 = optional first-string constraint,
+        // 3 = optional opts blob (everything between possibly a comma
+        // and the closing `}`).
+        Regex::new(r#"\{\s*:([a-zA-Z_][a-zA-Z0-9_]*)\s*(?:,\s*"([^"]+)")?(?:,\s*([^}]*))?\s*\}"#)
+            .expect("static dep regex")
+    });
+
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("read failed: {e}"))?;
+    let mut info = MixExsInfo {
+        app_name: app_re
+            .captures(&text)
+            .and_then(|c| c.get(1).map(|m| m.as_str().to_string())),
+        version: version_re
+            .captures(&text)
+            .and_then(|c| c.get(1).map(|m| m.as_str().to_string())),
+        is_umbrella: apps_path_re.is_match(&text),
+        deps: Vec::new(),
+    };
+
+    // Per-line tracking + dep extraction.
+    //
+    // `block_stack` distinguishes opener types: `true` for
+    // conditional openers (`if`/`unless`/`case`/`cond ... do`); `false`
+    // for everything else (`def`/`defp`/`defmodule`/`with`/`for` etc).
+    // A dep is `in_conditional` iff any `true` exists in the stack.
+    // We pop on every `end` (assumes balanced); imbalanced files emit
+    // best-effort results.
+    let mut block_stack: Vec<bool> = Vec::new();
+    let mut after_first_do = false;
+    for raw_line in text.lines() {
+        let line = strip_comment(raw_line);
+        let trimmed = line.trim();
+
+        // Detect `do`-opening line. We classify by first keyword.
+        let opens_do = trimmed.ends_with(" do") || trimmed == "do" || trimmed.contains(" do ");
+        if opens_do {
+            let is_conditional = trimmed.starts_with("if ")
+                || trimmed.starts_with("if(")
+                || trimmed.starts_with("unless ")
+                || trimmed.starts_with("unless(")
+                || trimmed.starts_with("case ")
+                || trimmed.starts_with("case(")
+                || trimmed.starts_with("cond ")
+                || trimmed == "cond do"
+                || trimmed.contains(" if ")
+                || trimmed.contains(" case ")
+                || trimmed.contains(" unless ");
+            block_stack.push(is_conditional);
+            after_first_do = true;
+        }
+        // `end` line — pop. Bare `end` or trailing ` end`.
+        if (trimmed == "end" || trimmed.ends_with(" end")) && !block_stack.is_empty() {
+            block_stack.pop();
+        }
+
+        // Skip dep extraction until we've entered at least one `do`
+        // block (avoids capturing tuples in module-level constants
+        // before any `defmodule` opener).
+        if !after_first_do {
+            continue;
+        }
+        // Dep tuple extraction — match each tuple in the line.
+        let in_conditional = block_stack.iter().any(|b| *b);
+        for caps in dep_re.captures_iter(line) {
+            let name = match caps.get(1) {
+                Some(m) => m.as_str().to_string(),
+                None => continue,
+            };
+            // Skip common false positives — keyword tuples that aren't
+            // actually dep declarations.
+            if name == "app" || name == "version" || name == "deps" || name == "elixir" {
+                continue;
+            }
+            let constraint = caps.get(2).map(|m| m.as_str().to_string());
+            let opts_blob = caps.get(3).map(|m| m.as_str()).unwrap_or("");
+            let dev_scope = detect_dev_scope(opts_blob);
+            let source_kind = detect_source_kind(opts_blob);
+            info.deps.push(DeclaredDep {
+                name,
+                constraint,
+                dev_scope,
+                in_conditional,
+                source_kind,
+            });
+        }
+    }
+    Ok(info)
+}
+
+fn strip_comment(line: &str) -> &str {
+    match line.split_once('#') {
+        Some((s, _)) => s,
+        None => line,
+    }
+    .trim_end()
+}
+
+fn detect_dev_scope(opts_blob: &str) -> bool {
+    if opts_blob.contains("runtime: false") {
+        return true;
+    }
+    // Match `only: :dev` / `only: :test` / `only: [:dev, :test]`.
+    if let Some(idx) = opts_blob.find("only:") {
+        let rest = &opts_blob[idx + 5..];
+        if rest.contains(":dev") || rest.contains(":test") || rest.contains(":doc") {
+            return true;
+        }
+    }
+    false
+}
+
+fn detect_source_kind(opts_blob: &str) -> DeclaredDepSource {
+    // Match `path: "..."`.
+    if let Some(p) = extract_kw_string(opts_blob, "path") {
+        let in_umbrella = opts_blob.contains("in_umbrella: true");
+        return DeclaredDepSource::Path { path: p, in_umbrella };
+    }
+    // Match `git: "..."`.
+    if let Some(u) = extract_kw_string(opts_blob, "git") {
+        return DeclaredDepSource::Git {
+            url: u,
+            declared_ref: extract_first_git_ref(opts_blob),
+        };
+    }
+    // Match `github: "owner/repo"` shortcut.
+    if let Some(slug) = extract_kw_string(opts_blob, "github") {
+        let url = format!("https://github.com/{slug}.git");
+        return DeclaredDepSource::Git {
+            url,
+            declared_ref: extract_first_git_ref(opts_blob),
+        };
+    }
+    if opts_blob.contains("in_umbrella: true") {
+        return DeclaredDepSource::Path {
+            path: String::new(),
+            in_umbrella: true,
+        };
+    }
+    DeclaredDepSource::Hex
+}
+
+fn extract_kw_string(opts: &str, key: &str) -> Option<String> {
+    let pat = format!(r#"\b{key}\s*:\s*"([^"]+)""#);
+    let re = Regex::new(&pat).ok()?;
+    re.captures(opts).and_then(|c| c.get(1).map(|m| m.as_str().to_string()))
+}
+
+fn extract_first_git_ref(opts: &str) -> Option<String> {
+    for key in &["ref", "tag", "branch", "commit"] {
+        if let Some(v) = extract_kw_string(opts, key) {
+            return Some(format!("{key}: {v}"));
+        }
+    }
+    None
+}
+
+fn build_purl_for_lock_entry(entry: &LockEntry) -> Result<Purl, String> {
+    let purl_str = match entry {
+        LockEntry::Hex {
+            name,
+            version,
+            repo,
+            ..
+        } => {
+            let lc_name = name.to_lowercase();
+            if let Some(org) = repo.strip_prefix("hexpm:") {
+                let lc_org = org.to_lowercase();
+                format!(
+                    "pkg:hex/{lc_org}/{lc_name}@{version}?repository_url=https://repo.hex.pm"
+                )
+            } else {
+                format!("pkg:hex/{lc_name}@{version}")
+            }
+        }
+        LockEntry::Git {
+            name,
+            url,
+            resolved_sha,
+            ..
+        } => {
+            format!(
+                "pkg:generic/{name}@{resolved_sha}?vcs_url=git+{url}",
+                url = minimal_qualifier_encode(url),
+            )
+        }
+        LockEntry::Path { name, .. } => {
+            format!("pkg:generic/{name}@unspecified")
+        }
+    };
+    Purl::new(&purl_str).map_err(|e| format!("PURL construction failed for {purl_str}: {e:?}"))
+}
+
+fn classify_source_type(entry: &LockEntry) -> &'static str {
+    match entry {
+        LockEntry::Hex { .. } => "hex-hex",
+        LockEntry::Git { .. } => "hex-git",
+        LockEntry::Path { .. } => "hex-path",
+    }
+}
+
+fn build_extra_annotations(
+    entry: &LockEntry,
+    source_type_value: &str,
+) -> BTreeMap<String, serde_json::Value> {
+    let mut out: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    out.insert(
+        "mikebom:source-type".to_string(),
+        serde_json::Value::String(source_type_value.to_string()),
+    );
+    match entry {
+        LockEntry::Git {
+            declared_ref: Some(r),
+            ..
+        } => {
+            out.insert(
+                "mikebom:vcs-declared-ref".to_string(),
+                serde_json::Value::String(r.clone()),
+            );
+        }
+        LockEntry::Path {
+            path, in_umbrella, ..
+        } => {
+            out.insert(
+                "mikebom:path".to_string(),
+                serde_json::Value::String(path.clone()),
+            );
+            if *in_umbrella {
+                out.insert(
+                    "mikebom:in-umbrella".to_string(),
+                    serde_json::Value::String("true".to_string()),
+                );
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+fn emit_main_module(
+    project_dir: &Path,
+    mix_exs_path: Option<&Path>,
+    lockfile_path: Option<&Path>,
+    info: Option<&MixExsInfo>,
+    doc_has_lockfile: bool,
+    declared_dep_names_for_depends: &[String],
+) -> Option<PackageDbEntry> {
+    let app_name = info
+        .and_then(|i| i.app_name.clone())
+        .or_else(|| {
+            project_dir
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(String::from)
+        })?;
+    if app_name.is_empty() {
+        return None;
+    }
+    let version = info
+        .and_then(|i| i.version.clone())
+        .unwrap_or_else(|| "0.0.0-unknown".to_string());
+    let lc_app_name = app_name.to_lowercase();
+    let purl_str = format!("pkg:hex/{lc_app_name}@{version}");
+    let purl = Purl::new(&purl_str).ok()?;
+
+    let source_path = mix_exs_path
+        .map(|p| p.to_string_lossy().into_owned())
+        .or_else(|| lockfile_path.map(|p| p.to_string_lossy().into_owned()))
+        .unwrap_or_else(|| project_dir.to_string_lossy().into_owned());
+
+    let mut extra_annotations: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    extra_annotations.insert(
+        "mikebom:component-role".to_string(),
+        serde_json::Value::String("main-module".to_string()),
+    );
+    extra_annotations.insert(
+        "mikebom:source-type".to_string(),
+        serde_json::Value::String("hex-main-module".to_string()),
+    );
+    if info.is_some_and(|i| i.is_umbrella) {
+        extra_annotations.insert(
+            "mikebom:umbrella-root".to_string(),
+            serde_json::Value::String("true".to_string()),
+        );
+    }
+
+    let sbom_tier = if doc_has_lockfile { "source" } else { "design" };
+
+    Some(PackageDbEntry {
+        purl,
+        name: app_name,
+        version,
+        arch: None,
+        source_path,
+        depends: declared_dep_names_for_depends.to_vec(),
+        maintainer: None,
+        licenses: Vec::new(),
+        lifecycle_scope: None,
+        requirement_range: None,
+        source_type: Some("hex-main-module".to_string()),
+        buildinfo_status: None,
+        sbom_tier: Some(sbom_tier.to_string()),
+        evidence_kind: Some("mix-exs".to_string()),
+        binary_class: None,
+        binary_stripped: None,
+        linkage_kind: None,
+        detected_go: None,
+        confidence: None,
+        binary_packed: None,
+        raw_version: None,
+        parent_purl: None,
+        npm_role: None,
+        co_owned_by: None,
+        hashes: Vec::new(),
+        shade_relocation: None,
+        extra_annotations,
+        binary_role: None,
+        build_inclusion: None,
+    })
+}
+
+fn emit_lockfile_components(
+    lockfile_path: &Path,
+    entries: &[LockEntry],
+    mix_exs_info: Option<&MixExsInfo>,
+) -> Vec<PackageDbEntry> {
+    let mut out = Vec::new();
+    let source_path = lockfile_path.to_string_lossy().into_owned();
+    for entry in entries {
+        let purl = match build_purl_for_lock_entry(entry) {
+            Ok(p) => p,
+            Err(err) => {
+                tracing::warn!(
+                    name = %entry.name(),
+                    path = %lockfile_path.display(),
+                    error = %err,
+                    "elixir: skipping malformed lockfile entry",
+                );
+                continue;
+            }
+        };
+        let source_type_value = classify_source_type(entry);
+        let extra_annotations = build_extra_annotations(entry, source_type_value);
+
+        // Hashes per FR-011 + Q3 — only for hex entries.
+        let hashes: Vec<ContentHash> = match entry {
+            LockEntry::Hex {
+                inner_sha256,
+                outer_sha256,
+                ..
+            } => {
+                let mut hs = Vec::new();
+                if let Ok(h) =
+                    ContentHash::with_algorithm(HashAlgorithm::Sha256, inner_sha256)
+                {
+                    hs.push(h);
+                }
+                if let Some(outer) = outer_sha256 {
+                    if let Ok(h) = ContentHash::with_algorithm(HashAlgorithm::Sha256, outer) {
+                        hs.push(h);
+                    }
+                }
+                hs
+            }
+            _ => Vec::new(),
+        };
+
+        // Scope cross-reference per FR-008.
+        let lifecycle_scope = mix_exs_info
+            .and_then(|info| info.deps.iter().find(|d| d.name == entry.name()))
+            .map(|d| {
+                if d.dev_scope {
+                    LifecycleScope::Development
+                } else {
+                    LifecycleScope::Runtime
+                }
+            })
+            .unwrap_or(LifecycleScope::Runtime);
+
+        let (name, version) = match entry {
+            LockEntry::Hex { name, version, .. } => (name.clone(), version.clone()),
+            LockEntry::Git {
+                name, resolved_sha, ..
+            } => (name.clone(), resolved_sha.clone()),
+            LockEntry::Path { name, .. } => (name.clone(), "unspecified".to_string()),
+        };
+
+        out.push(PackageDbEntry {
+            purl,
+            name,
+            version,
+            arch: None,
+            source_path: source_path.clone(),
+            depends: Vec::new(),
+            maintainer: None,
+            licenses: Vec::new(),
+            lifecycle_scope: Some(lifecycle_scope),
+            requirement_range: None,
+            source_type: Some(source_type_value.to_string()),
+            buildinfo_status: None,
+            sbom_tier: Some("source".to_string()),
+            evidence_kind: Some("mix-lock".to_string()),
+            binary_class: None,
+            binary_stripped: None,
+            linkage_kind: None,
+            detected_go: None,
+            confidence: None,
+            binary_packed: None,
+            raw_version: None,
+            parent_purl: None,
+            npm_role: None,
+            co_owned_by: None,
+            hashes,
+            shade_relocation: None,
+            extra_annotations,
+            binary_role: None,
+            build_inclusion: None,
+        });
+    }
+    out
+}
+
+fn emit_design_tier_components(
+    mix_exs_path: &Path,
+    info: &MixExsInfo,
+) -> Vec<PackageDbEntry> {
+    let mut out = Vec::new();
+    let source_path = mix_exs_path.to_string_lossy().into_owned();
+    let main_module_name = info.app_name.as_deref().unwrap_or("");
+
+    for decl in &info.deps {
+        if decl.name == main_module_name {
+            continue;
+        }
+        let constraint = decl
+            .constraint
+            .clone()
+            .unwrap_or_else(|| "unspecified".to_string());
+        let sanitized = sanitize_purl_version(&constraint);
+
+        // Per C2 remediation: dispatch on source_kind to construct
+        // correct PURL shape per FR-003.
+        let (purl_str, source_type_value, source_specific_anns) = match &decl.source_kind {
+            DeclaredDepSource::Hex => {
+                let lc_name = decl.name.to_lowercase();
+                let purl = format!("pkg:hex/{lc_name}@{sanitized}");
+                (purl, "hex-hex", BTreeMap::<String, serde_json::Value>::new())
+            }
+            DeclaredDepSource::Git { url, declared_ref } => {
+                let purl = format!(
+                    "pkg:generic/{}@unspecified?vcs_url=git+{}",
+                    decl.name,
+                    minimal_qualifier_encode(url),
+                );
+                let mut anns: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+                if let Some(r) = declared_ref {
+                    anns.insert(
+                        "mikebom:vcs-declared-ref".to_string(),
+                        serde_json::Value::String(r.clone()),
+                    );
+                }
+                (purl, "hex-git", anns)
+            }
+            DeclaredDepSource::Path { path, in_umbrella } => {
+                let purl = format!("pkg:generic/{}@unspecified", decl.name);
+                let mut anns: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+                if !path.is_empty() {
+                    anns.insert(
+                        "mikebom:path".to_string(),
+                        serde_json::Value::String(path.clone()),
+                    );
+                }
+                if *in_umbrella {
+                    anns.insert(
+                        "mikebom:in-umbrella".to_string(),
+                        serde_json::Value::String("true".to_string()),
+                    );
+                }
+                (purl, "hex-path", anns)
+            }
+        };
+
+        let Ok(purl) = Purl::new(&purl_str) else {
+            tracing::warn!(
+                name = %decl.name,
+                purl = %purl_str,
+                path = %mix_exs_path.display(),
+                "elixir: skipping design-tier entry with non-PURL-safe form",
+            );
+            continue;
+        };
+
+        let mut extra_annotations: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+        extra_annotations.insert(
+            "mikebom:source-type".to_string(),
+            serde_json::Value::String(source_type_value.to_string()),
+        );
+        for (k, v) in source_specific_anns {
+            extra_annotations.insert(k, v);
+        }
+        if decl.in_conditional {
+            extra_annotations.insert(
+                "mikebom:elixir-extraction-mode".to_string(),
+                serde_json::Value::String("conditional-flattened".to_string()),
+            );
+        }
+
+        let (version_field, requirement_range) = match &decl.source_kind {
+            DeclaredDepSource::Hex => (
+                sanitized.clone(),
+                Some(decl.constraint.clone().unwrap_or_default()),
+            ),
+            _ => ("unspecified".to_string(), None),
+        };
+
+        let lifecycle_scope = if decl.dev_scope {
+            LifecycleScope::Development
+        } else {
+            LifecycleScope::Runtime
+        };
+
+        out.push(PackageDbEntry {
+            purl,
+            name: decl.name.clone(),
+            version: version_field,
+            arch: None,
+            source_path: source_path.clone(),
+            depends: Vec::new(),
+            maintainer: None,
+            licenses: Vec::new(),
+            lifecycle_scope: Some(lifecycle_scope),
+            requirement_range,
+            source_type: Some(source_type_value.to_string()),
+            buildinfo_status: None,
+            sbom_tier: Some("design".to_string()),
+            evidence_kind: Some("mix-exs".to_string()),
+            binary_class: None,
+            binary_stripped: None,
+            linkage_kind: None,
+            detected_go: None,
+            confidence: None,
+            binary_packed: None,
+            raw_version: None,
+            parent_purl: None,
+            npm_role: None,
+            co_owned_by: None,
+            hashes: Vec::new(),
+            shade_relocation: None,
+            extra_annotations,
+            binary_role: None,
+            build_inclusion: None,
+        });
+    }
+    out
+}
+
+fn collect_apps_subdirs(umbrella_root: &Path) -> Vec<PathBuf> {
+    let apps_dir = umbrella_root.join("apps");
+    if !apps_dir.is_dir() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&apps_dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let mix_exs = path.join("mix.exs");
+            if mix_exs.is_file() {
+                out.push(mix_exs);
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+fn sanitize_purl_version(raw: &str) -> String {
+    raw.chars()
+        .map(|c| match c {
+            '/' | '?' | '#' | ' ' => '_',
+            other => other,
+        })
+        .collect()
+}
+
+fn minimal_qualifier_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            ' ' => out.push_str("%20"),
+            '?' => out.push_str("%3F"),
+            '#' => out.push_str("%23"),
+            '&' => out.push_str("%26"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenize_simple_lockfile() {
+        let text = r#"%{
+  "phoenix": {:hex, :phoenix, "1.7.10", "abc", [:mix], [], "hexpm", "def"},
+  "plug": {:hex, :plug, "1.15.2", "xyz", [:mix], [], "hexpm"}
+}
+"#;
+        let tokens = tokenize_mix_lock(text);
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens[0].0, "phoenix");
+        assert!(tokens[0].1.starts_with("{:hex"));
+        assert_eq!(tokens[1].0, "plug");
+    }
+
+    #[test]
+    fn parse_hex_entry_with_outer_sha() {
+        let body = r#"{:hex, :phoenix, "1.7.10", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", [:mix], [], "hexpm", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}"#;
+        let e = parse_lock_entry("phoenix", body).unwrap();
+        match e {
+            LockEntry::Hex {
+                name,
+                version,
+                inner_sha256,
+                repo,
+                outer_sha256,
+            } => {
+                assert_eq!(name, "phoenix");
+                assert_eq!(version, "1.7.10");
+                assert_eq!(inner_sha256.len(), 64);
+                assert_eq!(repo, "hexpm");
+                assert!(outer_sha256.is_some());
+            }
+            _ => panic!("expected Hex variant"),
+        }
+    }
+
+    #[test]
+    fn parse_hex_entry_without_outer_sha() {
+        let body = r#"{:hex, :plug, "1.15.2", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", [:mix], [], "hexpm"}"#;
+        let e = parse_lock_entry("plug", body).unwrap();
+        match e {
+            LockEntry::Hex { outer_sha256, .. } => {
+                assert!(outer_sha256.is_none(), "pre-Hex-2.0 entry must have None outer SHA");
+            }
+            _ => panic!("expected Hex"),
+        }
+    }
+
+    #[test]
+    fn parse_hex_entry_private_org() {
+        let body = r#"{:hex, :my_lib, "2.0.0", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", [:mix], [], "hexpm:acme", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}"#;
+        let e = parse_lock_entry("my_lib", body).unwrap();
+        match e {
+            LockEntry::Hex { repo, .. } => assert_eq!(repo, "hexpm:acme"),
+            _ => panic!("expected Hex"),
+        }
+    }
+
+    #[test]
+    fn parse_git_entry_with_ref() {
+        let body = r#"{:git, "https://github.com/foo/my-fork.git", "eb39649a76b87e8451baf75d10ce82ca3a3d5601", [ref: "main"]}"#;
+        let e = parse_lock_entry("my_fork", body).unwrap();
+        match e {
+            LockEntry::Git {
+                name,
+                url,
+                resolved_sha,
+                declared_ref,
+            } => {
+                assert_eq!(name, "my_fork");
+                assert_eq!(url, "https://github.com/foo/my-fork.git");
+                assert_eq!(resolved_sha.len(), 40);
+                assert_eq!(declared_ref, Some("ref: main".to_string()));
+            }
+            _ => panic!("expected Git"),
+        }
+    }
+
+    #[test]
+    fn parse_path_entry() {
+        let body = r#"{:path, "apps/shared_lib", []}"#;
+        let e = parse_lock_entry("shared_lib", body).unwrap();
+        match e {
+            LockEntry::Path {
+                name,
+                path,
+                in_umbrella,
+            } => {
+                assert_eq!(name, "shared_lib");
+                assert_eq!(path, "apps/shared_lib");
+                assert!(!in_umbrella);
+            }
+            _ => panic!("expected Path"),
+        }
+    }
+
+    #[test]
+    fn parse_path_entry_in_umbrella() {
+        let body = r#"{:path, "apps/core", [in_umbrella: true]}"#;
+        let e = parse_lock_entry("core", body).unwrap();
+        match e {
+            LockEntry::Path { in_umbrella, .. } => assert!(in_umbrella),
+            _ => panic!("expected Path"),
+        }
+    }
+
+    #[test]
+    fn build_purl_hex_default() {
+        let e = LockEntry::Hex {
+            name: "phoenix".into(),
+            version: "1.7.10".into(),
+            inner_sha256: "a".repeat(64),
+            repo: "hexpm".into(),
+            outer_sha256: None,
+        };
+        let p = build_purl_for_lock_entry(&e).unwrap();
+        assert_eq!(p.as_str(), "pkg:hex/phoenix@1.7.10");
+    }
+
+    #[test]
+    fn build_purl_hex_private_org_emits_namespace_and_repo_url() {
+        let e = LockEntry::Hex {
+            name: "internal_lib".into(),
+            version: "2.0.0".into(),
+            inner_sha256: "a".repeat(64),
+            repo: "hexpm:acme".into(),
+            outer_sha256: None,
+        };
+        let p = build_purl_for_lock_entry(&e).unwrap();
+        assert_eq!(
+            p.as_str(),
+            "pkg:hex/acme/internal_lib@2.0.0?repository_url=https://repo.hex.pm"
+        );
+    }
+
+    #[test]
+    fn build_purl_git_uses_pkg_generic() {
+        let e = LockEntry::Git {
+            name: "my_fork".into(),
+            url: "https://github.com/foo/my-fork.git".into(),
+            resolved_sha: "eb39649a76b87e8451baf75d10ce82ca3a3d5601".into(),
+            declared_ref: Some("ref: main".into()),
+        };
+        let p = build_purl_for_lock_entry(&e).unwrap();
+        assert_eq!(
+            p.as_str(),
+            "pkg:generic/my_fork@eb39649a76b87e8451baf75d10ce82ca3a3d5601?vcs_url=git+https://github.com/foo/my-fork.git"
+        );
+    }
+
+    #[test]
+    fn build_purl_path_uses_pkg_generic() {
+        let e = LockEntry::Path {
+            name: "shared_lib".into(),
+            path: "apps/shared_lib".into(),
+            in_umbrella: false,
+        };
+        let p = build_purl_for_lock_entry(&e).unwrap();
+        assert_eq!(p.as_str(), "pkg:generic/shared_lib@unspecified");
+    }
+
+    #[test]
+    fn build_purl_hex_name_lowercased() {
+        let e = LockEntry::Hex {
+            name: "Phoenix".into(),
+            version: "1.7.10".into(),
+            inner_sha256: "a".repeat(64),
+            repo: "hexpm".into(),
+            outer_sha256: None,
+        };
+        let p = build_purl_for_lock_entry(&e).unwrap();
+        assert_eq!(p.as_str(), "pkg:hex/phoenix@1.7.10");
+    }
+
+    #[test]
+    fn classify_source_type_dispatch() {
+        let h = LockEntry::Hex {
+            name: "x".into(),
+            version: "1".into(),
+            inner_sha256: "a".repeat(64),
+            repo: "hexpm".into(),
+            outer_sha256: None,
+        };
+        assert_eq!(classify_source_type(&h), "hex-hex");
+        let g = LockEntry::Git {
+            name: "x".into(),
+            url: "u".into(),
+            resolved_sha: "a".repeat(40),
+            declared_ref: None,
+        };
+        assert_eq!(classify_source_type(&g), "hex-git");
+        let p = LockEntry::Path {
+            name: "x".into(),
+            path: "p".into(),
+            in_umbrella: false,
+        };
+        assert_eq!(classify_source_type(&p), "hex-path");
+    }
+
+    #[test]
+    fn extra_annotations_git_carries_declared_ref() {
+        let e = LockEntry::Git {
+            name: "x".into(),
+            url: "u".into(),
+            resolved_sha: "a".repeat(40),
+            declared_ref: Some("ref: main".into()),
+        };
+        let ann = build_extra_annotations(&e, "hex-git");
+        assert_eq!(
+            ann.get("mikebom:vcs-declared-ref").and_then(|v| v.as_str()),
+            Some("ref: main")
+        );
+    }
+
+    #[test]
+    fn extra_annotations_path_carries_path() {
+        let e = LockEntry::Path {
+            name: "x".into(),
+            path: "../shared".into(),
+            in_umbrella: true,
+        };
+        let ann = build_extra_annotations(&e, "hex-path");
+        assert_eq!(ann.get("mikebom:path").and_then(|v| v.as_str()), Some("../shared"));
+        assert_eq!(
+            ann.get("mikebom:in-umbrella").and_then(|v| v.as_str()),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn parse_mix_exs_extracts_app_version_deps() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("mix.exs");
+        std::fs::write(
+            &path,
+            r#"defmodule MyApp.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :my_app,
+      version: "0.5.2",
+      elixir: "~> 1.16",
+      deps: deps()
+    ]
+  end
+
+  defp deps do
+    [
+      {:phoenix, "~> 1.7"},
+      {:plug, "~> 1.15", optional: false},
+      {:credo, "~> 1.7", only: [:dev, :test], runtime: false}
+    ]
+  end
+end
+"#,
+        )
+        .unwrap();
+        let info = parse_mix_exs(&path).unwrap();
+        assert_eq!(info.app_name.as_deref(), Some("my_app"));
+        assert_eq!(info.version.as_deref(), Some("0.5.2"));
+        assert!(!info.is_umbrella);
+        assert_eq!(info.deps.len(), 3);
+        assert_eq!(info.deps[0].name, "phoenix");
+        assert_eq!(info.deps[0].constraint.as_deref(), Some("~> 1.7"));
+        assert!(!info.deps[0].dev_scope);
+        assert!(matches!(info.deps[0].source_kind, DeclaredDepSource::Hex));
+        assert!(info.deps[2].dev_scope, "credo must have dev_scope (only/runtime: false)");
+    }
+
+    #[test]
+    fn parse_mix_exs_detects_umbrella_shorthand_form() {
+        // Regression for the apps_path KEY-presence regex needing to
+        // match mid-line `, apps_path:` (single-line `do:` shorthand).
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("mix.exs");
+        std::fs::write(
+            &path,
+            r#"defmodule MyUmbrella.MixProject do
+  def project, do: [app: :my_umbrella, version: "0.1.0", apps_path: "modules"]
+end
+"#,
+        )
+        .unwrap();
+        let info = parse_mix_exs(&path).unwrap();
+        assert!(
+            info.is_umbrella,
+            "shorthand form `, apps_path:` mid-line must trigger umbrella detection",
+        );
+        assert_eq!(info.app_name.as_deref(), Some("my_umbrella"));
+        assert_eq!(info.version.as_deref(), Some("0.1.0"));
+    }
+
+    #[test]
+    fn parse_mix_exs_detects_umbrella() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("mix.exs");
+        std::fs::write(
+            &path,
+            r#"defmodule Umbrella.MixProject do
+  def project do
+    [
+      apps_path: "apps",
+      version: "0.1.0",
+      app: :my_umbrella,
+      deps: deps()
+    ]
+  end
+
+  defp deps do
+    [{:dialyxir, "~> 1.4", only: [:dev], runtime: false}]
+  end
+end
+"#,
+        )
+        .unwrap();
+        let info = parse_mix_exs(&path).unwrap();
+        assert!(info.is_umbrella);
+    }
+
+    #[test]
+    fn parse_mix_exs_detects_git_and_path_source_kinds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("mix.exs");
+        std::fs::write(
+            &path,
+            r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0", deps: deps()]
+  defp deps do
+    [
+      {:phx, "~> 1.7"},
+      {:my_fork, git: "https://github.com/foo/my-fork.git", branch: "main"},
+      {:shared, path: "../shared"},
+      {:gh_shortcut, github: "owner/repo"}
+    ]
+  end
+end
+"#,
+        )
+        .unwrap();
+        let info = parse_mix_exs(&path).unwrap();
+        let by_name = |n: &str| info.deps.iter().find(|d| d.name == n).unwrap();
+
+        assert!(matches!(by_name("phx").source_kind, DeclaredDepSource::Hex));
+
+        match &by_name("my_fork").source_kind {
+            DeclaredDepSource::Git { url, declared_ref } => {
+                assert_eq!(url, "https://github.com/foo/my-fork.git");
+                assert_eq!(declared_ref.as_deref(), Some("branch: main"));
+            }
+            other => panic!("expected Git, got {other:?}"),
+        }
+
+        match &by_name("shared").source_kind {
+            DeclaredDepSource::Path { path, .. } => assert_eq!(path, "../shared"),
+            other => panic!("expected Path, got {other:?}"),
+        }
+
+        match &by_name("gh_shortcut").source_kind {
+            DeclaredDepSource::Git { url, .. } => {
+                assert_eq!(url, "https://github.com/owner/repo.git");
+            }
+            other => panic!("expected Git from :github shortcut, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_mix_exs_marks_conditional_deps() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("mix.exs");
+        std::fs::write(
+            &path,
+            r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0", deps: deps()]
+  defp deps do
+    [
+      {:phx, "~> 1.7"},
+      if Mix.env() == :test do
+        {:meck, "~> 0.9"}
+      end
+    ]
+  end
+end
+"#,
+        )
+        .unwrap();
+        let info = parse_mix_exs(&path).unwrap();
+        let phx = info.deps.iter().find(|d| d.name == "phx").unwrap();
+        let meck = info.deps.iter().find(|d| d.name == "meck").unwrap();
+        assert!(!phx.in_conditional, "top-level dep is not conditional");
+        assert!(meck.in_conditional, "dep inside `if Mix.env()` IS conditional");
+    }
+
+    #[test]
+    fn sanitize_purl_version_neutralizes_unsafe_chars() {
+        assert_eq!(sanitize_purl_version("~> 1.7"), "~>_1.7");
+        assert_eq!(sanitize_purl_version(">= 1.0 and < 2.0"), ">=_1.0_and_<_2.0");
+    }
+
+    #[test]
+    fn extract_first_git_ref_picks_first_present() {
+        assert_eq!(
+            extract_first_git_ref(r#"git: "u", ref: "main""#),
+            Some("ref: main".to_string()),
+        );
+        assert_eq!(
+            extract_first_git_ref(r#"git: "u", branch: "develop""#),
+            Some("branch: develop".to_string()),
+        );
+        assert_eq!(extract_first_git_ref(r#"git: "u""#), None);
+    }
+}

--- a/mikebom-cli/src/scan_fs/package_db/mod.rs
+++ b/mikebom-cli/src/scan_fs/package_db/mod.rs
@@ -23,6 +23,7 @@ pub mod dart;
 mod control_file;
 pub mod copyright;
 pub mod dpkg;
+pub mod elixir;
 pub mod exclude_path;
 pub mod file_hashes;
 pub mod gem;
@@ -1533,6 +1534,16 @@ pub fn read_all(
     // design-tier fallback (FR-005) when lockfile absent. Pure-Rust
     // YAML via `serde_yaml`; zero new Cargo deps.
     out.extend(dart::read(rootfs, include_dev, exclude_set));
+
+    // Milestone 140: Elixir/Mix ecosystem reader. One main-module
+    // per `mix.exs` (FR-012) + lockfile-driven (FR-002) + design-tier
+    // from Podfile-equivalent `mix.exs` (FR-005) emission. Three
+    // source discriminators: hex (with private-org namespace +
+    // repository_url per Phase 0), git (pkg:generic/ per Phase 0),
+    // path. Dual SHA-256 (inner + outer) emission per FR-011 + Q3.
+    // Umbrella project handling per FR-009 + Q2. Conditional-flattened
+    // design-tier extraction per Q1. Zero new Cargo deps.
+    out.extend(elixir::read(rootfs, include_dev, exclude_set));
 
     // G3: when a scan produced BOTH `pkg:golang` source-tier entries
     // (from `golang.rs`'s go.sum parsing) AND `pkg:golang` analyzed-

--- a/mikebom-cli/tests/elixir_edge_cases.rs
+++ b/mikebom-cli/tests/elixir_edge_cases.rs
@@ -1,0 +1,291 @@
+//! Milestone 140 polish — edge cases.
+
+#![cfg(test)]
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_mikebom")
+}
+
+fn run_scan(project_root: &Path) -> (Value, String) {
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("out.cdx.json");
+    let result = Command::new(binary_path())
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(project_root)
+        .arg("--no-deep-hash")
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(format!("cyclonedx-json={}", out_path.display()))
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&result.stderr),
+    );
+    let bytes = std::fs::read(&out_path).unwrap();
+    let doc: Value = serde_json::from_slice(&bytes).unwrap();
+    (doc, String::from_utf8_lossy(&result.stderr).into_owned())
+}
+
+fn component_with_purl<'a>(doc: &'a Value, purl: &str) -> Option<&'a Value> {
+    if let Some(c) = doc.get("metadata").and_then(|m| m.get("component")) {
+        if c.get("purl").and_then(|v| v.as_str()) == Some(purl) {
+            return Some(c);
+        }
+    }
+    doc.get("components")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|c| {
+                c.get("purl").and_then(|v| v.as_str()) == Some(purl)
+            })
+        })
+}
+
+fn hex_purls(doc: &Value) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut visit = |c: &Value| {
+        if let Some(p) = c.get("purl").and_then(|v| v.as_str()) {
+            if p.starts_with("pkg:hex/")
+                || (p.starts_with("pkg:generic/")
+                    && c.get("properties")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter().any(|p| {
+                                p.get("name").and_then(|v| v.as_str())
+                                    == Some("mikebom:source-type")
+                                    && p.get("value")
+                                        .and_then(|v| v.as_str())
+                                        .map(|s| s.starts_with("hex-"))
+                                        .unwrap_or(false)
+                            })
+                        })
+                        .unwrap_or(false))
+            {
+                out.push(p.to_string());
+            }
+        }
+    };
+    if let Some(arr) = doc.get("components").and_then(|v| v.as_array()) {
+        for c in arr {
+            visit(c);
+        }
+    }
+    if let Some(c) = doc.get("metadata").and_then(|m| m.get("component")) {
+        visit(c);
+    }
+    out
+}
+
+#[test]
+fn malformed_mix_lock_falls_back_to_design_tier() {
+    // SC-005: malformed mix.lock + sibling mix.exs → design-tier
+    // components emit + warning fires.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0", deps: deps()]
+  defp deps, do: [{:phoenix, "~> 1.7"}]
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(tmp.path().join("mix.lock"), "this is not valid elixir syntax }}}}").unwrap();
+    let (doc, _stderr) = run_scan(tmp.path());
+    // Design-tier phoenix emits.
+    assert!(
+        component_with_purl(&doc, "pkg:hex/phoenix@~>_1.7").is_some(),
+        "design-tier phoenix must emit when mix.lock is malformed; got purls: {:?}",
+        hex_purls(&doc)
+    );
+}
+
+#[test]
+fn multi_line_tuple_in_mix_lock_parses_correctly() {
+    // Multi-line :hex tuple — `:deps` element wraps across lines.
+    let tmp = tempfile::tempdir().unwrap();
+    let inner = "a".repeat(64);
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0"]
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("mix.lock"),
+        format!(
+            r#"%{{
+  "phoenix": {{:hex, :phoenix, "1.7.10", "{inner}", [:mix], [
+    {{:plug, "~> 1.15", [hex: :plug, repo: "hexpm", optional: false]}},
+    {{:telemetry, "~> 1.2", [hex: :telemetry, repo: "hexpm", optional: false]}}
+  ], "hexpm"}}
+}}
+"#
+        ),
+    )
+    .unwrap();
+    let (doc, _) = run_scan(tmp.path());
+    assert!(
+        component_with_purl(&doc, "pkg:hex/phoenix@1.7.10").is_some(),
+        "multi-line :hex tuple must parse correctly via brace-counting",
+    );
+}
+
+#[test]
+fn private_org_lowercased_in_purl_namespace() {
+    // Phase 0 + IX accuracy: private-org slug lowercased per purl-spec
+    // hex canonical form.
+    let tmp = tempfile::tempdir().unwrap();
+    let inner = "a".repeat(64);
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0"]
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("mix.lock"),
+        format!(
+            r#"%{{
+  "my_lib": {{:hex, :my_lib, "2.0.0", "{inner}", [:mix], [], "hexpm:ACME"}}
+}}
+"#
+        ),
+    )
+    .unwrap();
+    let (doc, _) = run_scan(tmp.path());
+    assert!(
+        component_with_purl(
+            &doc,
+            "pkg:hex/acme/my_lib@2.0.0?repository_url=https://repo.hex.pm"
+        )
+        .is_some(),
+        "private-org slug ACME must lowercase to acme",
+    );
+}
+
+#[test]
+fn unknown_source_atom_skipped_via_unparseable_entry() {
+    // Lockfile with unknown atom discriminator → entry skipped; other
+    // valid entries still emit.
+    let tmp = tempfile::tempdir().unwrap();
+    let inner = "a".repeat(64);
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0"]
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("mix.lock"),
+        format!(
+            r#"%{{
+  "valid": {{:hex, :valid, "1.0.0", "{inner}", [:mix], [], "hexpm"}},
+  "weird": {{:hg, "https://example.com/r", "abc123", []}}
+}}
+"#
+        ),
+    )
+    .unwrap();
+    let (doc, _) = run_scan(tmp.path());
+    assert!(
+        component_with_purl(&doc, "pkg:hex/valid@1.0.0").is_some(),
+        "valid entry must still emit when sibling unknown-source entry is present",
+    );
+    let purls = hex_purls(&doc);
+    assert!(
+        !purls.iter().any(|p| p.contains("weird")),
+        "unknown-source entry must NOT emit; got {purls:?}",
+    );
+}
+
+#[test]
+fn apps_path_with_custom_value_still_detected_as_umbrella() {
+    // R4: `apps_path:` KEY-presence detection (value-ignored).
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("my_umbrella");
+    std::fs::create_dir_all(root.join("modules").join("core")).unwrap();
+    std::fs::write(
+        root.join("mix.exs"),
+        r#"defmodule MyUmbrella.MixProject do
+  def project, do: [app: :my_umbrella, version: "0.1.0", apps_path: "modules"]
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("modules").join("core").join("mix.exs"),
+        r#"defmodule Core.MixProject do
+  def project, do: [app: :core, version: "0.1.0"]
+end
+"#,
+    )
+    .unwrap();
+    let (doc, _) = run_scan(root.as_path());
+    let umbrella = component_with_purl(&doc, "pkg:hex/my_umbrella@0.1.0")
+        .expect("custom apps_path value must still detect umbrella");
+    let props = umbrella.get("properties").and_then(|v| v.as_array()).unwrap();
+    let has_umbrella_root_annotation = props.iter().any(|p| {
+        p.get("name").and_then(|v| v.as_str()) == Some("mikebom:umbrella-root")
+            && p.get("value").and_then(|v| v.as_str()) == Some("true")
+    });
+    assert!(
+        has_umbrella_root_annotation,
+        "R4: apps_path KEY presence (not value) must trigger umbrella detection; got props: {props:#?}",
+    );
+}
+
+#[test]
+fn outer_sha256_empty_string_treated_as_absent() {
+    // Q3 edge: lockfile entry with empty-string outer SHA-256 ("")
+    // emits ONE hash (inner only), NOT two with one empty content.
+    let tmp = tempfile::tempdir().unwrap();
+    let inner = "a".repeat(64);
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0"]
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("mix.lock"),
+        format!(
+            r#"%{{
+  "phoenix": {{:hex, :phoenix, "1.7.10", "{inner}", [:mix], [], "hexpm", ""}}
+}}
+"#
+        ),
+    )
+    .unwrap();
+    let (doc, _) = run_scan(tmp.path());
+    let phx = component_with_purl(&doc, "pkg:hex/phoenix@1.7.10").unwrap();
+    let hashes = phx.get("hashes").and_then(|v| v.as_array()).unwrap();
+    let count = hashes
+        .iter()
+        .filter(|h| h.get("alg").and_then(|v| v.as_str()) == Some("SHA-256"))
+        .count();
+    assert_eq!(
+        count, 1,
+        "empty-string outer SHA-256 must be skipped per Q3 — only inner emits",
+    );
+}

--- a/mikebom-cli/tests/elixir_phoenix_baseline.rs
+++ b/mikebom-cli/tests/elixir_phoenix_baseline.rs
@@ -1,0 +1,369 @@
+//! Milestone 140 US1 — Phoenix baseline integration tests.
+//!
+//! Covers SC-001 (Phoenix baseline + lock count), SC-007 (dev-scope
+//! filterability), SC-008 (main-module emission + dep edges), SC-009
+//! (dual SHA-256 + pre-Hex-2.0 single hash per Q3).
+
+#![cfg(test)]
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_mikebom")
+}
+
+fn run_scan_with_flags(project_root: &Path, extra: &[&str]) -> Value {
+    let mut top_level_extra: Vec<&str> = Vec::new();
+    let mut subcommand_extra: Vec<&str> = Vec::new();
+    let mut iter = extra.iter().peekable();
+    while let Some(a) = iter.next() {
+        if *a == "--exclude-scope" {
+            top_level_extra.push(a);
+            if let Some(v) = iter.next() {
+                top_level_extra.push(v);
+            }
+        } else {
+            subcommand_extra.push(a);
+        }
+    }
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("out.cdx.json");
+    let mut cmd = Command::new(binary_path());
+    cmd.arg("--offline");
+    for a in &top_level_extra {
+        cmd.arg(a);
+    }
+    cmd.arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(project_root)
+        .arg("--no-deep-hash")
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(format!("cyclonedx-json={}", out_path.display()));
+    for a in &subcommand_extra {
+        cmd.arg(a);
+    }
+    let result = cmd.output().unwrap();
+    assert!(
+        result.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&result.stderr),
+    );
+    let bytes = std::fs::read(&out_path).unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn run_scan(project_root: &Path) -> Value {
+    run_scan_with_flags(project_root, &[])
+}
+
+fn hex_purls(doc: &Value) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut visit = |c: &Value| {
+        if let Some(p) = c.get("purl").and_then(|v| v.as_str()) {
+            if p.starts_with("pkg:hex/")
+                || (p.starts_with("pkg:generic/")
+                    && c.get("properties")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter().any(|p| {
+                                p.get("name").and_then(|v| v.as_str())
+                                    == Some("mikebom:source-type")
+                                    && p.get("value")
+                                        .and_then(|v| v.as_str())
+                                        .map(|s| s.starts_with("hex-"))
+                                        .unwrap_or(false)
+                            })
+                        })
+                        .unwrap_or(false))
+            {
+                out.push(p.to_string());
+            }
+        }
+    };
+    if let Some(arr) = doc.get("components").and_then(|v| v.as_array()) {
+        for c in arr {
+            visit(c);
+        }
+    }
+    if let Some(c) = doc.get("metadata").and_then(|m| m.get("component")) {
+        visit(c);
+    }
+    out
+}
+
+fn component_with_purl<'a>(doc: &'a Value, purl: &str) -> Option<&'a Value> {
+    if let Some(c) = doc.get("metadata").and_then(|m| m.get("component")) {
+        if c.get("purl").and_then(|v| v.as_str()) == Some(purl) {
+            return Some(c);
+        }
+    }
+    doc.get("components")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|c| {
+                c.get("purl").and_then(|v| v.as_str()) == Some(purl)
+            })
+        })
+}
+
+fn property_value<'a>(component: &'a Value, name: &str) -> Option<&'a str> {
+    component
+        .get("properties")
+        .and_then(|v| v.as_array())?
+        .iter()
+        .find(|p| p.get("name").and_then(|v| v.as_str()) == Some(name))
+        .and_then(|p| p.get("value").and_then(|v| v.as_str()))
+}
+
+fn write_phoenix_fixture(root: &Path) {
+    let inner = "a".repeat(64);
+    let outer = "b".repeat(64);
+    std::fs::write(
+        root.join("mix.exs"),
+        r#"defmodule MyApp.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :my_app,
+      version: "0.5.2",
+      elixir: "~> 1.16",
+      deps: deps()
+    ]
+  end
+
+  defp deps do
+    [
+      {:phoenix, "~> 1.7"},
+      {:plug, "~> 1.15"},
+      {:ecto, "~> 3.11"}
+    ]
+  end
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("mix.lock"),
+        format!(
+            r#"%{{
+  "phoenix": {{:hex, :phoenix, "1.7.10", "{inner}", [:mix], [{{:plug, "~> 1.15", [hex: :plug, repo: "hexpm", optional: false]}}], "hexpm", "{outer}"}},
+  "plug": {{:hex, :plug, "1.15.2", "{inner}", [:mix], [], "hexpm", "{outer}"}},
+  "ecto": {{:hex, :ecto, "3.11.1", "{inner}", [:mix], [], "hexpm", "{outer}"}},
+  "telemetry": {{:hex, :telemetry, "1.2.1", "{inner}", [:rebar3], [], "hexpm", "{outer}"}},
+  "mime": {{:hex, :mime, "2.0.5", "{inner}", [:mix], [], "hexpm", "{outer}"}}
+}}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn phoenix_baseline_emits_lock_count_plus_main_module() {
+    // SC-001: 5 lockfile entries + 1 main-module = 6 hex-derived components.
+    let tmp = tempfile::tempdir().unwrap();
+    write_phoenix_fixture(tmp.path());
+    let doc = run_scan(tmp.path());
+    let purls = hex_purls(&doc);
+    assert_eq!(
+        purls.len(),
+        6,
+        "expected 6 hex components (5 lockfile + 1 main-module); got {purls:#?}"
+    );
+    for expected in &[
+        "pkg:hex/phoenix@1.7.10",
+        "pkg:hex/plug@1.15.2",
+        "pkg:hex/ecto@3.11.1",
+        "pkg:hex/telemetry@1.2.1",
+        "pkg:hex/mime@2.0.5",
+        "pkg:hex/my_app@0.5.2",
+    ] {
+        assert!(
+            purls.contains(&expected.to_string()),
+            "expected PURL {expected} not found; got {purls:#?}"
+        );
+    }
+}
+
+#[test]
+fn main_module_from_mix_exs_app_keyword() {
+    // SC-008: mix.exs `app: :my_app, version: "0.5.2"` produces
+    // main-module PURL `pkg:hex/my_app@0.5.2`.
+    let tmp = tempfile::tempdir().unwrap();
+    write_phoenix_fixture(tmp.path());
+    let doc = run_scan(tmp.path());
+    let main = component_with_purl(&doc, "pkg:hex/my_app@0.5.2")
+        .expect("main-module must exist");
+    assert_eq!(
+        property_value(main, "mikebom:component-role"),
+        Some("main-module"),
+    );
+}
+
+#[test]
+fn main_module_depends_lists_direct_deps() {
+    // SC-008 cont: dependencies[] for main-module bom-ref targets each
+    // direct dep's bom-ref.
+    let tmp = tempfile::tempdir().unwrap();
+    write_phoenix_fixture(tmp.path());
+    let doc = run_scan(tmp.path());
+    let main = component_with_purl(&doc, "pkg:hex/my_app@0.5.2").unwrap();
+    let main_ref = main.get("bom-ref").and_then(|v| v.as_str()).unwrap();
+    let deps = doc.get("dependencies").and_then(|v| v.as_array()).unwrap();
+    let main_deps = deps
+        .iter()
+        .find(|d| d.get("ref").and_then(|v| v.as_str()) == Some(main_ref))
+        .and_then(|d| d.get("dependsOn").and_then(|v| v.as_array()))
+        .expect("main-module dependencies entry must exist");
+    let main_dep_refs: Vec<&str> =
+        main_deps.iter().filter_map(|v| v.as_str()).collect();
+    for direct_purl in &[
+        "pkg:hex/phoenix@1.7.10",
+        "pkg:hex/plug@1.15.2",
+        "pkg:hex/ecto@3.11.1",
+    ] {
+        let direct = component_with_purl(&doc, direct_purl)
+            .unwrap_or_else(|| panic!("direct dep {direct_purl} missing"));
+        let direct_ref = direct.get("bom-ref").and_then(|v| v.as_str()).unwrap();
+        assert!(
+            main_dep_refs.contains(&direct_ref),
+            "main-module dependsOn must include {direct_purl}; got {main_dep_refs:?}",
+        );
+    }
+}
+
+#[test]
+fn inner_and_outer_sha256_emitted() {
+    // SC-009 + Q3: hex entry with both inner + outer SHA-256 produces
+    // TWO CDX hashes[] entries with alg = SHA-256 and distinct contents.
+    let tmp = tempfile::tempdir().unwrap();
+    write_phoenix_fixture(tmp.path());
+    let doc = run_scan(tmp.path());
+    let phoenix = component_with_purl(&doc, "pkg:hex/phoenix@1.7.10").unwrap();
+    let hashes = phoenix
+        .get("hashes")
+        .and_then(|v| v.as_array())
+        .expect("phoenix must carry hashes[] (FR-011)");
+    let sha256_entries: Vec<&Value> = hashes
+        .iter()
+        .filter(|h| h.get("alg").and_then(|v| v.as_str()) == Some("SHA-256"))
+        .collect();
+    assert_eq!(
+        sha256_entries.len(),
+        2,
+        "expected 2 SHA-256 hashes (inner + outer); got {hashes:#?}"
+    );
+    let contents: Vec<&str> = sha256_entries
+        .iter()
+        .filter_map(|h| h.get("content").and_then(|v| v.as_str()))
+        .collect();
+    assert_eq!(contents.len(), 2);
+    assert_ne!(
+        contents[0], contents[1],
+        "inner + outer SHA-256 contents must differ"
+    );
+}
+
+#[test]
+fn pre_hex_2_entry_emits_only_inner_sha256() {
+    // Q3 edge: lockfile entry with only inner SHA-256 (no outer)
+    // emits ONE hash entry per Principle IX accuracy.
+    let tmp = tempfile::tempdir().unwrap();
+    let inner = "a".repeat(64);
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0", deps: deps()]
+  defp deps, do: [{:phoenix, "~> 1.7"}]
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("mix.lock"),
+        format!(
+            r#"%{{
+  "phoenix": {{:hex, :phoenix, "1.7.10", "{inner}", [:mix], [], "hexpm"}}
+}}
+"#
+        ),
+    )
+    .unwrap();
+    let doc = run_scan(tmp.path());
+    let phoenix = component_with_purl(&doc, "pkg:hex/phoenix@1.7.10").unwrap();
+    let hashes = phoenix
+        .get("hashes")
+        .and_then(|v| v.as_array())
+        .expect("phoenix must carry hashes[]");
+    let sha256_count = hashes
+        .iter()
+        .filter(|h| h.get("alg").and_then(|v| v.as_str()) == Some("SHA-256"))
+        .count();
+    assert_eq!(
+        sha256_count, 1,
+        "pre-Hex-2.0 entry must emit ONE hash (inner only); got {hashes:#?}"
+    );
+}
+
+#[test]
+fn dev_scope_filterability() {
+    // SC-007: mix.lock entry whose mix.exs deps/0 declares
+    // `only: [:dev, :test]` carries mikebom:lifecycle-scope=development;
+    // --exclude-scope dev suppresses (top-level flag BEFORE sbom subcommand).
+    let tmp = tempfile::tempdir().unwrap();
+    let inner = "a".repeat(64);
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0", deps: deps()]
+  defp deps do
+    [
+      {:phoenix, "~> 1.7"},
+      {:credo, "~> 1.7", only: [:dev, :test], runtime: false}
+    ]
+  end
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("mix.lock"),
+        format!(
+            r#"%{{
+  "phoenix": {{:hex, :phoenix, "1.7.10", "{inner}", [:mix], [], "hexpm"}},
+  "credo": {{:hex, :credo, "1.7.0", "{inner}", [:mix], [], "hexpm"}}
+}}
+"#
+        ),
+    )
+    .unwrap();
+
+    let doc_with_dev = run_scan(tmp.path());
+    let credo = component_with_purl(&doc_with_dev, "pkg:hex/credo@1.7.0")
+        .expect("credo must emit by default");
+    let lifecycle = property_value(credo, "mikebom:lifecycle-scope");
+    let cdx_scope = credo.get("scope").and_then(|v| v.as_str());
+    assert!(
+        lifecycle == Some("development")
+            || matches!(cdx_scope, Some("excluded") | Some("optional")),
+        "credo must carry development indicator; got property={lifecycle:?} scope={cdx_scope:?}",
+    );
+
+    let doc_without_dev = run_scan_with_flags(tmp.path(), &["--exclude-scope", "dev"]);
+    assert!(
+        component_with_purl(&doc_without_dev, "pkg:hex/credo@1.7.0").is_none(),
+        "--exclude-scope dev must suppress credo",
+    );
+    assert!(
+        component_with_purl(&doc_without_dev, "pkg:hex/phoenix@1.7.10").is_some(),
+        "--exclude-scope dev must NOT suppress phoenix",
+    );
+}

--- a/mikebom-cli/tests/elixir_source_discriminators.rs
+++ b/mikebom-cli/tests/elixir_source_discriminators.rs
@@ -1,0 +1,231 @@
+//! Milestone 140 US2 — source-discriminator distinction tests +
+//! Phase 0 correction regressions.
+//!
+//! Covers SC-002: hex (default + private-org) + git + path source
+//! types emit with correct purl-spec-conformant PURLs.
+
+#![cfg(test)]
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_mikebom")
+}
+
+fn run_scan(project_root: &Path) -> Value {
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("out.cdx.json");
+    let result = Command::new(binary_path())
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(project_root)
+        .arg("--no-deep-hash")
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(format!("cyclonedx-json={}", out_path.display()))
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&result.stderr),
+    );
+    let bytes = std::fs::read(&out_path).unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn component_with_purl<'a>(doc: &'a Value, purl: &str) -> Option<&'a Value> {
+    if let Some(c) = doc.get("metadata").and_then(|m| m.get("component")) {
+        if c.get("purl").and_then(|v| v.as_str()) == Some(purl) {
+            return Some(c);
+        }
+    }
+    doc.get("components")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|c| {
+                c.get("purl").and_then(|v| v.as_str()) == Some(purl)
+            })
+        })
+}
+
+fn property_value<'a>(component: &'a Value, name: &str) -> Option<&'a str> {
+    component
+        .get("properties")
+        .and_then(|v| v.as_array())?
+        .iter()
+        .find(|p| p.get("name").and_then(|v| v.as_str()) == Some(name))
+        .and_then(|p| p.get("value").and_then(|v| v.as_str()))
+}
+
+fn write_mixed_fixture(root: &Path) {
+    let inner = "a".repeat(64);
+    let resolved = "eb39649a76b87e8451baf75d10ce82ca3a3d5601";
+    std::fs::write(
+        root.join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0", deps: deps()]
+  defp deps do
+    [
+      {:phoenix, "~> 1.7"},
+      {:internal_lib, "~> 2.0", organization: "acme"},
+      {:my_fork, git: "https://github.com/foo/my-fork.git", ref: "main"},
+      {:shared_lib, path: "apps/shared_lib"}
+    ]
+  end
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("mix.lock"),
+        format!(
+            r#"%{{
+  "phoenix": {{:hex, :phoenix, "1.7.10", "{inner}", [:mix], [], "hexpm"}},
+  "internal_lib": {{:hex, :internal_lib, "2.0.0", "{inner}", [:mix], [], "hexpm:acme"}},
+  "my_fork": {{:git, "https://github.com/foo/my-fork.git", "{resolved}", [ref: "main"]}},
+  "shared_lib": {{:path, "apps/shared_lib", []}}
+}}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn default_hexpm_emits_bare_purl() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mixed_fixture(tmp.path());
+    let doc = run_scan(tmp.path());
+    let c = component_with_purl(&doc, "pkg:hex/phoenix@1.7.10")
+        .expect("default hexpm must emit bare PURL");
+    assert_eq!(property_value(c, "mikebom:source-type"), Some("hex-hex"));
+}
+
+#[test]
+fn private_hexpm_org_emits_namespace_and_repository_url() {
+    // Phase 0 correction regression: lockfile entry with "hexpm:acme"
+    // repo string emits pkg:hex/acme/internal_lib@2.0.0?repository_url=...
+    // NOT a mikebom:hex-repo annotation.
+    let tmp = tempfile::tempdir().unwrap();
+    write_mixed_fixture(tmp.path());
+    let doc = run_scan(tmp.path());
+    let expected =
+        "pkg:hex/acme/internal_lib@2.0.0?repository_url=https://repo.hex.pm";
+    let c = component_with_purl(&doc, expected)
+        .unwrap_or_else(|| panic!("private-org PURL {expected} not found"));
+    assert_eq!(property_value(c, "mikebom:source-type"), Some("hex-hex"));
+    // Should NOT have the deprecated mikebom:hex-repo annotation
+    // (verifies the initial spec-guess form was removed).
+    assert!(
+        property_value(c, "mikebom:hex-repo").is_none(),
+        "Phase 0 correction: mikebom:hex-repo annotation must NOT appear; private-org info goes in PURL namespace + repository_url qualifier",
+    );
+}
+
+#[test]
+fn git_source_emits_pkg_generic_with_vcs_url() {
+    // Phase 0 correction regression: :git lockfile entry emits
+    // pkg:generic/<name>@<sha>?vcs_url=git+<url>, NOT pkg:hex/...?vcs_url=.
+    let tmp = tempfile::tempdir().unwrap();
+    write_mixed_fixture(tmp.path());
+    let doc = run_scan(tmp.path());
+    let expected = "pkg:generic/my_fork@eb39649a76b87e8451baf75d10ce82ca3a3d5601?vcs_url=git+https://github.com/foo/my-fork.git";
+    let c = component_with_purl(&doc, expected)
+        .unwrap_or_else(|| panic!("git-source PURL {expected} not found"));
+    assert_eq!(property_value(c, "mikebom:source-type"), Some("hex-git"));
+}
+
+#[test]
+fn git_source_carries_vcs_declared_ref() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mixed_fixture(tmp.path());
+    let doc = run_scan(tmp.path());
+    let c = component_with_purl(
+        &doc,
+        "pkg:generic/my_fork@eb39649a76b87e8451baf75d10ce82ca3a3d5601?vcs_url=git+https://github.com/foo/my-fork.git",
+    )
+    .unwrap();
+    assert_eq!(
+        property_value(c, "mikebom:vcs-declared-ref"),
+        Some("ref: main"),
+    );
+}
+
+#[test]
+fn path_source_emits_pkg_generic_placeholder() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mixed_fixture(tmp.path());
+    let doc = run_scan(tmp.path());
+    let c = component_with_purl(&doc, "pkg:generic/shared_lib@unspecified")
+        .expect("path source must use pkg:generic/ placeholder");
+    assert_eq!(property_value(c, "mikebom:source-type"), Some("hex-path"));
+    assert_eq!(property_value(c, "mikebom:path"), Some("apps/shared_lib"));
+}
+
+#[test]
+fn path_in_umbrella_carries_in_umbrella_annotation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let inner = "a".repeat(64);
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0", deps: deps()]
+  defp deps, do: [{:core, in_umbrella: true}]
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("mix.lock"),
+        format!(
+            r#"%{{
+  "core": {{:path, "apps/core", [in_umbrella: true]}},
+  "phoenix": {{:hex, :phoenix, "1.7.10", "{inner}", [:mix], [], "hexpm"}}
+}}
+"#
+        ),
+    )
+    .unwrap();
+    let doc = run_scan(tmp.path());
+    let c = component_with_purl(&doc, "pkg:generic/core@unspecified").unwrap();
+    assert_eq!(property_value(c, "mikebom:in-umbrella"), Some("true"));
+}
+
+#[test]
+fn hex_name_lowercased_in_purl() {
+    // purl-spec canonical form: hex names lowercased. Hex.pm enforces
+    // at publish time so this is typically no-op, but the rule applies.
+    let tmp = tempfile::tempdir().unwrap();
+    let inner = "a".repeat(64);
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0"]
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("mix.lock"),
+        format!(
+            r#"%{{
+  "MixedCase": {{:hex, :MixedCase, "1.0.0", "{inner}", [:mix], [], "hexpm"}}
+}}
+"#
+        ),
+    )
+    .unwrap();
+    let doc = run_scan(tmp.path());
+    assert!(
+        component_with_purl(&doc, "pkg:hex/mixedcase@1.0.0").is_some(),
+        "Mixed-case name MixedCase must lowercase to mixedcase per purl-spec",
+    );
+}

--- a/mikebom-cli/tests/elixir_tier_fallbacks.rs
+++ b/mikebom-cli/tests/elixir_tier_fallbacks.rs
@@ -1,0 +1,393 @@
+//! Milestone 140 US3 — design-tier + Q1 conditional-flattened +
+//! Q2 umbrella aggregation + C2 source-kind dispatch.
+
+#![cfg(test)]
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_mikebom")
+}
+
+fn run_scan(project_root: &Path) -> Value {
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("out.cdx.json");
+    let result = Command::new(binary_path())
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(project_root)
+        .arg("--no-deep-hash")
+        .arg("--format")
+        .arg("cyclonedx-json")
+        .arg("--output")
+        .arg(format!("cyclonedx-json={}", out_path.display()))
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&result.stderr),
+    );
+    let bytes = std::fs::read(&out_path).unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn hex_components(doc: &Value) -> Vec<&Value> {
+    doc.get("components")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter(|c| {
+                    let purl = c.get("purl").and_then(|v| v.as_str()).unwrap_or("");
+                    let role = property_value(c, "mikebom:component-role");
+                    if role == Some("main-module") {
+                        return false;
+                    }
+                    purl.starts_with("pkg:hex/")
+                        || (purl.starts_with("pkg:generic/")
+                            && property_value(c, "mikebom:source-type")
+                                .map(|s| s.starts_with("hex-"))
+                                .unwrap_or(false))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn property_value<'a>(component: &'a Value, name: &str) -> Option<&'a str> {
+    component
+        .get("properties")
+        .and_then(|v| v.as_array())?
+        .iter()
+        .find(|p| p.get("name").and_then(|v| v.as_str()) == Some(name))
+        .and_then(|p| p.get("value").and_then(|v| v.as_str()))
+}
+
+fn find_by_name<'a>(components: &'a [&'a Value], name: &str) -> Option<&'a Value> {
+    components
+        .iter()
+        .copied()
+        .find(|c| c.get("name").and_then(|v| v.as_str()) == Some(name))
+}
+
+fn component_with_purl<'a>(doc: &'a Value, purl: &str) -> Option<&'a Value> {
+    if let Some(c) = doc.get("metadata").and_then(|m| m.get("component")) {
+        if c.get("purl").and_then(|v| v.as_str()) == Some(purl) {
+            return Some(c);
+        }
+    }
+    doc.get("components")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|c| {
+                c.get("purl").and_then(|v| v.as_str()) == Some(purl)
+            })
+        })
+}
+
+#[test]
+fn design_tier_mix_exs_only_emits_constraints() {
+    // SC-003: mix.exs only → 2 components with sbom-tier=design +
+    // requirement-range preserved.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :my_lib, version: "0.1.0", deps: deps()]
+  defp deps do
+    [
+      {:phoenix, "~> 1.7"},
+      {:plug, "~> 1.15"}
+    ]
+  end
+end
+"#,
+    )
+    .unwrap();
+    let doc = run_scan(tmp.path());
+    let comps = hex_components(&doc);
+    assert_eq!(comps.len(), 2);
+    for &c in &comps {
+        assert_eq!(property_value(c, "mikebom:sbom-tier"), Some("design"));
+    }
+    let phx = find_by_name(&comps, "phoenix").unwrap();
+    assert_eq!(
+        property_value(phx, "mikebom:requirement-range"),
+        Some("~> 1.7"),
+    );
+}
+
+#[test]
+fn design_tier_no_transitive_deps() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0", deps: deps()]
+  defp deps, do: [{:phoenix, "~> 1.7"}]
+end
+"#,
+    )
+    .unwrap();
+    let doc = run_scan(tmp.path());
+    let comps = hex_components(&doc);
+    let names: Vec<&str> = comps
+        .iter()
+        .filter_map(|c| c.get("name").and_then(|v| v.as_str()))
+        .collect();
+    assert!(names.contains(&"phoenix"));
+    assert!(
+        !names.contains(&"plug"),
+        "design-tier must NOT emit transitive plug; got {names:?}",
+    );
+}
+
+#[test]
+fn conditional_block_dep_carries_extraction_mode_annotation() {
+    // Q1: `if Mix.env() == :test do {:meck, "~> 0.9"} end` emits with
+    // mikebom:elixir-extraction-mode = "conditional-flattened".
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0", deps: deps()]
+  defp deps do
+    [
+      {:phoenix, "~> 1.7"},
+      if Mix.env() == :test do
+        {:meck, "~> 0.9"}
+      end
+    ]
+  end
+end
+"#,
+    )
+    .unwrap();
+    let doc = run_scan(tmp.path());
+    let comps = hex_components(&doc);
+    let meck = find_by_name(&comps, "meck")
+        .expect("meck must emit (conditional-flattened per Q1)");
+    assert_eq!(
+        property_value(meck, "mikebom:elixir-extraction-mode"),
+        Some("conditional-flattened"),
+    );
+}
+
+#[test]
+fn unconditional_dep_does_not_carry_extraction_mode_annotation() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0", deps: deps()]
+  defp deps, do: [{:phoenix, "~> 1.7"}]
+end
+"#,
+    )
+    .unwrap();
+    let doc = run_scan(tmp.path());
+    let comps = hex_components(&doc);
+    let phx = find_by_name(&comps, "phoenix").unwrap();
+    assert!(
+        property_value(phx, "mikebom:elixir-extraction-mode").is_none(),
+        "top-level dep must NOT carry conditional-flattened annotation",
+    );
+}
+
+#[test]
+fn umbrella_root_carries_umbrella_root_annotation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("my_umbrella");
+    let apps_core = root.join("apps").join("core");
+    std::fs::create_dir_all(&apps_core).unwrap();
+    std::fs::write(
+        root.join("mix.exs"),
+        r#"defmodule MyUmbrella.MixProject do
+  def project, do: [app: :my_umbrella, version: "0.1.0", apps_path: "apps", deps: deps()]
+  defp deps, do: [{:dialyxir, "~> 1.4", only: [:dev], runtime: false}]
+end
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        apps_core.join("mix.exs"),
+        r#"defmodule Core.MixProject do
+  def project, do: [app: :core, version: "0.1.0", deps: deps()]
+  defp deps, do: []
+end
+"#,
+    )
+    .unwrap();
+
+    let doc = run_scan(root.as_path());
+    let umbrella = component_with_purl(&doc, "pkg:hex/my_umbrella@0.1.0")
+        .expect("umbrella root main-module must emit");
+    assert_eq!(
+        property_value(umbrella, "mikebom:umbrella-root"),
+        Some("true"),
+    );
+
+    // Sub-app main-module does NOT carry umbrella-root annotation.
+    let core = component_with_purl(&doc, "pkg:hex/core@0.1.0")
+        .expect("sub-app core main-module must emit");
+    assert!(
+        property_value(core, "mikebom:umbrella-root").is_none(),
+        "sub-app must NOT carry umbrella-root annotation",
+    );
+}
+
+#[test]
+fn umbrella_root_dependencies_targets_sub_app_main_modules() {
+    // Q2 + SC-010 + I1: umbrella root's dependsOn (post-orchestrator
+    // name→bom-ref resolution) contains each sub-app's main-module
+    // bom-ref. PackageDbEntry.depends carries NAMES per I1; orchestrator
+    // resolves to bom-refs at dep-edge wiring.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("my_umbrella");
+    std::fs::create_dir_all(root.join("apps").join("core")).unwrap();
+    std::fs::create_dir_all(root.join("apps").join("web")).unwrap();
+    std::fs::create_dir_all(root.join("apps").join("worker")).unwrap();
+    std::fs::write(
+        root.join("mix.exs"),
+        r#"defmodule MyUmbrella.MixProject do
+  def project, do: [app: :my_umbrella, version: "0.1.0", apps_path: "apps", deps: deps()]
+  defp deps, do: []
+end
+"#,
+    )
+    .unwrap();
+    for sub in &["core", "web", "worker"] {
+        let sub_dir = root.join("apps").join(sub);
+        std::fs::write(
+            sub_dir.join("mix.exs"),
+            format!(
+                r#"defmodule {cap}.MixProject do
+  def project, do: [app: :{sub}, version: "0.1.0", deps: deps()]
+  defp deps, do: []
+end
+"#,
+                cap = sub.chars().next().unwrap().to_uppercase().collect::<String>() + &sub[1..],
+                sub = sub,
+            ),
+        )
+        .unwrap();
+    }
+
+    let doc = run_scan(root.as_path());
+    // 4 main-modules: root + 3 sub-apps.
+    for expected in &[
+        "pkg:hex/my_umbrella@0.1.0",
+        "pkg:hex/core@0.1.0",
+        "pkg:hex/web@0.1.0",
+        "pkg:hex/worker@0.1.0",
+    ] {
+        assert!(
+            component_with_purl(&doc, expected).is_some(),
+            "expected main-module {expected} not found",
+        );
+    }
+
+    // Umbrella root's dependsOn includes each sub-app's bom-ref (after
+    // name→bom-ref resolution per I1).
+    let umbrella = component_with_purl(&doc, "pkg:hex/my_umbrella@0.1.0").unwrap();
+    let umbrella_ref = umbrella.get("bom-ref").and_then(|v| v.as_str()).unwrap();
+    let deps = doc.get("dependencies").and_then(|v| v.as_array()).unwrap();
+    let umbrella_deps = deps
+        .iter()
+        .find(|d| d.get("ref").and_then(|v| v.as_str()) == Some(umbrella_ref))
+        .and_then(|d| d.get("dependsOn").and_then(|v| v.as_array()))
+        .expect("umbrella root must have a dependencies entry");
+    let dep_refs: Vec<&str> = umbrella_deps.iter().filter_map(|v| v.as_str()).collect();
+
+    for sub_purl in &["pkg:hex/core@0.1.0", "pkg:hex/web@0.1.0", "pkg:hex/worker@0.1.0"] {
+        let sub = component_with_purl(&doc, sub_purl).unwrap();
+        let sub_ref = sub.get("bom-ref").and_then(|v| v.as_str()).unwrap();
+        assert!(
+            dep_refs.contains(&sub_ref),
+            "umbrella root dependsOn must include {sub_purl}; got {dep_refs:?}",
+        );
+    }
+}
+
+#[test]
+fn design_tier_git_declared_dep_emits_pkg_generic() {
+    // C2 remediation: `{:my_fork, git: "https://...", branch: "main"}`
+    // in design-tier mode emits pkg:generic/, not pkg:hex/.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0", deps: deps()]
+  defp deps do
+    [{:my_fork, git: "https://github.com/foo/my-fork.git", branch: "main"}]
+  end
+end
+"#,
+    )
+    .unwrap();
+    let doc = run_scan(tmp.path());
+    let expected = "pkg:generic/my_fork@unspecified?vcs_url=git+https://github.com/foo/my-fork.git";
+    let c = component_with_purl(&doc, expected).unwrap_or_else(|| {
+        panic!(
+            "design-tier git dep must emit pkg:generic/ form per C2; got purls: {:?}",
+            doc.get("components")
+                .and_then(|v| v.as_array())
+                .map(|a| a
+                    .iter()
+                    .filter_map(|c| c.get("purl").and_then(|v| v.as_str()).map(String::from))
+                    .collect::<Vec<_>>())
+        )
+    });
+    assert_eq!(property_value(c, "mikebom:source-type"), Some("hex-git"));
+    assert_eq!(
+        property_value(c, "mikebom:vcs-declared-ref"),
+        Some("branch: main"),
+    );
+}
+
+#[test]
+fn design_tier_path_declared_dep_emits_pkg_generic() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0", deps: deps()]
+  defp deps, do: [{:shared, path: "../shared"}]
+end
+"#,
+    )
+    .unwrap();
+    let doc = run_scan(tmp.path());
+    let c = component_with_purl(&doc, "pkg:generic/shared@unspecified")
+        .expect("design-tier path dep must emit pkg:generic/ form per C2");
+    assert_eq!(property_value(c, "mikebom:source-type"), Some("hex-path"));
+    assert_eq!(property_value(c, "mikebom:path"), Some("../shared"));
+}
+
+#[test]
+fn design_tier_github_shortcut_expanded_to_git_url() {
+    // C2 + R3: `github: "owner/repo"` shortcut expands to
+    // `git: "https://github.com/owner/repo.git"`.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("mix.exs"),
+        r#"defmodule X.MixProject do
+  def project, do: [app: :x, version: "0.1.0", deps: deps()]
+  defp deps, do: [{:foo, github: "owner/repo"}]
+end
+"#,
+    )
+    .unwrap();
+    let doc = run_scan(tmp.path());
+    let expected = "pkg:generic/foo@unspecified?vcs_url=git+https://github.com/owner/repo.git";
+    assert!(
+        component_with_purl(&doc, expected).is_some(),
+        ":github shortcut must expand to git URL per R3",
+    );
+}

--- a/specs/140-elixir-mix-reader/checklists/requirements.md
+++ b/specs/140-elixir-mix-reader/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Elixir/Mix ecosystem reader
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-24
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Tech terms used (mix.lock, mix.exs, Hex, umbrella, OTP, sub-app, `:hex`/`:git`/`:path` atoms) are the standard names operators already know.
+- The spec references purl-spec `hex-definition.md` for normative PURL accuracy — references to the authoritative standard, not implementation details.
+- 16/16 checklist items pass. No iteration needed.

--- a/specs/140-elixir-mix-reader/contracts/elixir-component-purl.md
+++ b/specs/140-elixir-mix-reader/contracts/elixir-component-purl.md
@@ -1,0 +1,171 @@
+# Contract — `pkg:hex/*` and `pkg:generic/*` component PURL
+
+The only wire-format contract this feature introduces. Per Constitution Principle V audit (research §R1):
+
+- `pkg:hex/` is **purl-spec-blessed** ([hex-definition.md](https://github.com/package-url/purl-spec/blob/main/types-doc/hex-definition.md)) — used for `:hex` source-type entries (both default-hexpm and private-org).
+- `pkg:generic/` is the placeholder for `:git` (per Phase 0 correction — purl-spec doesn't bless `vcs_url=` for hex) and `:path` sources.
+- Private Hex orgs use the spec-blessed namespace-as-org form + `?repository_url=https://repo.hex.pm` qualifier per Phase 0 correction (replaces the initial `mikebom:hex-repo` annotation proposal).
+- Hex package names lowercased per purl-spec canonical form (Hex.pm enforces at publish time so typically no-op).
+
+## Wire shapes per source
+
+### Hex (default `"hexpm"` repo)
+
+```text
+pkg:hex/<lc-name>@<version>
+```
+
+### Hex (private organization `"hexpm:<org>"`)
+
+```text
+pkg:hex/<org>/<lc-name>@<version>?repository_url=https://repo.hex.pm
+```
+
+Reader splits the lockfile's `"hexpm:<org>"` repo string on the first colon; org slug becomes the PURL namespace.
+
+### Git
+
+```text
+pkg:generic/<name>@<resolved-sha>?vcs_url=git+<git-url>
+```
+
+Per Phase 0 correction: `pkg:generic/` placeholder because purl-spec hex-definition does NOT define a `vcs_url=` qualifier for hex. Once a dep is git-swapped it has no Hex.pm provenance — `pkg:hex/` would imply registry-resolution.
+
+Plus `mikebom:source-type = "hex-git"` annotation + `mikebom:vcs-declared-ref = "<opt-value>"` when present (preserves the operator's `ref:`/`branch:`/`tag:` declaration from `mix.exs`).
+
+### Path
+
+```text
+pkg:generic/<name>@<version-or-unspecified>
+```
+
+Plus `mikebom:source-type = "hex-path"` annotation + `mikebom:path = "<path-string>"` annotation. For umbrella sub-app deps (`in_umbrella: true` opt), also `mikebom:in-umbrella = "true"` annotation.
+
+### Main-module (per FR-012)
+
+```text
+pkg:hex/<app_name>@<version-or-"0.0.0-unknown">
+```
+
+Plus `mikebom:component-role = "main-module"` + `mikebom:source-type = "hex-main-module"` annotations. For umbrella roots: additional `mikebom:umbrella-root = "true"` annotation. App-name derivation cascade:
+1. `mix.exs::project/0::app:` atom (lowercased verbatim).
+2. Parent-directory basename fallback when `mix.exs` lacks `app:` or no `mix.exs` exists (matches milestone-139 Q1 pattern).
+
+## Examples
+
+| Scan input | Emitted PURL |
+|---|---|
+| `mix.exs` `app: :my_app`, `version: "0.5.2"` | `pkg:hex/my_app@0.5.2` (main-module) |
+| Lockfile `"phoenix": {:hex, :phoenix, "1.7.10", "abc...", [:mix], [...], "hexpm", "def..."}` | `pkg:hex/phoenix@1.7.10` (hashes: `[sha256:abc..., sha256:def...]`) |
+| Lockfile `"my_lib": {:hex, :my_lib, "2.0.0", "abc...", [:mix], [], "hexpm:acme", "def..."}` (private-org `acme`) | `pkg:hex/acme/my_lib@2.0.0?repository_url=https://repo.hex.pm` |
+| Lockfile `"my_fork": {:git, "https://github.com/foo/my-fork.git", "eb39649...3d5601", [ref: "main"]}` | `pkg:generic/my_fork@eb39649...3d5601?vcs_url=git+https://github.com/foo/my-fork.git` (annotations: `mikebom:source-type = "hex-git"`, `mikebom:vcs-declared-ref = "ref: main"`) |
+| Lockfile `"shared_lib": {:path, "apps/shared_lib", []}` | `pkg:generic/shared_lib@unspecified` (annotations: `mikebom:source-type = "hex-path"`, `mikebom:path = "apps/shared_lib"`) |
+| Umbrella root `mix.exs` with `apps_path: "apps"` | `pkg:hex/<root_app_name>@<version>` (annotations: `mikebom:component-role = "main-module"`, `mikebom:umbrella-root = "true"`) |
+| `mix.exs::deps/0` entry `{:credo, "~> 1.7", only: [:dev, :test], runtime: false}` (design-tier mode) | `pkg:hex/credo@~>_1.7` (annotations: `mikebom:sbom-tier = "design"`, `mikebom:requirement-range = "~> 1.7"`, `mikebom:lifecycle-scope = "development"`) |
+| Conditional `if Mix.env() == :test do {:meck, "~> 0.9"} end` | `pkg:hex/meck@~>_0.9` (annotations: `mikebom:sbom-tier = "design"`, `mikebom:elixir-extraction-mode = "conditional-flattened"` per Q1) |
+
+## Per-format emission
+
+### CycloneDX 1.6
+
+Location: `.components[].purl` (native).
+
+```json
+{
+  "type": "library",
+  "name": "phoenix",
+  "version": "1.7.10",
+  "purl": "pkg:hex/phoenix@1.7.10",
+  "hashes": [
+    {"alg": "SHA-256", "content": "<inner-sha256-from-4th-tuple-element>"},
+    {"alg": "SHA-256", "content": "<outer-sha256-from-8th-tuple-element>"}
+  ],
+  "properties": [
+    {"name": "mikebom:source-type", "value": "hex-hex"},
+    {"name": "mikebom:evidence-kind", "value": "mix-lock"},
+    {"name": "mikebom:sbom-tier", "value": "source"}
+  ]
+}
+```
+
+The `mikebom:source-type` / `mikebom:evidence-kind` / `mikebom:sbom-tier` properties are existing per-component annotations. The PURL + dual SHA-256 hashes (when both present per Q3) + `mikebom:vcs-declared-ref` / `mikebom:path` / `mikebom:elixir-extraction-mode` / `mikebom:umbrella-root` (source-type/scenario-specific) are the only new wire-format additions.
+
+### SPDX 2.3
+
+Location: `.packages[].externalRefs[]` with `referenceCategory: PACKAGE-MANAGER`.
+
+```json
+{
+  "name": "phoenix",
+  "versionInfo": "1.7.10",
+  "externalRefs": [
+    {
+      "referenceCategory": "PACKAGE-MANAGER",
+      "referenceType": "purl",
+      "referenceLocator": "pkg:hex/phoenix@1.7.10"
+    }
+  ],
+  "checksums": [
+    {"algorithm": "SHA256", "checksumValue": "<inner-hex>"},
+    {"algorithm": "SHA256", "checksumValue": "<outer-hex>"}
+  ]
+}
+```
+
+### SPDX 3.0.1
+
+Location: `software_Package.software_packageUrl` + `Element.externalIdentifier[]`.
+
+```json
+{
+  "type": "software_Package",
+  "spdxId": "...",
+  "name": "phoenix",
+  "software_packageVersion": "1.7.10",
+  "software_packageUrl": "pkg:hex/phoenix@1.7.10",
+  "externalIdentifier": [
+    {
+      "type": "ExternalIdentifier",
+      "externalIdentifierType": "packageUrl",
+      "identifier": "pkg:hex/phoenix@1.7.10"
+    }
+  ]
+}
+```
+
+## Determinism
+
+For a given `mix.lock` / `mix.exs`, the emitted PURL set MUST be identical across runs:
+
+- Lockfile entries processed in their YAML-map order (preserved by regex-tokenization — top-down).
+- Main-module components processed in walker discovery order (sorted directory entries per `safe_walk` convention from milestone 114).
+- `extra_annotations` `BTreeMap` ensures deterministic property emission order.
+
+## Absence semantics
+
+When the scanned root contains none of `mix.lock` / `mix.exs`:
+
+- Zero `pkg:hex/*` and zero Elixir-derived `pkg:generic/*` components emit.
+- No warnings fire (per FR-006).
+- SBOM bytes byte-identical (modulo timestamps + serial numbers) to a pre-feature scan (SC-004).
+
+## Parity-catalog note
+
+Because the wire-format addition is the native PURL field (including the spec-blessed namespace-as-org and `repository_url=` qualifier for private Hex orgs), no new C-row is added to `docs/reference/sbom-format-mapping.md` for identity. The PURL surfaces via the existing A1 row.
+
+The `mikebom:source-type` annotation reuses C1; Elixir contributes new VALUES (`hex-hex` / `hex-git` / `hex-path` / `hex-main-module`) to C1's value set without altering wire shape.
+
+NEW annotations introduced by this milestone:
+- `mikebom:vcs-declared-ref` (operator-declared `ref:`/`branch:`/`tag:`/`commit:` from lockfile `:git` opts) — reuses milestone-139's annotation name (CocoaPods used it identically; same semantics).
+- `mikebom:path` (path-source path string) — reuses milestone-137 + 138 + 139 precedent.
+- `mikebom:in-umbrella` (path-source `in_umbrella: true` flag preservation) — NEW. Deferred parity-catalog refresh.
+- `mikebom:umbrella-root` (umbrella-root main-module marker) — NEW. Deferred parity-catalog refresh.
+- `mikebom:elixir-extraction-mode = "conditional-flattened"` (design-tier extraction precision-loss marker per Q1) — NEW. Deferred parity-catalog refresh.
+
+## syft/trivy divergence (deferred to v1.1)
+
+Per Phase 0 research, both syft and trivy emit purl-spec-non-conformant PURLs for hex:
+- syft: empty namespace + no qualifiers (drops private-org info).
+- trivy: skips `:git` and `:path` entries entirely (hex-only).
+
+mikebom emits the spec-conformant form per Principle V. Emitting `mikebom:also-known-as` annotations for syft/trivy compatibility is **deferred to v1.1** — operators who need that ecosystem's compatibility can use those tools directly in the interim.

--- a/specs/140-elixir-mix-reader/data-model.md
+++ b/specs/140-elixir-mix-reader/data-model.md
@@ -1,0 +1,196 @@
+# Data Model — milestone 140
+
+The Elixir/Mix reader does NOT introduce new types in `mikebom-common`. Reader-private serde-deserializing structs aren't applicable here because `mix.lock` is Elixir source code, not standardized data — instead the reader uses regex-tokenized intermediate enums.
+
+## LockEntry (reader-private, lockfile)
+
+Enum-discriminated representation of one parsed lockfile entry:
+
+```rust
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+enum LockEntry {
+    Hex {
+        /// Top-level map key (the lockfile's `"<name>"` string).
+        name: String,
+        /// 3rd tuple element.
+        version: String,
+        /// 4th tuple element (always present in Elixir 1.4+).
+        inner_sha256: String,
+        /// 5th tuple element — atom list. Not consumed v1 (informational).
+        #[allow(dead_code)]
+        managers: Vec<String>,
+        /// 7th tuple element. `"hexpm"` (default) OR `"hexpm:<org>"`
+        /// (private org — colon-prefixed slug, NOT a URL).
+        repo: String,
+        /// 8th tuple element. OPTIONAL — pre-Hex-2.0 entries lack it.
+        outer_sha256: Option<String>,
+    },
+    Git {
+        /// Top-level map key.
+        name: String,
+        /// 2nd tuple element.
+        url: String,
+        /// 3rd tuple element — always present in lockfile (40-char SHA).
+        resolved_sha: String,
+        /// 4th tuple element. May contain `ref:`/`branch:`/`tag:`/etc.
+        /// Stored as a single string for simplicity (e.g., `ref: "main"`).
+        declared_ref: Option<String>,
+    },
+    Path {
+        /// Top-level map key.
+        name: String,
+        /// 2nd tuple element.
+        path: String,
+        /// 4th tuple element. May contain `in_umbrella: true` flag.
+        in_umbrella: bool,
+    },
+}
+```
+
+### Validation rules
+
+- `name` (map key) MUST be non-empty.
+- `:hex` `version` MUST be non-empty.
+- `:hex` `inner_sha256` MUST be 64-char lowercase hex; warn-and-skip otherwise.
+- `:hex` `outer_sha256` when present MUST be 64-char lowercase hex; non-conformant values become `None` per Q3 best-effort emission.
+- `:hex` `repo` MUST be one of `"hexpm"` OR matches regex `^hexpm:[a-zA-Z0-9_-]+$` (private-org slug). Unknown shapes warn-and-skip.
+- `:git` `resolved_sha` MUST be 40-char lowercase hex; warn-and-skip otherwise.
+- `:git` `url` MUST be non-empty.
+- `:path` `path` MUST be non-empty.
+
+## MixExsInfo (reader-private, manifest)
+
+Regex-extracted intermediate from `mix.exs`:
+
+```rust
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
+struct MixExsInfo {
+    /// `app:` keyword in `project/0`. Drives FR-012 main-module name.
+    app_name: Option<String>,
+    /// `version:` keyword in `project/0`. Drives FR-012 main-module version.
+    version: Option<String>,
+    /// `apps_path:` keyword presence in `project/0` (umbrella sentinel
+    /// per R4). Value not consumed.
+    is_umbrella: bool,
+    /// Direct deps extracted from `deps/0` function body.
+    deps: Vec<DeclaredDep>,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct DeclaredDep {
+    /// `{:<name>, ...}` atom name.
+    name: String,
+    /// First positional string after the atom: `"constraint"` for hex
+    /// deps; absent for non-hex (`git:`/`path:` deps lack the
+    /// positional version).
+    constraint: Option<String>,
+    /// Set when `only: [:dev, ...]` / `only: :dev` / `only: :test` /
+    /// `runtime: false` keyword present. Drives FR-008 LifecycleScope.
+    dev_scope: bool,
+    /// Set when the dep tuple's source line resides inside an
+    /// `if Mix.env() ... do` / `unless ...` / `case ... do` /
+    /// multi-clause `def deps(env)` block. Drives Q1
+    /// `mikebom:elixir-extraction-mode = "conditional-flattened"` annotation.
+    in_conditional: bool,
+    /// Source-kind discriminator extracted from the opts blob per C2
+    /// remediation. T018 dispatches on this to emit the correct PURL
+    /// shape per FR-003 (design-tier git/path deps emit as
+    /// `pkg:generic/`, not `pkg:hex/`). The `:github` shortcut is
+    /// expanded to `Git` at extraction time (T008).
+    source_kind: DeclaredDepSource,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+enum DeclaredDepSource {
+    /// Default — hex source; emit as `pkg:hex/<name>@<constraint>`.
+    Hex,
+    /// `git:` or `github:` shortcut in opts. `url` is the resolved git
+    /// remote URL (`:github` shortcut expanded to
+    /// `https://github.com/<owner>/<repo>.git` at extraction time per
+    /// research R3).
+    Git { url: String, declared_ref: Option<String> },
+    /// `path:` opt. `path` is the relative path string.
+    Path { path: String, in_umbrella: bool },
+}
+```
+
+### Validation rules
+
+- `app_name` is extracted via regex `(?m)^\s*app:\s*:([a-zA-Z_][a-zA-Z0-9_]*)\b` — atom name MUST match Elixir identifier syntax.
+- `version` is extracted via regex `(?m)^\s*version:\s*"([^"]+)"` — string-literal form only (no compile-time expression evaluation).
+- `is_umbrella` set when regex `(?m)^\s*apps_path:` matches anywhere in the file (key-presence detection per R4, value ignored).
+- `deps[*].name` MUST match Elixir atom syntax.
+
+## PackageDbEntry field mapping (per source type)
+
+### Common fields (all source types)
+
+| Field | Source | Notes |
+|---|---|---|
+| `name` | Lockfile map key (verbatim) | Lowercase enforced by Hex.pm publish-time; preserved as-is |
+| `version` | `:hex` tuple element 3, OR `:git` resolved SHA (40-char), OR `:path` from sibling `mix.exs::version` lookup (or `"unspecified"` placeholder when absent) | |
+| `arch` | `None` | N/A |
+| `source_path` | Absolute path to owning `mix.lock` / `mix.exs` | Drives `ResolutionEvidence.source_file_paths` |
+| `maintainer` | `None` | Not consumed v1 |
+| `lifecycle_scope` | `Runtime` default; `Development` when sibling `mix.exs::deps/0` entry has `only: [:dev,...]` / `runtime: false` per FR-008 | Cross-reference via `DeclaredDep.dev_scope` |
+| `requirement_range` | `None` for lockfile; `Some(constraint)` for design-tier per FR-005 | |
+| `evidence_kind` | `"mix-lock"` (source-tier) / `"mix-exs"` (design-tier) | NEW values added to cyclonedx/builder.rs enum |
+| `sbom_tier` | `"source"` (lockfile-derived) / `"design"` (FR-005) | |
+| `binary_class` through `build_inclusion` | `None` | N/A |
+| `licenses` | `Vec::new()` | License deferred per spec Out-of-Scope |
+| `extra_annotations` | Source-type discriminator + source-specific extras | |
+
+### Per-source-type fields
+
+| Source | `purl` | `source_type` | `extra_annotations` extras | `hashes` |
+|---|---|---|---|---|
+| **hex (default `"hexpm"`)** | `pkg:hex/<lc-name>@<version>` | `Some("hex-hex")` | `mikebom:source-type = "hex-hex"` | Inner SHA-256 always; outer SHA-256 when present + non-empty per Q3. Both as `ContentHash::with_algorithm(HashAlgorithm::Sha256, hex)` |
+| **hex (private org `"hexpm:<org>"`)** | `pkg:hex/<org>/<lc-name>@<version>?repository_url=https://repo.hex.pm` | `Some("hex-hex")` | `mikebom:source-type = "hex-hex"` (org distinguishable via PURL namespace) | Same as default hex |
+| **git** | `pkg:generic/<name>@<resolved-sha>?vcs_url=git+<url>` (per Phase 0: pkg:hex/ would be non-conformant since purl-spec doesn't bless vcs_url for hex) | `Some("hex-git")` | `mikebom:source-type = "hex-git"`; `mikebom:vcs-declared-ref = "<opt-value>"` when present (e.g., `"ref: main"` or `"branch: develop"`) | Empty (git source has no SHA-256 in lockfile) |
+| **path** | `pkg:generic/<name>@<version-or-unspecified>` | `Some("hex-path")` | `mikebom:source-type = "hex-path"`; `mikebom:path = "<path-string>"`; `mikebom:in-umbrella = "true"` when opts contain that flag | Empty |
+
+### Main-module field mapping (per FR-012)
+
+For each `mix.exs` discovered:
+
+| Field | Value |
+|---|---|
+| `purl` | `pkg:hex/<app_name>@<version-or-"0.0.0-unknown">` (lowercase app_name) OR fallback to dir-basename when `mix.exs` lacks parseable `app:` |
+| `name` | `app_name` per derivation cascade (preserved verbatim — display) |
+| `version` | `version` per `mix.exs::project/0::version:` keyword OR `"0.0.0-unknown"` fallback |
+| `source_path` | Absolute path to `mix.exs` (preferred) or `mix.lock` |
+| `evidence_kind` | `Some("mix-exs")` |
+| `sbom_tier` | `Some("source")` |
+| `source_type` | `Some("hex-main-module")` |
+| `extra_annotations` | `mikebom:component-role = "main-module"` + `mikebom:source-type = "hex-main-module"`; for umbrella roots: `mikebom:umbrella-root = "true"` |
+| `depends` | Lockfile mode: cross-reference lockfile entries against `mix.exs::deps/0` to enumerate direct deps + (for umbrella roots) each sub-app's main-module bom-ref per Q2. Design-tier mode: `mix.exs::deps/0` declared names + (umbrella) sub-app main-module bom-refs. |
+
+### Conditional-extraction annotation (per Q1)
+
+Components emitted from `mix.exs::deps/0` where `DeclaredDep.in_conditional == true`:
+- Additional `mikebom:elixir-extraction-mode = "conditional-flattened"` annotation.
+
+This annotation only applies to design-tier (FR-005) components; lockfile-derived components are post-resolution and don't carry the precision-loss signal.
+
+## Validation invariants (per spec FR-* + Constitution)
+
+- `purl.as_str().starts_with("pkg:hex/")` OR `purl.as_str().starts_with("pkg:generic/")` for every emitted Elixir entry.
+- `source_type` value MUST be one of `hex-hex` / `hex-git` / `hex-path` / `hex-main-module`.
+- `evidence_kind` MUST be one of `mix-lock` / `mix-exs`.
+- For hex entries: `purl.as_str().starts_with("pkg:hex/")` AND vendor segment (when present) matches `^[a-zA-Z0-9_-]+$` (org slug).
+- For private-org hex entries: `purl.as_str().contains("?repository_url=")`.
+- For git entries: `purl.as_str().contains("?vcs_url=git+")`.
+- SHA-256 hashes (when present) MUST be 64-char lowercase hex.
+
+## Out-of-scope data shapes
+
+- License extraction from per-package `mix.exs::package/0::licenses` field (cross-reader follow-up — `hex_metadata.config` for installed packages).
+- `deps/` directory walking for installed-tier scans (spec Out-of-Scope).
+- Per-package transitive dep edges from the lockfile tuple's 6th element (deferred to v1.1).
+- Hex.pm API enrichment (license, owner, downloads — spec Out-of-Scope).
+- syft/trivy compatibility `mikebom:also-known-as` annotation (deferred to v1.1).
+- Pre-Elixir-1.4 lockfile format (spec Out-of-Scope; warn-and-skip on detection — missing `:hex` discriminator atom in tuples).

--- a/specs/140-elixir-mix-reader/plan.md
+++ b/specs/140-elixir-mix-reader/plan.md
@@ -1,0 +1,113 @@
+# Implementation Plan: Elixir/Mix ecosystem reader
+
+**Branch**: `140-elixir-mix-reader` | **Date**: 2026-06-24 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/140-elixir-mix-reader/spec.md`
+
+## Summary
+
+Fourteenth language-ecosystem reader added to mikebom (joins cargo, npm, pip, gem, maven, golang, nuget, swift, kotlin, conan, dart, composer, cocoapods). Parses Elixir 1.4+ `mix.lock` (Elixir-syntax tuple map literal; regex-tokenized) + `mix.exs` (Elixir source; regex-extracted `deps/0` function body). Emits one main-module per `mix.exs` (FR-012) plus one component per lockfile entry. Three source-type discriminators: `:hex` (default) gets `pkg:hex/<name>@<version>` (or `pkg:hex/<org>/<name>@<version>?repository_url=https://repo.hex.pm` for private orgs per Phase 0 correction); `:git` gets `pkg:generic/<name>@<resolved-sha>?vcs_url=git+<url>` (per Phase 0 — purl-spec doesn't bless `vcs_url=` for hex); `:path` gets `pkg:generic/<name>@<version>` placeholder. Inner + outer SHA-256 hashes from `:hex` tuples flow into `PackageDbEntry.hashes` (Q3 best-effort — emit only what's present). Umbrella projects emit one main-module per sub-app + root, with root's `depends` listing each sub-app per Q2. Conditional `deps/0` blocks are flattened with `mikebom:elixir-extraction-mode = "conditional-flattened"` annotation per Q1. **Zero new Cargo dependencies** — `regex` is already a workspace dep.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–139; no nightly required).
+
+**Primary Dependencies**: Existing only — `regex` (workspace dep, used by alpm/brew/yocto/cocoapods for line-format and DSL extraction), `mikebom_common::types::hash::{ContentHash, HashAlgorithm}` (FR-011 SHA-256 emission), `mikebom_common::types::purl::Purl` (PURL construction), `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror`, `serde_json` (annotation values), `std::sync::OnceLock` (regex compile-once). **No new Cargo dependencies.**
+
+**Storage**: N/A — all state is in-process for the duration of a single scan.
+
+**Testing**: `cargo +stable test --workspace`. Synthetic-fixture pattern via `tempfile::tempdir()` constructing minimal `mix.exs` + `mix.lock` trees. Four new integration test files at `mikebom-cli/tests/elixir_*.rs` mirroring the milestone-139 cocoapods_*.rs family. SC-004 byte-identity preservation guarded by the existing 11-ecosystem golden suite.
+
+**Target Platform**: Cross-platform reader. Pure-Rust regex extraction; no Elixir/Erlang runtime required.
+
+**Project Type**: CLI tool — extends the `mikebom sbom scan` pipeline via the `read_all` dispatcher.
+
+**Performance Goals**: ≤2 ms overhead per `mix.lock` entry. Typical Phoenix app (~80 hex deps): ~5 ms. Heavy umbrella project (~250 deps across sub-apps): ~15 ms. No-Elixir-detected fast path adds ≤5 µs per non-Elixir scan.
+
+**Constraints**:
+- Byte-identical SBOM goldens when no Elixir project present (SC-004).
+- Zero new Cargo deps.
+- Per-file parse failures warn-and-skip; malformed lockfile → fall back to design-tier from sibling `mix.exs` per FR-007.
+- The `hex` PURL type IS purl-spec-blessed (with namespace + `repository_url=` qualifier for private orgs per Phase 0 correction).
+- Hex package names lowercased per purl-spec canonical form (typically no-op since Hex.pm enforces).
+- `:git` source uses `pkg:generic/` per Phase 0 (purl-spec doesn't bless `vcs_url=` for hex).
+- No `mix` / Elixir runtime invocation; regex-only parsing.
+- Conditional `deps/0` blocks flattened per Q1 with `mikebom:elixir-extraction-mode = "conditional-flattened"` annotation.
+
+**Scale/Scope**: Typical Phoenix app: 50–100 hex deps. Heavy LiveView/Ash project: ~150. Umbrella with 5 sub-apps × 50 deps each: ~250 unique components after dedup. Per-lockfile regex parse: ~2–5 ms warm-cache.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Verdict | Justification |
+|---|---|---|
+| I. Pure Rust, Zero C | ✓ | All new code is user-space Rust; no FFI, no C. Regex tokenization via the workspace `regex` crate. No Elixir runtime evaluation. |
+| II. eBPF-Only Observation | N/A | Source-tree language reader; pre-existing discovery surface per every prior language-reader milestone. |
+| III. Fail Closed | ✓ | A source tree without any of `mix.lock` / `mix.exs` is a clean no-op (FR-006). Per-file parse failures warn-and-skip (FR-007). |
+| IV. Type-Driven Correctness | ✓ | Uses `Purl` newtype + `ContentHash` newtype; no stringly-typed identifiers. Lockfile tuple parsing uses an enum-discriminated `LockEntry` per data-model.md. Production code MUST NOT call `.unwrap()` — error propagation via `Result`. |
+| V. Specification Compliance | ✓ | **`hex` IS a purl-spec-defined type** ([hex-definition.md](https://github.com/package-url/purl-spec/blob/main/types-doc/hex-definition.md)). Names lowercased per spec. Private orgs use spec-blessed namespace-as-org + `repository_url=` qualifier (Phase 0 correction — replaces the initial `mikebom:hex-repo` annotation proposal). Git-source pods use `pkg:generic/` placeholder per Phase 0 correction (purl-spec doesn't bless `vcs_url=` for hex). Path-source uses `pkg:generic/` + `mikebom:source-type = "hex-path"` annotation as parity-bridge per Principle V. `mikebom:source-type` annotation reuses C1 parity-catalog row. **syft/trivy divergence note**: syft emits empty namespace + no qualifiers (misses private-org info); trivy SKIPS `:git` and `:path` entries entirely. mikebom is more spec-correct than both. Compatibility `mikebom:also-known-as` annotations deferred to v1.1. Documented in research §R1 + spec Phase 0 corrections. |
+| VI. Three-Crate Architecture | ✓ | All new code lives in `mikebom-cli`. No new workspace crate. |
+| VII. Test Isolation | ✓ | Synthetic tempfile fixtures only; no host-state dependency. |
+| VIII. Completeness | ✓ | Closes the Elixir gap entirely. Q1 (conditional-flattened extraction) chose completeness over silent omission; Q2 (umbrella root aggregation) preserves topology. |
+| IX. Accuracy | ✓ | PURL identity from lockfile fields directly; no heuristic guesses. Hex names lowercased per spec. Private-org translation `"hexpm:<org>"` → spec-correct namespace + `repository_url=`. Q3 (best-effort SHA-256 emission) — don't synthesize hashes the lockfile doesn't carry. |
+| X. Transparency | ✓ | Per-file parse failures emit `tracing::warn!`. Source-type via `mikebom:source-type`. Conditional-extraction precision-loss surfaces via `mikebom:elixir-extraction-mode = "conditional-flattened"` annotation per Q1. |
+| XII. External Data Source Enrichment | ✓ | The lockfile + `mix.exs` ARE the discovery sources. No external enrichment (license + Hex API explicitly out of scope). |
+
+**Verdict: PASS.** No violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/140-elixir-mix-reader/
+├── plan.md
+├── spec.md              # corrected post-Phase 0
+├── research.md          # Phase 0 — 8 sections
+├── data-model.md        # Phase 1
+├── quickstart.md        # Phase 1
+├── contracts/
+│   └── elixir-component-purl.md
+├── checklists/requirements.md  # 16/16 PASS
+└── tasks.md             # Phase 2 via /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/src/
+├── scan_fs/
+│   ├── package_db/
+│   │   ├── mod.rs                     # MODIFY: register elixir in read_all
+│   │   ├── elixir.rs                  # NEW: mix.lock + mix.exs parsing,
+│   │   │                              # main-module emission, source-type
+│   │   │                              # discrimination, umbrella handling,
+│   │   │                              # design-tier conditional-flattened
+│   │   │                              # extraction
+│   │   ├── cocoapods.rs               # REFERENCE: milestone 139 — main-module
+│   │   │                              # + multi-source + regex-extracted DSL
+│   │   ├── composer.rs                # REFERENCE: milestone 138 — SHA hash +
+│   │   │                              # multi-tier precedent
+│   │   └── gem.rs                     # REFERENCE: regex Ruby DSL parsing
+│   └── (no other scan_fs changes — elixir is purely additive)
+├── generate/cyclonedx/builder.rs       # MODIFY: extend mikebom:evidence-kind
+│                                       # enum to include "mix-lock", "mix-exs"
+└── (no changes to other generate/, parity/, common/)
+
+mikebom-cli/tests/
+├── elixir_phoenix_baseline.rs          # NEW: US1 — Phoenix app fixture
+├── elixir_source_discriminators.rs     # NEW: US2 — hex + git + path + private-org
+├── elixir_tier_fallbacks.rs            # NEW: US3 — design-tier + conditional-flat
+└── elixir_edge_cases.rs                # NEW: malformed + umbrella + multi-line +
+                                       # `:github` shortcut + dual SHA-256 edge cases
+```
+
+**Structure Decision**: New file `elixir.rs` is a peer of cargo/dart/composer/cocoapods/gem/maven/golang. Integration site is `read_all` dispatcher (placed alphabetically between `dpkg` and `exclude_path` — first reader starting with 'e'). Test files follow `<reader>_<scenario>.rs` convention. **No new workspace crate per Principle VI; no new Cargo deps.**
+
+## Complexity Tracking
+
+> No Constitution Check violations — no justifications required.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none)    | n/a        | n/a                                  |

--- a/specs/140-elixir-mix-reader/quickstart.md
+++ b/specs/140-elixir-mix-reader/quickstart.md
@@ -1,0 +1,183 @@
+# Quickstart — milestone 140 Elixir/Mix reader
+
+Operator-facing walkthrough of the scenarios this milestone surfaces.
+
+## Scenario 1 — Scan a Phoenix app (US1 / SC-001)
+
+```bash
+mikebom --offline sbom scan --path . --output /tmp/app.cdx.json
+```
+
+```bash
+# Main-module:
+jq '.metadata.component' /tmp/app.cdx.json
+# {"bom-ref": "pkg:hex/my_app@0.5.2",
+#  "name": "my_app", "version": "0.5.2",
+#  "purl": "pkg:hex/my_app@0.5.2", ...
+#  "properties": [
+#    {"name": "mikebom:component-role", "value": "main-module"},
+#    {"name": "mikebom:source-type", "value": "hex-main-module"}
+#  ]}
+
+jq '.components[] | select(.purl | startswith("pkg:hex/")) | .purl' /tmp/app.cdx.json | sort | head -10
+# "pkg:hex/ecto@3.11.1"
+# "pkg:hex/jason@1.4.4"
+# "pkg:hex/mime@2.0.5"
+# "pkg:hex/phoenix@1.7.10"
+# "pkg:hex/plug@1.15.2"
+# "pkg:hex/plug_crypto@2.0.0"
+# "pkg:hex/telemetry@1.2.1"
+```
+
+## Scenario 2 — Source discriminator distinction (US2 / SC-002)
+
+```bash
+mikebom --offline sbom scan --path . --output /tmp/mixed.cdx.json
+
+# Hex (default hexpm):
+jq '.components[] | select(.properties[]? | .name == "mikebom:source-type" and .value == "hex-hex") | .purl' /tmp/mixed.cdx.json
+
+# Hex (private organization) — note the namespace + repository_url qualifier:
+jq '.components[] | select(.purl | contains("?repository_url=")) | .purl' /tmp/mixed.cdx.json
+# "pkg:hex/acme/internal_lib@2.0.0?repository_url=https://repo.hex.pm"
+
+# Git source — pkg:generic/ placeholder per Phase 0 correction:
+jq '.components[] | select(.properties[]? | .name == "mikebom:source-type" and .value == "hex-git") | .purl' /tmp/mixed.cdx.json
+# "pkg:generic/my_fork@eb39649a76b87e8451baf75d10ce82ca3a3d5601?vcs_url=git+https://github.com/foo/my-fork.git"
+
+# Path source:
+jq '.components[] | select(.properties[]? | .name == "mikebom:source-type" and .value == "hex-path") | .purl' /tmp/mixed.cdx.json
+# "pkg:generic/shared_lib@unspecified"
+```
+
+## Scenario 3 — Inner + outer SHA-256 emission (Q3 / FR-011)
+
+```bash
+jq '.components[] | select(.name == "phoenix") | .hashes' /tmp/app.cdx.json
+# [
+#   {"alg": "SHA-256", "content": "<inner_sha256_from_4th_tuple_element>"},
+#   {"alg": "SHA-256", "content": "<outer_sha256_from_8th_tuple_element>"}
+# ]
+```
+
+Pre-Hex-2.0 entries lack the outer hash; mikebom emits ONE hash entry (Q3 best-effort).
+
+## Scenario 4 — Design-tier with conditional extraction (US3 / Q1)
+
+`mix.exs` only, no lockfile:
+
+```bash
+jq '.components[] | {name, purl, props: .properties}' /tmp/lib.cdx.json
+# {
+#   "name": "phoenix",
+#   "purl": "pkg:hex/phoenix@~>_1.7",         # constraint preserved (sanitized for PURL)
+#   "props": [
+#     {"name": "mikebom:sbom-tier", "value": "design"},
+#     {"name": "mikebom:requirement-range", "value": "~> 1.7"},
+#     {"name": "mikebom:evidence-kind", "value": "mix-exs"},
+#     {"name": "mikebom:source-type", "value": "hex-hex"}
+#   ]
+# },
+# {
+#   "name": "meck",
+#   "purl": "pkg:hex/meck@~>_0.9",            # extracted from inside `if Mix.env() == :test`
+#   "props": [
+#     {"name": "mikebom:elixir-extraction-mode", "value": "conditional-flattened"}  # Q1 precision-loss signal
+#   ]
+# }
+```
+
+## Scenario 5 — Umbrella project (Q2 / SC-010)
+
+```bash
+# Apps under apps/:
+ls /tmp/umbrella-project/apps/
+# core/  web/  worker/
+
+mikebom --offline sbom scan --path /tmp/umbrella-project --output /tmp/u.cdx.json
+
+# Main-modules per sub-app + root = 4 total:
+jq '.components[] | select(.properties[]? | .name == "mikebom:component-role" and .value == "main-module") | .purl' /tmp/u.cdx.json
+# "pkg:hex/my_umbrella@0.1.0"     ← root (with mikebom:umbrella-root annotation)
+# "pkg:hex/core@0.1.0"
+# "pkg:hex/web@0.1.0"
+# "pkg:hex/worker@0.1.0"
+
+# Root's depends list = its own tooling + each sub-app main-module per Q2:
+jq '.dependencies[] | select(.ref | contains("my_umbrella"))' /tmp/u.cdx.json
+```
+
+## Scenario 6 — Dev-scope filtering (SC-007)
+
+```bash
+# default scan includes dev/test deps:
+jq '.components[] | select(.name == "credo") | .properties' /tmp/lib.cdx.json
+# [{"name": "mikebom:lifecycle-scope", "value": "development"}]
+
+# --exclude-scope dev suppresses (top-level flag BEFORE sbom subcommand):
+mikebom --offline --exclude-scope dev sbom scan --path . --output /tmp/lib-prod.cdx.json
+jq '.components[] | select(.name == "credo")' /tmp/lib-prod.cdx.json
+# (empty — credo suppressed)
+```
+
+## Scenario 7 — No-op on non-Elixir rootfs (SC-004)
+
+```bash
+mikebom --offline sbom scan --path /mnt/server-rootfs --output /tmp/server.cdx.json 2>/tmp/scan.log
+
+jq '[.components[] | select(.purl | startswith("pkg:hex/"))] | length' /tmp/server.cdx.json
+# (matches pre-feature baseline — Elixir contributes zero)
+
+grep -c 'elixir\|mix.lock\|mix.exs' /tmp/scan.log
+# 0
+```
+
+## Scenario 8 — Malformed lockfile graceful degradation (SC-005)
+
+```bash
+mikebom --offline sbom scan --path /tmp/corrupted-elixir --output /tmp/corrupted.cdx.json 2>/tmp/scan.log
+
+echo $?
+# 0  (scan succeeded)
+
+grep 'failed to parse mix.lock' /tmp/scan.log
+# WARN mikebom::scan_fs::package_db::elixir: elixir: failed to parse mix.lock, falling back to design-tier from mix.exs path=...
+```
+
+## Verification commands
+
+```bash
+cargo test -p mikebom --test elixir_phoenix_baseline       # SC-001 + SC-007 + SC-008 + SC-009
+cargo test -p mikebom --test elixir_source_discriminators  # SC-002
+cargo test -p mikebom --test elixir_tier_fallbacks         # SC-003 + Q1 conditional-flatten + SC-010 umbrella
+cargo test -p mikebom --test elixir_edge_cases             # SC-005 + multi-line tuples + dual SHA-256 + :github shortcut
+cargo test -p mikebom --test cdx_regression --test spdx_regression --test spdx3_regression  # SC-004
+```
+
+## Cross-format byte-equivalence check
+
+```bash
+mikebom --offline sbom scan --path my_elixir_app \
+  --format cyclonedx-json --format spdx-2.3-json --format spdx-3-json \
+  --output cyclonedx-json=/tmp/e.cdx.json \
+  --output spdx-2.3-json=/tmp/e.spdx.json \
+  --output spdx-3-json=/tmp/e.spdx3.json
+
+jq '[.components[] | select(.purl | startswith("pkg:hex/")) | .purl] | sort' /tmp/e.cdx.json > /tmp/cdx-hex.txt
+jq '[.packages[].externalRefs[]? | select(.referenceType == "purl") | .referenceLocator | select(startswith("pkg:hex/"))] | sort' /tmp/e.spdx.json > /tmp/spdx-hex.txt
+jq '[.["@graph"][] | select(.software_packageUrl? | tostring | startswith("pkg:hex/")) | .software_packageUrl] | sort' /tmp/e.spdx3.json > /tmp/spdx3-hex.txt
+
+diff /tmp/cdx-hex.txt /tmp/spdx-hex.txt
+diff /tmp/cdx-hex.txt /tmp/spdx3-hex.txt
+# (no output = success)
+```
+
+## Known deferrals (spec Out-of-Scope)
+
+- License extraction (cross-reader follow-up; lives in per-package `hex_metadata.config` under `deps/<pkg>/`).
+- Transitive dep edges from lockfile tuple's 6th element (v1.1).
+- Per-target attribution for umbrella sub-apps (v1.1).
+- Private Hex API enrichment (license / owner / downloads).
+- syft/trivy compatibility `mikebom:also-known-as` annotation (v1.1).
+- Pre-Elixir-1.4 lockfile format (warn-and-skip).
+- `deps/` directory walking for installed-tier scans.

--- a/specs/140-elixir-mix-reader/research.md
+++ b/specs/140-elixir-mix-reader/research.md
@@ -1,0 +1,199 @@
+# Research — milestone 140 Elixir/Mix reader
+
+Resolves the Phase 0 open items from `plan.md`'s Technical Context: Constitution Principle V audit + purl-spec authority audit, `mix.lock` tuple shape, `mix.exs::deps/0` regex extraction, umbrella detection, integration site, per-file error posture.
+
+## R1: Constitution Principle V audit — `hex` PURL type is purl-spec-blessed
+
+**Decision**: Emit per [purl-spec `hex-definition.md`](https://github.com/package-url/purl-spec/blob/main/types-doc/hex-definition.md). For private Hex orgs, use spec-blessed `namespace = org` + `?repository_url=https://repo.hex.pm` qualifier (NOT a custom annotation). For `:git` source, use `pkg:generic/` placeholder (purl-spec doesn't bless `vcs_url=` for hex). For `:path` source, same `pkg:generic/` pattern as path-deps in milestones 137/138/139.
+
+**Key purl-spec rules**:
+
+- **Namespace**: OPTIONAL. Used for private Hex orgs (`pkg:hex/<org>/<name>@<version>`). Default-hexpm packages omit it.
+- **Default repository URL**: `https://repo.hex.pm` (NOT `hex.pm` — that's the web app; `repo.hex.pm` is the registry-API host).
+- **Name case-sensitivity**: lowercased per spec (Hex.pm enforces at publish time so this is typically no-op).
+- **`repository_url=` qualifier**: defined; canonical for private orgs.
+- **`vcs_url=` for git-source**: NOT defined for `hex` type. Use `pkg:generic/` placeholder instead.
+
+**syft/trivy divergence**:
+- syft (`elixir/package.go`) — emits `pkg:hex/<name>@<version>` with EMPTY namespace + EMPTY qualifiers. Drops private-org info.
+- trivy (`hex/mix/parse.go`) — SKIPS `:git` and `:path` entries entirely. Hex-only.
+- Both are purl-spec-non-conformant in different ways. mikebom emits the spec-conformant form per Principle V; syft/trivy compatibility `mikebom:also-known-as` annotations deferred to v1.1.
+
+**Source-discriminator handling**:
+
+| Source kind | `mikebom:source-type` value | PURL form |
+|---|---|---|
+| Default hexpm | `hex-hex` | `pkg:hex/<name>@<version>` |
+| Private org (`hexpm:<org>`) | `hex-hex` (repo distinguished via PURL namespace + `repository_url=`) | `pkg:hex/<org>/<name>@<version>?repository_url=https://repo.hex.pm` |
+| Git | `hex-git` | `pkg:generic/<name>@<resolved-sha>?vcs_url=git+<url>` |
+| Path | `hex-path` | `pkg:generic/<name>@<version>` |
+| Main-module | `hex-main-module` | `pkg:hex/<app_name>@<version>` |
+
+## R2: `mix.lock` tuple format (Elixir 1.4+)
+
+**Decision**: Regex-tokenize the Elixir map literal. Per-entry dispatch on the first atom (`:hex` / `:git` / `:path`). Multi-line tuples handled via brace-counting (the tuple shape isn't line-bounded).
+
+**Canonical shapes** (per [elixir/lib/mix/lib/mix/dep/lock.ex](https://github.com/elixir-lang/elixir/blob/main/lib/mix/lib/mix/dep/lock.ex) + [hex/lib/hex/scm.ex](https://github.com/hexpm/hex/blob/main/lib/hex/scm.ex)):
+
+```elixir
+%{
+  "phoenix": {:hex, :phoenix, "1.7.10", "<inner_sha256>", [:mix], [{:plug, ...}], "hexpm", "<outer_sha256>"},
+  "my_fork": {:git, "https://github.com/foo/my-fork.git", "abc123...", [ref: "main"]},
+  "shared_lib": {:path, "apps/shared_lib", []},
+  "private_pkg": {:hex, :private_pkg, "2.0.0", "<inner>", [:mix], [], "hexpm:acme", "<outer>"}
+}
+```
+
+**`:hex` tuple field positions**:
+1. `:hex` (discriminator atom)
+2. `:<atom_name>` — package name as Elixir atom; matches the top-level map key
+3. `"<version>"` — version string
+4. `"<inner_sha256>"` — package-contents SHA-256 (lowercase hex; 64 chars)
+5. `[<managers>]` — Mix build managers atom list (e.g., `[:mix]`, `[:rebar3]`, `[:make]`); not consumed v1
+6. `[<deps>]` — transitive dep references (e.g., `[{:plug, "~> 1.15", [hex: :plug, repo: "hexpm", optional: false]}]`); not consumed v1 (deferred to v1.1)
+7. `"<repo>"` — repo identifier; `"hexpm"` default OR `"hexpm:<org>"` private. NOT a URL.
+8. `"<outer_sha256>"` — OPTIONAL. Outer hex-archive checksum. Pre-Hex-2.0 entries lack this; handle as `Option<String>`.
+
+**`:git` tuple field positions**:
+1. `:git`
+2. `"<url>"` — git remote URL
+3. `"<resolved_sha>"` — resolved 40-char SHA (always present in lock)
+4. `[<opts>]` — keyword list; may contain `ref:` / `branch:` / `tag:` / `submodules:` / `sparse:` / `subdir:`
+
+**`:path` tuple field positions**:
+1. `:path`
+2. `"<path>"` — relative path string
+3. `[<opts>]` — keyword list; may contain `in_umbrella: true`
+
+**Other source types**: NONE. No `:rebar` or `:bare` lockfile entries per Phase 0 research. Rebar-built packages still come through `:hex` with `[:rebar3]` in the `managers` field.
+
+**Top-level wrapping**: Plain `%{ ... }` Elixir map literal — no module wrapper, no preamble.
+
+## R3: `mix.exs::deps/0` regex extraction
+
+**Decision**: Regex-extract the `deps/0` function body. Match every `{:<name>, ...}` tuple within the file, flattening any conditional nesting per Q1.
+
+**Canonical tuple shapes** (per [Mix.Tasks.Deps docs](https://hexdocs.pm/mix/Mix.Tasks.Deps.html)):
+
+```elixir
+defp deps do
+  [
+    {:phoenix, "~> 1.7"},                                # Hex with version
+    {:plug, "~> 1.15", optional: false},                 # Hex with opts
+    {:credo, "~> 1.7", only: [:dev, :test], runtime: false},  # Dev/test scope
+    {:my_fork, git: "https://github.com/foo/my-fork.git"},  # git source, no version
+    {:my_lib, github: "owner/repo", branch: "main"},     # :github shortcut → expands to :git
+    {:shared, in_umbrella: true},                        # umbrella sub-app
+    {:local_lib, path: "../my-lib"}                      # path source
+  ]
+end
+```
+
+**Regex patterns** (compiled once via `std::sync::OnceLock`):
+
+- `app:` (project name): `(?m)^\s*app:\s*:([a-zA-Z_][a-zA-Z0-9_]*)\b`
+- `version:` (project version): `(?m)^\s*version:\s*"([^"]+)"`
+- Dep tuple (full sig): `\{\s*:([a-zA-Z_][a-zA-Z0-9_]*)\s*,([^}]*)\}` — capture name + opts blob; post-process the opts to detect `git:` / `github:` / `path:` / `in_umbrella:` / `only:` / `runtime:` markers.
+- The `\{...\}` regex is multi-line-safe via `(?s)` flag where needed; tuple bodies that contain nested `[...]` lists are handled via brace-counting if regex matches truncate.
+
+**Conditional detection**: when a dep tuple is found inside an `if Mix.env() ... do ... end` / `unless ...` / `case ... do ... end` block, emit with `mikebom:elixir-extraction-mode = "conditional-flattened"` annotation per Q1. Detection: scan the file line-by-line; track an `in_conditional: bool` stack via simple keyword counting.
+
+**Scope detection from `only:` / `runtime:` keywords** (FR-008):
+- `only: [:dev, :test]` OR `only: :dev` OR `only: :test` OR `runtime: false` → `LifecycleScope::Development`
+- Otherwise → `LifecycleScope::Runtime`
+
+**`:github` shortcut**: `github: "owner/repo"` expands to `git: "https://github.com/owner/repo.git"` per Phase 0. Combinable with `branch:`/`tag:`/`ref:` identically to `:git`. v1 design-tier extraction recognizes the shortcut; lockfile mode doesn't see it (the resolved entry is already `:git` shape).
+
+**Alternatives considered**:
+- Real Elixir AST parser (`tree-sitter-elixir` crate). Rejected: significantly increases dep tree for marginal accuracy gain over regex; matches gem/cocoapods reader posture.
+- Shell out to `mix deps`. Rejected: Principle I + host-portability.
+
+## R4: Umbrella project detection
+
+**Decision**: Detect umbrella by KEY PRESENCE of `apps_path:` in root `mix.exs::project/0` return list. Per Phase 0 research, the default value is `"apps"` BUT user-configurable — don't string-match the value. Sub-app indicators (`build_path: "../../_build"`, `lockfile: "../../mix.lock"`) are advisory conventions, not authoritative detection.
+
+**Regex**: `(?m)^\s*apps_path:\s*("[^"]*"|:[a-zA-Z_]+)` — capture the value verbatim (the value matters less than the key presence).
+
+Sub-app `mix.exs` files are detected by walking under `apps_path` directory + finding `<sub_app>/mix.exs`. Each sub-app emits its own main-module + deps; no special handling beyond the standard "one main-module per `mix.exs`" rule.
+
+Per Q2, the umbrella root's `depends` list = root's own `deps/0` entries + each sub-app's main-module bom-ref.
+
+## R5: purl-spec `hex` canonical form (post-corrections)
+
+Already documented in R1 above. Reference table:
+
+| Source | PURL |
+|---|---|
+| Default hexpm | `pkg:hex/jason@1.4.4` |
+| Private org | `pkg:hex/acme/internal_lib@2.0.0?repository_url=https://repo.hex.pm` |
+| Git | `pkg:generic/my_fork@<resolved-sha>?vcs_url=git+https://github.com/foo/my-fork.git` |
+| Path | `pkg:generic/shared_lib@<version-or-unspecified>` |
+| Main-module | `pkg:hex/my_app@0.5.2` |
+
+Hex names lowercased per purl-spec (no-op for Hex.pm-published packages; matters for case-mixed `:github`-shortcut deps in design-tier mode).
+
+## R6: Integration site within `read_all`
+
+**Decision**: register `pub mod elixir;` in `mikebom-cli/src/scan_fs/package_db/mod.rs` (placed alphabetically between `pub mod dpkg;` and `pub mod exclude_path;`) and add a call site in `read_all` after `dpkg::read` and before `exclude_path` (which isn't a reader — first reader 'e' would be standalone).
+
+Looking at actual current ordering: existing readers include `alpm`, `apk`, `bazel`, `brew`, `cargo`, `cmake`, `cocoapods`, `composer`, `conan`, `dart`, `dpkg`... So `elixir` goes alphabetically after `dpkg`. Call site placement in `read_all`: between `dpkg::read(...)` invocation and the next reader's call. (Note: actual `dpkg::read` may not be a peer in the same dispatch chain — verify at impl time and pick the closest alphabetical neighbor.)
+
+No `collect_claimed_paths` integration. Signature: `pub fn read(rootfs: &Path, include_dev: bool, exclude_set: &ExclusionSet) -> Vec<PackageDbEntry>`.
+
+## R7: Multi-project / umbrella handling + per-file error posture
+
+**Decision**: three walker passes, mirroring milestones 138/139.
+
+Algorithm:
+
+1. **Walker pass A** — `mix.lock` walker via `safe_walk`. For each:
+   1. Parse via `regex` + brace-counted tokenizer. On error → `tracing::warn!` + skip project (or fall back to sibling-`mix.exs` design-tier per FR-007).
+   2. Look for sibling `mix.exs` → parse via regex for `app:` / `version:` (FR-012 main-module name + version) + `deps/0` body (for scope cross-reference per FR-008 + conditional-extraction annotation per Q1).
+   3. Emit main-module per FR-012.
+   4. Emit lockfile components per FR-002 + FR-003 + FR-008 (cross-reference `mix.exs::deps/0` for scope tags) + FR-011 (SHA-256 hashes).
+
+2. **Walker pass B** — `mix.exs` design-tier walker. For each `mix.exs` whose parent dir has NO sibling `mix.lock`: emit main-module + design-tier components per FR-005.
+
+3. **Umbrella detection** — for any `mix.exs` whose `project/0` carries `apps_path:` key, treat as umbrella root. After Pass A + B, populate root's `depends` with each sub-app main-module bom-ref per Q2.
+
+**Same-PURL dedup**: standard orchestrator `seen_purls` HashSet across all three sources.
+
+**Per-file error matrix**:
+
+| Condition | Behavior | Justification |
+|---|---|---|
+| No `mix.lock` / `mix.exs` | Return `Vec::new()` | Clean no-op (FR-006) |
+| `mix.lock` parses; sibling `mix.exs` parseable | Standard source-tier + cross-ref scope | Common case |
+| `mix.lock` parses; no sibling `mix.exs` | Lockfile emit; main-module from dir-basename per milestone-139 Q1 fallback | Lockfile-only commits |
+| `mix.lock` malformed; sibling `mix.exs` present | Warn + design-tier per FR-007 | Best-effort preservation |
+| Per-entry tuple malformed | Warn + skip single entry | Forward compat |
+| `mix.exs` Elixir syntax error breaks regex | Warn + skip entry | Best-effort regex |
+| `apps_path:` value not string/atom | Warn but still detect umbrella by key presence per R4 | Standards-compatible |
+
+## R8: Performance considerations
+
+**Decision**: no performance budget violations expected.
+
+- Per-`mix.lock`: read ~10–30 KB typical, regex-tokenize. ~2–8 ms warm-cache.
+- Typical Phoenix app (~80 hex deps): ~5 ms total.
+- Heavy umbrella with 5 sub-apps × 80 deps: ~25 ms.
+- Source-tree walker: sub-millisecond on typical repos.
+
+The no-Elixir-detected fast path: walker finds no relevant files; reader returns empty Vec; statistically free.
+
+---
+
+## Summary of Phase 0 resolutions
+
+| Unknown | Decision | Reference |
+|---|---|---|
+| Principle V audit | `hex` is purl-spec-blessed; private orgs use namespace + `repository_url=`; git source uses `pkg:generic/` (Phase 0 correction) | R1 |
+| `mix.lock` schema | 3-source enum dispatch; brace-counted regex; outer SHA-256 is `Option<String>` | R2 |
+| `mix.exs::deps/0` extraction | Regex per-tuple; conditional-flattened per Q1; `:github` shortcut → expand to `:git` | R3 |
+| Umbrella detection | `apps_path:` KEY presence (not value match) in root `mix.exs::project/0` | R4 |
+| purl-spec hex canonical form | Lowercase names; default URL `https://repo.hex.pm`; namespace for private orgs | R5 |
+| Integration site | `read_all` dispatcher alphabetically between `dpkg` and next reader | R6 |
+| Multi-project + error posture | Three walker passes; warn-and-skip; design-tier fallback on lockfile error | R7 |
+| Performance | ~25 ms on heavy umbrella; no budget concerns | R8 |
+
+All Phase 0 unknowns resolved. Ready for Phase 1.

--- a/specs/140-elixir-mix-reader/spec.md
+++ b/specs/140-elixir-mix-reader/spec.md
@@ -1,0 +1,194 @@
+# Feature Specification: Elixir/Mix ecosystem reader
+
+**Feature Branch**: `140-elixir-mix-reader`
+**Created**: 2026-06-24
+**Status**: Draft
+**Input**: User description: "422"
+
+## Background
+
+Elixir is a notable production ecosystem with disproportionate footprint in banking (Bleacher Report, Bank of America), telecom (WhatsApp's spiritual ancestor BEAM stack), real-time messaging (Discord), and high-availability systems where Erlang/OTP's actor model is the architectural foundation. The community is smaller than Ruby/Python by absolute headcount but dense and production-serious — every modern Elixir project commits a `mix.lock` for reproducible installs.
+
+mikebom currently emits **zero** Elixir components when scanning a Phoenix web app, a Nerves embedded project, or any source tree containing `mix.lock`. Every Hex package pulled from `hex.pm` — plus the typically-rich graph of OTP-app dependencies (Plug, Ecto, Phoenix, Tesla, GenStage, Broadway, Oban) — is invisible to the scan.
+
+The Elixir ecosystem has three discrimination surfaces a reader must handle:
+
+- **Hex deps** (the dominant case): from `hex.pm` (the central package registry). PURL: `pkg:hex/<package>@<version>`.
+- **Git deps**: directly-pinned git URLs (`{:foo, git: "https://github.com/owner/repo.git", ref: "abc123"}`). Identity is the resolved Git SHA.
+- **Path deps**: local-filesystem deps (`{:my_lib, path: "../my-lib"}`) typically used for umbrella apps or in-flight library development.
+
+The `mix.lock` file format is unique among lockfiles supported by mikebom: it's **Elixir source code** parsed by the Mix tooling, not a standardized data format. Each line is roughly `"<pkg_name>": {:hex, :<pkg_name>, "<version>", "<sha256>", [<build_tools>], [<deps>], "<repo>", "<hex_sha256_outer>"},` for Hex deps, with similar tuple-shapes for git/path. The file IS stable + regex-extractable (every prominent SBOM tool does this) — no Elixir runtime needed for parsing.
+
+This feature closes the Elixir gap so an operator scanning any Mix-managed project gets a complete SBOM with every Hex-managed dep represented, source-type discriminators surfaced, and inner+outer SHA-256 hashes preserved.
+
+## Clarifications
+
+### Session 2026-06-24
+
+- Q: When `mix.exs::deps/0` contains env-conditional blocks (`if Mix.env() == :prod do ... end`, multi-clause `deps(env)` dispatch, or routing through `deps(Mix.env())`), how should the regex extractor handle them? → A: Extract every `{:name, ...}` tuple regardless of conditional nesting (flatten all `if`/`unless`/multi-clause branches). Operator may see deps from a dev-only branch in a prod-context scan; design-tier mode is already best-effort and over-inclusion is safer than omission per Principle VIII Completeness. Components extracted from inside a conditional block carry an additional `mikebom:elixir-extraction-mode = "conditional-flattened"` annotation so consumers can detect the precision loss. Matches the milestone-139 CocoaPods Q3 / Podfile-conditional extraction posture.
+- Q: For umbrella projects, what should the umbrella ROOT main-module's `depends` edges list — given that the root `mix.exs` typically declares only umbrella-wide tooling (`:dialyxir`, `:credo`) while sub-app `deps/0` declarations are the real production deps? → A: Root's `depends` = its own `deps/0` entries + each sub-app's main-module bom-ref (root → sub-apps + root-level tooling). Two-level topology: the umbrella root orchestrates the sub-apps; each sub-app's own main-module independently lists its production deps. Matches the operator-mental-model of umbrella architecture (root is the project orchestrator; sub-apps are the units of deployment).
+- Q: When the inner SHA-256 (package contents) and/or outer SHA-256 (hex-archive wire-transport checksum) is missing or empty-string in a `mix.lock` entry (common for pre-Hex-2.0 entries which lack outer; rare empty-outer cases when the registry hasn't published it yet), what should the reader emit? → A: Emit only the hashes that are present AND non-empty in the lockfile. When inner is present + outer is missing/empty: emit one `ContentHash::sha256` entry. When both present + non-empty: emit two. Empty-string outers are skipped silently (they're a registry artifact, not operator-meaningful). Principle IX-aligned (no synthetic hashes). FR-011 below is updated to reflect this best-effort posture rather than the original "two separate entries" claim.
+
+#### Phase 0 research corrections (post-clarification)
+
+Plan-phase research against the [purl-spec `hex-definition.md`](https://github.com/package-url/purl-spec/blob/main/types-doc/hex-definition.md) and the canonical [elixir-lang/elixir Mix.Dep.Lock](https://github.com/elixir-lang/elixir/blob/main/lib/mix/lib/mix/dep/lock.ex) + [hexpm/hex SCM](https://github.com/hexpm/hex/blob/main/lib/hex/scm.ex) sources surfaced four corrections to initial spec guesses. These are CORRECTIONS to align with the authority, not scope changes:
+
+- **Private Hex orgs use spec-blessed namespace + `repository_url=` qualifier** (NOT a custom `mikebom:hex-repo` annotation as initially proposed). purl-spec `hex-definition.md` defines `pkg:hex/<org>/<name>@<version>` (namespace = private org slug) PLUS `?repository_url=https://repo.hex.pm` for explicit registry pinning. The lockfile records the repo as `"hexpm"` (default) or `"hexpm:<org>"` (private org — colon-prefixed slug, NOT a URL). The reader MUST translate `"hexpm:<org>"` → `pkg:hex/<org>/<name>@<version>?repository_url=https://repo.hex.pm`. This is MORE correct than syft/trivy (both silently strip private-org info) and is Principle V-aligned (standards-native first).
+- **Git-source hex deps use `pkg:generic/` placeholder, NOT `pkg:hex/`**. purl-spec hex-definition does NOT define a `vcs_url=` qualifier for the `hex` type, so emitting `pkg:hex/<name>@<sha>?vcs_url=git+<url>` is purl-spec-non-conformant. The honest emission is `pkg:generic/<name>@<resolved-sha>?vcs_url=git+<url>` + `mikebom:source-type = "hex-git"` annotation as the discriminator (path-source already uses this pattern; symmetric posture). The git-source dep has no Hex.pm provenance once it's been swapped to a git remote — `pkg:hex/` would falsely imply registry-resolution.
+- **Default repository URL is `https://repo.hex.pm`** (NOT `hex.pm` — the latter is the user-facing web app; `repo.hex.pm` is the registry-API host that purl-spec records as the canonical default).
+- **Lockfile tuple positions clarification**: per [hex/lib/hex/scm.ex](https://github.com/hexpm/hex/blob/main/lib/hex/scm.ex), the 5th tuple element is `managers` (atom list like `[:mix]` or `[:rebar3]`), not free-form "build_tools". The 8th element (outer SHA-256) IS truly optional per Q3. `:git` opts can include `ref:` / `branch:` / `tag:` / `submodules:` / `sparse:` / `subdir:` — broader than the initial spec's "ref: only" implication.
+
+FR-002 + FR-003 + FR-011 (already updated) are amended below to reflect these corrections.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Operator scans a Phoenix or Nerves project (Priority: P1) 🎯 MVP
+
+An Elixir backend developer runs `mikebom sbom scan --path .` on their Phoenix web app source tree containing `mix.exs` + `mix.lock`. They receive an SBOM containing one component per Hex package pinned in `mix.lock`. Each component carries a `pkg:hex/<package>@<version>` PURL identity and a dependsOn edge from the app's root component to each direct dep.
+
+**Why this priority**: The headline use case. Every production Elixir project commits `mix.lock`; without this, the entire feature has no operator value.
+
+**Independent Test** (SC-001): Synthetic fixture with `mix.exs` (3 direct deps: `phoenix`, `plug`, `ecto`) + `mix.lock` (5 entries — 3 direct + 2 transitives). Run `mikebom sbom scan --path <tmp>`. Assert exactly 5 `pkg:hex/*` components emit with correct names + versions; main-module + dep-edges wire correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Phoenix project with `mix.lock` pinning `phoenix 1.7.10`, `plug 1.15.2`, `ecto 3.11.1`, **When** the operator runs `mikebom sbom scan --path <project>`, **Then** the emitted SBOM contains components for each pinned dep with PURL `pkg:hex/<name>@<version>`.
+2. **Given** the same project, **When** the operator inspects the emitted SBOM, **Then** transitive deps pinned in `mix.lock` (e.g., `telemetry`, `mime`, `plug_crypto`) also appear as components — the lockfile is the authoritative dep set, not just `mix.exs`'s `deps/0` list.
+3. **Given** a source tree WITHOUT `mix.lock` or `mix.exs`, **When** the operator scans, **Then** no Elixir components or annotations appear AND no warning fires (clean no-op).
+4. **Given** a project whose `mix.exs` declares `def project, do: [app: :my_app, version: "0.5.2", ...]`, **When** the operator scans, **Then** a main-module component emits with PURL `pkg:hex/my_app@0.5.2`, `mikebom:component-role = "main-module"`, and `mikebom:sbom-tier = "source"` annotations; dep edges flow from this main-module bom-ref to each direct dep's bom-ref.
+
+---
+
+### User Story 2 — Operator distinguishes Hex vs git / path deps (Priority: P2)
+
+The operator's Elixir project's `mix.lock` mixes Hex deps (the default), a `:git` dep pinning a fork (`{:git, "https://github.com/foo/bar.git", "abc...", [ref: "main"]}`), and a `:path` dep pointing to an umbrella sibling app (`{:path, "apps/shared_lib", []}`). The SBOM must distinguish these sources so downstream supply-chain risk tooling can correctly assess each.
+
+**Why this priority**: Important for supply-chain risk assessment but the headline value (US1) ships independently.
+
+**Independent Test** (SC-002): Synthetic fixture with one each of `:hex`, `:git`, `:path` dep in `mix.lock`. Scan. Assert correct PURL shape and `mikebom:source-type` annotation per FR-003.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `mix.lock` entry `"my_fork": {:git, "https://github.com/foo/my-fork.git", "abc123def456..."}`, **When** the operator scans, **Then** the emitted PURL embeds the resolved Git SHA per the purl-spec git-source convention (`pkg:hex/my_fork@<sha>?vcs_url=git+https://github.com/foo/my-fork.git`) AND carries `mikebom:source-type = "hex-git"` evidence.
+2. **Given** a `mix.lock` entry `"shared_lib": {:path, "apps/shared_lib", []}`, **When** the operator scans, **Then** that dep emits with `mikebom:source-type = "hex-path"` evidence and a `pkg:generic/shared_lib` placeholder PURL.
+3. **Given** an umbrella project (a Mix project containing `apps/<sub_app>/mix.exs` files), **When** the operator scans the umbrella root, **Then** sub-app `:path` deps emit with `mikebom:source-type = "hex-path"` AND the path string preserved as `mikebom:path` annotation.
+
+---
+
+### User Story 3 — Operator scans an Elixir library project WITHOUT a committed lockfile (Priority: P3)
+
+Some Elixir library projects (especially those published to Hex.pm with permissive version constraints) deliberately do NOT commit `mix.lock` — only `mix.exs` with `deps/0` function returning constraint tuples like `{:phoenix, "~> 1.7"}`. Scanning such a project should produce SOME inventory rather than empty output, marked as `design`-tier.
+
+**Why this priority**: Important for library publishers but smaller user base than app developers. Most production Elixir projects DO commit `mix.lock`.
+
+**Independent Test** (SC-003): Synthetic fixture with `mix.exs` declaring 2 direct deps but NO `mix.lock`. Scan. Assert 2 components emit with `mikebom:sbom-tier = "design"` annotation, each carrying the declared constraint string as `mikebom:requirement-range` evidence.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Elixir library project with `mix.exs` only (no `mix.lock`), **When** the operator scans, **Then** components emit for declared deps from `deps/0` with `mikebom:sbom-tier = "design"` and the original version constraint preserved as evidence.
+2. **Given** the same project, **When** the operator inspects the emitted SBOM, **Then** NO transitive deps appear (lockfile is required for transitive resolution; design-tier captures only what's explicitly declared).
+3. **Given** a `mix.exs` declaring `{:credo, "~> 1.7", only: [:dev, :test], runtime: false}`, **When** the operator scans in design-tier mode, **Then** the emitted `credo` component carries `mikebom:lifecycle-scope = "development"` annotation (per `only: [:dev, :test]` discriminator); downstream `--exclude-scope dev` filtering successfully suppresses it.
+
+---
+
+### Edge Cases
+
+- **Mixed Hex/git/path in one project**: a Phoenix app with a forked Plug + an umbrella sub-app dep has all three source types. Each MUST surface with the correct `source-type` evidence; none MUST silently masquerade as a Hex dep.
+- **Private Hex organization (`organization: "acme"` option)**: some organizations run a private Hex repository. The Hex lockfile entry can include an optional outer field naming the repo (`"hexpm"` for the default, `"acme"` for private orgs). When the repo isn't `"hexpm"`, emit a `repository_url=` qualifier on the PURL — though the spec is silent on what the URL should be (Hex private orgs resolve from `hex.pm/api/repos/acme` via authenticated download). v1 deferral: surface the repo name as `mikebom:hex-repo` evidence rather than synthesize a `repository_url=`.
+- **`mix.lock` syntax edge cases**: Elixir tuples can wrap across lines. The regex-extraction approach MUST handle multi-line tuples (the entry's text is bounded by `{` ... `}` rather than newlines).
+- **Pre-Elixir-1.4 lockfile format**: lacks the second `:hex` sigil in the tuple (`{:hex, :name, "version", ...}` vs older `{"version", "sha256"}`). Out of scope for v1 — Elixir 1.4+ (released 2017) is universal in 2026 production. Pre-1.4 detection → warn-and-skip.
+- **Erlang `rebar3` deps via `:rebar` source type**: some Hex packages compile via rebar; the lockfile tuple's build_tools array carries `:rebar` instead of `:mix`. v1 treats this as identical to `:mix` Hex deps — the source-type distinction is build-tooling, not provenance.
+- **Umbrella projects** (`apps/<sub_app>/mix.exs` under the umbrella root): the root `mix.exs` typically has `apps_path: "apps"` declaration; sub-apps each have their own `mix.exs`. v1 emits one main-module per sub-app's `mix.exs` PLUS one for the umbrella root (consistent with the milestone-064 / 138 monorepo pattern). Same-PURL deps across sub-apps collapse via standard `seen_purls` dedup.
+- **Malformed `mix.lock`**: skip-the-file with `tracing::warn!`; when sibling `mix.exs` exists, fall back to design-tier emission per FR-005.
+- **`mix.exs` is Elixir source code, not a data format**: parsing it requires either a real Elixir parser OR regex-extraction of the `deps/0` function body. v1 uses regex-extraction (matches the gem reader's posture from milestone 069 for Ruby `.gemspec`).
+- **Build/dev/test scope classification**: `mix.exs` deps can carry `only: [:dev, :test]` or `runtime: false` keywords. These map to mikebom's `LifecycleScope::Development` (matches the cross-ecosystem convention from milestones 052 + 137 + 138).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST detect Elixir/Mix projects by the presence of `mix.lock` OR `mix.exs` files anywhere under the scan root. Either triggers reader activation.
+- **FR-002**: System MUST parse `mix.lock` (Elixir-syntax tuple lockfile, Elixir 1.4+ schema) and extract from each top-level map entry: package name (the map key), source-type discriminator (`:hex`/`:git`/`:path` — the first tuple element after `{`), and source-specific identity payload:
+  - **`:hex`** tuple shape: `{:hex, :<atom_name>, "<version>", "<inner_sha256>", [<managers>], [<deps>], "<repo>", "<outer_sha256>"}`. Per Phase 0 research, the 5th element is `managers` (atom list — `[:mix]` / `[:rebar3]` / `[:make]`), not free-form "build_tools"; the 8th element (outer SHA-256) IS truly optional (pre-Hex-2.0 entries lack it — handle as `Option<String>`). The `<repo>` string is `"hexpm"` for default registry OR `"hexpm:<org>"` (colon-prefixed slug) for private Hex organizations. NOT a URL.
+  - **`:git`** tuple shape: `{:git, "<url>", "<resolved_sha>", [<opts>]}`. Extract URL, resolved 40-char SHA, optional opts keyword list. Opts may contain `ref:`/`branch:`/`tag:`/`submodules:`/`sparse:`/`subdir:` per Phase 0 research.
+  - **`:path`** tuple shape: `{:path, "<path>", [<opts>]}`. Extract path string. Opts may contain `in_umbrella: true` for umbrella sub-app deps.
+- **FR-003**: System MUST emit one component per parsed lockfile entry with PURL according to the source discriminator (shapes per the [purl-spec `hex-definition.md`](https://github.com/package-url/purl-spec/blob/main/types-doc/hex-definition.md)):
+  - **hex (default `"hexpm"` repo)**: `pkg:hex/<name>@<version>`. Names lowercased per purl-spec canonical form (Hex.pm enforces lowercase at publish time, so this is typically a no-op).
+  - **hex (private organization, repo `"hexpm:<org>"`)**: `pkg:hex/<org>/<name>@<version>?repository_url=https://repo.hex.pm` per purl-spec hex-definition (namespace = private-org slug; `repository_url=` qualifier carries the canonical hex registry host). The reader MUST split the lockfile's `"hexpm:<org>"` repo string on the first colon to extract the org slug. Per Phase 0 correction, this replaces the initial `mikebom:hex-repo` annotation proposal — purl-spec actually blesses both the namespace-as-org form AND the `repository_url=` qualifier.
+  - **git**: `pkg:generic/<name>@<resolved-sha>?vcs_url=git+<url>` per Phase 0 correction — purl-spec hex-definition does NOT define a `vcs_url=` qualifier for the `hex` type, so emitting `pkg:hex/<name>@<sha>?vcs_url=git+<url>` would be non-conformant. `pkg:generic/` is honest about the lack of Hex.pm provenance once the dep is git-swapped. Plus `mikebom:source-type = "hex-git"` annotation as discriminator. The operator-declared opt (`ref:`/`branch:`/`tag:`/`commit:`) from the lockfile tuple is preserved as `mikebom:vcs-declared-ref` evidence when present.
+  - **path**: `pkg:generic/<name>@<version-or-unspecified>` placeholder + `mikebom:source-type = "hex-path"` evidence + `mikebom:path = "<lockfile-path-value>"` annotation. Path-deps have no Hex.pm-addressable identity.
+- **FR-004**: System MUST emit dependency edges from each project's main-module (per FR-012) to each direct dep declared in `mix.exs`'s `deps/0` function (lockfile mode: cross-reference lockfile entries against `mix.exs`'s direct-dep list; design-tier mode: use `deps/0` directly). Transitive components (lockfile entries not declared in `mix.exs`) surface as standalone components but their inter-package dependency edges (the per-entry `[<deps>]` array element) are deferred to v1.1.
+- **FR-005**: When `mix.lock` is absent but `mix.exs` is present, system MUST emit components for direct deps declared in the `deps/0` function via regex extraction of `{:<name>, "<constraint>"[, <kw_opts>]}` tuples, with `mikebom:sbom-tier = "design"` annotation and the original version constraint string as `mikebom:requirement-range` evidence. Per Q1 clarification, extraction is conditional-flattened: every dep tuple found in the file is emitted regardless of `if`/`unless`/multi-clause function nesting (the regex extractor has no `Mix.env()` visibility). Components whose source line resides inside any conditional construct (`if Mix.env() == ...`, `unless ...`, `case ...`, `def deps(:dev)`, etc.) MUST additionally carry `mikebom:elixir-extraction-mode = "conditional-flattened"` annotation so consumers can detect the precision loss. No transitive deps emit in this design-tier mode.
+- **FR-006**: System MUST treat a source tree containing no `mix.lock` AND no `mix.exs` as a clean no-op — no components emitted, no warnings logged. Existing scans on non-Elixir projects MUST stay byte-identical pre/post this feature.
+- **FR-007**: System MUST tolerate per-file parse errors (malformed lockfile tuple syntax, missing required fields) without aborting the whole scan — log a structured warning naming the affected file path and continue. When a lockfile is malformed AND a sibling `mix.exs` exists, fall back to design-tier emission from the manifest per FR-005.
+- **FR-008**: System MUST tag deps declared with `only: [:dev, :test, :doc]` or `runtime: false` in `mix.exs`'s `deps/0` function with `mikebom:lifecycle-scope = "development"` (matches dpkg/maven/npm/dart/composer/cocoapods precedent). When in lockfile mode, cross-reference the `mix.exs`-declared scope back to the lockfile entry (lockfile itself doesn't carry scope info; `mix.exs` is the authoritative scope source).
+- **FR-009**: System MUST handle Elixir umbrella projects (a root `mix.exs` with `apps_path: "apps"` declaration, plus `apps/<sub_app>/mix.exs` for each member) by emitting **one main-module component per `mix.exs`** regardless of umbrella membership. Each sub-app's lockfile (when present) is parsed independently for the dep edges attributed to that sub-app's main-module. Same-PURL deps across sub-apps collapse via the standard cross-component `seen_purls` dedup. No synthetic umbrella-root component is emitted beyond the root `mix.exs`'s own main-module. Per Q2 clarification, the umbrella ROOT main-module's `depends` list is the union of (a) its own `deps/0` entries (typically umbrella-wide tooling like `:dialyxir`, `:credo`) and (b) each sub-app's main-module bom-ref — producing a two-level topology where the root orchestrates the sub-apps and each sub-app independently lists its production deps. Mirrors the cargo (milestone 064) + dart (milestone 137) workspace pattern with the umbrella-specific root-aggregation refinement.
+- **FR-010**: System MUST NOT make any network calls during the scan — `mix.lock` is fully self-contained. Resolving a Hex package's `hex.pm` API metadata is out of scope.
+- **FR-011**: System MUST preserve content-addressable hashes when present in the lockfile: each Hex entry's INNER SHA-256 (the package-contents hash; 4th tuple element) and OUTER SHA-256 (the hex-archive wire-transport checksum; 8th tuple element when present) flow into `PackageDbEntry.hashes` as separate `ContentHash::with_algorithm(HashAlgorithm::Sha256, hex)` entries. Per Q3 clarification, only hashes that are present AND non-empty are emitted (skip empty-string outers silently per Principle IX accuracy — don't synthesize hashes the lockfile doesn't carry): pre-Hex-2.0 entries with only an inner SHA-256 emit one hash entry; Hex 2.0+ entries with both populated emit two. Per the milestone-138 Composer SHA-1 + milestone-139 CocoaPods SHA-1 precedent, hashes flow via the standards-native CDX `hashes[]` array. Elixir is the first mikebom-supported ecosystem to potentially emit multiple hashes per single component.
+- **FR-012**: For each `mix.exs` encountered under the scan root, system MUST emit one **main-module component** with PURL `pkg:hex/<app_name>@<version>` (where `<app_name>` is extracted from the `app: :<atom_name>` keyword in the `project/0` function's return-list, and `<version>` is extracted from the `version: "<version>"` keyword). The component MUST carry `mikebom:component-role = "main-module"` and `mikebom:sbom-tier = "source"` annotations. Dep edges MUST flow from this main-module to each direct dep declared in `deps/0`. When `mix.exs` lacks a parseable `app:` keyword, fall back to the parent-directory basename (per the milestone-138 + 139 Q1/Q3 cascade pattern). When `mix.exs` lacks a parseable `version:` keyword, use `0.0.0-unknown` as the placeholder per the cargo/dart/composer main-module convention.
+
+### Key Entities
+
+- **mix.lock**: Elixir-syntax map literal pinning each direct + transitive dep. Top-level shape: `%{ "<name>": {<tuple>}, ... }`. Each entry's tuple discriminates on the first atom (`:hex` / `:git` / `:path`) and carries source-specific fields. Format is Elixir source code parsed by the Mix tooling; regex-extractable for SBOM purposes.
+- **mix.exs**: Elixir source file declaring the Mix project. Contains a `defmodule MyApp.MixProject` with two key functions: `project/0` (returns keyword list with `app:`, `version:`, `deps: deps()`) and `deps/0` (returns list of `{:dep_name, "version", kw_opts}` tuples). Lower fidelity than lockfile.
+- **Mix project**: A directory containing `mix.exs`. The project's app name (`:my_app` atom from `app:` keyword) is the conventional Hex package name.
+- **Hex package**: A package published to `hex.pm` (or a private Hex organization repo). Identified by `pkg:hex/<name>@<version>` per purl-spec; lowercase-required.
+- **Umbrella project**: A Mix project containing `apps/<sub_app>/mix.exs` files; the root `mix.exs` declares `apps_path: "apps"`. Each sub-app is a peer Mix project with its own `deps/0`. Common in domain-decomposed Elixir architectures (e.g., separating `web`, `core`, `worker` apps).
+- **Inner/outer SHA-256**: Hex lockfile tuples carry two distinct SHA-256 hashes — the INNER (4th tuple element) is the package contents hash; the OUTER (8th tuple element, optional) is the wire-transport hex-archive checksum. Both flow into mikebom's `hashes[]` per FR-011.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A scan of a synthetic Phoenix project with `mix.exs` (3 direct deps) + `mix.lock` (those 3 plus 2 transitives = 5 total) produces a CDX SBOM whose Elixir component count matches the lockfile entry count exactly (5) plus 1 main-module (= 6 total Elixir-derived components); direct-dep edges target real bom-refs.
+- **SC-002**: A scan of a fixture mixing one `:hex`, one `:git`, and one `:path` dep produces correct PURLs per FR-003: hex as `pkg:hex/<name>@<version>` (or `pkg:hex/<org>/<name>@<version>?repository_url=https://repo.hex.pm` for private orgs per Phase 0 correction), git as `pkg:generic/<name>@<resolved-sha>?vcs_url=git+<url>` (per Phase 0 correction — purl-spec doesn't bless `vcs_url=` for hex; pkg:generic/ placeholder is honest), path as `pkg:generic/<name>@<version>` (placeholder). Each carries the correct `mikebom:source-type` evidence (`hex-hex` / `hex-git` / `hex-path`).
+- **SC-003**: A scan of an Elixir library project with `mix.exs` only (no `mix.lock`) produces components for declared `deps/0` entries with `mikebom:sbom-tier = "design"` annotation and the constraint string preserved as `mikebom:requirement-range` evidence.
+- **SC-004**: A source tree containing no Elixir files produces an SBOM byte-identical (modulo timestamps + serial numbers) to a pre-feature baseline scan. (No-op preservation invariant.)
+- **SC-005**: A scan completes successfully (exit code 0, valid SBOM) on a fixture where one `mix.lock` has corrupted tuple syntax alongside three valid Elixir project subdirectories. The output contains components from the three valid projects plus a warning naming the corrupted lockfile; the corrupted project falls back to design-tier emission from its sibling `mix.exs`.
+- **SC-006**: An external SBOM consumer reading the emitted CDX JSON can enumerate every Hex-managed dep via the standard `components[]` array filtered on `purl =~ "^pkg:hex/"`. No Elixir-specific consumer code is required.
+- **SC-007**: A scan of a fixture with a `mix.exs` `deps/0` entry declared `{:credo, "~> 1.7", only: [:dev, :test]}` produces a component carrying `mikebom:lifecycle-scope = "development"` annotation; downstream `--exclude-scope dev` filtering on that property successfully suppresses the component.
+- **SC-008**: A scan of a project whose `mix.exs` declares `app: :my_app` and `version: "0.5.2"` produces a main-module component with PURL `pkg:hex/my_app@0.5.2` carrying `mikebom:component-role = "main-module"` annotation; the SBOM's `dependencies[]` block contains an entry for the main-module's bom-ref with `dependsOn` targeting every direct dep's bom-ref.
+- **SC-009**: A scan of a fixture with `mix.lock` entries containing both inner and outer SHA-256 hashes produces CDX `hashes[]` entries with `alg = SHA-256` and BOTH hash values present (two separate hash entries per component when both are available). A scan of a pre-Hex-2.0 fixture with only the inner SHA-256 produces ONE hash entry per component (per Q3 — Principle IX accuracy; no synthetic empty-string hashes).
+- **SC-010**: A scan of an umbrella project with 3 sub-apps under `apps/` produces 3 main-module components (one per sub-app's `mix.exs`) plus 1 for the umbrella root — total 4 main-modules. Same-PURL deps across sub-apps collapse to single component entries via standard dedup.
+
+## Assumptions
+
+- **Modern Elixir 1.4+ lockfile format only**: pre-1.4 (released 2017) lockfiles are out of scope. Modern Mix is universal in 2026 production.
+- **`mix.lock` is the authoritative source when present**: prefer lockfile over `mix.exs` (design-tier fallback).
+- **No live `mix` invocation**: the reader parses on-disk metadata directly. It does NOT shell out to `mix deps.tree` or `mix deps.get` — the `mix` binary (Elixir/Erlang runtime) isn't guaranteed to exist on the scan host (mikebom is host-portable; scanned target may be a containerized Elixir release on Linux scanned from macOS).
+- **The `hex` PURL type IS purl-spec-blessed**: the [purl-spec PURL-TYPES.rst](https://github.com/package-url/purl-spec/blob/main/PURL-TYPES.rst) defines the `hex` type explicitly. mikebom emits per the spec.
+- **Existing milestone-138/139 language-reader pattern is the template**: the reader will share architectural shape with `composer.rs` (closest siblings — both parse lockfiles in source-tree-walked project directories with source-discriminator handling) and `cocoapods.rs` (multi-source PURL form + git-resolved-SHA + manifest regex-extraction pattern).
+- **Regex parsing of `mix.lock`**: per spec Edge Cases, `mix.lock` is Elixir source code but its tuple shape is stable + regex-extractable. Matches the gem reader's posture (Ruby `.gemspec` regex extraction from milestone 069). Multi-line tuples handled via brace-counting.
+- **Regex parsing of `mix.exs::deps/0`**: same posture as `mix.lock` — regex-extract the `deps/0` function body and parse each `{:name, "constraint", kw_opts}` tuple. No Elixir runtime needed.
+- **Hex package names lowercased**: per purl-spec `hex-definition.md` (confirmed in Phase 0 research). Hex.pm enforces lowercase at publish time so this is typically a no-op, but the rule applies regardless.
+- **Git-source PURL convention**: per purl-spec, git-sourced packages use `?vcs_url=git+<url>` qualifier; the resolved 40-char SHA from the lockfile tuple is preserved BOTH in the PURL version segment AND as `mikebom:vcs-ref` evidence (some downstream tools filter on `mikebom:vcs-ref`; others read the version segment).
+- **`mikebom:source-type` value set**: uses the `hex-` prefix (`hex-hex` / `hex-git` / `hex-path` / `hex-main-module`) to avoid collision with cargo's existing C1 values + dart's `pub-` + composer's `composer-` + cocoapods's `cocoapods-`. Per the established convention.
+
+## Out of Scope
+
+- **Live invocation of `mix` or any Elixir/Erlang toolchain binary**: read-only metadata parse only.
+- **Pre-Elixir-1.4 lockfile format**: deferred indefinitely (exceptionally rare in 2026).
+- **Private Hex organization `repository_url=` qualifier**: v1 surfaces the repo name as `mikebom:hex-repo` evidence; emitting a true `repository_url=` would require knowing the operator's private-org URL (`hex.pm/api/repos/<org>` for hex.pm-hosted orgs; arbitrary for self-hosted Hex mirrors). Deferred.
+- **`mix.exs` Elixir-runtime evaluation**: regex extraction of `deps/0` function body only. We do NOT execute Elixir code (matches the gem reader's posture from milestone 069 — Ruby `.gemspec` files are parsed lenient regex-only).
+- **Constraint-resolution simulation**: when only `mix.exs` is present (no lockfile), we emit at design-tier with raw constraints preserved. We do NOT resolve constraints (`"~> 1.7"`, `">= 1.5.0 and < 2.0.0"`, etc.) into pinned versions.
+- **Erlang `rebar.lock` format**: tracked separately as issue #428. This feature ONLY discovers Mix-managed deps; rebar-managed pure-Erlang projects are out of scope.
+- **Per-dep transitive edges from individual lockfile tuple's `[<deps>]` element**: v1 emits main-module → direct deps only; transitive components surface but their inter-edges are deferred to v1.1.
+- **`deps/` directory walking** for installed-tier scans: spec Out-of-Scope. lockfile is the v1 source of truth.
+- **License extraction**: `mix.lock` does NOT carry license; license lives in each package's `mix.exs::package/0::licenses` (or in the published hex_metadata.config under `deps/<pkg>/`). Same shape as prior milestone deferrals.
+
+## Dependencies and Constraints
+
+- **Builds on milestone 002** (initial language-reader architecture).
+- **Builds on milestone 137** (Dart — prefixed `mikebom:source-type` convention).
+- **Builds on milestone 138** (Composer — multi-tier emission + SHA hash precedent).
+- **Builds on milestone 139** (CocoaPods — git-source resolved-SHA pattern + main-module dir-basename cascade).
+- **Builds on milestone 069** (gem — Ruby `.gemspec` regex extraction posture, which `mix.lock` + `mix.exs` parsing mirrors).
+- **Reuses the existing source-tree walker** (`scan_fs::walk::safe_walk`).
+- **Does NOT touch existing language readers** — Elixir support is strictly additive.
+- **Does NOT introduce new external dependencies** — `regex` is already a workspace dep.
+
+## Related
+
+- Closes: #422 (Add Elixir/Mix ecosystem support (mix.lock))
+- Adjacent: #428 (Erlang/OTP rebar.lock — closely related but distinct ecosystem)
+- Foundational reference: milestone 069 (gem regex parsing precedent), milestone 137/138/139 (recent multi-tier language-reader convention)

--- a/specs/140-elixir-mix-reader/tasks.md
+++ b/specs/140-elixir-mix-reader/tasks.md
@@ -1,0 +1,273 @@
+---
+
+description: "Task list for milestone 140 — Elixir/Mix ecosystem reader"
+---
+
+# Tasks: Elixir/Mix ecosystem reader
+
+**Input**: Design documents from `/specs/140-elixir-mix-reader/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/elixir-component-purl.md ✓, quickstart.md ✓
+
+**Tests**: Integration tests included — established convention for milestones 064 / 066 / 068 / 069 / 070 / 122 / 135 / 136 / 137 / 138 / 139. Synthetic-fixture pattern via `tempfile::tempdir()`.
+
+**Organization**: Tasks grouped by user story (US1 = P1 MVP; US2 = P2 source-discriminator distinction; US3 = P3 design-tier fallback). Setup + Foundational phases are blocking prerequisites for ALL user stories.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Maps task to user story phase (US1 / US2 / US3)
+- Setup / Foundational / Polish phases: no story label
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Module skeleton + cyclonedx evidence-kind enum extension.
+
+- [X] T001 Create `mikebom-cli/src/scan_fs/package_db/elixir.rs` with module-level docstring (mirrors cocoapods.rs preamble: milestone reference, FR list, PURL shape summary, Phase 0 correction notes), `use` block (`anyhow`, `serde_json`, `tracing`, `std::collections::{BTreeMap, HashSet, HashMap}`, `std::path::{Path, PathBuf}`, `std::sync::OnceLock`, `regex::Regex`, `mikebom_common::types::purl::Purl`, `mikebom_common::types::hash::{ContentHash, HashAlgorithm}`, `mikebom_common::resolution::LifecycleScope`, the existing `PackageDbEntry` from `super`, `ExclusionSet` from `super::exclude_path`), and `pub fn read(rootfs: &Path, _include_dev: bool, exclude_set: &ExclusionSet) -> Vec<PackageDbEntry>` stub returning `Vec::new()`.
+
+- [X] T002 Add `pub mod elixir;` declaration to `mikebom-cli/src/scan_fs/package_db/mod.rs` (placed alphabetically — after `pub mod dpkg;` and before the next `pub mod`). No `read_all` integration yet — that lands in T012.
+
+- [X] T002b Extend the cyclonedx evidence-kind allowlist in `mikebom-cli/src/generate/cyclonedx/builder.rs` to accept `"mix-lock"` and `"mix-exs"`. Append the two new values per the milestone-135 / 136 / 137 / 138 / 139 T002b pattern. Without this, T015 + T021 would panic in debug builds.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Reader-private types + parsing + PURL helpers + dispatcher integration. MUST complete before ANY user story phase.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 Define reader-private types in `mikebom-cli/src/scan_fs/package_db/elixir.rs` per `data-model.md`: `LockEntry` enum with `Hex { name, version, inner_sha256, managers, repo, outer_sha256 }`, `Git { name, url, resolved_sha, declared_ref }`, `Path { name, path, in_umbrella }` variants. Plus `MixExsInfo { app_name, version, is_umbrella, deps }` struct + inner `DeclaredDep { name, constraint, dev_scope, in_conditional, source_kind }` where `source_kind: DeclaredDepSource` is an enum with `Hex` / `Git { url, declared_ref }` / `Path { path, in_umbrella }` variants per C2 remediation (drives T018 design-tier PURL dispatch). `#[allow(dead_code)]` on each.
+
+- [X] T004 Implement `fn find_mix_locks(rootfs: &Path, exclude_set: &ExclusionSet) -> Vec<PathBuf>` in `elixir.rs` walking via `scan_fs::walk::safe_walk` returning every `mix.lock` file. Skip descent into `.git`, `.svn`, `.hg`, `_build`, `deps`, `node_modules`, `priv`, `cover` (standard Elixir/Phoenix build-output dirs). Output lex-sorted.
+
+- [X] T005 Implement `fn find_mix_exs(rootfs: &Path, exclude_set: &ExclusionSet) -> Vec<PathBuf>` in `elixir.rs` walking via `safe_walk` returning every `mix.exs` file. Same skip-set as T004. Output lex-sorted. Used for: (a) main-module name extraction in lockfile mode (T016), (b) design-tier fallback in Pass B (T021/T022).
+
+- [X] T006 Implement `fn tokenize_mix_lock(text: &str) -> Vec<(String, String)>` in `elixir.rs` that splits the lockfile map literal into per-entry `(name, tuple_body)` pairs. Strategy: find the outer `%{...}`, then iterate top-level entries via brace-counting (each entry is `"<name>": {...},` where the value's `{...}` may contain nested `[...]` lists with their own delimiters — track `paren_depth + brace_depth + bracket_depth` to find the matching closing `}` and trailing comma). Names are double-quoted strings; tuple bodies are everything from the first `{` to its matching `}` inclusive.
+
+- [X] T007 Implement `fn parse_lock_entry(name: &str, tuple_body: &str) -> Option<LockEntry>` in `elixir.rs` per data-model.md. Dispatch on the first atom inside the tuple:
+  - `{:hex, :<atom_name>, "<version>", "<inner_sha>", [<managers>], [<deps>], "<repo>", "<outer_sha>"}` → `LockEntry::Hex`. Use regex `^\{\s*:hex\s*,\s*:([a-zA-Z_][a-zA-Z0-9_]*)\s*,\s*"([^"]+)"\s*,\s*"([0-9a-f]{64})"\s*,\s*\[([^\]]*)\]\s*,\s*\[(.*)\]\s*,\s*"([^"]+)"\s*(?:,\s*"([0-9a-f]{64})")?\s*\}$` (with `(?s)` flag for multi-line). Outer SHA-256 is optional (group 8 may be `None`).
+  - `{:git, "<url>", "<resolved_sha>", [<opts>]}` → `LockEntry::Git`. Use regex `^\{\s*:git\s*,\s*"([^"]+)"\s*,\s*"([0-9a-f]{40})"\s*,\s*\[(.*)\]\s*\}$`. Extract first `(<key>: <value>)` from opts as `declared_ref` (e.g., `ref: "main"` → `"ref: main"`).
+  - `{:path, "<path>", [<opts>]}` → `LockEntry::Path`. Use regex `^\{\s*:path\s*,\s*"([^"]+)"\s*,\s*\[(.*)\]\s*\}$`. Detect `in_umbrella: true` in opts.
+  - Unknown discriminator → return `None` (caller warns + skips).
+
+- [X] T008 Implement `fn parse_mix_exs(path: &Path) -> Result<MixExsInfo>` in `elixir.rs` per data-model.md + R3. Read file via `std::fs::read_to_string`. Use four `OnceLock<Regex>` patterns:
+  - `app:` (project name): `(?m)^\s*app:\s*:([a-zA-Z_][a-zA-Z0-9_]*)\b` — first-match wins
+  - `version:`: `(?m)^\s*version:\s*"([^"]+)"` — first-match wins
+  - `apps_path:` (umbrella sentinel): `(?m)^\s*apps_path:\s*` — KEY-presence detection per R4 (value ignored)
+  - Dep tuple: `\{\s*:([a-zA-Z_][a-zA-Z0-9_]*)\s*,\s*("[^"]+")?(?:,\s*([^}]*))?\}` — capture name, optional first-string constraint, optional opts blob
+
+  For `deps[]` extraction: iterate line-by-line, tracking `in_conditional: bool` via simple keyword counting (`if Mix.env()`, `unless `, `case `, `do` increment; `end` decrement). When a dep tuple regex matches, set `DeclaredDep.in_conditional` to the current stack state. Detect `dev_scope` by inspecting the opts blob for `only:` (followed by `:dev`, `:test`, or list containing them) or `runtime: false`. Per C2 remediation, also populate `DeclaredDep.source_kind` via opts-blob inspection: when opts contain `git: "<url>"` → `DeclaredDepSource::Git { url, declared_ref }`; when `github: "<owner>/<repo>"` → expand to `Git { url: format!("https://github.com/{owner}/{repo}.git"), declared_ref }` per research R3; when `path: "<path>"` → `DeclaredDepSource::Path { path, in_umbrella }` (with `in_umbrella` set when `in_umbrella: true` is also in opts); otherwise → `DeclaredDepSource::Hex` (default).
+
+- [X] T009 Implement `fn build_purl_for_lock_entry(entry: &LockEntry) -> Result<Purl, String>` in `elixir.rs` per FR-003 + contracts/elixir-component-purl.md:
+  - `LockEntry::Hex` with `repo == "hexpm"` → `pkg:hex/<lc_name>@<version>`.
+  - `LockEntry::Hex` with `repo == "hexpm:<org>"` → split on first colon; emit `pkg:hex/<org>/<lc_name>@<version>?repository_url=https://repo.hex.pm` per Phase 0 correction.
+  - `LockEntry::Git` → `pkg:generic/<name>@<resolved_sha>?vcs_url=git+<url>` per Phase 0 correction (purl-spec doesn't bless `vcs_url=` for hex).
+  - `LockEntry::Path` → `pkg:generic/<name>@unspecified` (path-source has no version; placeholder).
+  - On error (PURL construction failure) → `Err(...)`.
+
+- [X] T010 Implement `fn classify_source_type(entry: &LockEntry) -> &'static str` in `elixir.rs`. Always `"hex-hex"` for Hex variant (private-org distinction surfaces via PURL namespace + `repository_url=`, not source-type); `"hex-git"` for Git; `"hex-path"` for Path.
+
+- [X] T011 Implement `fn build_extra_annotations(entry: &LockEntry, source_type_value: &str) -> BTreeMap<String, serde_json::Value>` in `elixir.rs` per data-model.md per-source-type fields. Always sets `mikebom:source-type`. Source-specific:
+  - Git: `mikebom:vcs-declared-ref = "<declared_ref>"` when `LockEntry::Git.declared_ref` is `Some`.
+  - Path: `mikebom:path = "<path>"`; plus `mikebom:in-umbrella = "true"` when `LockEntry::Path.in_umbrella` is true.
+
+- [X] T012 Wire `elixir::read(rootfs, include_dev, exclude_set)` into `read_all` in `mikebom-cli/src/scan_fs/package_db/mod.rs`. Place the call alphabetically — after the `dpkg::read(...)` call. Mirror the cocoapods/composer pattern (`out.extend(...)`). NO `collect_claimed_paths` integration — language readers don't claim binary paths.
+
+**Checkpoint**: Foundation ready — `elixir::read` callable from dispatcher, returns empty Vec, cyclonedx gate accepts new evidence-kind values. US1/US2/US3 phases can proceed.
+
+---
+
+## Phase 3: User Story 1 — Phoenix/Nerves baseline (Priority: P1) 🎯 MVP
+
+**Goal**: Lockfile-driven SBOM emission for canonical Phoenix/Nerves projects — one main-module per `mix.exs` + one component per `mix.lock` entry + dep edges from main-module to direct deps + inner+outer SHA-256 hashes per Q3.
+
+**Independent Test (SC-001)**: Synthetic fixture with `mix.exs` (3 direct deps) + `mix.lock` (5 entries — 3 direct + 2 transitives). Scan produces exactly 5 `pkg:hex/*` lockfile-derived components + 1 main-module + main-module's `depends` lists the 3 direct deps by name.
+
+### Implementation for User Story 1
+
+- [X] T013 [US1] Implement `fn emit_main_module(project_dir: &Path, mix_exs_path: Option<&Path>, lockfile_path: Option<&Path>, info: Option<&MixExsInfo>, doc_has_lockfile: bool, declared_dep_names_for_depends: &[String]) -> Option<PackageDbEntry>` in `elixir.rs` per FR-012. App-name derivation cascade per the milestone-139 Q1 pattern: `info.and_then(|i| i.app_name.clone())` else `project_dir.file_name().and_then(|s| s.to_str()).map(String::from)`. Version from `info.and_then(|i| i.version.clone()).unwrap_or_else(|| "0.0.0-unknown".into())`. PURL: `pkg:hex/<lc_app_name>@<version>`. Annotations: `mikebom:component-role = "main-module"` + `mikebom:source-type = "hex-main-module"` + (when `info.is_umbrella`) `mikebom:umbrella-root = "true"`. `depends` populated from `declared_dep_names_for_depends`. `sbom_tier = Some("source")` when `doc_has_lockfile`; else `Some("design")`. `evidence_kind = Some("mix-exs")`.
+
+- [X] T014 [US1] Implement `fn emit_lockfile_components(lockfile_path: &Path, entries: &[LockEntry], mix_exs_info: Option<&MixExsInfo>) -> Vec<PackageDbEntry>` in `elixir.rs` per FR-002 + FR-003 + FR-008 + FR-011. For each `LockEntry`:
+  - Call `build_purl_for_lock_entry` (T009) — on `Err`, `tracing::warn!` with name + path and `continue`.
+  - Call `classify_source_type` (T010) → `source_type_value`.
+  - Call `build_extra_annotations` (T011) → `extra_annotations`.
+  - Build `hashes` per FR-011 + Q3: for `LockEntry::Hex` only — push `ContentHash::with_algorithm(HashAlgorithm::Sha256, inner_sha256)` always; push outer only when `outer_sha256` is `Some` AND non-empty. Validate 64-char lowercase hex; skip individual hash on failure.
+  - Cross-reference scope per FR-008: if `mix_exs_info` is `Some` AND its `DeclaredDep` matching the entry's name has `dev_scope == true`, set `lifecycle_scope = Some(LifecycleScope::Development)`; else `Some(LifecycleScope::Runtime)`.
+  - Construct `PackageDbEntry` per data-model.md common-fields table.
+
+- [X] T015 [US1] Implement the `elixir::read` orchestrator body — Pass A (lockfile walker) per R7. Maintain `seen_purls: HashSet<String>` for orchestrator dedup. Track `lockfile_dirs: HashSet<PathBuf>` (parent dirs of each parsed `mix.lock`) for use by Pass B's design-tier skip-logic. For each `mix.lock`:
+  1. Read text via `std::fs::read_to_string`. On error → warn + skip.
+  2. Tokenize via T006 → `Vec<(name, tuple_body)>`. On parse error → `tracing::warn!`; check for sibling `mix.exs`; if present → fall back to design-tier emission per Pass B (orchestrator wiring in T019; emitter T018).
+  3. Parse each entry via T007 → `Vec<LockEntry>`. Skip malformed individual entries with debug log.
+  4. Look for sibling `mix.exs` → parse via T008 → `Option<MixExsInfo>`.
+  5. Mark project dir in `lockfile_dirs`.
+  6. Emit main-module via T013 with `doc_has_lockfile = true` + `declared_dep_names_for_depends` populated from `info.deps[*].name` (or empty Vec if no mix.exs).
+  7. Emit lockfile components via T014; dedupe through `seen_purls`.
+
+- [X] T016 [US1] Write integration test file `mikebom-cli/tests/elixir_phoenix_baseline.rs` with `#[test]` functions:
+  - `phoenix_baseline_emits_lock_count_plus_main_module` — SC-001: 3 direct + 2 transitives = 5 lockfile + 1 main-module = 6 hex-derived components.
+  - `main_module_from_mix_exs_app_keyword` — SC-008: `mix.exs` `app: :my_app, version: "0.5.2"` → main-module PURL `pkg:hex/my_app@0.5.2`.
+  - `main_module_depends_lists_direct_deps` — SC-008 cont: dependencies[] for main-module bom-ref targets each `deps/0` entry's bom-ref.
+  - `inner_and_outer_sha256_emitted` — SC-009 + Q3: hex entry with both inner + outer SHA-256 produces TWO CDX `hashes[]` entries with `alg = SHA-256` and distinct contents.
+  - `pre_hex_2_entry_emits_only_inner_sha256` — Q3 edge: lockfile entry with only inner SHA-256 (no outer / empty outer) emits ONE hash entry per Principle IX accuracy.
+  - `dev_scope_filterability` — SC-007: lockfile entry whose `mix.exs::deps/0` has `only: [:dev, :test]` carries `mikebom:lifecycle-scope = "development"`; `--exclude-scope dev` suppresses.
+
+  Use `tempfile::tempdir()` + `env!("CARGO_BIN_EXE_mikebom")`. Splice `--exclude-scope dev` BEFORE `sbom scan` subcommand per the milestone-137/138/139 pattern. Guard `.unwrap()` with `#[cfg_attr(test, allow(clippy::unwrap_used))]`.
+
+**Checkpoint**: US1 (Phoenix baseline + dual SHA-256 + dev-scope) fully functional. SC-001/007/008/009 pass independently.
+
+---
+
+## Phase 4: User Story 2 — Source discriminators + private Hex orgs (Priority: P2)
+
+**Goal**: Surface trunk vs git vs path vs private-org distinction so downstream tooling can correctly classify. Validate Phase 0 corrections (private-org namespace form + git `pkg:generic/` placeholder).
+
+**Independent Test (SC-002)**: Synthetic fixture with one each of `:hex` (default), `:hex` (private org), `:git`, `:path` in `mix.lock`. Scan. Assert correct PURL shape per FR-003.
+
+### Implementation for User Story 2
+
+US2's helpers (`build_purl_for_lock_entry` + `classify_source_type` + `build_extra_annotations`) already exist after Foundational. This phase adds end-to-end correctness validation.
+
+- [X] T017 [US2] Write integration test file `mikebom-cli/tests/elixir_source_discriminators.rs` with `#[test]` functions covering SC-002 + Phase 0 corrections:
+  - `default_hexpm_emits_bare_purl` — `pkg:hex/jason@1.4.4` with `mikebom:source-type = "hex-hex"`.
+  - `private_hexpm_org_emits_namespace_and_repository_url` — Phase 0 correction regression: lockfile entry with `"hexpm:acme"` repo string emits `pkg:hex/acme/internal_lib@2.0.0?repository_url=https://repo.hex.pm`. NOT a `mikebom:hex-repo` annotation.
+  - `git_source_emits_pkg_generic_with_vcs_url` — Phase 0 correction regression: `:git` entry emits `pkg:generic/my_fork@<sha>?vcs_url=git+https://github.com/foo/my-fork.git` (NOT `pkg:hex/.../?vcs_url=`). With `mikebom:source-type = "hex-git"`.
+  - `git_source_carries_vcs_declared_ref` — git entry with `[ref: "main"]` opts carries `mikebom:vcs-declared-ref = "ref: main"` annotation.
+  - `path_source_emits_pkg_generic_placeholder` — `:path` entry emits `pkg:generic/shared_lib@unspecified` with `mikebom:source-type = "hex-path"` + `mikebom:path = "<path>"`.
+  - `path_in_umbrella_carries_in_umbrella_annotation` — `:path` entry with `[in_umbrella: true]` opts carries `mikebom:in-umbrella = "true"` annotation.
+  - `hex_name_lowercased_in_purl` — purl-spec canonical-form regression: lockfile entry with mixed-case name (rare since Hex.pm enforces lowercase, but verify the rule) → PURL lowercased.
+
+**Checkpoint**: US1 + US2 functional. All 4 source discriminators correctly surfaced; private-org Phase 0 correction validated.
+
+---
+
+## Phase 5: User Story 3 — Design-tier + conditional-flattened + umbrella (Priority: P3)
+
+**Goal**: Design-tier emission for library projects (no `mix.lock`); Q1 conditional-flattened extraction with precision-loss annotation; Q2 umbrella root aggregation.
+
+**Independent Test (SC-003 + Q1 + Q2 + SC-010)**: Three sub-fixtures: (1) `mix.exs` only → design-tier with constraints; (2) `mix.exs` with `if Mix.env() == :test do ... end` → conditional-flattened annotation; (3) umbrella project with 3 sub-apps → 4 main-modules (root + 3 sub-apps) with root `depends` listing each sub-app.
+
+### Implementation for User Story 3
+
+- [X] T018 [US3] Implement `fn emit_design_tier_components(mix_exs_path: &Path, info: &MixExsInfo) -> Vec<PackageDbEntry>` in `elixir.rs` per FR-005 + Q1 + C2 remediation. For each `DeclaredDep` in `info.deps`:
+  - Skip if dep name equals `info.app_name` (defensive).
+  - Constraint: `decl.constraint.clone().unwrap_or_else(|| "unspecified".to_string())`. Sanitize for PURL safety via local helper `sanitize_purl_version` (mirror milestone-138/139's helper — replace `/`, `?`, `#`, ` ` with `_`).
+  - **Per C2 remediation**: dispatch on `decl.source_kind` for PURL construction matching FR-003:
+    - `DeclaredDepSource::Hex` → `pkg:hex/<lc_name>@<sanitized>`; `source_type = "hex-hex"`.
+    - `DeclaredDepSource::Git { url, declared_ref }` → `pkg:generic/<name>@unspecified?vcs_url=git+<url>` (no resolved SHA in design-tier — that's the lockfile's role; use `unspecified` as the version segment); `source_type = "hex-git"`; add `mikebom:vcs-declared-ref = "<ref>"` annotation when `declared_ref` is `Some`.
+    - `DeclaredDepSource::Path { path, in_umbrella }` → `pkg:generic/<name>@unspecified`; `source_type = "hex-path"`; add `mikebom:path = "<path>"` annotation; plus `mikebom:in-umbrella = "true"` when `in_umbrella`.
+  - Construct `PackageDbEntry` with `sbom_tier = Some("design")`, `evidence_kind = Some("mix-exs")`, `requirement_range = Some(decl.constraint.clone().unwrap_or_default())`, dispatched `source_type` per above, `lifecycle_scope = Some(LifecycleScope::Development)` when `decl.dev_scope`, else `Runtime`.
+  - `extra_annotations`: dispatched `mikebom:source-type` per above; PLUS source-kind-specific annotations per above; PLUS `mikebom:elixir-extraction-mode = "conditional-flattened"` when `decl.in_conditional` per Q1.
+
+- [X] T019 [US3] Implement Pass B + Pass C (umbrella root aggregation) of the `elixir::read` orchestrator per R7:
+  - **Pass B** (design-tier walker): For each `mix.exs` whose project dir is NOT in `lockfile_dirs` (Pass A skip): parse via T008. Emit main-module via T013 with `doc_has_lockfile = false`. Emit design-tier components via T018; dedupe through `seen_purls`.
+  - **Pass C** (umbrella root aggregation per Q2): After Pass A + B, iterate the emitted main-modules. For any main-module whose source `MixExsInfo.is_umbrella == true`: enumerate sibling `apps/<sub_app>/mix.exs` files; for each that produced a main-module in Pass A or B, append that sub-app's main-module NAME (e.g., `"core"` from `app: :core` declaration) to the umbrella root's `depends` list — per I1 remediation, `PackageDbEntry.depends` is a list of NAMES (strings), not bom-refs (the orchestrator handles name→bom-ref translation at the dep-edge wiring stage; see milestone-002 dpkg/apk convention). (Since main-modules are emitted into the `out` Vec, this requires a post-pass mutation: find the root by `mikebom:umbrella-root = "true"` annotation, then mutate its `depends`.)
+
+- [X] T020 [US3] Implement helper `fn collect_apps_subdirs(umbrella_root: &Path) -> Vec<PathBuf>` in `elixir.rs` — given an umbrella project root (parent of `apps/`), enumerate `apps/<sub_app>/mix.exs` files. Used by T019 Pass C to find sub-app main-module bom-refs.
+
+- [X] T021 [US3] Write integration test file `mikebom-cli/tests/elixir_tier_fallbacks.rs` with `#[test]` functions:
+  - `design_tier_mix_exs_only_emits_constraints` — SC-003: `mix.exs` only → 2 components with `mikebom:sbom-tier = "design"` + `mikebom:requirement-range = "~> 1.7"` preserved.
+  - `design_tier_no_constraint_uses_unspecified_placeholder` — `deps/0` entry `{:foo, git: "..."}` (no version) → PURL `pkg:hex/foo@unspecified`.
+  - `design_tier_no_transitive_deps` — design-tier scan emits ONLY declared `deps/0` entries; no inferred transitives.
+  - `conditional_block_dep_carries_extraction_mode_annotation` — Q1: `if Mix.env() == :test do {:meck, "~> 0.9"} end` → emitted `meck` carries `mikebom:elixir-extraction-mode = "conditional-flattened"`.
+  - `unconditional_dep_does_not_carry_extraction_mode_annotation` — Q1 negative: top-level dep tuple does NOT carry the annotation.
+  - `umbrella_root_depends_lists_sub_app_main_modules` — Q2 + SC-010 + I1 remediation: umbrella project with 3 sub-apps under `apps/` → 4 main-modules total. Verify via CDX `dependencies[]` block: find the `dependencies[].ref` matching the umbrella root's `bom-ref`, assert its `dependsOn` array contains each sub-app's main-module `bom-ref` (the orchestrator translates names → bom-refs during dep-edge wiring; `PackageDbEntry.depends` itself carries names, NOT bom-refs).
+  - `umbrella_root_carries_umbrella_root_annotation` — Q2 cont: umbrella root main-module carries `mikebom:umbrella-root = "true"` annotation; sub-app main-modules do NOT.
+  - `design_tier_git_declared_dep_emits_pkg_generic` — C2 remediation: `mix.exs::deps/0` entry `{:my_fork, git: "https://github.com/foo/my-fork.git", branch: "main"}` (no lockfile) emits `pkg:generic/my_fork@unspecified?vcs_url=git+https://github.com/foo/my-fork.git` with `mikebom:source-type = "hex-git"` AND `mikebom:vcs-declared-ref = "branch: main"`. Defends against re-introduction of the `pkg:hex/my_fork@unspecified` (incorrect Hex shape for a git-declared dep).
+  - `design_tier_path_declared_dep_emits_pkg_generic` — C2 remediation: `{:shared, path: "../shared"}` (no lockfile) emits `pkg:generic/shared@unspecified` with `mikebom:source-type = "hex-path"` AND `mikebom:path = "../shared"`.
+  - `design_tier_github_shortcut_expanded_to_git_url` — C2 remediation + R3: `{:foo, github: "owner/repo"}` emits `pkg:generic/foo@unspecified?vcs_url=git+https://github.com/owner/repo.git` (shortcut expanded at extraction time).
+
+**Checkpoint**: All three user stories functional. Design-tier + conditional-flattened + umbrella aggregation all validated.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Edge-case coverage + invariant validation + pre-PR gate.
+
+- [X] T022 [P] Write integration test file `mikebom-cli/tests/elixir_edge_cases.rs` covering spec Edge Cases + Phase 0 + Q1/Q2/Q3 nuances:
+  - `malformed_mix_lock_falls_back_to_design_tier` — SC-005: malformed lockfile + sibling `mix.exs` → design-tier components emit; warning fires.
+  - `multi_line_tuple_in_mix_lock_parses_correctly` — multi-line tuple form (e.g., `:deps` list breaks across lines) parses correctly via brace-counting.
+  - `github_shortcut_treated_as_git_in_design_tier` — `mix.exs::deps/0` entry `{:foo, github: "owner/repo"}` in design-tier mode emits as if `git: "https://github.com/owner/repo.git"`.
+  - `private_org_namespace_lowercased` — private-org `:hex` entry with mixed-case org slug (rare; Hex.pm enforces lowercase orgs too) → PURL emits lowercased org.
+  - `unknown_source_type_atom_warns_and_skips` — lockfile entry with unknown discriminator atom (e.g., `:hg`) → warn + skip that single entry; other entries still emit.
+  - `apps_path_with_custom_value_still_detected_as_umbrella` — R4 KEY-presence regression: `apps_path: "modules"` (custom value, not `"apps"`) still triggers umbrella detection.
+  - `multi_target_mix_exs_extracts_all_deps_flattened` — Q1 regression: `defp deps(:dev), do: [...]` + `defp deps(:prod), do: [...]` multi-clause → all entries flattened with conditional-extraction annotation.
+  - `outer_sha256_empty_string_treated_as_absent` — Q3 edge: lockfile entry with empty-string outer SHA-256 (`""`) emits ONE hash (inner only), NOT two with one empty.
+  - `pre_elixir_1_4_lockfile_warns_and_skips` — Out-of-Scope: pre-1.4 lockfile (missing `:hex` discriminator) → warn + skip; rare in 2026.
+
+- [X] T023 [P] Verify SC-004 no-Elixir byte-identity invariant by running existing CDX/SPDX 2.3/SPDX 3 regression test suites. Command: `cargo +stable test -p mikebom --test cdx_regression --test spdx_regression --test spdx3_regression`. All passing = baseline preserved.
+
+- [X] T024 Run `./scripts/pre-pr.sh` from repo root per CLAUDE.md MANDATORY pre-PR gate. Fix any clippy warnings (especially `unwrap_used` in test files — guard with `#[cfg_attr(test, allow(clippy::unwrap_used))]`) and failing tests. Re-run until both lanes show `0 errors` / `N passed; 0 failed`.
+
+- [X] T025 Run quickstart.md SC-006 standard-PURL-filter check + cross-format byte-equivalence diff (CDX vs SPDX 2.3 vs SPDX 3) on synthetic Phoenix fixture. The three formats' Hex PURL sets MUST be identical when sorted.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: T001 → T002 (T002 imports module declared in T001); T002b independent. T002b BLOCKS T014 + T018 (cyclonedx gate would panic in debug builds).
+- **Foundational (Phase 2)**: All depend on Phase 1. Within Phase 2: T003 → T006/T007/T008 (parsers need struct definitions); T003 → T009/T010/T011 (helpers need structs); T004 + T005 independent walkers. T012 depends on `elixir::read` stub (T001).
+- **User Story phases (3 / 4 / 5)**: ALL depend on Foundational. Within each phase, tasks sequential unless `[P]`.
+- **Polish (Phase 6)**: T022 + T023 marked `[P]` — independent files. T024 + T025 depend on all preceding phases.
+
+### User Story Dependencies
+
+- **US1 (P1) MVP**: Depends on Foundational. T013 → T014 → T015 → T016 sequential.
+- **US2 (P2)**: Depends on Foundational only (helpers already exist). T017 is pure integration test.
+- **US3 (P3)**: Depends on Foundational + T013 (main-module helper shared) + T015 (orchestrator structure). T018 → T019 → T020 → T021 sequential.
+
+### Parallel Opportunities
+
+- **Phase 1**: T001 + T002b parallel; T002 sequential after T001.
+- **Phase 2**: T004 + T005 + T006 + T008 can run in parallel (independent functions in same file).
+- **Phase 3**: T013–T016 sequential (all touch `elixir.rs`).
+- **Phase 4**: T017 standalone.
+- **Phase 5**: T018 → T019 → T020 → T021 sequential.
+- **Phase 6**: T022 + T023 parallel.
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1)
+
+1. Phase 1: Setup (T001–T002b).
+2. Phase 2: Foundational (T003–T012).
+3. Phase 3: US1 (T013–T016).
+4. **STOP and VALIDATE**: `cargo +stable test -p mikebom --test elixir_phoenix_baseline` — confirm SC-001/007/008/009 pass.
+5. Headline use case shippable: Phoenix/Nerves app scan with main-module + lockfile-driven hex components + dual SHA-256 + dev-scope filtering.
+
+### Incremental Delivery
+
+1. Setup + Foundational → dispatcher wired, empty Vec.
+2. + US1 → MVP: Phoenix/Nerves baseline + dev-scope + dual SHA-256.
+3. + US2 → adds private-org Phase 0 correction validation + git/path discriminator coverage.
+4. + US3 → adds library-project design-tier + Q1 conditional-flattened + Q2 umbrella aggregation.
+5. + Polish → edge-case coverage + pre-PR gate green.
+
+### Single-PR Pattern
+
+All phases land in ONE PR per established convention:
+- Module: `mikebom-cli/src/scan_fs/package_db/elixir.rs` (~1000–1200 LOC incl. unit tests)
+- Dispatcher integration: `mikebom-cli/src/scan_fs/package_db/mod.rs` (≤10 LOC)
+- Cyclonedx evidence-kind extension: `mikebom-cli/src/generate/cyclonedx/builder.rs` (≤4 LOC)
+- Four integration test files: `mikebom-cli/tests/elixir_*.rs` (~900–1200 LOC total)
+- Closes #422.
+
+---
+
+## Notes
+
+- `[P]` tasks = different files, no dependencies on incomplete tasks.
+- `[Story]` label maps task to specific user story for traceability.
+- Each user story independently completable and testable.
+- Commit after each logical group.
+- **Pre-PR gate (CLAUDE.md MANDATORY)**: `./scripts/pre-pr.sh` MUST pass before opening PR.
+- **No-op invariant (SC-004)**: every change MUST preserve byte-identical SBOM output on non-Elixir source trees. T023 is the validation.
+- **`--exclude-scope dev` is a TOP-LEVEL mikebom flag** (BEFORE `sbom scan` subcommand) per milestone-137/138/139 convention.
+- **Per-PR diff size estimate**: ~2,000–2,500 LOC total (similar to milestone 138/139).


### PR DESCRIPTION
## Summary

- New language reader for Elixir 1.4+ Mix projects under `mikebom-cli/src/scan_fs/package_db/elixir.rs`. Parses `mix.lock` (Elixir-syntax tuple map literal — first mikebom reader where the lockfile isn't standardized data; uses a brace-counted tokenizer with multi-line tuple support) + `mix.exs` (Ruby DSL via regex extraction, no Elixir runtime).
- **More spec-correct than syft + trivy**: emits purl-spec-blessed namespace-as-org + `repository_url=` qualifier for private Hex organizations (syft drops org info; trivy skips git/path entries entirely).
- **Zero new Cargo dependencies** — `regex` is already a workspace dep.

## PURL shapes (per FR-003 + purl-spec hex-definition)

| Source | PURL |
|---|---|
| hex (default `hexpm`) | `pkg:hex/<lc-name>@<version>` |
| hex (private org `hexpm:<org>`) | `pkg:hex/<org>/<lc-name>@<version>?repository_url=https://repo.hex.pm` |
| git | `pkg:generic/<name>@<resolved-sha>?vcs_url=git+<url>` (Phase 0: purl-spec doesn't bless vcs_url for hex) |
| path | `pkg:generic/<name>@unspecified` placeholder |
| main-module | `pkg:hex/<app_name>@<version>` |

Hex names lowercased per purl-spec canonical form (Hex.pm enforces at publish time so typically no-op).

## Clarifications applied

- **Q1**: Design-tier `deps/0` extraction is conditional-flattened — every dep tuple emits regardless of `if Mix.env() ...` nesting; conditional components carry `mikebom:elixir-extraction-mode = \"conditional-flattened\"` annotation as precision-loss signal.
- **Q2**: Umbrella root's `depends` = its own `deps/0` tooling + each sub-app's main-module name (two-level topology).
- **Q3**: Inner + outer SHA-256 emission best-effort — emit only what's present + non-empty; don't synthesize hashes.
- **C2**: `DeclaredDep.source_kind` enum dispatches design-tier PURL construction so git-declared deps emit as `pkg:generic/`, not `pkg:hex/`. `:github` shortcut expands to git URL.
- **I1**: Umbrella aggregation appends sub-app NAMES (not bom-refs) to `depends`; orchestrator handles name→bom-ref resolution at dep-edge wiring.

## v1 scope notes

- Transitive inter-pod dependency edges deferred to v1.1.
- Private Hex API enrichment (license, owner) out of scope.
- License extraction deferred (parallels prior milestones).
- Pre-Elixir-1.4 lockfile format warn-and-skip.
- syft/trivy compatibility `mikebom:also-known-as` annotation deferred to v1.1.

## Cross-reader infrastructure change

Extended `cyclonedx/metadata.rs` to propagate `mikebom:umbrella-root` annotation to the metadata.component path (mirrors milestone-116 `produces-binaries` + milestone-134 `duplicate-purl-divergent` propagation patterns).

## Mid-stream discoveries

1. **Conditional-detection bug**: initial `do_depth` counter with baseline-1 was wrong — `defmodule do` + `defp deps do` both increment, false-flagging plain deps inside `deps()` as conditional. Fixed via stack-of-opener-types distinguishing conditional (`if`/`unless`/`case`/`cond`) from non-conditional (`def`/`defp`/`defmodule`).
2. **Regex anchor too strict**: `^\\s*app:` only matched multi-line form; single-line shorthand `def project, do: [app: :x, ...]` needed alternative anchor `[\\[,]\\s*app:`. Same fix for `version:` + `apps_path:`.
3. **CDX metadata.component property curation**: builder's `metadata.rs` curates property emission for promoted main-modules (only emits a specific allowlist). New `mikebom:umbrella-root` annotation had to be added to the curated list — cross-reader infrastructure change documented inline.

## Test plan

- [x] 22 elixir unit tests pass (tokenizer + LockEntry parser + mix.exs regex + PURL builder + source-type classification + private-org translation)
- [x] 28 elixir integration tests pass across 4 test files
- [x] 33 byte-identity regression tests preserved (cdx + spdx 2.3 + spdx 3) — SC-004 invariant
- [x] `./scripts/pre-pr.sh` clean (clippy + workspace tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)