### PR TITLE
fix(annotations): emission parity fixes from sbom-conformance audit — file-paths native array + SPDX 3 lifecycle-scope + source-files dedup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-26
+Auto-generated from all feature plans. Last updated: 2026-06-28
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -164,6 +164,7 @@ Auto-generated from all feature plans. Last updated: 2026-06-26
 - Rust stable (workspace toolchain inherited from milestones 001–142; no nightly required). + Existing only — `regex` (workspace dep, used by gem/alpm/brew/yocto/cocoapods/elixir/erlang/scala for DSL extraction), `serde_yaml = "0.9"` (workspace dep, used by dart/cocoapods readers for YAML parsing — Stack lockfile is YAML), `serde_json` (workspace dep), `mikebom_common::types::purl::Purl` (PURL construction), `tracing` (warn-and-skip per FR-009 + Q3 Hpack-detect diagnostic per FR-015), `anyhow`/`thiserror`, `std::sync::OnceLock` (regex compile-once). **No new Cargo dependencies.** (143-haskell-reader)
 - Rust stable (workspace toolchain inherited from milestones 001–143; no nightly required for this user-space-only work). + Existing only — `rpm = "0.22"` (already used by `rpm_file.rs` for the `rpm::Package::open()` path), `serde`/`serde_json`, `tracing`, `anyhow`, `thiserror`, `clap` (new flags via `Args`-derive). Reuses milestone-003's `mikebom_common::types::purl::Purl::new` for PURL validation and `mikebom_common::types::purl::encode_purl_segment` for segment encoding. Reuses milestone-135-era `mikebom-cli/src/scan_fs/os_release.rs::read_id_from_rootfs()` helper. **No new Cargo dependencies.** (144-rpm-purl-size-fixes)
 - N/A — all state in-process per scan; no caches, no persistence (matches every milestone since 002). (144-rpm-purl-size-fixes)
+- Rust stable (workspace toolchain inherited from milestones 001–144; no nightly required). + Existing only — `serde`/`serde_json` (Value construction + emission), `tracing`, `anyhow`, `thiserror`. Reuses milestone-133's `file_tier` module, milestone-005-era `evidence.source_file_paths` field, milestone-049/052's `LifecycleScope` newtype, milestone-071's parity catalog (C18 source-files, C42 lifecycle-scope, C92 file-paths — all `Directionality::SymmetricEqual`). **No new Cargo dependencies.** (145-annotation-parity-fixes)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -226,9 +227,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 145-annotation-parity-fixes: Added Rust stable (workspace toolchain inherited from milestones 001–144; no nightly required). + Existing only — `serde`/`serde_json` (Value construction + emission), `tracing`, `anyhow`, `thiserror`. Reuses milestone-133's `file_tier` module, milestone-005-era `evidence.source_file_paths` field, milestone-049/052's `LifecycleScope` newtype, milestone-071's parity catalog (C18 source-files, C42 lifecycle-scope, C92 file-paths — all `Directionality::SymmetricEqual`). **No new Cargo dependencies.**
 - 144-rpm-purl-size-fixes: Added Rust stable (workspace toolchain inherited from milestones 001–143; no nightly required for this user-space-only work). + Existing only — `rpm = "0.22"` (already used by `rpm_file.rs` for the `rpm::Package::open()` path), `serde`/`serde_json`, `tracing`, `anyhow`, `thiserror`, `clap` (new flags via `Args`-derive). Reuses milestone-003's `mikebom_common::types::purl::Purl::new` for PURL validation and `mikebom_common::types::purl::encode_purl_segment` for segment encoding. Reuses milestone-135-era `mikebom-cli/src/scan_fs/os_release.rs::read_id_from_rootfs()` helper. **No new Cargo dependencies.**
 - 143-haskell-reader: Added Rust stable (workspace toolchain inherited from milestones 001–142; no nightly required). + Existing only — `regex` (workspace dep, used by gem/alpm/brew/yocto/cocoapods/elixir/erlang/scala for DSL extraction), `serde_yaml = "0.9"` (workspace dep, used by dart/cocoapods readers for YAML parsing — Stack lockfile is YAML), `serde_json` (workspace dep), `mikebom_common::types::purl::Purl` (PURL construction), `tracing` (warn-and-skip per FR-009 + Q3 Hpack-detect diagnostic per FR-015), `anyhow`/`thiserror`, `std::sync::OnceLock` (regex compile-once). **No new Cargo dependencies.**
-- 142-scala-sbt-reader: Added Rust stable (workspace toolchain inherited from milestones 001–141; no nightly required). + Existing only — `regex` (workspace dep, used by gem/alpm/brew/yocto/cocoapods/elixir/erlang for line-format and DSL extraction), `serde_json` (workspace dep, used by every JSON-format reader), `mikebom_common::types::hash::{ContentHash, HashAlgorithm}` (FR-011 SHA-256 emission), `mikebom_common::types::purl::Purl` (PURL construction), `tracing` (warn-and-skip per FR-007), `anyhow`/`thiserror`, `std::sync::OnceLock` (regex compile-once). **No new Cargo dependencies.**
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/generate/cyclonedx/builder.rs
+++ b/mikebom-cli/src/generate/cyclonedx/builder.rs
@@ -1084,7 +1084,15 @@ impl CycloneDxBuilder {
             // `mikebom:is-workspace-root` signal that drives root-selector
             // logic but is NOT meant to surface in emitted SBOMs).
             for (key, value) in &component.extra_annotations {
-                if crate::generate::root_selector::is_internal_emission_key(key) {
+                if crate::generate::root_selector::is_internal_emission_key(key)
+                    || crate::generate::root_selector::is_field_owned_annotation_key(key)
+                {
+                    // Milestone 145 US3 (FR-009): skip keys already
+                    // emitted from a field-derived source (e.g.,
+                    // `mikebom:source-files` comes from
+                    // `c.evidence.source_file_paths` higher up in
+                    // this function — re-emitting from the bag
+                    // would double-stamp and produce value drift.
                     continue;
                 }
                 let value_str = match value {

--- a/mikebom-cli/src/generate/root_selector.rs
+++ b/mikebom-cli/src/generate/root_selector.rs
@@ -438,6 +438,21 @@ pub fn is_internal_emission_key(key: &str) -> bool {
     key == IS_WORKSPACE_ROOT_KEY
 }
 
+/// Milestone 145 US3 (FR-009 + research §C/§C.1): annotation keys that
+/// are emitted from a field-derived source (typically
+/// `c.evidence.*`) and MUST NOT be re-emitted from the
+/// `extra_annotations` bag — doing so produces double-emission +
+/// per-emitter value-drift like the 2026-06-26 audit flagged for
+/// `mikebom:source-files` on Maven nested-JAR components.
+///
+/// Defense-in-depth: callers that intend to carry per-reader source
+/// provenance MUST use a DISTINCT annotation key (e.g.,
+/// `mikebom:<reader>-source-url`) to avoid colliding with the
+/// field-derived emission.
+pub fn is_field_owned_annotation_key(key: &str) -> bool {
+    matches!(key, "mikebom:source-files")
+}
+
 #[cfg(test)]
 #[cfg_attr(test, allow(clippy::unwrap_used))]
 mod tests {
@@ -447,6 +462,21 @@ mod tests {
     };
     use mikebom_common::types::purl::Purl;
     use std::collections::BTreeMap;
+
+    /// Milestone 145 US3 (FR-009): the field-owned-key helper protects
+    /// `mikebom:source-files` from double-emission. New field-owned
+    /// keys can be added by extending the `matches!` arm; the test
+    /// guards the contract.
+    #[test]
+    fn is_field_owned_annotation_key_md145() {
+        assert!(is_field_owned_annotation_key("mikebom:source-files"));
+        // Unrelated keys MUST NOT be filtered (they're emitted from
+        // extra_annotations as the only source).
+        assert!(!is_field_owned_annotation_key("mikebom:source-files-nested-url"));
+        assert!(!is_field_owned_annotation_key("mikebom:lifecycle-scope"));
+        assert!(!is_field_owned_annotation_key("mikebom:cpe-candidates"));
+        assert!(!is_field_owned_annotation_key("mikebom:file-paths"));
+    }
 
     fn make_main_module(
         purl_str: &str,

--- a/mikebom-cli/src/generate/spdx/annotations.rs
+++ b/mikebom-cli/src/generate/spdx/annotations.rs
@@ -369,7 +369,13 @@ pub fn annotate_component(
     // `mikebom:is-workspace-root` signal that drives root-selector
     // logic but is NOT meant to surface in emitted SBOMs).
     for (key, value) in &c.extra_annotations {
-        if crate::generate::root_selector::is_internal_emission_key(key) {
+        if crate::generate::root_selector::is_internal_emission_key(key)
+            || crate::generate::root_selector::is_field_owned_annotation_key(key)
+        {
+            // Milestone 145 US3 (FR-009): skip keys already emitted
+            // from a field-derived source (e.g., `mikebom:source-files`
+            // comes from `c.evidence.source_file_paths` at line ~302
+            // above) — re-emitting from the bag double-stamps.
             continue;
         }
         push(&mut out, key, value.clone());

--- a/mikebom-cli/src/generate/spdx/v3_annotations.rs
+++ b/mikebom-cli/src/generate/spdx/v3_annotations.rs
@@ -263,24 +263,16 @@ fn push_component_fields(
     if let Some(ref v) = c.raw_version {
         push(out, "mikebom:raw-version", json!(v));
     }
-    // C42 mikebom:lifecycle-scope — parity-bridging annotation mirroring
-    // the SPDX 2.3 sibling at annotations.rs:227-236 (milestone 145 US2).
-    // CDX and SPDX 2.3 both emit this annotation for non-Runtime scopes
-    // (CDX at cyclonedx/builder.rs:851 via `s.is_non_runtime()`, SPDX 2.3
-    // at annotations.rs:233 via the `LifecycleScope::Runtime => None`
-    // match arm). SPDX 3 was the pre-145 outlier.
-    if let Some(ref scope) = c.lifecycle_scope {
-        use mikebom_common::resolution::LifecycleScope;
-        let s = match scope {
-            LifecycleScope::Development => Some("development"),
-            LifecycleScope::Build => Some("build"),
-            LifecycleScope::Test => Some("test"),
-            LifecycleScope::Runtime => None, // runtime is the default; no annotation
-        };
-        if let Some(s) = s {
-            push(out, "mikebom:lifecycle-scope", json!(s));
-        }
-    }
+    // C42 mikebom:lifecycle-scope — DELIBERATELY OMITTED in SPDX 3.
+    // SPDX 3 carries scope natively via `LifecycleScopedRelationship.
+    // scope` (set in `v3_relationships.rs` for Dev/Build/TestDependsOn
+    // edges). Per Constitution Principle V, the native field is the
+    // primary signal and mikebom MUST NOT add a redundant annotation.
+    // Issue #228 + spdx3_annotation_fidelity test enforces this contract.
+    // Milestone 145 US2 originally tried to emit here; reverted after the
+    // fidelity test caught the Principle-V violation. The 261 audit
+    // findings flagged on this annotation are false positives from the
+    // harness misreading the SPDX 3 scope mechanism.
     // C18 source-files
     if include_source_files && !c.evidence.source_file_paths.is_empty() {
         push(
@@ -675,96 +667,40 @@ mod tests {
             .collect()
     }
 
-    /// T007 (SC-005 first half + FR-005): SPDX 3 emits
-    /// `mikebom:lifecycle-scope=development` for `Development` scope.
+    /// Milestone 145 US2 REVERTED (Principle V): SPDX 3 carries
+    /// lifecycle scope natively via `LifecycleScopedRelationship.scope`.
+    /// Asserts the `mikebom:lifecycle-scope` annotation is NOT emitted
+    /// at the Package level — issue #228's existing design contract.
+    /// Guards against future reintroduction of the redundant emission.
     #[test]
-    fn spdx3_lifecycle_scope_development_emits() {
+    fn spdx3_lifecycle_scope_not_emitted_as_annotation_md145() {
         use mikebom_common::resolution::LifecycleScope;
-        let c = synthetic_resolved_component(Some(LifecycleScope::Development));
-        let mut out = Vec::new();
-        push_component_fields(
-            &mut out,
-            "https://example.org/doc#SPDXRef-comp-1",
-            "https://example.org/doc",
-            "_:creationinfo",
-            &c,
-            /* include_dev = */ true,
-            /* include_source_files = */ true,
-        );
-        let envs = envelopes_for_field(&out, "mikebom:lifecycle-scope");
-        assert_eq!(
-            envs.len(),
-            1,
-            "expected exactly one mikebom:lifecycle-scope annotation, got {envs:?}",
-        );
-        assert_eq!(envs[0].value, serde_json::json!("development"));
-    }
-
-    /// T008 (SC-005 second half + FR-006): SPDX 3 OMITS
-    /// `mikebom:lifecycle-scope` when scope is `Runtime` (parity with
-    /// CDX at `cyclonedx/builder.rs:851` via `is_non_runtime()` filter
-    /// and SPDX 2.3 at `annotations.rs:233` via `Runtime => None`).
-    #[test]
-    fn spdx3_lifecycle_scope_runtime_omitted() {
-        use mikebom_common::resolution::LifecycleScope;
-        let c = synthetic_resolved_component(Some(LifecycleScope::Runtime));
-        let mut out = Vec::new();
-        push_component_fields(
-            &mut out,
-            "https://example.org/doc#SPDXRef-comp-1",
-            "https://example.org/doc",
-            "_:creationinfo",
-            &c,
-            true,
-            true,
-        );
-        let envs = envelopes_for_field(&out, "mikebom:lifecycle-scope");
-        assert!(
-            envs.is_empty(),
-            "FR-006 violation: Runtime scope must NOT emit mikebom:lifecycle-scope; got {envs:?}"
-        );
-    }
-
-    /// T009 (FR-007): SPDX 3 OMITS `mikebom:lifecycle-scope` when
-    /// `lifecycle_scope == None` (matches SPDX 2.3 existing behavior).
-    #[test]
-    fn spdx3_lifecycle_scope_none_omitted() {
-        let c = synthetic_resolved_component(None);
-        let mut out = Vec::new();
-        push_component_fields(
-            &mut out,
-            "https://example.org/doc#SPDXRef-comp-1",
-            "https://example.org/doc",
-            "_:creationinfo",
-            &c,
-            true,
-            true,
-        );
-        let envs = envelopes_for_field(&out, "mikebom:lifecycle-scope");
-        assert!(
-            envs.is_empty(),
-            "FR-007 violation: None scope must NOT emit mikebom:lifecycle-scope; got {envs:?}"
-        );
-    }
-
-    /// T008 sibling: SPDX 3 emits with value "build" for Build scope.
-    #[test]
-    fn spdx3_lifecycle_scope_build_emits() {
-        use mikebom_common::resolution::LifecycleScope;
-        let c = synthetic_resolved_component(Some(LifecycleScope::Build));
-        let mut out = Vec::new();
-        push_component_fields(
-            &mut out,
-            "https://example.org/doc#SPDXRef-comp-1",
-            "https://example.org/doc",
-            "_:creationinfo",
-            &c,
-            true,
-            true,
-        );
-        let envs = envelopes_for_field(&out, "mikebom:lifecycle-scope");
-        assert_eq!(envs.len(), 1);
-        assert_eq!(envs[0].value, serde_json::json!("build"));
+        for scope in [
+            Some(LifecycleScope::Development),
+            Some(LifecycleScope::Build),
+            Some(LifecycleScope::Test),
+            Some(LifecycleScope::Runtime),
+            None,
+        ] {
+            let c = synthetic_resolved_component(scope);
+            let mut out = Vec::new();
+            push_component_fields(
+                &mut out,
+                "https://example.org/doc#SPDXRef-comp-1",
+                "https://example.org/doc",
+                "_:creationinfo",
+                &c,
+                true,
+                true,
+            );
+            let envs = envelopes_for_field(&out, "mikebom:lifecycle-scope");
+            assert!(
+                envs.is_empty(),
+                "Principle V violation: SPDX 3 carries scope natively via \
+                 LifecycleScopedRelationship.scope — mikebom:lifecycle-scope \
+                 annotation MUST NOT appear on Package elements. Got: {envs:?} (scope={scope:?})"
+            );
+        }
     }
 
     /// T016 (US3 + FR-009 + SC-009): when a component has BOTH a
@@ -815,23 +751,4 @@ mod tests {
         );
     }
 
-    /// T008 sibling: SPDX 3 emits with value "test" for Test scope.
-    #[test]
-    fn spdx3_lifecycle_scope_test_emits() {
-        use mikebom_common::resolution::LifecycleScope;
-        let c = synthetic_resolved_component(Some(LifecycleScope::Test));
-        let mut out = Vec::new();
-        push_component_fields(
-            &mut out,
-            "https://example.org/doc#SPDXRef-comp-1",
-            "https://example.org/doc",
-            "_:creationinfo",
-            &c,
-            true,
-            true,
-        );
-        let envs = envelopes_for_field(&out, "mikebom:lifecycle-scope");
-        assert_eq!(envs.len(), 1);
-        assert_eq!(envs[0].value, serde_json::json!("test"));
-    }
 }

--- a/mikebom-cli/src/generate/spdx/v3_annotations.rs
+++ b/mikebom-cli/src/generate/spdx/v3_annotations.rs
@@ -263,6 +263,24 @@ fn push_component_fields(
     if let Some(ref v) = c.raw_version {
         push(out, "mikebom:raw-version", json!(v));
     }
+    // C42 mikebom:lifecycle-scope — parity-bridging annotation mirroring
+    // the SPDX 2.3 sibling at annotations.rs:227-236 (milestone 145 US2).
+    // CDX and SPDX 2.3 both emit this annotation for non-Runtime scopes
+    // (CDX at cyclonedx/builder.rs:851 via `s.is_non_runtime()`, SPDX 2.3
+    // at annotations.rs:233 via the `LifecycleScope::Runtime => None`
+    // match arm). SPDX 3 was the pre-145 outlier.
+    if let Some(ref scope) = c.lifecycle_scope {
+        use mikebom_common::resolution::LifecycleScope;
+        let s = match scope {
+            LifecycleScope::Development => Some("development"),
+            LifecycleScope::Build => Some("build"),
+            LifecycleScope::Test => Some("test"),
+            LifecycleScope::Runtime => None, // runtime is the default; no annotation
+        };
+        if let Some(s) = s {
+            push(out, "mikebom:lifecycle-scope", json!(s));
+        }
+    }
     // C18 source-files
     if include_source_files && !c.evidence.source_file_paths.is_empty() {
         push(
@@ -330,7 +348,13 @@ fn push_component_fields(
     // `mikebom:is-workspace-root` signal that drives root-selector
     // logic but is NOT meant to surface in emitted SBOMs).
     for (key, value) in &c.extra_annotations {
-        if crate::generate::root_selector::is_internal_emission_key(key) {
+        if crate::generate::root_selector::is_internal_emission_key(key)
+            || crate::generate::root_selector::is_field_owned_annotation_key(key)
+        {
+            // Milestone 145 US3 (FR-009): skip keys already emitted
+            // from a field-derived source (e.g., `mikebom:source-files`
+            // comes from `c.evidence.source_file_paths` at line ~267
+            // above) — re-emitting from the bag double-stamps.
             continue;
         }
         push(out, key, value.clone());
@@ -577,5 +601,237 @@ mod tests {
             !statement.contains(r#""value":true"#),
             "statement must NOT serialize bool as bare true: {statement}",
         );
+    }
+
+    // -----------------------------------------------------------------
+    // Milestone 145 US2 (T007/T008/T009): SPDX 3 lifecycle-scope
+    // emission parity with CDX + SPDX 2.3.
+    // -----------------------------------------------------------------
+
+    /// Helper: construct a minimal valid `ResolvedComponent` for tests.
+    /// Only `purl` is required; everything else defaults. The caller
+    /// overrides specific fields (e.g., `lifecycle_scope`) before use.
+    fn synthetic_resolved_component(
+        lifecycle_scope: Option<mikebom_common::resolution::LifecycleScope>,
+    ) -> ResolvedComponent {
+        use mikebom_common::resolution::{
+            ResolutionEvidence, ResolutionTechnique, ResolvedComponent,
+        };
+        let purl = mikebom_common::types::purl::Purl::new("pkg:npm/test@1.0.0").unwrap();
+        ResolvedComponent {
+            build_inclusion: None,
+            name: "test".to_string(),
+            version: "1.0.0".to_string(),
+            purl,
+            evidence: ResolutionEvidence {
+                technique: ResolutionTechnique::PackageDatabase,
+                confidence: 0.9,
+                source_connection_ids: vec![],
+                source_file_paths: vec![],
+                deps_dev_match: None,
+            },
+            licenses: vec![],
+            concluded_licenses: vec![],
+            hashes: vec![],
+            supplier: None,
+            cpes: vec![],
+            advisories: vec![],
+            occurrences: vec![],
+            lifecycle_scope,
+            requirement_range: None,
+            source_type: None,
+            sbom_tier: None,
+            buildinfo_status: None,
+            evidence_kind: None,
+            binary_class: None,
+            binary_stripped: None,
+            linkage_kind: None,
+            detected_go: None,
+            confidence: None,
+            binary_packed: None,
+            npm_role: None,
+            raw_version: None,
+            parent_purl: None,
+            co_owned_by: None,
+            shade_relocation: None,
+            external_references: vec![],
+            extra_annotations: Default::default(),
+            binary_role: None,
+        }
+    }
+
+    /// Returns the parsed `MikebomAnnotationCommentV1` envelopes from a
+    /// vector of SPDX 3 annotation graph elements whose `field` matches
+    /// the supplied predicate.
+    fn envelopes_for_field(
+        annos: &[Value],
+        field_name: &str,
+    ) -> Vec<MikebomAnnotationCommentV1> {
+        annos
+            .iter()
+            .filter_map(|a| a.get("statement").and_then(|s| s.as_str()))
+            .filter_map(|s| serde_json::from_str::<MikebomAnnotationCommentV1>(s).ok())
+            .filter(|env| env.field == field_name)
+            .collect()
+    }
+
+    /// T007 (SC-005 first half + FR-005): SPDX 3 emits
+    /// `mikebom:lifecycle-scope=development` for `Development` scope.
+    #[test]
+    fn spdx3_lifecycle_scope_development_emits() {
+        use mikebom_common::resolution::LifecycleScope;
+        let c = synthetic_resolved_component(Some(LifecycleScope::Development));
+        let mut out = Vec::new();
+        push_component_fields(
+            &mut out,
+            "https://example.org/doc#SPDXRef-comp-1",
+            "https://example.org/doc",
+            "_:creationinfo",
+            &c,
+            /* include_dev = */ true,
+            /* include_source_files = */ true,
+        );
+        let envs = envelopes_for_field(&out, "mikebom:lifecycle-scope");
+        assert_eq!(
+            envs.len(),
+            1,
+            "expected exactly one mikebom:lifecycle-scope annotation, got {envs:?}",
+        );
+        assert_eq!(envs[0].value, serde_json::json!("development"));
+    }
+
+    /// T008 (SC-005 second half + FR-006): SPDX 3 OMITS
+    /// `mikebom:lifecycle-scope` when scope is `Runtime` (parity with
+    /// CDX at `cyclonedx/builder.rs:851` via `is_non_runtime()` filter
+    /// and SPDX 2.3 at `annotations.rs:233` via `Runtime => None`).
+    #[test]
+    fn spdx3_lifecycle_scope_runtime_omitted() {
+        use mikebom_common::resolution::LifecycleScope;
+        let c = synthetic_resolved_component(Some(LifecycleScope::Runtime));
+        let mut out = Vec::new();
+        push_component_fields(
+            &mut out,
+            "https://example.org/doc#SPDXRef-comp-1",
+            "https://example.org/doc",
+            "_:creationinfo",
+            &c,
+            true,
+            true,
+        );
+        let envs = envelopes_for_field(&out, "mikebom:lifecycle-scope");
+        assert!(
+            envs.is_empty(),
+            "FR-006 violation: Runtime scope must NOT emit mikebom:lifecycle-scope; got {envs:?}"
+        );
+    }
+
+    /// T009 (FR-007): SPDX 3 OMITS `mikebom:lifecycle-scope` when
+    /// `lifecycle_scope == None` (matches SPDX 2.3 existing behavior).
+    #[test]
+    fn spdx3_lifecycle_scope_none_omitted() {
+        let c = synthetic_resolved_component(None);
+        let mut out = Vec::new();
+        push_component_fields(
+            &mut out,
+            "https://example.org/doc#SPDXRef-comp-1",
+            "https://example.org/doc",
+            "_:creationinfo",
+            &c,
+            true,
+            true,
+        );
+        let envs = envelopes_for_field(&out, "mikebom:lifecycle-scope");
+        assert!(
+            envs.is_empty(),
+            "FR-007 violation: None scope must NOT emit mikebom:lifecycle-scope; got {envs:?}"
+        );
+    }
+
+    /// T008 sibling: SPDX 3 emits with value "build" for Build scope.
+    #[test]
+    fn spdx3_lifecycle_scope_build_emits() {
+        use mikebom_common::resolution::LifecycleScope;
+        let c = synthetic_resolved_component(Some(LifecycleScope::Build));
+        let mut out = Vec::new();
+        push_component_fields(
+            &mut out,
+            "https://example.org/doc#SPDXRef-comp-1",
+            "https://example.org/doc",
+            "_:creationinfo",
+            &c,
+            true,
+            true,
+        );
+        let envs = envelopes_for_field(&out, "mikebom:lifecycle-scope");
+        assert_eq!(envs.len(), 1);
+        assert_eq!(envs[0].value, serde_json::json!("build"));
+    }
+
+    /// T016 (US3 + FR-009 + SC-009): when a component has BOTH a
+    /// field-derived `mikebom:source-files` (from
+    /// `c.evidence.source_file_paths`) AND a legacy stamping in
+    /// `extra_annotations["mikebom:source-files"]` (the pre-145 Maven
+    /// nested-JAR pattern), the SPDX 3 emitter MUST emit EXACTLY ONE
+    /// `mikebom:source-files` annotation — the field-derived one.
+    /// Guards against regression of the per-emitter double-emission
+    /// bug that caused 51 audit findings on polyglot-builder-image.
+    #[test]
+    fn spdx3_source_files_dedup_no_double_emission_md145() {
+        let mut c = synthetic_resolved_component(None);
+        c.evidence.source_file_paths =
+            vec!["root/.m2/repository/test/foo/1.0/foo-1.0.jar".to_string()];
+        // Pre-145 the Maven reader stamped THIS key (now renamed to
+        // mikebom:source-files-nested-url per Option 2b); we replicate
+        // the pre-145 shape to PROVE the emitter-side guard (Option 1)
+        // would suppress the double-emission even if a future reader
+        // recreated the trap.
+        c.extra_annotations.insert(
+            "mikebom:source-files".to_string(),
+            serde_json::json!("root/.m2/.../foo-1.0.jar!META-INF/MANIFEST.MF"),
+        );
+        let mut out = Vec::new();
+        push_component_fields(
+            &mut out,
+            "https://example.org/doc#SPDXRef-comp-1",
+            "https://example.org/doc",
+            "_:creationinfo",
+            &c,
+            /* include_dev = */ true,
+            /* include_source_files = */ true,
+        );
+        let envs = envelopes_for_field(&out, "mikebom:source-files");
+        assert_eq!(
+            envs.len(),
+            1,
+            "FR-009 violation: SPDX 3 emitted {} mikebom:source-files entries; \
+             expected EXACTLY ONE (the field-derived one wins). envs={envs:?}",
+            envs.len()
+        );
+        // The surviving entry MUST be the field-derived rootfs-relative
+        // JAR path, NOT the legacy `<outer>!<inner>!...` URL string.
+        assert_eq!(
+            envs[0].value,
+            serde_json::json!(["root/.m2/repository/test/foo/1.0/foo-1.0.jar"])
+        );
+    }
+
+    /// T008 sibling: SPDX 3 emits with value "test" for Test scope.
+    #[test]
+    fn spdx3_lifecycle_scope_test_emits() {
+        use mikebom_common::resolution::LifecycleScope;
+        let c = synthetic_resolved_component(Some(LifecycleScope::Test));
+        let mut out = Vec::new();
+        push_component_fields(
+            &mut out,
+            "https://example.org/doc#SPDXRef-comp-1",
+            "https://example.org/doc",
+            "_:creationinfo",
+            &c,
+            true,
+            true,
+        );
+        let envs = envelopes_for_field(&out, "mikebom:lifecycle-scope");
+        assert_eq!(envs.len(), 1);
+        assert_eq!(envs[0].value, serde_json::json!("test"));
     }
 }

--- a/mikebom-cli/src/scan_fs/file_tier/mod.rs
+++ b/mikebom-cli/src/scan_fs/file_tier/mod.rs
@@ -187,7 +187,12 @@ impl FileTierEntry {
     ///
     /// **Annotations** seeded:
     /// - `mikebom:component-tier = "file"` (FR-002)
-    /// - `mikebom:file-paths = <JSON-encoded-sorted-array>` (FR-007)
+    /// - `mikebom:file-paths = <sorted JSON array of paths>` (FR-007)
+    ///   — native JSON array, NOT a JSON-string-encoded array.
+    ///   The stringified-array shape (pre-milestone-145) was a wire
+    ///   bug; consumers were forced to do a second `JSON.parse(value)`
+    ///   to extract the paths. Fixed in milestone 145 US1 per
+    ///   `specs/145-annotation-parity-fixes/contracts/file-paths-shape.md`.
     /// - `mikebom:file-paths-truncated = "true"` (only when capped)
     pub(crate) fn into_resolved_component(self) -> ResolvedComponent {
         let basename = self
@@ -229,9 +234,11 @@ impl FileTierEntry {
             COMPONENT_TIER_KEY.to_string(),
             json!(COMPONENT_TIER_FILE_VALUE),
         );
-        if let Ok(file_paths_json) = serde_json::to_string(&paths_str) {
-            extra_annotations.insert(FILE_PATHS_KEY.to_string(), json!(file_paths_json));
-        }
+        // Milestone 145 US1 (FR-001 + research §A): emit the value as a
+        // native JSON array, NOT a JSON-string-encoding of the array.
+        // Pre-145: `Value::String("[\"path1\",\"path2\"]")`.
+        // Post-145: `Value::Array([Value::String("path1"), ...])`.
+        extra_annotations.insert(FILE_PATHS_KEY.to_string(), json!(paths_str));
         if truncated {
             extra_annotations.insert(FILE_PATHS_TRUNCATED_KEY.to_string(), json!("true"));
         }
@@ -395,14 +402,20 @@ mod tests {
                 .and_then(|v| v.as_str()),
             Some(COMPONENT_TIER_FILE_VALUE)
         );
-        // file-paths emitted as JSON-encoded string array (matches
-        // the milestone 133 US2.1 source-files shape).
+        // Milestone 145 US1: file-paths emitted as a native JSON array
+        // (NOT a JSON-string-encoding of the array). Pre-145 this test
+        // round-tripped through `serde_json::from_str(value)`; post-145
+        // the value IS the array directly.
         let fp = c
             .extra_annotations
             .get(FILE_PATHS_KEY)
-            .and_then(|v| v.as_str())
             .expect("file-paths annotation present");
-        let parsed: Vec<String> = serde_json::from_str(fp).expect("file-paths JSON parses");
+        let parsed: Vec<String> = fp
+            .as_array()
+            .expect("file-paths is array (milestone 145 US1)")
+            .iter()
+            .map(|v| v.as_str().expect("path is string").to_string())
+            .collect();
         assert_eq!(parsed, vec!["opt/custom/foo".to_string()]);
         // Single path → no truncated flag.
         assert!(!c.extra_annotations.contains_key(FILE_PATHS_TRUNCATED_KEY));
@@ -421,12 +434,19 @@ mod tests {
         }
         e.finalize();
         let c = e.into_resolved_component();
+        // Milestone 145 US1: file-paths is a native JSON array (NOT a
+        // JSON-string-encoding of the array). See the sibling test
+        // above for the rationale.
         let fp = c
             .extra_annotations
             .get(FILE_PATHS_KEY)
-            .and_then(|v| v.as_str())
             .expect("file-paths annotation present");
-        let parsed: Vec<String> = serde_json::from_str(fp).expect("file-paths JSON parses");
+        let parsed: Vec<String> = fp
+            .as_array()
+            .expect("file-paths is array (milestone 145 US1)")
+            .iter()
+            .map(|v| v.as_str().expect("path is string").to_string())
+            .collect();
         assert_eq!(parsed.len(), FILE_PATHS_CAP);
         assert_eq!(
             c.extra_annotations
@@ -452,6 +472,33 @@ mod tests {
         // mikebom:component-tier-driven PURL drop at emission.
         assert!(c.purl.as_str().contains(&sha));
         assert!(c.purl.as_str().starts_with("pkg:generic/file-tier"));
+    }
+
+    /// Milestone 145 US1 T004 (SC-002): the `mikebom:file-paths`
+    /// annotation value MUST be a `Value::Array`, NOT a `Value::String`
+    /// holding a JSON-string-encoding of the array. Guards against
+    /// regression of the pre-145 double-encoding bug.
+    #[test]
+    fn mikebom_file_paths_is_native_array_not_stringified() {
+        let mut e = FileTierEntry::new(
+            "abcd".repeat(16),
+            PathBuf::from("usr/sbin/losetup"),
+            ContentShape::ElfBinary,
+            10,
+        );
+        e.finalize();
+        let c = e.into_resolved_component();
+        let value = c
+            .extra_annotations
+            .get(FILE_PATHS_KEY)
+            .expect("mikebom:file-paths is present");
+        assert!(
+            value.is_array(),
+            "FR-001 violation: expected Value::Array, got {value:?}"
+        );
+        let arr = value.as_array().expect("file-paths is array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0].as_str(), Some("usr/sbin/losetup"));
     }
 
     #[test]

--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -195,6 +195,15 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
                 // record it, so all three SBOM formats (CDX/SPDX 2.3/SPDX 3)
                 // get the same clean value (holistic_parity test asserts the
                 // C18 row's `SymmetricEqual` directionality across formats).
+                //
+                // NOTE (milestone 145 US3): `mikebom:source-files` has TWO
+                // emission sources — this field (canonical) AND
+                // `extra_annotations["mikebom:source-files"]` (legacy,
+                // dedup'd at emit time via
+                // `root_selector::is_field_owned_annotation_key`). DO NOT
+                // stamp the latter from a new reader; if you need to carry
+                // per-reader source provenance, use a distinct key like
+                // `mikebom:<reader>-source-url`.
                 source_file_paths: vec![crate::scan_fs::sbom_path::normalize_sbom_path_relative(
                     &path_string,
                     Some(root),
@@ -633,6 +642,10 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
                     // Milestone 133 US2.1 (FR-012 Defects A + C): see same-
                     // numbered comment above; normalize at source-population
                     // time so SPDX/CDX/SPDX3 all read the clean value.
+                    //
+                    // NOTE (milestone 145 US3): canonical source for
+                    // `mikebom:source-files` emission — see also
+                    // `root_selector::is_field_owned_annotation_key`.
                     source_file_paths: vec![crate::scan_fs::sbom_path::normalize_sbom_path_relative(
                         &entry.source_path,
                         Some(root),

--- a/mikebom-cli/src/scan_fs/package_db/maven.rs
+++ b/mikebom-cli/src/scan_fs/package_db/maven.rs
@@ -2240,8 +2240,24 @@ fn extract_nested_meta<R: std::io::Read + std::io::Seek>(
             "mikebom:source-mechanism".to_string(),
             serde_json::Value::String("maven-jar-nested".to_string()),
         );
+        // Milestone 145 US3 (Option 2b): the nested-JAR URL notation
+        // (`<outer>!<inner>!...`) lives under its OWN annotation key so
+        // it doesn't collide with the field-derived
+        // `mikebom:source-files` (which carries the rootfs-relative JAR
+        // path from `c.evidence.source_file_paths` via the milestone-
+        // 133 normalization pipeline). Pre-145 both stamped the same
+        // key and produced per-emitter value drift on the
+        // polyglot-builder-image fixture (51 audit findings).
+        //
+        // NOTE: `mikebom:source-files` has TWO emission sources — this
+        // crate's `c.evidence.source_file_paths` field (canonical) AND
+        // `extra_annotations["mikebom:source-files"]` (legacy, dedup'd
+        // at emit time via `root_selector::is_field_owned_annotation_key`).
+        // DO NOT stamp the latter from a new reader; use a distinct key
+        // like `mikebom:<reader>-source-url` (this one is
+        // `mikebom:source-files-nested-url`).
         annotations.insert(
-            "mikebom:source-files".to_string(),
+            "mikebom:source-files-nested-url".to_string(),
             serde_json::Value::String(source_files_url.clone()),
         );
         // Milestone 131 US2b: stash nested-JAR <licenses> raw names
@@ -6978,14 +6994,25 @@ mod tests {
             .get("mikebom:source-mechanism")
             .and_then(|v| v.as_str());
         assert_eq!(mech, Some("maven-jar-nested"));
-        // mikebom:source-files annotation uses the JAR-URL `!`
-        // separator convention per FR-016.
+        // Milestone 145 US3 (T017 / Option 2b): the JAR-URL
+        // `!`-separator value is stamped under the RENAMED key
+        // `mikebom:source-files-nested-url` to avoid colliding with
+        // the field-derived `mikebom:source-files` (which carries the
+        // rootfs-relative JAR path from `c.evidence.source_file_paths`).
+        // Pre-145 this assertion read `mikebom:source-files`.
         let sf = nested
             .extra_annotations
-            .get("mikebom:source-files")
+            .get("mikebom:source-files-nested-url")
             .and_then(|v| v.as_str())
             .unwrap();
         assert!(sf.ends_with("!BOOT-INF/lib/depA-1.2.3.jar"), "got: {sf}");
+        // Belt-and-suspenders: the OLD key MUST NOT appear post-145.
+        assert!(
+            !nested.extra_annotations.contains_key("mikebom:source-files"),
+            "FR-009 violation: nested-JAR reader still stamps the legacy \
+             `mikebom:source-files` key — should have moved to \
+             `mikebom:source-files-nested-url` per milestone 145 US3"
+        );
         // Top-level entry has NO walker annotations — byte-identity
         // preservation per SC-005. (We don't assert `is_primary` here
         // because the tempfile's randomized stem can't match the
@@ -7030,9 +7057,10 @@ mod tests {
             .iter()
             .find(|m| m.coord.artifact_id == "leaf")
             .expect("leaf entry at 4 levels deep present");
+        // Milestone 145 US3 (T017): renamed key, see sibling test above.
         let sf = leaf_meta
             .extra_annotations
-            .get("mikebom:source-files")
+            .get("mikebom:source-files-nested-url")
             .and_then(|v| v.as_str())
             .unwrap();
         // Path uses the JAR-URL `!`-separator chain.

--- a/mikebom-cli/tests/fixtures/golden/spdx-2.3/npm.spdx.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-2.3/npm.spdx.json
@@ -229,7 +229,7 @@
           "annotationDate": "1970-01-01T00:00:00Z",
           "annotationType": "OTHER",
           "annotator": "Tool: mikebom-0.1.0-alpha.51",
-          "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:file-paths\",\"value\":\"[\\\"package.json\\\"]\"}"
+          "comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:file-paths\",\"value\":[\"package.json\"]}"
         }
       ],
       "downloadLocation": "NOASSERTION",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/bazel.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/bazel.spdx3.json
@@ -233,6 +233,14 @@
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-YGXGXM2344FEFXFIONNHE7N6/anno-B4MJRJBIDUBHZGZI",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:lifecycle-scope\",\"value\":\"development\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-YGXGXM2344FEFXFIONNHE7N6/pkg-LM6FBYXSKLDBXQVU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-YGXGXM2344FEFXFIONNHE7N6/anno-COPKKLC6APWPCRTF",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"MODULE.bazel\"]}",
       "subject": "https://mikebom.kusari.dev/spdx3/doc-YGXGXM2344FEFXFIONNHE7N6/pkg-SFZ6ZH3BHKUFYZNC",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/bazel.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/bazel.spdx3.json
@@ -233,14 +233,6 @@
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-YGXGXM2344FEFXFIONNHE7N6/anno-B4MJRJBIDUBHZGZI",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:lifecycle-scope\",\"value\":\"development\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-YGXGXM2344FEFXFIONNHE7N6/pkg-LM6FBYXSKLDBXQVU",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-YGXGXM2344FEFXFIONNHE7N6/anno-COPKKLC6APWPCRTF",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-files\",\"value\":[\"MODULE.bazel\"]}",
       "subject": "https://mikebom.kusari.dev/spdx3/doc-YGXGXM2344FEFXFIONNHE7N6/pkg-SFZ6ZH3BHKUFYZNC",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/maven.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/maven.spdx3.json
@@ -392,14 +392,6 @@
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
-      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XA7UOG4FWNCFYY6MVFNEBGBT/anno-UEDMBWMMW3NY3X5C",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:lifecycle-scope\",\"value\":\"test\"}",
-      "subject": "https://mikebom.kusari.dev/spdx3/doc-XA7UOG4FWNCFYY6MVFNEBGBT/pkg-B7B65U5T2YH5ZD5T",
-      "type": "Annotation"
-    },
-    {
-      "annotationType": "other",
-      "creationInfo": "_:creation-info",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XA7UOG4FWNCFYY6MVFNEBGBT/anno-UHAHTKLWH2XRI5TH",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"workspace\"}",
       "subject": "https://mikebom.kusari.dev/spdx3/doc-XA7UOG4FWNCFYY6MVFNEBGBT/pkg-B7B65U5T2YH5ZD5T",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/maven.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/maven.spdx3.json
@@ -392,6 +392,14 @@
     {
       "annotationType": "other",
       "creationInfo": "_:creation-info",
+      "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XA7UOG4FWNCFYY6MVFNEBGBT/anno-UEDMBWMMW3NY3X5C",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:lifecycle-scope\",\"value\":\"test\"}",
+      "subject": "https://mikebom.kusari.dev/spdx3/doc-XA7UOG4FWNCFYY6MVFNEBGBT/pkg-B7B65U5T2YH5ZD5T",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "_:creation-info",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-XA7UOG4FWNCFYY6MVFNEBGBT/anno-UHAHTKLWH2XRI5TH",
       "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:source-type\",\"value\":\"workspace\"}",
       "subject": "https://mikebom.kusari.dev/spdx3/doc-XA7UOG4FWNCFYY6MVFNEBGBT/pkg-B7B65U5T2YH5ZD5T",

--- a/mikebom-cli/tests/fixtures/golden/spdx-3/npm.spdx3.json
+++ b/mikebom-cli/tests/fixtures/golden/spdx-3/npm.spdx3.json
@@ -336,7 +336,7 @@
       "annotationType": "other",
       "creationInfo": "_:creation-info",
       "spdxId": "https://mikebom.kusari.dev/spdx3/doc-7LMLT6DQIPVVOCVFIGMR2DBR/anno-UXAUVWV7MOJV7J4R",
-      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:file-paths\",\"value\":\"[\\\"package.json\\\"]\"}",
+      "statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:file-paths\",\"value\":[\"package.json\"]}",
       "subject": "https://mikebom.kusari.dev/spdx3/doc-7LMLT6DQIPVVOCVFIGMR2DBR/pkg-RI7DYUP7YVSLGONA",
       "type": "Annotation"
     },

--- a/specs/145-annotation-parity-fixes/checklists/requirements.md
+++ b/specs/145-annotation-parity-fixes/checklists/requirements.md
@@ -1,0 +1,53 @@
+# Specification Quality Checklist: Annotation-emission parity fixes from sbom-conformance audit (2026-06-26)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+  - Spec references specific files and line numbers as scope anchors (`file_tier/mod.rs:232-234`, `annotations.rs:227-236`, `v3_annotations.rs:267`) so the planner can locate the bug sites; these are scope-bounding pointers, not implementation prescriptions. No control flow, function bodies, or Rust syntax in the spec proper.
+- [X] Focused on user value and business needs
+  - US1 framed around downstream-consumer JSON parsing and jq queries; US2 framed around compliance gates for prod/dev distinction; US3 framed around cross-format SBOM consumer parity.
+- [X] Written for non-technical stakeholders
+  - Each user story has a plain-language journey + an explicit "Why this priority" paragraph + Given/When/Then scenarios that name observable behaviors.
+- [X] All mandatory sections completed
+  - Origin, User Scenarios & Testing, Requirements, Success Criteria, Assumptions, Out of Scope all present.
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+  - Zero markers. All design decisions documented in Assumptions.
+- [X] Requirements are testable and unambiguous
+  - FR-001 to FR-011 each name a specific behavior with a verifiable assertion. Example: FR-001 specifies "MUST emit ... as a native JSON array of strings ... NOT as a JSON-string-encoding" — directly testable via type-check on the emitted value.
+- [X] Success criteria are measurable
+  - SC-001/SC-004/SC-008 name exact pre/post finding counts (3112→0, 261→0, 51→0). SC-002/SC-005/SC-009 name specific assertion types. SC-003/SC-006 name the golden-refresh scope. SC-010 names the pre-PR gate. SC-011 names cumulative finding-reduction floor. SC-012 names the no-regression invariant.
+- [X] Success criteria are technology-agnostic (no implementation details)
+  - SCs describe observable outcomes (harness findings counts, value type assertions, golden refresh scope, exit codes, byte-equivalent values). The only "technology" references are the three SBOM formats (CDX, SPDX 2.3, SPDX 3) which are spec-bounded artifact formats, not implementation choices.
+- [X] All acceptance scenarios are defined
+  - US1 has 4 scenarios; US2 has 4 scenarios; US3 has 4 scenarios. Each is Given/When/Then-shaped.
+- [X] Edge cases are identified
+  - 6 distinct edge cases covered: empty file-paths list, embedded quotes in paths, `LifecycleScope::Runtime` omission, `include_source_files = false` gating, empty `source_file_paths`, cross-US Maven/file-tier interaction.
+- [X] Scope is clearly bounded
+  - Out of Scope section lists 7 explicit exclusions (image-pseudo-component, sbom-tier disagreement, new mikebom:* annotations, BTreeMap restructuring, prior-run `<component-presence>` cluster, perf optimization, source-file-paths population-time changes).
+- [X] Dependencies and assumptions identified
+  - Assumptions section names 7 explicit assumptions including audit-count stability, file-paths shape-change as accepted wire-output break, additive-only SPDX 3 lifecycle-scope addition, shared `evidence.source_file_paths` field, canonical-value choice for source-files (with explicit conditional caveat), no new Cargo deps, and harness-as-oracle.
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+  - FR-001 ↔ US1 scenarios 1+2 + SC-001/SC-002/SC-003. FR-002 ↔ Edge Cases §empty + §embedded quote. FR-003 ↔ US1 scenario 3. FR-004 ↔ US1 scenario 4 + SC-003. FR-005 ↔ US2 scenarios 1+4 + SC-004/SC-005. FR-006/FR-007 ↔ US2 + Edge Cases §Runtime + SC-005's second test. FR-008 ↔ SC-007 (research artifact). FR-009 ↔ US3 scenarios 1+2 + SC-008. FR-010 ↔ SC-003/SC-006. FR-011 ↔ explicit Constitution V audit-result statement.
+- [X] User scenarios cover primary flows
+  - US1 + US2 + US3 cover the three harness-flagged issues, each with their own Given/When/Then. P1/P1/P2 priority reflects audit-finding count + fix-complexity ratio.
+- [X] Feature meets measurable outcomes defined in Success Criteria
+  - Every SC is achievable purely via the FR set (no SC requires work outside the listed FRs).
+- [X] No implementation details leak into specification
+  - File paths and line numbers referenced are scope anchors, not implementation prescriptions. No function signatures, no Rust syntax, no library API calls in the spec body.
+
+## Notes
+
+- All checklist items pass on first iteration.
+- The spec deliberately names specific file paths (`file_tier/mod.rs:232-234`, `annotations.rs:227-236`, `v3_annotations.rs:267`) because they bound the scope of the change — a planner reading this spec needs to know that the file-paths fix is in the file-tier constructor (not in any of the three emitters) and that the lifecycle-scope fix is in the SPDX 3 annotation emitter (not in the per-ecosystem readers). Without those anchors, the planner could mis-scope the work.
+- The US3 investigation-first structure is deliberate: per FR-008 and SC-007, the research artifact MUST document the diagnosis before any code fix lands. This matches the spec's Assumption that the per-emitter drift is somewhere upstream of emission (both emitters consume the same `c.evidence.source_file_paths` field).
+- Ready for `/speckit-clarify` (probably zero questions; the spec is fairly self-contained) or directly for `/speckit-plan`.

--- a/specs/145-annotation-parity-fixes/contracts/file-paths-shape.md
+++ b/specs/145-annotation-parity-fixes/contracts/file-paths-shape.md
@@ -1,0 +1,94 @@
+# Contract — `mikebom:file-paths` value shape
+
+Phase 1 output. Defines the wire-format contract for the `mikebom:file-paths` annotation across CDX 1.6, SPDX 2.3, and SPDX 3 outputs.
+
+## Pre-145 (broken)
+
+The `extra_annotations` BTreeMap stores the value as `Value::String`:
+
+```rust
+// file_tier/mod.rs:232-234
+if let Ok(file_paths_json) = serde_json::to_string(&paths_str) {
+    extra_annotations.insert(FILE_PATHS_KEY.to_string(), json!(file_paths_json));
+}
+```
+
+Result: every emitter sees `Value::String("[\"usr/sbin/losetup\"]")`.
+
+Wire output:
+- **CDX**: `{"name": "mikebom:file-paths", "value": "[\"usr/sbin/losetup\"]"}` (correct — CDX `properties[].value` is spec-typed `xs:string`, so the stringified form IS the canonical CDX shape)
+- **SPDX 2.3**: envelope contains `"value": "[\"usr/sbin/losetup\"]"` (BROKEN — envelope value is free-form JSON, the stringified form is non-canonical)
+- **SPDX 3**: envelope contains `"value": "[\"usr/sbin/losetup\"]"` (BROKEN — same reason)
+
+## Post-145 (correct)
+
+The `extra_annotations` BTreeMap stores the value as `Value::Array`:
+
+```rust
+// file_tier/mod.rs:232-234 (post-fix)
+extra_annotations.insert(FILE_PATHS_KEY.to_string(), json!(paths_str));
+```
+
+Result: every emitter sees `Value::Array([String("usr/sbin/losetup"), ...])`.
+
+Wire output:
+- **CDX**: `{"name": "mikebom:file-paths", "value": "[\"usr/sbin/losetup\"]"}` (UNCHANGED — CDX's emitter at `cyclonedx/builder.rs:1086-1098` still stringifies non-String `Value`s via the milestone-144 envelope-coercion fix, so CDX wire bytes are byte-identical pre/post 145)
+- **SPDX 2.3**: envelope contains `"value": ["usr/sbin/losetup"]` (FIXED — native array inside the envelope)
+- **SPDX 3**: envelope contains `"value": ["usr/sbin/losetup"]` (FIXED — native array inside the envelope)
+
+## Invariants
+
+| | CDX 1.6 | SPDX 2.3 | SPDX 3 |
+|---|---|---|---|
+| Wire-output type | `xs:string` (stringified) | native JSON array | native JSON array |
+| Sort order | ascending | ascending | ascending |
+| Cap | `FILE_PATHS_CAP` entries | same | same |
+| Truncation flag | `mikebom:file-paths-truncated = "true"` | same | same |
+| Empty list | omit the annotation entirely | same | same |
+
+## Wire byte-deltas vs pre-145
+
+| Format | File changed? |
+|---|---|
+| CDX | NO — byte-identical to pre-145 (the milestone-144 envelope-coercion handles it) |
+| SPDX 2.3 | YES — envelope `"value"` shifts from quoted-string-of-array to native array |
+| SPDX 3 | YES — same as SPDX 2.3 |
+
+## Test contract (in-file unit test, post-fix)
+
+```rust
+#[test]
+fn mikebom_file_paths_is_native_array_not_stringified() {
+    let dir = tempfile::tempdir().unwrap();
+    // Construct a synthetic file-tier component with one path.
+    let entry = OrphanEntry::synthetic("usr/sbin/losetup", "deadbeef".repeat(8));
+    let resolved = entry.into_resolved_component();
+    let value = resolved
+        .extra_annotations
+        .get("mikebom:file-paths")
+        .expect("mikebom:file-paths is present");
+    // The KEY assertion:
+    assert!(
+        value.is_array(),
+        "expected Value::Array, got {value:?}"
+    );
+    // Plus the existing FR-007 sort + cap invariants (preserved unchanged).
+    let arr = value.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0].as_str(), Some("usr/sbin/losetup"));
+}
+```
+
+## Migration guidance for consumers
+
+Consumers that currently parse `mikebom:file-paths` from SPDX 2.3 or SPDX 3 envelopes via `serde_json::from_str(value)` (treating value as a JSON-string-encoded array) MUST update to treat the value as a native JSON array. The expected transition:
+
+```javascript
+// BEFORE
+const paths = JSON.parse(annotation.value);  // parse value as JSON string → array
+
+// AFTER
+const paths = annotation.value;              // value IS the array, directly
+```
+
+CDX consumers are unaffected (CDX wire shape unchanged).

--- a/specs/145-annotation-parity-fixes/contracts/lifecycle-scope-emission.md
+++ b/specs/145-annotation-parity-fixes/contracts/lifecycle-scope-emission.md
@@ -1,0 +1,101 @@
+# Contract — `mikebom:lifecycle-scope` SPDX 3 emission
+
+Phase 1 output. Defines the SPDX 3 emission contract for the `mikebom:lifecycle-scope` annotation, bringing SPDX 3 into parity with CDX 1.6 + SPDX 2.3.
+
+## Pre-145 (broken)
+
+| Format | Behavior |
+|---|---|
+| CDX 1.6 | Emits for non-Runtime scopes (`cyclonedx/builder.rs:851` via `s.is_non_runtime()` filter) |
+| SPDX 2.3 | Emits for non-Runtime scopes (`spdx/annotations.rs:227-236`, `LifecycleScope::Runtime => None` match arm) |
+| SPDX 3 | **DOES NOT EMIT** (the emitter at `spdx/v3_annotations.rs` has zero references to `lifecycle_scope` / `LifecycleScope`) |
+
+Audit cluster pattern: `Y | Y | -` on 261 components in the `node-dev-vs-prod` fixture.
+
+## Post-145 (parity restored)
+
+All three formats emit `mikebom:lifecycle-scope` with the SAME value mapping:
+
+| `ResolvedComponent.lifecycle_scope` | Emit annotation? | Value string |
+|---|---|---|
+| `Some(LifecycleScope::Development)` | YES | `"development"` |
+| `Some(LifecycleScope::Build)` | YES | `"build"` |
+| `Some(LifecycleScope::Test)` | YES | `"test"` |
+| `Some(LifecycleScope::Runtime)` | **NO** (Runtime is the default; no annotation needed; preserves CDX + SPDX 2.3 existing behavior) | n/a |
+| `None` | NO | n/a |
+
+## Insertion location in SPDX 3 emitter
+
+Per research §B, insert after the existing `mikebom:raw-version` push at approximately line 264 of `v3_annotations.rs`:
+
+```rust
+// C42 mikebom:lifecycle-scope — parity-bridging annotation mirroring
+// the SPDX 2.3 sibling at annotations.rs:227-236 (milestone 145 US2).
+// CDX and SPDX 2.3 both emit this annotation for non-Runtime scopes;
+// SPDX 3 was the pre-145 outlier.
+if let Some(ref scope) = c.lifecycle_scope {
+    use mikebom_common::resolution::LifecycleScope;
+    let s = match scope {
+        LifecycleScope::Development => Some("development"),
+        LifecycleScope::Build => Some("build"),
+        LifecycleScope::Test => Some("test"),
+        LifecycleScope::Runtime => None,
+    };
+    if let Some(s) = s {
+        push(out, "mikebom:lifecycle-scope", json!(s));
+    }
+}
+```
+
+## Test contract (in-file unit tests, post-fix)
+
+```rust
+#[test]
+fn spdx3_lifecycle_scope_development_emits() {
+    let c = ResolvedComponent {
+        lifecycle_scope: Some(LifecycleScope::Development),
+        ..synthetic_resolved_component()
+    };
+    let annos = build_component_annotations_v3(&c, /* include_dev = */ true);
+    assert!(
+        annos.iter().any(|a| envelope_field(a) == "mikebom:lifecycle-scope"
+            && envelope_value(a) == &json!("development")),
+        "expected mikebom:lifecycle-scope=development for Development scope; got {annos:?}"
+    );
+}
+
+#[test]
+fn spdx3_lifecycle_scope_runtime_omitted() {
+    let c = ResolvedComponent {
+        lifecycle_scope: Some(LifecycleScope::Runtime),
+        ..synthetic_resolved_component()
+    };
+    let annos = build_component_annotations_v3(&c, /* include_dev = */ true);
+    assert!(
+        !annos.iter().any(|a| envelope_field(a) == "mikebom:lifecycle-scope"),
+        "expected no mikebom:lifecycle-scope annotation for Runtime scope; got {annos:?}"
+    );
+}
+```
+
+(`envelope_field` and `envelope_value` are test helpers parsing the `MikebomAnnotationCommentV1` envelope; depending on the test-module already-existing infrastructure in `v3_annotations.rs`, these may need to be added.)
+
+## Wire byte-deltas vs pre-145
+
+| Format | Goldens affected? |
+|---|---|
+| CDX | NO |
+| SPDX 2.3 | NO |
+| SPDX 3 | YES — every golden containing a fixture with a non-Runtime `lifecycle_scope` component will gain a new annotation entry. `node-dev-vs-prod` and similar npm fixtures dominate. |
+
+## Cross-emitter parity invariant
+
+For every `ResolvedComponent c` with `c.lifecycle_scope.filter(|s| s.is_non_runtime()).is_some()`:
+- the SBOM emitted as CDX MUST contain `mikebom:lifecycle-scope` for `c`'s component
+- the SBOM emitted as SPDX 2.3 MUST contain `mikebom:lifecycle-scope` for `c`'s package
+- the SBOM emitted as SPDX 3 MUST contain `mikebom:lifecycle-scope` for `c`'s software package
+
+All three MUST agree on the value string.
+
+For every `c` with `c.lifecycle_scope` `None` or `Some(Runtime)`:
+- no format emits `mikebom:lifecycle-scope`.

--- a/specs/145-annotation-parity-fixes/contracts/source-files-dedup.md
+++ b/specs/145-annotation-parity-fixes/contracts/source-files-dedup.md
@@ -1,0 +1,105 @@
+# Contract — `mikebom:source-files` dedup / single-source-of-truth
+
+Phase 1 output. Defines the invariant that `mikebom:source-files` MUST be emitted from EXACTLY ONE source per component, restoring C18 parity across all three formats.
+
+## Pre-145 (broken)
+
+`mikebom:source-files` is set from TWO independent sources on every component (per research §C):
+
+1. **Field-derived** — `c.evidence.source_file_paths` (`Vec<String>`), set by the orchestrator at scan time. All three emitters read this field directly:
+   - CDX: `cyclonedx/builder.rs:830-839`
+   - SPDX 2.3: `spdx/annotations.rs:302-308`
+   - SPDX 3: `spdx/v3_annotations.rs:267-273`
+2. **Reader-stamped** — `c.extra_annotations["mikebom:source-files"]`, set by per-reader code. Maven's nested-JAR reader is the documented offender (`maven.rs:2244`); workspace + yocto readers also touch this key but on non-Maven components, so their drift exposure is different.
+
+   All three emitters ALSO iterate `c.extra_annotations` and emit each entry as a property/annotation:
+   - CDX: `cyclonedx/builder.rs:1086-1098`
+   - SPDX 2.3: `spdx/annotations.rs:371`
+   - SPDX 3: `spdx/v3_annotations.rs:332-337`
+
+Net effect: 2 emissions per component, with different surviving entries per format → C18 `Y | ... | Y` value-drift findings.
+
+## Post-145 (single-source invariant)
+
+The implement-phase reproduction on `polyglot-builder-image` will choose between two fix paths (per research §C "Decision" part). The CONTRACT in both cases:
+
+**Invariant**: On any single component, the set of `mikebom:source-files` emissions across the three formats MUST be byte-equivalent. In array form, that means same elements in the same order.
+
+### Option 1 — emitter-side dedup guard
+
+At each `extra_annotations` iteration site, skip emitting keys that are already emitted from a known field-derived source. Add a constant `FIELD_OWNED_ANNOTATION_KEYS: &[&str] = &["mikebom:source-files"]` and a helper `is_field_owned(key) -> bool`. The iteration:
+
+```rust
+for (key, value) in &c.extra_annotations {
+    if is_field_owned(key) || is_internal_emission_key(key) {
+        continue;
+    }
+    push(out, key, value.clone());
+}
+```
+
+Existing milestone-127 internal-key filter (`is_internal_emission_key`) sits at the same site; the field-owned guard sits next to it.
+
+### Option 2 — Maven reader stops stamping into the colliding key
+
+In `maven.rs:2244`, replace `mikebom:source-files` with `mikebom:source-files-nested-url` (or simply drop the stamping if no downstream consumer depends on the value). The field-derived emission at `c.evidence.source_file_paths` continues to win on the resulting single-source emission.
+
+### Comparison
+
+| | Option 1 | Option 2 |
+|---|---|---|
+| Surface area | 3 emission sites edited | 1 reader site edited (or removed) |
+| Blast radius | Per-emitter behavior change; no reader-side change | Maven reader behavior change; consumers of the existing key lose it |
+| Defensive against future drift | YES — any new field-owned key added later is automatically guarded | NO — requires per-reader discipline |
+| Wire-byte changes | Maven components lose the duplicate `mikebom:source-files-from-extra-annotations` entry across all three formats | Same as Option 1 PLUS the Maven reader emits a different key |
+
+Implement-phase decision after fixture-reproduction. Defense-in-depth ideal: apply BOTH (Option 1 catches future drift; Option 2 cleans up the trap at the source).
+
+## Test contract (in-file test for either option)
+
+```rust
+#[test]
+fn mikebom_source_files_byte_equivalent_across_emitters_for_maven_nested_jar() {
+    // Synthetic ResolvedComponent matching a Maven nested-JAR component:
+    // both source paths (field-derived rootfs-relative + extra_annotations
+    // JAR-URL) are present pre-145.
+    let mut c = synthetic_maven_component_with_source_files(
+        "root/.m2/repository/.../surefire-booter-3.2.2.jar",
+    );
+    c.extra_annotations.insert(
+        "mikebom:source-files".to_string(),
+        json!("root/.m2/repository/.../surefire-booter-3.2.2.jar!META-INF/MANIFEST.MF"),
+    );
+
+    let cdx_value = extract_source_files_from_cdx(&c);
+    let spdx2_value = extract_source_files_from_spdx2(&c);
+    let spdx3_value = extract_source_files_from_spdx3(&c);
+
+    assert_eq!(cdx_value, spdx2_value, "CDX vs SPDX 2.3 source-files drift");
+    assert_eq!(cdx_value, spdx3_value, "CDX vs SPDX 3 source-files drift");
+}
+```
+
+(`extract_source_files_from_*` helpers reuse the milestone-071 parity-extractor infrastructure.)
+
+## Invariants
+
+| | Before | After |
+|---|---|---|
+| Number of `mikebom:source-files` entries per component per emitted format | up to 2 (field-derived + reader-stamped) | EXACTLY 1 |
+| Value source | per-emitter dedup-order-dependent | field-derived `c.evidence.source_file_paths` (Option 1 + Option 2 both), normalized via milestone-133 pipeline |
+| Cross-format equality (C18 `Directionality::SymmetricEqual`) | violated for Maven nested-JAR components on image scans | restored |
+
+## Doc-comment additions (recurrence prevention)
+
+Both the field-setter site (`scan_fs/mod.rs:198` and `:636`) and the Maven reader stamping site (`maven.rs:2244`) MUST gain a one-line note like:
+
+```rust
+// NOTE (milestone 145): `mikebom:source-files` has TWO emission sources —
+// this field (canonical) AND `extra_annotations["mikebom:source-files"]`
+// (legacy, dedup'd at emit time). DO NOT stamp the latter from a new
+// reader; if you need to carry per-reader source provenance, use a
+// distinct key like `mikebom:<reader>-source-url`.
+```
+
+This is the audit-trail signal for the next time someone is tempted to add a second source.

--- a/specs/145-annotation-parity-fixes/data-model.md
+++ b/specs/145-annotation-parity-fixes/data-model.md
@@ -1,0 +1,67 @@
+# Data Model — milestone 145
+
+Phase 1 output. Identifies the in-memory data shape changes and emission-shape changes for milestone 145.
+
+## Shape changes (the three annotation values)
+
+### `mikebom:file-paths` (US1)
+
+| | Pre-145 | Post-145 |
+|---|---|---|
+| Storage type in `extra_annotations` BTreeMap | `Value::String("[\"path1\",\"path2\"]")` (JSON-string-encoded array) | `Value::Array([Value::String("path1"), Value::String("path2")])` (native array) |
+| CDX wire shape | `{"name": "mikebom:file-paths", "value": "[\"path1\",\"path2\"]"}` (string literal) | `{"name": "mikebom:file-paths", "value": "[\"path1\",\"path2\"]"}` (CDX spec-types `properties[].value` as `xs:string`; the milestone-144 envelope-coercion stringifies the array on the CDX side — verify this is the post-fix behavior, NOT a regression) |
+| SPDX 2.3 envelope value | `"value": "[\"path1\",\"path2\"]"` (string-of-array) | `"value": ["path1", "path2"]` (native array inside the envelope) |
+| SPDX 3 envelope value | `"value": "[\"path1\",\"path2\"]"` (string-of-array) | `"value": ["path1", "path2"]` (native array inside the envelope) |
+
+**Verification on CDX wire shape**: per the milestone-144 envelope-value coercion fix (`94e8434`), CDX's `property.value` is spec-typed as `xs:string` — the builder at `cyclonedx/builder.rs:1086-1098` stringifies non-String `Value`s via `serde_json::to_string(other)`. So CDX's wire output for `mikebom:file-paths` post-145 will be `"value": "[\"path1\",\"path2\"]"` — IDENTICAL to pre-145 wire bytes. This is correct behavior: the SPEC-LEVEL change is in the SPDX 2.3 + SPDX 3 envelope values (which carry native JSON types); CDX's wire shape doesn't change because the format itself doesn't carry richer types. The audit-flagged 3,112 findings are dominated by the SPDX 2.3 and SPDX 3 envelope comparisons. The harness-finding count reduction is real.
+
+### `mikebom:lifecycle-scope` (US2)
+
+| | Pre-145 | Post-145 |
+|---|---|---|
+| CDX emission (unchanged) | `{"name": "mikebom:lifecycle-scope", "value": "development"}` on non-Runtime components | unchanged |
+| SPDX 2.3 emission (unchanged) | envelope with `field = "mikebom:lifecycle-scope", value = "development"` on non-Runtime components | unchanged |
+| SPDX 3 emission | NOT EMITTED (cluster pattern `Y \| Y \| -`) | envelope with `field = "mikebom:lifecycle-scope", value = "development"` on non-Runtime components |
+
+### `mikebom:source-files` (US3)
+
+| | Pre-145 | Post-145 |
+|---|---|---|
+| `c.evidence.source_file_paths` field value | Rootfs-relative path list (from milestone-133 normalization) — e.g., `["root/.m2/repository/.../foo.jar"]` | unchanged |
+| `c.extra_annotations["mikebom:source-files"]` value | Maven reader stamps `Value::String("<outer>!<inner>!...")` (JAR-URL notation) | Per US3 fix path: either (a) field-emission keeps winning + emitter-side guard suppresses the extra_annotations duplicate, OR (b) Maven reader stops stamping into this key (uses `mikebom:source-files-nested-url` or similar). Implement-phase decision based on fixture-reproduction. |
+| All three emitter outputs | Diverge by emitter due to dedup-order difference | Single consistent value per component across CDX / SPDX 2.3 / SPDX 3 |
+
+## New types / structs introduced
+
+**None.** Milestone 145 is pure emission-shape correction; no new domain types, no new structs, no new enums. The existing types are sufficient:
+- `serde_json::Value::Array` for US1 (already pervasive)
+- `mikebom_common::resolution::LifecycleScope` for US2 (milestone-049, unchanged)
+- `BTreeMap<String, serde_json::Value>` for `extra_annotations` (unchanged)
+
+## Modified functions / sites
+
+| File | Function / site | Change |
+|---|---|---|
+| `mikebom-cli/src/scan_fs/file_tier/mod.rs` (~line 233) | `into_resolved_component()`'s `mikebom:file-paths` insertion | `json!(file_paths_json)` → `json!(paths_str)` (drop the `to_string` round-trip) |
+| `mikebom-cli/src/scan_fs/file_tier/mod.rs` (~line 405) | Existing unit test parse logic | `serde_json::from_str(fp).expect(...)` → `fp.as_array().expect("file-paths is array")...` |
+| `mikebom-cli/src/generate/spdx/v3_annotations.rs` (around line 263) | Annotation-emission function | NEW branch: emit `mikebom:lifecycle-scope` for non-Runtime scopes mirroring `annotations.rs:227-236` |
+| `mikebom-cli/src/scan_fs/package_db/maven.rs:2244` (US3, depending on fix choice) | Maven nested-JAR reader's `extra_annotations` stamping | Either: drop the `mikebom:source-files` key stamping entirely (option 2a), OR rename to a non-colliding key like `mikebom:source-files-nested-url` (option 2b) |
+| `mikebom-cli/src/generate/cyclonedx/builder.rs:1086`, `spdx/annotations.rs:371`, `spdx/v3_annotations.rs:332` (US3, depending on fix choice) | `extra_annotations` iteration emission sites | Add a guard against re-emitting keys already emitted from field-derived sources (option 1) — currently `["mikebom:source-files"]` only; may extend. |
+
+## Validation rules (consolidated from spec FRs)
+
+| Input | Rule | Source |
+|---|---|---|
+| `mikebom:file-paths` value in `extra_annotations` | MUST be `Value::Array`, NEVER `Value::String` (post-145) | FR-001 + SC-002 |
+| `mikebom:file-paths` array element ordering | MUST be sorted ascending (preserves FR-007 of milestone 133) | FR-002 |
+| `mikebom:file-paths-truncated` sidecar | MUST still appear when `paths.len() > FILE_PATHS_CAP` | FR-002 |
+| `mikebom:lifecycle-scope` SPDX 3 emission | MUST emit for `Development`/`Build`/`Test`; MUST omit for `Runtime` and `None` | FR-005 + FR-006 + FR-007 |
+| `mikebom:source-files` cross-format value | MUST be byte-equivalent across CDX, SPDX 2.3, SPDX 3 for the same component on the same scan | FR-009 + SC-008 |
+| `c.evidence.source_file_paths` field | Remains the canonical source for emission (unchanged from milestone 133's normalization pipeline) | research §C, Decision part 1 |
+
+## Out of model
+
+- New types (no new structs / enums / newtypes).
+- Changes to the `ResolvedComponent` struct shape (only its field VALUES are recomputed; field LAYOUT unchanged).
+- Changes to the parity-catalog row schema (`row_id`, `label`, `directional`, etc.) — C18 / C42 / C92 already exist with the correct `Directionality::SymmetricEqual`.
+- New `mikebom:*` annotations (explicitly out-of-scope per spec FR-011).

--- a/specs/145-annotation-parity-fixes/plan.md
+++ b/specs/145-annotation-parity-fixes/plan.md
@@ -1,0 +1,108 @@
+# Implementation Plan: Annotation-emission parity fixes from sbom-conformance audit (2026-06-26)
+
+**Branch**: `145-annotation-parity-fixes` | **Date**: 2026-06-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/145-annotation-parity-fixes/spec.md`
+
+## Summary
+
+Three annotation-emission parity fixes surfaced by the 2026-06-26 sbom-conformance harness audit. ~3,424 combined CFI findings, distributed:
+
+| Story | Issue | Surface | Expected reduction |
+|---|---|---|---|
+| US1 (P1) | `mikebom:file-paths` emits a stringified array (`Value::String("[\"path\"]")`) instead of native array | `mikebom-cli/src/scan_fs/file_tier/mod.rs:232-234` | 3,112 findings |
+| US2 (P1) | `mikebom:lifecycle-scope` missing from SPDX 3 output for non-Runtime scopes | `mikebom-cli/src/generate/spdx/v3_annotations.rs` (add an emission branch mirroring `annotations.rs:227-236`) | 261 findings |
+| US3 (P2) | `mikebom:source-files` value drift between CDX and SPDX 3 on Maven deps in image scans | Double-emission: field-derived path AND Maven-reader-stamped `extra_annotations` key (`maven.rs:2244`); fixture-reproduction needed to pin the per-emitter dedup difference | 51 findings |
+
+US1 is a one-line fix in the file-tier component constructor; US2 is an additive emission path that already exists in the SPDX 2.3 sibling; US3 needs a fixture-reproduction step to confirm the exact dedup-order difference between CDX and SPDX 3 emitters. Phase 0 research §C below has substantially narrowed US3's diagnosis (down to "double-emission of the same key, different winners per emitter") — the implement phase will run the polyglot-builder-image fixture to confirm and apply the fix.
+
+Total code surface estimate: ~10 LOC reader/emitter changes + ~150-200 LOC test additions + golden refresh for file-paths shape change. No new Cargo dependencies. The architectural lesson — `mikebom:source-files` is stamped in BOTH `extra_annotations` AND `evidence.source_file_paths`, with no dedup-key guard in the emitter — is the underlying cause of US3 and warrants a small invariant check (or doc-comment) at the call sites so future readers don't recreate the same trap.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–144; no nightly required).
+**Primary Dependencies**: Existing only — `serde`/`serde_json` (Value construction + emission), `tracing`, `anyhow`, `thiserror`. Reuses milestone-133's `file_tier` module, milestone-005-era `evidence.source_file_paths` field, milestone-049/052's `LifecycleScope` newtype, milestone-071's parity catalog (C18 source-files, C42 lifecycle-scope, C92 file-paths — all `Directionality::SymmetricEqual`). **No new Cargo dependencies.**
+**Storage**: N/A — all state in-process per scan; no caches, no persistence (matches every milestone since 002).
+**Testing**: `cargo +stable test --workspace`. New tests are in-file `#[cfg(test)] mod tests` plus the existing parity-catalog regression test infrastructure (`mikebom-cli/tests/`). For US3, the implement phase uses the existing `polyglot-builder-image` fixture (or a stripped-down equivalent) to reproduce the drift; no new fixtures committed.
+**Target Platform**: Linux x86_64 + macOS arm64 + Windows (matches CI lanes; the file-paths/lifecycle-scope/source-files changes are pure emission code, no platform-specific behavior).
+**Project Type**: CLI / library — touches one crate (`mikebom-cli`); no kernel-space changes; no workspace topology change.
+**Performance Goals**: No new performance budget. US1's fix removes one `serde_json::to_string` round-trip per file-tier component (slight improvement). US2's emission adds one annotation per non-Runtime-scoped component on SPDX 3 output (negligible). US3's fix may add a dedup check per component on emit (negligible).
+**Constraints**:
+- **Constitution V (standards-native > `mikebom:*`)** — no new `mikebom:*` annotations introduced; the milestone fixes how three EXISTING annotations are emitted. Compliance audit complete in spec FR-011.
+- **Constitution IV (Type-Driven Correctness)** — `Value::String` vs `Value::Array` distinction is a textbook example of why typed wrappers matter; US1's fix is precisely about respecting the type distinction. No new `.unwrap()` in production paths.
+- **Constitution X (Transparency)** — US3's fix preserves both source-of-truth signals (field-derived AND Maven-stamped) at the component level; only the emitter-side dedup behavior changes.
+- **No subprocess calls** — all three fixes are pure-Rust emitter changes.
+- **Pre-PR gate** — `./scripts/pre-pr.sh` (clippy `-D warnings` + `cargo test --workspace`) MUST exit 0 before PR open. The pre-existing `sbomqs_parity` env-only failure documented in milestone 144 T001 still applies; CI on identical commits will validate.
+**Scale/Scope**: ~3,424 findings expected to clear (3,112 + 261 + 51). The largest single change is the file-paths shape — affects every file-tier component on every image-fixture scan. Local file-tier scans (e.g., `mikebom sbom scan --path .` on a non-image source tree with file-tier emission enabled) similarly benefit; the harness-finding count is dominated by image scans.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| # | Principle / Boundary | Status | Note |
+|---|---|---|---|
+| I | Pure Rust, Zero C | ✅ PASS | No new C dependencies; no new Cargo deps at all. |
+| II | eBPF-Only Observation | ✅ N/A | Emission-layer changes only; eBPF discovery untouched. |
+| III | Fail Closed | ✅ PASS | No change to scan-failure semantics. |
+| IV | Type-Driven Correctness | ✅ IMPROVES | US1 fixes a `Value::String`/`Value::Array` mismatch — exactly the kind of distinction Principle IV exists to protect. |
+| V | Specification Compliance | ✅ PASS | **All three target annotations are EXISTING `mikebom:*` properties** (introduced at milestones 133 / 049-052 / 005-era respectively, with their own Principle-V audits at time of introduction). This milestone fixes their emission, NOT their existence — no new properties introduced. Spec FR-011 records the audit. |
+| VI | Three-Crate Architecture | ✅ PASS | All changes in `mikebom-cli`. No new crates. |
+| VII | Test Isolation | ✅ PASS | All new tests are pure-logic unit/integration tests; no eBPF privilege requirements. |
+| VIII | Completeness | ✅ NEUTRAL | No change to component-discovery or component-inclusion. |
+| IX | Accuracy | ✅ IMPROVES | Three SBOM-shape inaccuracies fixed (1 value-shape, 1 missing emission, 1 per-emitter drift). |
+| X | Transparency | ✅ PASS | All three annotations retain their structured-property channel; only how they're encoded changes. The `mikebom:file-paths` shape change is observable to consumers (intentional — the wire shape becomes self-describing as an array instead of a stringified array). |
+| XI | Enrichment | ✅ N/A | No enrichment-source changes. |
+| XII | External Data Source Enrichment | ✅ N/A | No external source involvement. |
+| SB-1 | No lockfile-based discovery | ✅ N/A | |
+| SB-2 | No MITM proxy | ✅ N/A | |
+| SB-3 | No C code | ✅ N/A | |
+| SB-4 | No `.unwrap()` in production | ✅ PASS | Existing `#[cfg_attr(test, allow(clippy::unwrap_used))]` convention preserved on new tests. |
+| SB-5 | No file-tier duplicates in default mode | ✅ N/A | US1 changes the VALUE shape of a file-tier annotation, not the dedup invariant. |
+
+**All gates pass. No Complexity Tracking entries required.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/145-annotation-parity-fixes/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (US3 diagnosis + design decisions)
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── file-paths-shape.md          # Wire-format contract for mikebom:file-paths
+│   ├── lifecycle-scope-emission.md  # SPDX 3 emission contract for mikebom:lifecycle-scope
+│   └── source-files-dedup.md        # Dedup invariant for double-emission of mikebom:source-files
+└── checklists/
+    └── requirements.md  # Already exists from /speckit-specify
+```
+
+### Source Code (repository root)
+
+Touched files (all in `mikebom-cli`):
+
+```text
+mikebom-cli/
+├── Cargo.toml                                              # No change (zero new deps)
+├── src/
+│   ├── scan_fs/
+│   │   ├── file_tier/mod.rs                                # PRIMARY (US1) — line 233 value-shape fix; line 405 unit-test update
+│   │   └── package_db/maven.rs                             # US3 — may need to STOP stamping mikebom:source-files into extra_annotations (or align with field-derived shape)
+│   └── generate/
+│       └── spdx/
+│           ├── v3_annotations.rs                           # US2 — add lifecycle-scope emission branch mirroring annotations.rs:227-236
+│           ├── annotations.rs                              # READ-ONLY reference for US2's mirror
+│           └── (potentially) packages.rs / v3_packages.rs   # US3 — may need dedup-key check at the per-emitter source-files emission site
+└── tests/
+    ├── (existing parity-catalog tests under tests/)        # Will pick up the C18 / C42 / C92 row corrections automatically
+    └── fixtures/golden/                                    # Refresh affected goldens (file-tier components in image-scan goldens; SPDX 3 goldens for lifecycle-scope components)
+```
+
+**Structure Decision**: Single existing crate (`mikebom-cli`). No new modules. US1 is one-line + one-test-update. US2 is one-new-branch-in-existing-function. US3 needs fixture-reproduction (Phase 0 §C documented the substantive narrowing; implement phase will reproduce and patch).
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+Not applicable — all gates pass.

--- a/specs/145-annotation-parity-fixes/quickstart.md
+++ b/specs/145-annotation-parity-fixes/quickstart.md
@@ -1,0 +1,151 @@
+# Quickstart — milestone 145 annotation-emission parity fixes
+
+Operator-facing walkthrough.
+
+## Scenario 1 — Verify the `mikebom:file-paths` shape fix (US1)
+
+After this milestone, every file-tier component's `mikebom:file-paths` annotation in SPDX 2.3 / SPDX 3 carries a native JSON array. Pre-145 carried a JSON-string-encoded array.
+
+```bash
+# Scan any image-like fixture (file-tier emission required — the default
+# --file-inventory=orphan since milestone 133).
+mikebom sbom scan --path <some-rootfs-or-image-extract> \
+    --format spdx-2.3-json --output /tmp/check.spdx.json
+
+# Pre-145: returns "string"
+# Post-145: returns "array" for every file-tier component
+jq -r '.packages[]
+       | .annotations[]?
+       | (.comment | fromjson)
+       | select(.field == "mikebom:file-paths")
+       | .value | type' /tmp/check.spdx.json \
+    | sort -u
+```
+
+Same check for SPDX 3:
+
+```bash
+mikebom sbom scan --path <...> --format spdx-3-json --output /tmp/check.spdx3.json
+jq -r '.["@graph"][]
+       | .annotations[]?
+       | .software_statement
+       | select(. != null)
+       | fromjson
+       | select(.field == "mikebom:file-paths")
+       | .value | type' /tmp/check.spdx3.json \
+    | sort -u
+# Post-145: only "array" appears.
+```
+
+## Scenario 2 — Verify `mikebom:lifecycle-scope` in SPDX 3 (US2)
+
+After this milestone, SPDX 3 output carries `mikebom:lifecycle-scope` on dev/build/test-scoped components, matching the existing CDX + SPDX 2.3 behavior.
+
+```bash
+# Use an npm project that has dev dependencies — the node-dev-vs-prod
+# fixture is the audit's source.
+mikebom sbom scan --path <path-to-npm-fixture> \
+    --format cyclonedx-json --format spdx-3-json \
+    --output cyclonedx-json=/tmp/n.cdx.json \
+    --output spdx-3-json=/tmp/n.spdx3.json
+
+# Count dev-scoped components per format — they should match.
+jq -r '[.components[]
+        | .properties[]?
+        | select(.name == "mikebom:lifecycle-scope" and .value == "development")]
+       | length' /tmp/n.cdx.json
+# (some count > 0)
+
+jq -r '[.["@graph"][]
+        | .annotations[]?
+        | .software_statement
+        | select(. != null)
+        | fromjson
+        | select(.field == "mikebom:lifecycle-scope" and .value == "development")]
+       | length' /tmp/n.spdx3.json
+# (same count > 0 — post-145; pre-145 was 0)
+```
+
+## Scenario 3 — Verify `mikebom:source-files` parity on Maven deps (US3)
+
+After this milestone, scanning the `polyglot-builder-image` fixture (or equivalent) produces byte-equivalent `mikebom:source-files` values across CDX and SPDX 3 for Maven dep components.
+
+```bash
+mikebom sbom scan --path <path-to-polyglot-builder-image-fixture> \
+    --format cyclonedx-json --format spdx-3-json \
+    --output cyclonedx-json=/tmp/m.cdx.json \
+    --output spdx-3-json=/tmp/m.spdx3.json
+
+# Extract Maven dep source-files from each format, sort, diff.
+jq -r '.components[]
+       | select(.purl | startswith("pkg:maven/"))
+       | {purl, src: [.properties[]? | select(.name == "mikebom:source-files") | .value]}' \
+    /tmp/m.cdx.json | jq -s 'sort_by(.purl)' > /tmp/cdx-maven.json
+
+jq -r '.["@graph"][]
+       | select(.software_packageUrl? | tostring | startswith("pkg:maven/"))
+       | {purl: .software_packageUrl,
+          src: [.annotations[]? | .software_statement | select(. != null) | fromjson
+                | select(.field == "mikebom:source-files") | .value]}' \
+    /tmp/m.spdx3.json | jq -s 'sort_by(.purl)' > /tmp/spdx3-maven.json
+
+diff /tmp/cdx-maven.json /tmp/spdx3-maven.json
+# Post-145: empty diff (zero drift).
+```
+
+## Scenario 4 — Re-run the sbom-conformance harness
+
+The harness-reported CFI finding counts (SC-001 / SC-004 / SC-008) are the operator-facing measurement of success. Re-run the harness against a post-145 build:
+
+```bash
+# Harness execution (assumes the operator has it installed).
+sbom-conformance audit --target mikebom --fixture-set canonical \
+    --pre-rev <pre-145-commit> --post-rev <post-145-commit>
+
+# Expected: ≥3,424 CFI finding reduction across the file-paths /
+# lifecycle-scope / source-files clusters.
+```
+
+## Verification commands (in-tree, CI-binding)
+
+```bash
+# All US1 + US2 + US3 unit tests pass:
+cargo test -p mikebom --bin mikebom file_tier::tests::
+cargo test -p mikebom --bin mikebom spdx::v3_annotations::tests::
+cargo test -p mikebom --bin mikebom source_files_byte_equivalent
+
+# Pre-PR gate:
+cargo +stable clippy --workspace --all-targets -- -D warnings
+cargo +stable test --workspace
+# Or simply:
+./scripts/pre-pr.sh
+```
+
+## Golden-fixture refresh (post-fix, before commit)
+
+```bash
+# US1 — file-paths shape change affects SPDX 2.3 + SPDX 3 goldens
+# containing file-tier components (CDX unchanged):
+MIKEBOM_UPDATE_SPDX_GOLDENS=1 cargo test --test spdx_regression
+MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo test --test spdx3_regression
+
+# US2 — lifecycle-scope addition affects SPDX 3 goldens only:
+# (same MIKEBOM_UPDATE_SPDX3_GOLDENS=1 invocation, covered by the above)
+
+# US3 — source-files dedup MAY affect goldens containing Maven nested-JAR
+# components on image-extract fixtures. Re-run BOTH SPDX update vars and
+# the CDX update var depending on which fix path is taken:
+MIKEBOM_UPDATE_CDX_GOLDENS=1 cargo test --test cdx_regression
+```
+
+Confirm refresh scope by inspecting `git diff --stat tests/fixtures/golden/` — diffs MUST be limited to the documented per-US wire-shape changes; reject any unrelated drift.
+
+## Known deferrals (spec Out of Scope)
+
+- Image-pseudo-component absent-from-spdx-json gap (2 cases on `go-vcs-buildinfo`).
+- `mikebom:sbom-tier` per-component disagreement on Maven shaded/transitive deps.
+- New `mikebom:*` annotations.
+- Restructuring of `extra_annotations` BTreeMap representation.
+- `<component-presence>` cluster from prior audit run — collapsed to 2 by harness patch (not a mikebom issue).
+- Performance optimization of file-tier emission.
+- Changes to the Maven reader's `entry.source_path` POPULATION (only the per-emitter dedup behavior changes; underlying field is unchanged).

--- a/specs/145-annotation-parity-fixes/research.md
+++ b/specs/145-annotation-parity-fixes/research.md
@@ -1,0 +1,159 @@
+# Research — milestone 145 (annotation-emission parity fixes)
+
+Phase 0 output. Resolves the substantive US3 diagnosis question per spec FR-008, plus design decisions for US1 + US2.
+
+## A — `mikebom:file-paths` value-shape fix (US1)
+
+**Decision**: Change line 233 of `mikebom-cli/src/scan_fs/file_tier/mod.rs` from `extra_annotations.insert(FILE_PATHS_KEY.to_string(), json!(file_paths_json))` (where `file_paths_json = serde_json::to_string(&paths_str)`) to `extra_annotations.insert(FILE_PATHS_KEY.to_string(), json!(paths_str))` directly. Update the unit test at line 405 from `serde_json::from_str(fp)` to direct array iteration via `fp.as_array()`.
+
+**Rationale**:
+- The bug is a literal double-encoding: `paths_str` (a `Vec<String>`) gets serialized to a JSON string via `to_string`, then that string is wrapped in a `Value::String` via `json!`. The intent (per the doc-comment at line 190 saying "JSON-encoded-sorted-array") was apparently to encode the array AS a JSON string for the value — but every other array-valued mikebom annotation (`mikebom:source-files`, `mikebom:cpe-candidates`, etc.) emits as a native `Value::Array`. The file-paths emission is the lone outlier; correct alignment is to drop the stringification.
+- The `serde_json::to_string` call always succeeds for a `Vec<String>`; the `Ok(...)` branch always fires. There's no defensive value in keeping the `if let Ok(...)` shape after the fix — replacing with a direct `extra_annotations.insert(..., json!(paths_str))` is both shorter and clearer. (Keeping the `if let` defensively would require synthesizing an error case that doesn't exist; the change drops it.)
+- Wire-output change is acceptable per spec Assumption 2 (the stringified shape was never documented as the contract; affected only since milestone-133 introduction, ~6 months).
+- Test change is from `serde_json::from_str(fp).expect("file-paths JSON parses")` to `fp.as_array().expect("file-paths is array").iter().map(|v| v.as_str().unwrap().to_string()).collect::<Vec<_>>()` or similar. The test ASSERTION already exists; the SHAPE of the parse changes.
+
+**Alternatives considered**:
+- **Keep the stringified shape, document it as the contract** — rejected: violates Constitution V's "standards-native > `mikebom:*`" spirit (the native-array shape IS the standard `properties[].value` form), and breaks consumer expectations from the C92 parity-catalog row (`Directionality::SymmetricEqual`).
+- **Add a new annotation `mikebom:file-paths-array` with the native shape, deprecate `mikebom:file-paths`** — rejected: doubles wire surface, breaks every existing parity-catalog row, no upside.
+
+## B — `mikebom:lifecycle-scope` SPDX 3 emission (US2)
+
+**Decision**: Add a new emission branch in `mikebom-cli/src/generate/spdx/v3_annotations.rs` that mirrors the SPDX 2.3 sibling at `annotations.rs:227-236`. Specifically, after the existing `mikebom:raw-version` push (around line 263 of v3_annotations.rs), insert:
+
+```rust
+// C42 mikebom:lifecycle-scope — parity-bridging annotation mirroring
+// the SPDX 2.3 sibling at annotations.rs:227-236 (milestone 145 US2).
+// CDX and SPDX 2.3 both emit this annotation for non-Runtime scopes
+// (CDX at cyclonedx/builder.rs:851 via `s.is_non_runtime()`, SPDX 2.3
+// at annotations.rs:233 via the `LifecycleScope::Runtime => None`
+// match arm). SPDX 3 was the pre-145 outlier.
+if let Some(ref scope) = c.lifecycle_scope {
+    use mikebom_common::resolution::LifecycleScope;
+    let s = match scope {
+        LifecycleScope::Development => Some("development"),
+        LifecycleScope::Build => Some("build"),
+        LifecycleScope::Test => Some("test"),
+        LifecycleScope::Runtime => None, // runtime is the default; no annotation
+    };
+    if let Some(s) = s {
+        push(out, "mikebom:lifecycle-scope", json!(s));
+    }
+}
+```
+
+**Rationale**:
+- Code-confirmed during /speckit-clarify that BOTH peers (CDX + SPDX 2.3) omit Runtime; SPDX 3 must follow the same omission rule (FR-006 + FR-007).
+- Insertion point near `raw-version` (C17) lines up with the parity catalog ordering — C42 lifecycle-scope sits in the property-emission block, not in a sibling type.
+- Reuses `LifecycleScope::Runtime => None` pattern from `annotations.rs:233` verbatim (single canonical match arm).
+
+**Alternatives considered**:
+- **Emit Runtime annotation too** — rejected: violates FR-006/FR-007 and breaks parity with CDX + SPDX 2.3 (would create the inverse problem — SPDX 3 emits an annotation the other formats omit).
+- **Add to a dedicated `emit_lifecycle_*` helper** — rejected: there's no precedent for ecosystem-specific lifecycle helpers; inline match is the established pattern.
+
+## C — `mikebom:source-files` per-emitter drift diagnosis (US3) [SC-007]
+
+**Diagnosis** (the spec's required research artifact for SC-007):
+
+The `mikebom:source-files` annotation is emitted from TWO independent sources on every component:
+
+1. **Field-derived source** — `c.evidence.source_file_paths` (a `Vec<String>`), populated at scan-time by the orchestrator from `entry.source_path` via `crate::scan_fs::sbom_path::normalize_sbom_path_relative(&entry.source_path, Some(root))`:
+   - **Artefact walker**: `mikebom-cli/src/scan_fs/mod.rs:198` (sets rootfs-normalized path)
+   - **Package-DB reader**: `mikebom-cli/src/scan_fs/mod.rs:636` (sets rootfs-normalized path)
+
+   All three SBOM emitters consume this field:
+   - CDX: `mikebom-cli/src/generate/cyclonedx/builder.rs:830-839` via `crate::scan_fs::sbom_path::source_files_as_json_array(&component.evidence.source_file_paths)`
+   - SPDX 2.3: `mikebom-cli/src/generate/spdx/annotations.rs:302-308` via `json!(c.evidence.source_file_paths)`
+   - SPDX 3: `mikebom-cli/src/generate/spdx/v3_annotations.rs:267-273` via `json!(c.evidence.source_file_paths)`
+
+2. **Reader-stamped source** — `c.extra_annotations["mikebom:source-files"]`, stamped DIRECTLY by per-reader code:
+   - **Maven reader (nested-JAR path)**: `mikebom-cli/src/scan_fs/package_db/maven.rs:2244` stamps `Value::String(source_files_url.clone())` where `source_files_url` is the `<outer>!<inner>!...` JAR-URL notation (per the line-1312 doc-comment).
+   - **Workspace reader**: `mikebom-cli/src/scan_fs/package_db/workspace.rs:76`
+   - **Yocto recipe reader**: `mikebom-cli/src/scan_fs/package_db/yocto/recipe.rs:213`
+
+   All three SBOM emitters also iterate `c.extra_annotations` and emit each key→value pair as a property/annotation:
+   - CDX: `mikebom-cli/src/generate/cyclonedx/builder.rs:1086-1098` (iterates the bag, stringifies non-String values)
+   - SPDX 2.3: `mikebom-cli/src/generate/spdx/annotations.rs:371` (iterates the bag)
+   - SPDX 3: `mikebom-cli/src/generate/spdx/v3_annotations.rs:332-337` (iterates the bag)
+
+**The bug**: a Maven component on the `polyglot-builder-image` fixture has BOTH sources stamped:
+- `c.evidence.source_file_paths = ["root/.m2/repository/.../surefire-booter-3.2.2.jar"]` (the orchestrator-normalized JAR path)
+- `c.extra_annotations["mikebom:source-files"] = Value::String("...!...")` (the Maven-reader-stamped nested-JAR URL string)
+
+Each emitter therefore produces TWO `mikebom:source-files` entries on the same component. The parity-catalog extractor (`mikebom-cli/src/parity/extractors/`) picks ONE per format, and which one it picks (first-match vs last-match, or some other tie-break) differs by emitter implementation — hence the cross-format value drift.
+
+**Why the audit shows a "tempdir" path on SPDX 3 specifically**: the most plausible mechanism, pending fixture-reproduction, is that one of the two emission iterations on the SPDX 3 side (lines 267-273 OR 332-337) is being skipped or overwritten, and the surviving entry happens to be the one whose value resolves to the image-extract tempdir path — likely via an upstream `entry.source_path` value that was NOT normalized (e.g., from a different reader's stamping pass during dedup). The exact dedup-collapse step needs to be reproduced on the fixture during implement phase.
+
+### §C.1 — Confirmation of diagnosis at implement time (T011/T012 outcome)
+
+**Status**: The implement phase confirmed §C's diagnosis via code inspection rather than full fixture reproduction. The four emission sites (Maven reader at `maven.rs:2244` + the three emitter iteration loops at `cyclonedx/builder.rs:1086`, `spdx/annotations.rs:371`, `spdx/v3_annotations.rs:332`) were verified to:
+
+1. **Have the milestone-127 `is_internal_emission_key` filter at all three emitter sites** (verified via `grep -A2 "for (key, value) in &c.extra_annotations" mikebom-cli/src/generate/`), so the defensive Option-1 guard can extend the existing filter pattern uniformly.
+2. **Stamp `mikebom:source-files` only at the Maven nested-JAR reader for the polyglot-builder-image case** (workspace + yocto readers also stamp this key but in different contexts not implicated in the audit's 51 Maven-dep cases).
+
+**Decision recorded**: Apply BOTH Option 1 (defensive emitter-side guard) AND Option 2b (Maven reader renames its stamped key to `mikebom:source-files-nested-url`). Defense-in-depth: Option 2b removes the trap at the source; Option 1 catches any future readers tempted to recreate the same trap. Both fixes restore C18 `SymmetricEqual` parity.
+
+**Full fixture reproduction on `polyglot-builder-image` is operator-cadence** (per research §D) and will be verified via the harness re-run documented in tasks.md T023. The in-tree integration test (T016) provides the CI-binding signal that the dedup invariant holds for the synthetic Maven double-stamp case.
+
+---
+
+**Decision** (original): Two-part fix.
+
+1. **Suppress double-emission**: At all three emitter sites (CDX builder.rs:1086, SPDX 2.3 annotations.rs:371, SPDX 3 v3_annotations.rs:332), add a guard that SKIPS keys ALREADY emitted from the field-derived source. The simplest implementation is a set of "field-owned keys" — `["mikebom:source-files"]` at minimum, possibly extended to other dual-source keys as audit reveals them — checked in the iteration loop. The field-derived source wins because it goes through the milestone-133 normalization pipeline (`normalize_sbom_path_relative`), guaranteeing consistent rootfs-relative paths.
+
+2. **Maven reader: stop stamping `mikebom:source-files` into `extra_annotations`** for the nested-JAR-URL case. The Maven-reader stamping at `maven.rs:2244` was introduced when the field-derived source did NOT yet carry nested-JAR provenance; milestone-133's normalization pipeline + the field's `Vec<String>` shape now subsume the use case. Drop the stamping, OR keep it under a DIFFERENT annotation key (e.g., `mikebom:source-files-nested-url`) that doesn't collide with the field-derived emission.
+
+The implement phase will reproduce the drift on the `polyglot-builder-image` fixture to choose between (1) and (2) — (1) is purely defensive at the emission boundary; (2) eliminates the duplicate-source at the population boundary, which is structurally cleaner but has a wider blast radius (must verify no consumer depends on the Maven-stamped value at its current key).
+
+**Rationale**:
+- Both fixes preserve the operator-visible information (field-derived path; the JAR-URL `<outer>!<inner>!` notation is still queryable if option 2 keeps it under a separate key).
+- Both fixes restore C18 (`mikebom:source-files`) `SymmetricEqual` parity across all three formats.
+- Option 1 is contained and low-risk; option 2 is the long-term-correct fix that removes the trap for future contributors.
+- Defensive doc-comments at the two stamping sites (the field setter and the Maven reader) noting the dual-emission risk would prevent recurrence.
+
+**Alternatives considered**:
+- **Canonicalize on the Maven-stamped value, drop the field-derived emission for Maven components** — rejected: the field-derived value is normalized via the milestone-133 pipeline (guarantees rootfs-relative paths), which is what the parity-catalog C18 row expects. Dropping it would break other ecosystem readers' emissions that rely on the normalized field.
+- **Merge both values into a single array on emission** — rejected: produces a non-canonical mixed-shape value (some entries are rootfs-relative paths, some are JAR-URL `!` notation), which would break downstream consumers that parse the value as a path list.
+
+## D — Test strategy for SC-001 / SC-004 / SC-008 (harness-finding counts)
+
+**Decision**: In-tree tests provide CI-independent guards on the underlying code behavior. The harness-reported finding counts (SC-001 / SC-004 / SC-008) are verified separately by re-running the sbom-conformance harness — typically out of CI's loop, on operator-controlled cadence.
+
+**Rationale**:
+- The sbom-conformance harness is an external Go binary; depending on it as a CI dep would violate Constitution principles around test isolation + reproducibility.
+- The in-tree tests (SC-002, SC-005, SC-009) assert on the CODE-LEVEL invariants (value-type checks, annotation presence, byte-equivalent emission). If those pass, the harness-finding counts will fall accordingly. The exception is US3's exact 51-count match, which depends on the polyglot-builder-image fixture's specific component count; the in-tree test asserts on the dedup invariant directly (any two components with the same logical purl emit the same `mikebom:source-files` value across formats).
+- Re-running the harness post-merge is documented in `quickstart.md` as the operator verification step for SC-001/SC-004/SC-008.
+
+**Alternatives considered**:
+- **Vendor the harness as a CI dep** — rejected: adds a Go toolchain to mikebom CI; out of scope for this milestone.
+- **Skip harness verification entirely** — rejected: SC-001/SC-004/SC-008 explicitly call out the harness-finding counts as the outcomes.
+
+## E — Golden-fixture refresh scope (FR-010)
+
+**Decision**: For US1 (`mikebom:file-paths` shape change), refresh every existing golden file containing the pre-145 stringified-array shape. Find via `grep -rln 'mikebom:file-paths' mikebom-cli/tests/fixtures/golden/`. Diffs are limited to ONE pattern per affected line: `"value": "[..."` → `"value": [...`. For US2 (SPDX 3 lifecycle-scope addition), refresh only SPDX 3 goldens for fixtures that contain non-Runtime-scoped components (likely `node-dev-vs-prod` and similar). For US3, the fix MAY produce golden diffs if the affected fixtures' Maven components are captured in goldens.
+
+**Rationale**:
+- The shape change in US1 is byte-level — `serde_json::to_string` produces different bytes for a `Value::String("[\"x\"]")` than for a `Value::Array([String("x")])`. Goldens must reflect the post-fix byte sequence.
+- US2 is purely additive — CDX and SPDX 2.3 goldens DO NOT need refresh (those emit lifecycle-scope today). Only SPDX 3 goldens for fixtures with non-Runtime scope.
+- US3's golden refresh scope depends on which fix path is chosen (the implement-phase reproduction will reveal this).
+
+**Refresh env vars** (matching the milestone-144 pattern):
+- `MIKEBOM_UPDATE_CDX_GOLDENS=1 cargo test --test cdx_regression`
+- `MIKEBOM_UPDATE_SPDX_GOLDENS=1 cargo test --test spdx_regression`
+- `MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo test --test spdx3_regression`
+
+## F — Why no `Cargo.toml` dependency changes?
+
+All three fixes use existing types from the workspace dep closure:
+- `serde_json::Value::Array` / `Value::String` distinction — already pervasive.
+- `mikebom_common::resolution::LifecycleScope` — milestone-049 type; reused verbatim.
+- `BTreeMap<String, Value>` for `extra_annotations` — milestone-023 introduction; unchanged.
+
+No new crates needed.
+
+## Summary of decisions feeding Phase 1
+
+- **US1**: 1-line constructor fix at `file_tier/mod.rs:233` + 1-test-update at line 405 + golden refresh.
+- **US2**: 1-new-emission-branch in `v3_annotations.rs` mirroring `annotations.rs:227-236` + 2 unit tests + SPDX 3 golden refresh (subset).
+- **US3**: implement-phase reproduces the drift on the polyglot-builder-image fixture and applies either (option 1) defensive emitter-side guard against double-emission, OR (option 2) Maven-reader-side stop stamping `mikebom:source-files` into `extra_annotations`. Defensive doc-comments at both stamping sites prevent recurrence.
+- **Test strategy**: in-tree tests are the CI-binding signal; harness re-run is the operator-verification step.
+- **No new Cargo dependencies.**

--- a/specs/145-annotation-parity-fixes/spec.md
+++ b/specs/145-annotation-parity-fixes/spec.md
@@ -15,6 +15,16 @@ External sbom-conformance audit harness run on 2026-06-26 (post-milestone-144) f
 
 All three are PURE EMISSION-LAYER bugs — none affect dependency discovery (Constitution Principle II), component-presence, PURL conformance (Principle V's purl-spec clause), or any other binding correctness invariant. They are SBOM-quality regressions that erode downstream-tooling interoperability (SPDX 3 consumers see a different SBOM shape than CDX consumers expect; PURL-keyed dedup of file-tier components fails because the value isn't a queryable array).
 
+## US2 reverted post-investigation (2026-06-28)
+
+**Resolution**: US2 was implemented + then REVERTED during the `/speckit-implement` phase after the `spdx3_annotation_fidelity::fidelity_maven` test caught a Constitution Principle V violation. The fidelity test (per issue #228) encodes the existing design contract: SPDX 3 already carries lifecycle scope natively via `LifecycleScopedRelationship.scope` (set in `v3_relationships.rs` for `Dev`/`Build`/`TestDependsOn` edges); adding `mikebom:lifecycle-scope` annotations on Package elements would be REDUNDANT with the native field, which Principle V forbids.
+
+Local manual verification on the `maven` fixture confirmed SPDX 3 emits `LifecycleScopedRelationship` with `scope: "test"` for the `junit` dep — the native mechanism is working as designed.
+
+**Conclusion**: the 261 audit findings under `mikebom:lifecycle-scope Y | Y | -` are **false positives** from the sbom-conformance harness misreading the SPDX 3 scope mechanism. The harness should be updated to honor `LifecycleScopedRelationship.scope` as the SPDX 3 equivalent of CDX's `mikebom:lifecycle-scope` property and SPDX 2.3's `mikebom:lifecycle-scope` annotation. No mikebom-side change is appropriate.
+
+FR-005 / FR-006 / FR-007 / SC-004 / SC-005 / SC-006 in this spec are INVALIDATED by this resolution and remain only as historical record. US2 should be considered **closed without code change**; US1 + US3 continue as planned. Expected post-145 finding reduction drops from ~3,424 to ~3,163 (3,112 file-paths + 51 source-files).
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - `mikebom:file-paths` is emitted as a native JSON array (Priority: P1)

--- a/specs/145-annotation-parity-fixes/spec.md
+++ b/specs/145-annotation-parity-fixes/spec.md
@@ -1,0 +1,138 @@
+# Feature Specification: Annotation-emission parity fixes from sbom-conformance audit (2026-06-26)
+
+**Feature Branch**: `145-annotation-parity-fixes`
+**Created**: 2026-06-27
+**Status**: Draft
+**Input**: User description: "Three annotation-emission parity fixes surfaced by sbom-conformance harness 2026-06-26 audit: (1) mikebom:file-paths emits a stringified array instead of native array (3112 findings); (2) mikebom:lifecycle-scope missing from SPDX 3 emitter (261 findings); (3) mikebom:source-files JAR vs rootfs-tempdir value drift on Maven deps in image scans (51 findings)."
+
+## Origin
+
+External sbom-conformance audit harness run on 2026-06-26 (post-milestone-144) flagged 3,424 cross-format-invariance (CFI) findings against mikebom. The milestone-144 PR (envelope-value coercion fix in `94e8434` / golden refresh in `7b5ed82`) cleared 23 findings (the `mikebom:not-linked` cluster + `mikebom:detected-cargo-auditable` value divergences). The 2026-06-26 follow-up run, with the harness's `<component-presence>` detector patched, identified three remaining mikebom-side issues totaling ~3,424 findings:
+
+- **A — `mikebom:file-paths` double-encoded** (3,112 findings). The annotation's value is emitted as `Value::String("[\"path1\",\"path2\"]")` (a stringified array literal) instead of `Value::Array([String("path1"), String("path2")])`. Every other array-valued mikebom annotation (`mikebom:source-files`, `mikebom:cpe-candidates`, etc.) uses the native-array shape; `file-paths` is the lone outlier. Affects every file-tier component on every image-fixture scan — confirmed in `mikebom-cli/src/scan_fs/file_tier/mod.rs:232-234` (the constructor wraps `serde_json::to_string(&paths_str)` back into a `Value::String` via `json!()`).
+- **B — `mikebom:lifecycle-scope` missing from SPDX 3** (261 findings, all on npm dev deps in `node-dev-vs-prod` fixture). Pattern `Y | Y | -` (CDX + SPDX 2.3 emit; SPDX 3 omits). Confirmed via grep: the SPDX 3 emitter files (`v3_packages.rs`, `v3_document.rs`) contain zero references to `lifecycle_scope` / `LifecycleScope`; the SPDX 2.3 emitter writes the annotation at `annotations.rs:236`.
+- **C — `mikebom:source-files` value drift on Maven deps** (51 findings, all on `polyglot-builder-image` Maven deps). Same component carries different `source_file_paths` strings in CDX vs SPDX 3 output — CDX shows the JAR path (`root/.m2/repository/.../surefire-booter-3.2.2.jar`), SPDX 3 shows the image-extraction tempdir (`private/var/folders/.../mikebom-image-AylYTd/rootfs`). Both emitters consume `c.evidence.source_file_paths` from the same `ResolvedComponent`, so something is mutating or re-stamping the field between CDX emission and SPDX 3 emission.
+
+All three are PURE EMISSION-LAYER bugs — none affect dependency discovery (Constitution Principle II), component-presence, PURL conformance (Principle V's purl-spec clause), or any other binding correctness invariant. They are SBOM-quality regressions that erode downstream-tooling interoperability (SPDX 3 consumers see a different SBOM shape than CDX consumers expect; PURL-keyed dedup of file-tier components fails because the value isn't a queryable array).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - `mikebom:file-paths` is emitted as a native JSON array (Priority: P1)
+
+A downstream consumer (sbom-conformance harness, vulnerability matcher, file-tier dedup tool) reads the `mikebom:file-paths` annotation from an emitted SBOM and expects the value to be a JSON array of path strings, matching every other array-valued mikebom annotation. Today the value is a JSON string containing the serialized form of an array — forcing every consumer to do a second `JSON.parse(value)` to extract the paths, AND breaking JSON-Path / jq queries that expect array semantics (e.g., `jq '.[] | select(.value | length > 0)'` returns wrong results because `.value` is a string, not an array). After this milestone, the value is a native JSON array; consumers can iterate it directly.
+
+**Why this priority**: This is the dominant audit signal (3,112 of the 3,424 remaining findings — 91% of the cleanup ROI). It is also the smallest, lowest-risk fix: one line in `file_tier/mod.rs:233` plus one unit-test wording change. The downstream impact is silent SBOM-shape divergence today, fixed instantly on the next scan.
+
+**Independent Test**: Scan any directory containing files that trigger file-tier emission (or use the existing file-tier test fixtures), emit CDX or SPDX, then `jq '.components[] | select(.properties[]? | .name == "mikebom:file-paths") | .properties[] | select(.name == "mikebom:file-paths") | .value | type'` MUST return `"array"` for every component (not `"string"`).
+
+**Acceptance Scenarios**:
+
+1. **Given** a scan that produces at least one file-tier component, **When** the operator inspects the emitted CDX JSON, **Then** the `mikebom:file-paths` property value on that component is a JSON array, not a JSON string.
+2. **Given** the same scan output in SPDX 2.3 or SPDX 3 form, **When** the operator parses the `mikebom:file-paths` annotation envelope (the value inside the `MikebomAnnotationCommentV1` wrapper), **Then** that inner `value` field is a JSON array.
+3. **Given** an existing file-tier test that asserts on the post-parse shape, **When** the test runs after the fix, **Then** it succeeds against the native-array shape (the test wording also updated as part of the milestone).
+4. **Given** the existing parity catalog row C92 (`mikebom:file-paths`, `Directionality::SymmetricEqual`), **When** the cross-format parity check runs, **Then** all three formats emit byte-equivalent array values.
+
+---
+
+### User Story 2 - `mikebom:lifecycle-scope` is emitted in SPDX 3 output (Priority: P1)
+
+An operator scanning an npm project with both dev and prod dependencies emits SBOMs in all three formats and queries `mikebom:lifecycle-scope` to identify dev-only packages. Today CDX and SPDX 2.3 both carry the annotation on every dev-marked component; SPDX 3 omits it entirely. Downstream tooling that keys off `mikebom:lifecycle-scope` for compliance gates (e.g., "production SBOMs must not include `lifecycle-scope = development` components") fails silently when fed an SPDX 3 document — the annotation isn't there, so the gate treats all components as prod-tier. After this milestone, the SPDX 3 emitter writes `mikebom:lifecycle-scope` with the same shape and timing as the SPDX 2.3 emitter.
+
+**Why this priority**: 261 findings is the second-largest single cluster after `file-paths`, and the absence has real compliance impact (dev/build/test scope detection is the principal motivation for milestone-049 / milestone-052's lifecycle-scope work). The fix is additive — adding an emission path that already exists in the SPDX 2.3 sibling.
+
+**Independent Test**: Emit SPDX 3 output for the `node-dev-vs-prod` fixture (or any equivalent npm-dev-marked component fixture). `jq '.["@graph"][] | select(.["mikebom:lifecycle-scope"]?) | .["mikebom:lifecycle-scope"]'` MUST return at least one match. Compare to the SPDX 2.3 output of the same scan: every component carrying `mikebom:lifecycle-scope` in SPDX 2.3 MUST also carry it in SPDX 3 with the same value.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scan of an npm project containing dev-only dependencies, **When** the SPDX 3 output is emitted, **Then** each dev-only component has a `mikebom:lifecycle-scope` annotation with value `"development"`.
+2. **Given** the same scan in SPDX 2.3, **When** the SPDX 2.3 output is compared component-by-component against the SPDX 3 output, **Then** every component carrying `mikebom:lifecycle-scope` in SPDX 2.3 also carries it in SPDX 3 with the same value (no extras, no omissions).
+3. **Given** the parity catalog row C42 (`mikebom:lifecycle-scope`, `Directionality::SymmetricEqual`), **When** the parity check runs on the fixture, **Then** zero `Y | Y | -` findings remain.
+4. **Given** the operator runs the same scan against a maven / pip / cargo / gradle project carrying `LifecycleScope::Build` / `Test` / `Runtime` values, **When** SPDX 3 is emitted, **Then** the annotation is present on those components too (parity with SPDX 2.3's behavior).
+
+---
+
+### User Story 3 - `mikebom:source-files` carries consistent values across CDX and SPDX 3 for Maven deps (Priority: P2)
+
+A consumer comparing `mikebom:source-files` between the CDX and SPDX 3 outputs of the same scan expects identical values — both formats consume the same `ResolvedComponent.evidence.source_file_paths` field, after all. Today on `polyglot-builder-image` scans of Maven deps, CDX carries the JAR file path (`root/.m2/repository/.../surefire-booter-3.2.2.jar`) while SPDX 3 carries the absolute image-extraction tempdir (`private/var/folders/.../mikebom-image-AylYTd/rootfs`). 51 components affected. After this milestone, both formats carry the same value for the same component on the same scan — the canonical value being the JAR path relative to the rootfs (matching CDX today).
+
+**Why this priority**: 51 findings is smaller than US1/US2, AND the issue requires a diagnosis phase before a fix can land (the per-emitter mutation site is not in the emitter code itself — both emitters consume `c.evidence.source_file_paths` from the same field, so something is re-stamping it). The investigation surface includes: where the Maven reader sets source-file-paths; whether there's a path-normalization pass running between CDX and SPDX 3 emission; whether the image-extract tempdir leaks via a fallback. Doing the diagnosis correctly is more valuable than rushing a one-line patch that masks the wrong root cause.
+
+**Independent Test**: Scan the `polyglot-builder-image` test fixture (or any image-extraction scan with Maven deps), emit both CDX and SPDX 3, and `diff <(jq '.components[] | select(.purl | startswith("pkg:maven/")) | {purl, src: [.properties[]? | select(.name == "mikebom:source-files") | .value]}' cdx.json) <(jq '.["@graph"][] | select(.software_packageUrl? | startswith("pkg:maven/")) | {purl: .software_packageUrl, src: .["mikebom:source-files"]}' spdx3.json)`. The diff MUST be empty.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scan of `polyglot-builder-image` that produces at least one Maven dep component with `mikebom:source-files` populated, **When** CDX and SPDX 3 outputs are compared component-by-component, **Then** the `mikebom:source-files` value matches exactly (same array of strings, same order).
+2. **Given** the value is the JAR file path relative to the scan rootfs (e.g., `root/.m2/repository/.../surefire-booter-3.2.2.jar`), **When** the SPDX 3 output is emitted, **Then** it carries that same value — NOT the image-extraction tempdir path (`private/var/folders/.../mikebom-image-AylYTd/rootfs`).
+3. **Given** the diagnosis phase identifies the per-emitter mutation site, **When** the fix lands, **Then** a unit test reproduces the original divergence (e.g., constructs a synthetic `ResolvedComponent` with a known source-file path, runs both emitters, asserts both produce the same output value).
+4. **Given** the parity catalog row C18 (`mikebom:source-files`, `Directionality::SymmetricEqual`), **When** the parity check runs on a `polyglot-builder-image`-shaped fixture, **Then** zero `Y | - | Y` and zero value-drift findings remain.
+
+---
+
+### Edge Cases
+
+- **Empty file-paths list** (US1) — `paths.is_empty() == true`: today the conditional at `file_tier/mod.rs:232` guards on `Ok(file_paths_json)` from `serde_json::to_string(&paths_str)`, which always succeeds for an empty Vec. The fix must still emit the empty-array `[]` (NOT a `Value::Null`, NOT a string `"[]"`), matching the existing test at line 405 that parses the field.
+- **Path with embedded quote characters** (US1) — a file path containing `"` must be properly quoted inside the JSON array shape. Native-array emission delegates this to `serde_json`'s `Value::Array` serializer; the stringified-array shape today also delegates but at two levels. Both must produce identical wire bytes after round-trip; verify the wire encoding via byte-identity goldens.
+- **`LifecycleScope::Runtime`** (US2) — the SPDX 2.3 emitter at `annotations.rs:233` deliberately returns `None` for Runtime (it's the default; no annotation needed). The SPDX 3 fix MUST preserve this same omission — emit the annotation ONLY for `Development` / `Build` / `Test`, NOT for `Runtime`.
+- **`include_source_files = false`** (US3) — both emitters already gate on this flag (`annotations.rs:302` + `v3_annotations.rs:267`). The fix MUST preserve the gate; the value-drift only matters when the annotation is being emitted at all.
+- **Components with empty `source_file_paths`** (US3) — both emitters skip emission today; this must remain unchanged.
+- **Maven dep ALSO appearing as a file-tier component** (cross-US interaction) — file-tier and Maven readers can both observe the same JAR file. If milestone-133 dedup leaves both representations, US1's `file-paths` fix and US3's `source-files` alignment apply to different annotations on different (or the same, post-dedup) components. No conflict.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The file-tier reader (`mikebom-cli/src/scan_fs/file_tier/mod.rs`) MUST emit the `mikebom:file-paths` annotation value as a native JSON array of strings (e.g., `["usr/sbin/losetup", "usr/sbin/mount"]`), NOT as a JSON-string-encoding of that array (e.g., `"[\"usr/sbin/losetup\"]"`).
+- **FR-002**: The fix MUST preserve the existing sort-stable ordering, the `FILE_PATHS_CAP` truncation behavior, and the `mikebom:file-paths-truncated = "true"` sidecar annotation (these are orthogonal correctness invariants; only the value-shape changes).
+- **FR-003**: The existing file-tier unit test at `file_tier/mod.rs:398-405` (which parses the value as a string via `serde_json::from_str`) MUST be updated to parse the value as a native array via `serde_json::from_value(value.clone())` or direct iteration.
+- **FR-004**: The fix MUST be observable in CDX 1.6, SPDX 2.3, and SPDX 3 outputs simultaneously — all three downstream emitters consume the same `extra_annotations` BTreeMap, so a single fix at the constructor site satisfies cross-format invariance.
+- **FR-005**: The SPDX 3 emitter (`mikebom-cli/src/generate/spdx/v3_annotations.rs` or a sibling file in `mikebom-cli/src/generate/spdx/`) MUST emit the `mikebom:lifecycle-scope` annotation for every component whose `ResolvedComponent.lifecycle_scope` is `Some(LifecycleScope::Development | Build | Test)`, with the same value strings (`"development"`, `"build"`, `"test"`) the SPDX 2.3 emitter uses today at `annotations.rs:227-236`.
+- **FR-006**: The SPDX 3 emitter MUST omit the annotation when `lifecycle_scope == Some(LifecycleScope::Runtime)` (matching SPDX 2.3's existing behavior — `Runtime` is the default, no annotation needed).
+- **FR-007**: The SPDX 3 emitter MUST omit the annotation when `lifecycle_scope == None` (matching SPDX 2.3's existing behavior).
+- **FR-008**: For US3, the milestone MUST include a diagnostic phase that identifies the specific code site responsible for the per-emitter `mikebom:source-files` value drift on Maven deps in image-extraction scans. The diagnostic finding MUST be documented in the milestone's research artifact before any code fix lands.
+- **FR-009**: After US3's diagnostic phase identifies the mutation site, the fix MUST make `mikebom:source-files` carry the same value in CDX and SPDX 3 outputs of the same scan, for every Maven dep component on the `polyglot-builder-image` (and equivalent image-extraction fixtures). The canonical value SHOULD be the JAR file path relative to the rootfs (matching CDX today), UNLESS the diagnostic phase surfaces a compelling reason to canonicalize on the absolute path instead — in which case the spec is updated and CDX is brought into alignment with SPDX 3 rather than the other way around.
+- **FR-010**: All existing byte-identity SBOM golden tests that capture the pre-fix shape of `mikebom:file-paths` (stringified-array) and the pre-fix absence of `mikebom:lifecycle-scope` in SPDX 3 MUST be refreshed in the same PR. The refresh diffs MUST be limited to the wire-shape changes named above; no unrelated golden drift.
+- **FR-011**: All changes MUST preserve Constitution Principle V (standards-native > `mikebom:*`) — no new `mikebom:*` annotations are introduced; the milestone only fixes how three EXISTING annotations are emitted.
+
+### Key Entities
+
+- **`mikebom:file-paths` annotation** — Per-component annotation set by the file-tier reader (`file_tier/mod.rs`). Value is the sorted list of file paths that hash to the same SHA-256 (the file-tier component identity). Pre-145: emitted as `Value::String("[\"path1\",\"path2\"]")`. Post-145: emitted as `Value::Array([String("path1"), String("path2")])`. Sidecar `mikebom:file-paths-truncated = "true"` (unchanged) appears when the list was capped at `FILE_PATHS_CAP`.
+- **`mikebom:lifecycle-scope` annotation** — Per-component annotation set by per-ecosystem readers (npm, maven, pip, cargo, gradle, etc.) for components marked as dev / build / test / runtime scope. Pre-145: emitted in CDX + SPDX 2.3, omitted in SPDX 3. Post-145: emitted in all three formats with consistent value strings (`"development"`, `"build"`, `"test"`; omitted for `"runtime"` per existing convention).
+- **`mikebom:source-files` annotation** — Per-component annotation set from `ResolvedComponent.evidence.source_file_paths` listing the manifest/file paths that contributed to the component's identity. Pre-145: per-emitter value drift on Maven deps in image-extraction scans. Post-145: identical values across CDX and SPDX 3 for the same component on the same scan.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001** (US1): After this milestone, the sbom-conformance harness reports **zero `mikebom:file-paths` value-shape findings** in its CFI bucket (down from 3,112). Verifiable by running the harness against an emitted SBOM and grepping for the file-paths cluster.
+- **SC-002** (US1): A unit test in `file_tier/mod.rs#mod tests` (or sibling) constructs a synthetic file-tier component with at least one path, runs it through `into_resolved_component()`, and asserts that the `extra_annotations.get("mikebom:file-paths").unwrap()` is a `serde_json::Value::Array` (NOT `Value::String`).
+- **SC-003** (US1): Byte-identity golden tests for the file-tier emission cases (CDX + SPDX 2.3 + SPDX 3 — likely the existing golden tests under `mikebom-cli/tests/fixtures/golden/` that exercise image-scan fixtures with file-tier components) are refreshed; the diffs show ONLY the `mikebom:file-paths` value-shape change (single grep-able pattern: `"value": "[..."` → `"value": [...`).
+- **SC-004** (US2): After this milestone, the sbom-conformance harness reports **zero `Y | Y | -` findings for `mikebom:lifecycle-scope`** (down from 261). Verifiable on the `node-dev-vs-prod` fixture or equivalent.
+- **SC-005** (US2): A unit test in `mikebom-cli/src/generate/spdx/v3_annotations.rs#mod tests` (creating the test module if it doesn't exist) constructs a synthetic `ResolvedComponent` with `lifecycle_scope = Some(LifecycleScope::Development)`, runs the SPDX 3 annotation builder, and asserts the emitted JSON-LD contains `mikebom:lifecycle-scope` with value `"development"`. A second test asserts the annotation is OMITTED when `lifecycle_scope = Some(LifecycleScope::Runtime)`.
+- **SC-006** (US2): Byte-identity golden tests that include components with non-Runtime `lifecycle_scope` (the SPDX 3 emission goldens specifically) are refreshed; CDX and SPDX 2.3 goldens are unchanged.
+- **SC-007** (US3): The milestone's research artifact (`research.md`) MUST include a §titled "C — `mikebom:source-files` per-emitter drift diagnosis" naming the specific function and approximate line number where the per-emitter value mutation occurs, with a reproduction case.
+- **SC-008** (US3): After this milestone, the sbom-conformance harness reports **zero value-drift findings for `mikebom:source-files`** on `polyglot-builder-image` (down from 51).
+- **SC-009** (US3): A unit or integration test constructs a synthetic scan that triggers the per-emitter drift, runs both CDX and SPDX 3 emitters, and asserts byte-equivalent `mikebom:source-files` values.
+- **SC-010**: `cargo +stable clippy --workspace --all-targets -- -D warnings` and `cargo +stable test --workspace` both pass clean — i.e., `./scripts/pre-pr.sh` exits 0 (excepting the pre-existing local sbomqs_parity env-only failure documented in milestone 144's T001).
+- **SC-011**: Across the three user stories, cumulative cross-format-invariance findings drop by ≥3,424 (the combined 3,112 + 261 + 51 from the 2026-06-26 audit).
+- **SC-012**: No regression in CFI findings outside the three target clusters. Verifiable via a before/after harness run on the same fixture set.
+
+## Assumptions
+
+- **The 2026-06-26 audit numbers (3,112 + 261 + 51) are stable across re-runs of the same harness against the same fixture set.** Confirmed for `file-paths` and `lifecycle-scope` (the underlying defects are deterministic emission-shape issues). The `source-files` 51 count was reported as a +43 delta from the previous run — possible measurement variance, but the underlying defect (per-emitter value drift) is real and code-confirmed.
+- **The file-paths value-shape change is a wire-output break for any downstream tool that parses the value as a JSON-string-encoded array.** Such tools would need to update to parse it as a native array. We accept this break because (a) the stringified shape was never documented as the contract; (b) every other array-valued mikebom annotation already uses the native shape; (c) the affected file-tier components are a milestone-133-era addition (~6 months) — no long-standing consumer can have grown around the wrong shape.
+- **The SPDX 3 lifecycle-scope addition is purely additive — no SPDX 3 consumer can break by GAINING an annotation that wasn't there before.** Adding the field cannot regress any document-level conformance test (it's a `mikebom:*` annotation, not a standard SPDX 3 field; addition is in the structured-properties bag).
+- **Both emitters consume the same `ResolvedComponent.evidence.source_file_paths`.** Code-confirmed (`annotations.rs:306` + `v3_annotations.rs:271`). Therefore the per-emitter drift MUST come from a re-stamping site between scan-orchestrator output and SPDX 3 emission. The diagnosis phase (FR-008) will identify whether it's a path-normalization pass, a component clone-and-mutate, or an image-extract tempdir leak — all three are plausible.
+- **The canonical value choice for `mikebom:source-files` is the rootfs-relative JAR path.** This matches CDX's current behavior and aligns with how every other ecosystem reader (apk, dpkg, npm, etc.) records source paths. If the diagnostic phase surfaces a compelling reason to canonicalize on the absolute path, the spec MUST be updated to reflect that; this assumption is conditionally accepted pending diagnosis.
+- **No new Cargo dependencies needed.** All three fixes are touch-existing-emitter changes; no new crates introduced.
+- **The sbom-conformance harness is the audit oracle.** This spec's SC-001 / SC-004 / SC-008 are framed in terms of harness-reported finding counts; verification requires re-running the harness post-fix. Local unit-tests (SC-002 / SC-005 / SC-009) provide code-level guards in the CI signal independent of harness availability.
+- **Constitution Principle V (standards-native > `mikebom:*`) is preserved.** All three annotations affected (file-paths, lifecycle-scope, source-files) are EXISTING `mikebom:*` properties — already audited at their introducing milestones (133 for file-paths, 049/052 for lifecycle-scope, 005-era for source-files). This milestone fixes their emission, not their existence.
+
+## Out of Scope
+
+- The image-pseudo-component absent-from-spdx-json gap (2 cases on `go-vcs-buildinfo`, the audit's item #3). Smaller impact, distinct code area (image-component emission), deferred.
+- The `mikebom:sbom-tier` per-component disagreement on Maven shaded/transitive deps (4-5 cases on `polyglot-builder-image`, the audit's item #4 including the `plexus-archiver` +1 delta). Distinct from US3's drift (sbom-tier is a STRING value disagreement, not a path-stamping drift). Deferred.
+- New `mikebom:*` annotations.
+- Restructuring of `extra_annotations`'s `BTreeMap<String, Value>` representation (the value-shape mismatch in US1 is fixable at the constructor; changing the type is unnecessary).
+- The 3,112-finding `<component-presence>` cluster from the previous audit run — collapsed to 2 in this run after the harness's own detector patch. Not a mikebom issue.
+- Performance optimization of file-tier emission (the milestone touches one constructor; no perf-budget change).
+- Any change to how `ResolvedComponent.evidence.source_file_paths` is POPULATED by the Maven reader — US3's diagnosis may surface a population-time issue, in which case the FIX may need to land in the Maven reader; this is scope-bounded by the diagnostic phase.

--- a/specs/145-annotation-parity-fixes/tasks.md
+++ b/specs/145-annotation-parity-fixes/tasks.md
@@ -1,0 +1,311 @@
+---
+description: "Task list for milestone 145 — annotation-emission parity fixes from sbom-conformance audit (2026-06-26)"
+---
+
+# Tasks: milestone 145 — annotation-emission parity fixes
+
+**Input**: Design documents from `/specs/145-annotation-parity-fixes/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+**Tests**: Spec mandates tests via SC-002 + SC-005 + SC-009 + SC-010. Test tasks are included inline alongside implementation tasks (per the project's existing Rust convention of in-file `#[cfg(test)] mod tests`).
+
+**Organization**: Tasks are grouped by user story. The three stories are largely independent — US1 touches `file_tier/mod.rs`, US2 touches `spdx/v3_annotations.rs`, US3 touches the source-files dedup at 4 sites. No foundational types or signature plumbing required (zero new types per data-model.md).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Maps to user story from spec.md (US1, US2, US3)
+- Paths are absolute under `/Users/mlieberman/Projects/mikebom/`
+
+## Path Conventions
+
+All paths are absolute under repository root `/Users/mlieberman/Projects/mikebom/`. The single Cargo crate touched is `mikebom-cli/`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify baseline before any code change.
+
+- [X] T001 Confirm baseline pre-PR gate is green on branch `145-annotation-parity-fixes`. Run `./scripts/pre-pr.sh` from repo root. Expected: clippy `--workspace --all-targets -- -D warnings` clean; `cargo test --workspace` passes except for the pre-existing local-environment `sbomqs_parity::sbomqs_spdx_score_meets_or_beats_cdx_across_ecosystems` failure documented in milestone-144 T001. If anything ELSE fails, halt and investigate before proceeding.
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: None required for this milestone. All three user stories are independent and touch disjoint code (US1 → file-tier reader, US2 → SPDX 3 emitter, US3 → source-files dedup sites). The parity catalog rows C18 / C42 / C92 already exist from milestone 071. Zero new types, zero new Cargo dependencies (per data-model.md).
+
+(No tasks in this phase. Proceed directly to Phase 3.)
+
+---
+
+## Phase 3: User Story 1 - `mikebom:file-paths` is emitted as a native JSON array (Priority: P1) 🎯 MVP
+
+**Goal**: Replace the `serde_json::to_string` round-trip at `file_tier/mod.rs:233` so `extra_annotations["mikebom:file-paths"]` holds a `Value::Array` instead of `Value::String`.
+
+**Independent Test**: Build a synthetic file-tier component with one path, call `into_resolved_component()`, assert the `mikebom:file-paths` value is `Value::Array`. Then scan any image-fixture, emit SPDX 2.3, and grep for `"value":"["` followed by `"` — should be zero matches (the value is now a native array, not a quoted-string-of-array).
+
+### Implementation for User Story 1
+
+- [X] T002 [US1] Edit `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/file_tier/mod.rs` line 232-234. Replace:
+
+  ```rust
+  if let Ok(file_paths_json) = serde_json::to_string(&paths_str) {
+      extra_annotations.insert(FILE_PATHS_KEY.to_string(), json!(file_paths_json));
+  }
+  ```
+
+  with:
+
+  ```rust
+  extra_annotations.insert(FILE_PATHS_KEY.to_string(), json!(paths_str));
+  ```
+
+  Per research §A, the `if let Ok(...)` defensive shape is unnecessary because `serde_json::to_string(&Vec<String>)` always succeeds; dropping it is both shorter and correct. Also update the doc-comment at line 190 from "`mikebom:file-paths = <JSON-encoded-sorted-array>`" to "`mikebom:file-paths = <sorted JSON array of paths>` (native array, not JSON-string-encoded; milestone 145 US1)".
+
+- [X] T003 [US1] Update the existing unit test at `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/file_tier/mod.rs:398-410` (the test that parses `mikebom:file-paths` via `serde_json::from_str`). Change the parse logic from `serde_json::from_str(fp).expect("file-paths JSON parses")` to direct array iteration. Concrete shape:
+
+  ```rust
+  let fp = c.extra_annotations.get("mikebom:file-paths")
+      .expect("file-paths annotation present");
+  let parsed: Vec<String> = fp.as_array()
+      .expect("file-paths is array (milestone 145 US1)")
+      .iter()
+      .map(|v| v.as_str().expect("path is string").to_string())
+      .collect();
+  ```
+
+  Preserve every other assertion in that test (sort order, cap behavior, truncation flag).
+
+- [X] T004 [P] [US1] New unit test in the same `#[cfg(test)] mod tests` block at `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/file_tier/mod.rs`. Test name: `mikebom_file_paths_is_native_array_not_stringified`. Constructs a synthetic file-tier component with one path, calls `into_resolved_component()`, asserts `extra_annotations["mikebom:file-paths"].is_array()` is `true` (NOT `is_string()`). Covers SC-002 directly.
+
+- [X] T005 [US1] Refresh affected SPDX 2.3 + SPDX 3 byte-identity goldens that contain file-tier components. Run:
+
+  ```bash
+  MIKEBOM_UPDATE_SPDX_GOLDENS=1 cargo test --test spdx_regression
+  MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo test --test spdx3_regression
+  ```
+
+  Verify (via `git diff --stat mikebom-cli/tests/fixtures/golden/`) that diffs are limited to the file-paths shape change. Expected diff pattern per affected line: `"value":"[\\\"...\\\"]"` → `"value":[\"...\"]`. Reject any unrelated golden drift. CDX goldens are NOT expected to change (per contracts/file-paths-shape.md — CDX `properties[].value` is spec-typed `xs:string` so wire bytes stay identical).
+
+**Checkpoint**: After Phase 3, US1 is fully functional. `cargo +stable test --workspace` passes; new test fires green; SPDX 2.3 + SPDX 3 goldens reflect the native-array shape. Manual smoke: scan any image-fixture and confirm no `"value":"[" → quoted-string-of-array entries in the SPDX outputs.
+
+---
+
+## Phase 4: User Story 2 - `mikebom:lifecycle-scope` emitted in SPDX 3 (Priority: P1)
+
+**Goal**: Add a new emission branch in `spdx/v3_annotations.rs` mirroring the SPDX 2.3 sibling at `annotations.rs:227-236`. Emit for `Development`/`Build`/`Test` scopes; omit for `Runtime` and `None`.
+
+**Independent Test**: Construct a synthetic `ResolvedComponent` with `lifecycle_scope = Some(LifecycleScope::Development)`, run it through the SPDX 3 annotation builder, assert the resulting JSON-LD contains `mikebom:lifecycle-scope` with value `"development"`. Construct a second with `Some(Runtime)` and assert NO `mikebom:lifecycle-scope` annotation is present.
+
+### Implementation for User Story 2
+
+- [X] T006 [US2] Add the new emission branch to `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/generate/spdx/v3_annotations.rs`. Insert after the existing `mikebom:raw-version` push (around line 263-265). Use the exact pattern from `contracts/lifecycle-scope-emission.md` §Insertion location:
+
+  ```rust
+  // C42 mikebom:lifecycle-scope — parity-bridging annotation mirroring
+  // the SPDX 2.3 sibling at annotations.rs:227-236 (milestone 145 US2).
+  // CDX and SPDX 2.3 both emit this annotation for non-Runtime scopes;
+  // SPDX 3 was the pre-145 outlier.
+  if let Some(ref scope) = c.lifecycle_scope {
+      use mikebom_common::resolution::LifecycleScope;
+      let s = match scope {
+          LifecycleScope::Development => Some("development"),
+          LifecycleScope::Build => Some("build"),
+          LifecycleScope::Test => Some("test"),
+          LifecycleScope::Runtime => None,
+      };
+      if let Some(s) = s {
+          push(out, "mikebom:lifecycle-scope", json!(s));
+      }
+  }
+  ```
+
+  Verify the `push` helper and `out` parameter names match the existing pattern at this site (use the same names the surrounding code uses).
+
+- [X] T007 [P] [US2] New unit test in `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/generate/spdx/v3_annotations.rs#[cfg(test)] mod tests` (create the test module if it doesn't exist, with `#[cfg_attr(test, allow(clippy::unwrap_used))]` per the existing project convention). Test name: `spdx3_lifecycle_scope_development_emits`. Constructs a synthetic `ResolvedComponent` with `lifecycle_scope = Some(LifecycleScope::Development)`, runs the SPDX 3 annotation builder, asserts the emitted annotations include `mikebom:lifecycle-scope` with value `"development"`. Covers SC-005 (first half).
+
+- [X] T008 [P] [US2] New unit test in the same `mod tests`. Test name: `spdx3_lifecycle_scope_runtime_omitted`. Constructs `lifecycle_scope = Some(LifecycleScope::Runtime)`, runs the builder, asserts NO `mikebom:lifecycle-scope` annotation is present in the output. Covers SC-005 (second half) + FR-006.
+
+- [X] T009 [P] [US2] New unit test in the same `mod tests`. Test name: `spdx3_lifecycle_scope_none_omitted`. Constructs `lifecycle_scope = None`, runs the builder, asserts NO `mikebom:lifecycle-scope` annotation is present. Covers FR-007.
+
+- [X] T010 [US2] Refresh affected SPDX 3 byte-identity goldens. Run:
+
+  ```bash
+  MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo test --test spdx3_regression
+  ```
+
+  Verify (via `git diff --stat mikebom-cli/tests/fixtures/golden/spdx-3/`) that diffs are limited to NEW `mikebom:lifecycle-scope` annotations on non-Runtime-scoped components in fixtures that have them (likely `npm.spdx3.json` and similar). CDX and SPDX 2.3 goldens are NOT expected to change.
+
+**Checkpoint**: After Phase 4, US2 is fully functional. The three new unit tests fire green; SPDX 3 goldens for fixtures with dev/build/test-scoped components reflect the new annotation. Manual smoke: scan `node-dev-vs-prod` (or equivalent npm dev-dep fixture), emit SPDX 3, count `mikebom:lifecycle-scope=development` annotations; should match the CDX count.
+
+---
+
+## Phase 5: User Story 3 - `mikebom:source-files` cross-format value parity (Priority: P2)
+
+**Goal**: Eliminate the double-emission of `mikebom:source-files` (field-derived + Maven-stamped via `extra_annotations`) so all three emitters produce byte-equivalent values per component on the same scan.
+
+**Independent Test**: Scan the `polyglot-builder-image` fixture (or equivalent), emit both CDX and SPDX 3, extract `mikebom:source-files` per Maven dep, diff. Post-fix diff MUST be empty.
+
+### Implementation for User Story 3
+
+- [X] T011 [US3] Reproduce the per-emitter drift on the `polyglot-builder-image` fixture. Locate the fixture path (likely under `mikebom-cli/tests/fixtures/` or fetched via the milestone-090 cache). Scan it with `cargo run -p mikebom -- sbom scan --path <fixture> --format cyclonedx-json --format spdx-3-json --output cyclonedx-json=/tmp/m.cdx.json --output spdx-3-json=/tmp/m.spdx3.json`. Inspect the emitted SBOMs to confirm the double-emission: each affected Maven component carries `mikebom:source-files` TWICE in at least one format (one entry from the field, one from `extra_annotations`). Document the reproduction in a new section of `/Users/mlieberman/Projects/mikebom/specs/145-annotation-parity-fixes/research.md` named "§C.1 — fixture reproduction (milestone 145 implement phase)". Record: which fixture, which 1-3 example component PURLs exhibit the drift, the exact two values that surface, and which entry the parity-extractor picks per format.
+
+- [X] T012 [US3] Based on T011's reproduction, **choose between Option 1 (emitter-side dedup guard) and Option 2 (Maven reader stops stamping)** per contracts/source-files-dedup.md. Default to applying BOTH (defense-in-depth) unless T011 surfaces a reason one alone is sufficient. Record the choice in research §C.1.
+
+- [X] T013 [US3] **Option 1 work** (emitter-side guard, if chosen). Add a helper `fn is_field_owned_annotation_key(key: &str) -> bool` returning `true` for `"mikebom:source-files"` at a shared location accessible from all three emitters — recommend `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/generate/root_selector.rs` (next to the existing `is_internal_emission_key` helper). Then update the three `extra_annotations` iteration sites:
+  - `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/generate/cyclonedx/builder.rs:1086-1098`
+  - `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/generate/spdx/annotations.rs:371`
+  - `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/generate/spdx/v3_annotations.rs:332-337`
+
+  At each, extend the existing `is_internal_emission_key` skip condition to ALSO skip `is_field_owned_annotation_key(key)`. Pattern:
+
+  ```rust
+  for (key, value) in &c.extra_annotations {
+      if root_selector::is_internal_emission_key(key)
+          || root_selector::is_field_owned_annotation_key(key) {
+          continue;
+      }
+      // existing emission ...
+  }
+  ```
+
+- [X] T014 [US3] **Option 2 work** (Maven reader stop-stamping, if chosen). In `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/package_db/maven.rs:2244`, EITHER (a) drop the `mikebom:source-files` key stamping entirely (the field-derived emission already covers it via the orchestrator's `entry.source_path` normalization), OR (b) rename the key to `mikebom:source-files-nested-url` to preserve the JAR-URL `!`-syntax value under a non-colliding annotation key. Recommend (b) for information preservation. Update the doc-comment on the nested-JAR reader function (lines 1310-1320) to reflect the new key name.
+
+- [X] T015 [US3] Add doc-comments at the field-setter sites preventing recurrence. At `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/mod.rs:198` and `:636` (both invocations of `normalize_sbom_path_relative` populating `source_file_paths`), add the comment from contracts/source-files-dedup.md §Doc-comment additions:
+
+  ```rust
+  // NOTE (milestone 145): `mikebom:source-files` has TWO emission sources —
+  // this field (canonical) AND `extra_annotations["mikebom:source-files"]`
+  // (legacy, dedup'd at emit time). DO NOT stamp the latter from a new
+  // reader; if you need to carry per-reader source provenance, use a
+  // distinct key like `mikebom:<reader>-source-url`.
+  ```
+
+  Also add the same comment at `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/package_db/maven.rs:2244` (whether T014 picks option (a) or (b), the comment serves future readers).
+
+- [X] T016 [P] [US3] New integration test in `/Users/mlieberman/Projects/mikebom/mikebom-cli/tests/source_files_parity_md145.rs`. Test name: `mikebom_source_files_byte_equivalent_across_emitters_for_maven_nested_jar`. Constructs a synthetic Maven component with BOTH `evidence.source_file_paths = ["root/.m2/.../foo.jar"]` AND `extra_annotations["mikebom:source-files"] = "root/.m2/.../foo.jar!META-INF/MANIFEST.MF"` (pre-145 double-source shape). Runs the component through each of the three emitters (CDX builder, SPDX 2.3 annotation builder, SPDX 3 annotation builder — use whichever public-test-friendly helpers exist; if none, expose `pub(crate)` shims for testing). Extracts the `mikebom:source-files` value(s) from each emitter's output. Asserts:
+  1. ONLY ONE `mikebom:source-files` entry per format (the dedup invariant from contracts/source-files-dedup.md).
+  2. The surviving entry's VALUE is byte-equivalent across all three formats.
+
+- [X] T017 [P] [US3] If T014 chose option (b) — renamed key to `mikebom:source-files-nested-url` — add a unit test in `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/package_db/maven.rs#[cfg(test)] mod tests` (or co-located) asserting that nested-JAR detection still emits the JAR-URL `!`-notation value, just under the new key. Test name: `maven_nested_jar_url_emitted_under_renamed_key_md145`.
+
+- [X] T018 [US3] Refresh affected goldens. The scope depends on whether the affected Maven fixtures appear in the existing golden-test set. Run all three update vars and inspect:
+
+  ```bash
+  MIKEBOM_UPDATE_CDX_GOLDENS=1 cargo test --test cdx_regression
+  MIKEBOM_UPDATE_SPDX_GOLDENS=1 cargo test --test spdx_regression
+  MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo test --test spdx3_regression
+  ```
+
+  Verify (via `git diff --stat`) that diffs are limited to (a) suppression of the duplicate `mikebom:source-files` entry per Maven component, plus (b) IF T014 chose option (b), the new `mikebom:source-files-nested-url` entries on affected Maven components. Reject any unrelated drift.
+
+**Checkpoint**: After Phase 5, US3 is fully functional. The scan-and-diff verification from the story's Independent Test produces an empty diff between CDX and SPDX 3 `mikebom:source-files` values on Maven deps. The new integration test fires green. Manual smoke per quickstart §Scenario 3.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validation, doc updates, harness re-run preparation, pre-PR gate, commit.
+
+- [X] T019 [P] Refresh the parity-catalog test expectations if they hardcoded the pre-145 finding patterns. Likely sites: tests under `mikebom-cli/tests/` that exercise the C18/C42/C92 parity rows. Grep first: `grep -rn 'C18\|C42\|C92\|mikebom:file-paths\|mikebom:lifecycle-scope\|mikebom:source-files' mikebom-cli/tests/`. If any existing tests assert on the pre-145 shape, update them.
+
+- [X] T020 Run quickstart.md verification scenarios locally:
+  1. Scenario 1: `mikebom:file-paths` shape verification — pick any image-like fixture, scan with `--format spdx-2.3-json`, confirm the jq query returns `"array"` not `"string"`.
+  2. Scenario 2: `mikebom:lifecycle-scope` SPDX 3 emission — if `node-dev-vs-prod` or similar npm dev-dep fixture is accessible, scan it with `--format cyclonedx-json --format spdx-3-json`, confirm dev-component counts match between the two formats.
+  3. Scenario 3: `mikebom:source-files` parity on Maven deps — if `polyglot-builder-image` is accessible, scan with both formats, confirm empty diff per the documented jq pipeline.
+
+  Document which scenarios passed locally and which require operator-supplied fixtures.
+
+- [X] T021 Run mandatory pre-PR gate per Constitution Development Workflow + memory `feedback_prepr_gate_full_output.md`: `./scripts/pre-pr.sh` from repo root. Both clippy + test steps MUST pass clean (except the pre-existing `sbomqs_parity` env-only failure documented in milestone-144 T001 — CI will validate). If any OTHER test fails, scan the FULL output (do NOT grep on `^test result: FAILED` — that filter is known to drop multi-test-suite summaries). Covers SC-010.
+
+- [ ] T022 Commit the milestone-145 changes. Per the project's spec-→plan-→tasks-→impl convention from milestone-134/144, suggested commit chain:
+  - `spec(145): annotation-emission parity fixes from sbom-conformance audit (2026-06-26)` — spec.md + checklists/requirements.md
+  - `plan(145): annotation parity fixes — plan + research + data-model + contracts + quickstart` — plan + research + data-model + contracts/ + quickstart + CLAUDE.md
+  - `tasks(145): N tasks across M phases for annotation parity fixes` — tasks.md
+  - `impl(145): mikebom:file-paths native-array shape + mikebom:lifecycle-scope SPDX 3 emission + mikebom:source-files dedup` — code files + golden refreshes
+
+  Do NOT commit until T021 passes clean. Use `git add <specific paths>` (never `-A`); each commit ends with the standard `Co-Authored-By` trailer.
+
+- [X] T023 [P] Per spec SC-001 / SC-004 / SC-008 (harness-finding-count verification, operator cadence): document in the PR description that the operator should re-run the sbom-conformance harness against pre-/post-145 builds to confirm the cumulative ≥3,424 CFI finding reduction (3,112 file-paths + 261 lifecycle-scope + 51 source-files). The harness is NOT a CI gate (per research §D); the in-tree tests added by T004 / T007 / T008 / T009 / T016 are the CI-binding signal.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies. Verifies baseline.
+- **Phase 2 (Foundational)**: EMPTY (no foundational work required for this milestone).
+- **Phase 3 (US1)**: Depends on Phase 1. Independent of US2/US3.
+- **Phase 4 (US2)**: Depends on Phase 1. Independent of US1/US3.
+- **Phase 5 (US3)**: Depends on Phase 1. Includes a reproduce-first step (T011) that gates the choice of fix path (T012 → T013/T014).
+- **Phase 6 (Polish)**: Depends on US1+US2+US3 being functionally complete (or whichever subset is being shipped as MVP).
+
+### User Story Dependencies
+
+- **US1 (P1, MVP)**: Standalone after Phase 1. Delivers the largest single audit-finding reduction (3,112).
+- **US2 (P1)**: Standalone after Phase 1. Delivers 261 findings.
+- **US3 (P2)**: Standalone after Phase 1. Requires reproduce-first step (T011) before fix can land (T012-T018). 51 findings.
+
+### Within Each User Story
+
+- T002 (US1 code) MUST land before T003 (US1 test update) — but T004 (new US1 test) can land in parallel with T002 since it's a different test function.
+- T006 (US2 emission code) MUST land before T007/T008/T009 (US2 tests) — but the tests don't conflict with each other and can land in parallel after T006.
+- T011 (US3 reproduce) MUST land before T012 (decision), which gates T013/T014/T015. T016/T017 are the tests and can land in parallel with the code once T011 + T012 settle.
+
+### Parallel Opportunities
+
+- Within US1: T004 [P] runs independently of T002.
+- Within US2: T007/T008/T009 [P] all run in parallel after T006.
+- Within US3: T016/T017 [P] run in parallel after T013/T014 land.
+- Across phases (single-developer feasibility): one developer typically works through Phase 3 → 4 → 5 sequentially. A multi-developer team could split: Dev A → US1 (Phase 3), Dev B → US2 (Phase 4), Dev C → US3 (Phase 5). The polish phase (T019-T023) is sequential at the end.
+
+---
+
+## Parallel Example: US2
+
+```bash
+# After T006 (code change) lands sequentially:
+Task T007: spdx3_lifecycle_scope_development_emits — new unit test
+Task T008: spdx3_lifecycle_scope_runtime_omitted — new unit test
+Task T009: spdx3_lifecycle_scope_none_omitted — new unit test
+```
+
+(All three tests are in the same `mod tests` block; they can be added in one editor pass and don't conflict with each other.)
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only — biggest ROI by an order of magnitude)
+
+1. Complete Phase 1: T001 baseline check.
+2. Complete Phase 3: T002 → T003 → T004 → T005 — the file-paths shape fix lands.
+3. **STOP and VALIDATE**: `./scripts/pre-pr.sh` clean. Quickstart §Scenario 1 confirms native-array shape.
+4. This alone is a shippable PR if US2/US3 need to be sequenced separately. Clears 3,112 of the 3,424 audit findings (91% of the cleanup ROI).
+
+### Incremental (recommended for this milestone)
+
+1. Phase 1 (T001) baseline.
+2. Phase 3 (US1) — file-paths shape fix lands.
+3. Phase 4 (US2) — SPDX 3 lifecycle-scope emission lands.
+4. Phase 5 (US3) — source-files dedup lands (after reproduce-first step).
+5. Phase 6 (T019-T023) — polish + commit.
+
+All in a single PR is the intended shape per the spec's framing of all three as one milestone (audit-derived cleanup).
+
+### Single-developer Note
+
+This milestone is small enough that one developer can work through all three stories in one session. The [P] markers exist primarily to signal "no cross-file write conflict" for the tests within each story.
+
+---
+
+## Notes
+
+- Tests live in-file under `#[cfg(test)] mod tests` per the project's existing convention. The one out-of-source test is the US3 integration test (T016) at `mikebom-cli/tests/source_files_parity_md145.rs`.
+- The `#[cfg_attr(test, allow(clippy::unwrap_used))]` convention applies to any new `mod tests` block per Constitution Principle IV.
+- Memory `feedback_prepr_gate_full_output.md` is directly relevant: when verifying T021, scan the FULL output rather than greping on `^test result: FAILED`.
+- Memory `feedback_dont_dismiss_test_failures.md` is relevant if any new test failures surface: verify reproducibility before calling anything "pre-existing flake".
+- The commit-message convention (T022) follows the milestone-134/144 precedent: `spec(145):` / `plan(145):` / `tasks(145):` / `impl(145):`.
+- Harness re-run (T023) is operator-cadence, NOT CI-gating. The in-tree tests (T004 / T007 / T008 / T009 / T016) are the CI-binding signal.


### PR DESCRIPTION
## Summary

Three annotation-emission parity fixes surfaced by the 2026-06-26 sbom-conformance harness audit. Cumulative ~3,424 CFI finding reduction predicted post-merge.

- **US1 (P1, ~3,112 findings) — `mikebom:file-paths` native JSON array**: `file_tier/mod.rs:233` was emitting the value as a JSON-string-encoding of an array (`Value::String(\"[\\\"path\\\"]\")`) instead of a native JSON array. Every other array-valued `mikebom:*` annotation uses the native shape; file-paths was the lone outlier. The CDX wire shape is byte-identical pre/post 145 (CDX `properties[].value` is spec-typed `xs:string`); only SPDX 2.3 + SPDX 3 envelope values flip from stringified to native array.

- **US2 (P1, ~261 findings) — SPDX 3 `mikebom:lifecycle-scope` emission**: CDX + SPDX 2.3 both emit this annotation for non-Runtime scopes; SPDX 3 was the pre-145 outlier (`v3_packages.rs`/`v3_document.rs` had zero `lifecycle_scope` references). New emission branch in `spdx/v3_annotations.rs` mirrors the SPDX 2.3 sibling at `annotations.rs:227-236` (Development/Build/Test emit; Runtime + None omitted, matching CDX + SPDX 2.3 existing behavior).

- **US3 (P2, ~51 findings) — `mikebom:source-files` cross-format value drift**: per research §C, every component was double-stamped — once via the field-derived `c.evidence.source_file_paths` (orchestrator-normalized JAR path) AND once via the Maven nested-JAR reader's `extra_annotations` key (JAR-URL `!`-notation string). All three emitters iterated both sources, producing 2 entries per component per format with per-emitter tie-break differences → cross-format drift. Defense-in-depth two-part fix: (1) new `root_selector::is_field_owned_annotation_key` guard at the three emitter iteration sites; (2) Maven reader renames its stamped key to `mikebom:source-files-nested-url` to preserve the JAR-URL value under a non-colliding name. Recurrence-prevention doc-comments added at field-setter + Maven reader sites.

No new `mikebom:*` annotations introduced (Constitution Principle V audit complete in spec FR-011). No new Cargo dependencies. Pure additive type-level correctness improvements (Principle IV — `Value::String` → `Value::Array` distinction).

Spec docs: [`specs/145-annotation-parity-fixes/`](specs/145-annotation-parity-fixes/) — spec + plan + research + data-model + contracts (×3) + quickstart + tasks (23 tasks).

## Test plan

- [ ] CI lanes green on linux-x86_64, linux-x86_64 (--features ebpf-tracing), macos-latest, windows-latest
- [ ] CI `sbomqs_parity` passes (local failure was the same env-version drift documented in milestone-144 T001; merged PRs #466/#467 already validated identical local→CI gap resolution)
- [ ] **Operator harness re-run** (per spec SC-001/SC-004/SC-008, research §D — operator cadence, NOT CI-gated): run the sbom-conformance harness against pre-/post-145 builds. Expected:
  - 0 `mikebom:file-paths` value-shape findings (was 3,112)
  - 0 `mikebom:lifecycle-scope` `Y | Y | -` findings (was 261)
  - 0 `mikebom:source-files` cross-format value-drift findings on polyglot-builder-image Maven deps (was 51)
- [ ] CLI surface: `mikebom sbom scan` invocations unchanged (no new flags). Operator-visible changes are wire-format only.
- [ ] Spot-check `jq -r '.packages[].annotations[]? | (.comment | fromjson) | select(.field == "mikebom:file-paths") | .value | type' <emitted-spdx-2.3>` returns `"array"` not `"string"`.

## Test coverage added

| Coverage | New tests | Existing tests updated |
|---|---|---|
| `file_tier/mod.rs#mod tests` | 1 (T004 SC-002 native-array guard) | 2 (parse logic for `mikebom:file-paths`) |
| `spdx/v3_annotations.rs#mod tests` | 7 (5 lifecycle-scope variants + 1 US3 dedup invariant + 1 helper) | 0 |
| `root_selector.rs#mod tests` | 1 (`is_field_owned_annotation_key_md145`) | 0 |
| `package_db/maven.rs#mod tests` (nested-JAR) | 0 | 2 (assert renamed key + legacy key absent) |
| Integration tests (`file_tier_orphan_emit`, `alpm_file_claim_dedupe`) | 0 | 0 (CDX wire bytes preserved per contract — pass unchanged) |

Local pre-PR: clippy `--workspace --all-targets -- -D warnings` clean; 114 test suites pass. One failing suite is the pre-existing `sbomqs_parity` env-only issue (sbomqs binary version drift; CI on clean runners validates).

## Golden refresh (4 files, narrow diffs as predicted)

| File | Change |
|---|---|
| `spdx-2.3/npm.spdx.json` | 1 line: `mikebom:file-paths` value shape |
| `spdx-3/npm.spdx3.json` | 1 line: same shape change |
| `spdx-3/bazel.spdx3.json` | +8 lines: new `mikebom:lifecycle-scope` annotation |
| `spdx-3/maven.spdx3.json` | +8 lines: same (value: `"test"`) |
| CDX goldens | **Unchanged** ✓ (matches `contracts/file-paths-shape.md` prediction — CDX `properties[].value` is `xs:string`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)