### PR TITLE
fix(resolve): canonicalize evidence.source_file_paths across same-PURL entries (closes Maven nested-coord cross-format divergence)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,8 @@ Auto-generated from all feature plans. Last updated: 2026-06-28
 - N/A — pure-function dedup; no state, no caches, no persistence. (146-license-expression-dedup)
 - Rust stable (workspace toolchain inherited from milestones 001–146; no nightly required). + Existing only — `serde_json` (already pervasive in the npm reader), `BTreeMap` (already used at `package_lock.rs:166` for the existing `depends_set`), `BTreeSet` (for tracking peer-edge target uniqueness). **No new Cargo dependencies.** (147-npm-peer-edges)
 - N/A — per-scan in-process state; no persistence. (147-npm-peer-edges)
+- Rust stable (workspace toolchain inherited from milestones 001–147; no nightly required for this user-space-only work). + Existing only — `std::collections::HashMap` + `std::collections::BTreeSet` (both pervasive in the codebase, no new use). The pass operates on `mikebom_common::resolution::ResolvedComponent` (already a workspace type). **No new Cargo dependencies.** (148-source-files-union)
+- N/A — purely in-process per-scan transformation; no persistence. (148-source-files-union)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -231,9 +233,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 148-source-files-union: Added Rust stable (workspace toolchain inherited from milestones 001–147; no nightly required for this user-space-only work). + Existing only — `std::collections::HashMap` + `std::collections::BTreeSet` (both pervasive in the codebase, no new use). The pass operates on `mikebom_common::resolution::ResolvedComponent` (already a workspace type). **No new Cargo dependencies.**
 - 147-npm-peer-edges: Added Rust stable (workspace toolchain inherited from milestones 001–146; no nightly required). + Existing only — `serde_json` (already pervasive in the npm reader), `BTreeMap` (already used at `package_lock.rs:166` for the existing `depends_set`), `BTreeSet` (for tracking peer-edge target uniqueness). **No new Cargo dependencies.**
 - 146-license-expression-dedup: Added Rust stable (workspace toolchain inherited from milestones 001–145; no nightly required). + Existing only — `spdx = "0.10"` (already a workspace dep at `mikebom-common`; reused for parse + tree-walking + display). **No new Cargo dependencies.**
-- 145-annotation-parity-fixes: Added Rust stable (workspace toolchain inherited from milestones 001–144; no nightly required). + Existing only — `serde`/`serde_json` (Value construction + emission), `tracing`, `anyhow`, `thiserror`. Reuses milestone-133's `file_tier` module, milestone-005-era `evidence.source_file_paths` field, milestone-049/052's `LifecycleScope` newtype, milestone-071's parity catalog (C18 source-files, C42 lifecycle-scope, C92 file-paths — all `Directionality::SymmetricEqual`). **No new Cargo dependencies.**
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/resolve/deduplicator.rs
+++ b/mikebom-cli/src/resolve/deduplicator.rs
@@ -436,6 +436,72 @@ fn fold_declared_not_cached(components: &mut Vec<ResolvedComponent>) {
     }
 }
 
+/// Milestone 148: cross-PURL canonicalization of evidence.source_file_paths.
+///
+/// After the existing `deduplicate()` pass merges same-(ecosystem, name,
+/// version, parent_purl)-key groups, some ecosystems (Maven nested-coord
+/// case at `scan_fs/package_db/maven.rs:3429-3457`, Cargo workspace
+/// vendoring, Go vendored modules) intentionally retain multiple
+/// `ResolvedComponent` instances sharing the same `Purl::as_str()` value
+/// but differing in `parent_purl`. The CDX nested-components topology
+/// depends on this two-entry shape.
+///
+/// Each entry carries its own `evidence.source_file_paths` Vec (one
+/// observed path from the standalone reader pass, one observed path from
+/// the nested reader pass). Per-emitter iteration-order differences (CDX
+/// `cyclonedx/builder.rs:830-839`, SPDX 2.3 `spdx/annotations.rs:302-308`,
+/// SPDX 3 `spdx/v3_annotations.rs:267-273`) cause the sbom-conformance
+/// audit harness to observe cross-format divergence on the
+/// `mikebom:source-files` annotation for what the harness treats as the
+/// same PURL (51 polyglot-builder-image findings, 2026-06-28 audit).
+///
+/// This pass, keyed on the full canonical `Purl::as_str()` string,
+/// replaces each same-PURL entry's `source_file_paths` Vec with the
+/// alphabetically-sorted UNION of paths observed across all same-PURL
+/// entries. After the pass, every emitter sees the same Vec content for
+/// every same-PURL pair, so the wire-side `mikebom:source-files`
+/// annotation is identical across formats regardless of which entry the
+/// harness happens to pick.
+///
+/// - **Idempotent** — running twice produces byte-identical output
+///   (FR-004) via `BTreeSet` set-union semantics.
+/// - **Topology-preserving** — does NOT modify `parent_purl` or any
+///   other field (FR-005 + FR-006).
+/// - **Content-preserving no-op for single-entry PURLs** — the path
+///   *set* is unchanged (FR-007). Wire-order MAY canonicalize to
+///   alphabetical via the `BTreeSet` collection semantic; that's a
+///   non-breaking shift because `mikebom:source-files` value-order has
+///   no documented semantic and consumers parse the value as a set.
+/// - **Cross-ecosystem isolation** — keying on `Purl::as_str()` (which
+///   includes the ecosystem segment) prevents cross-ecosystem path
+///   cross-pollination (FR-003 + Edge Case 7).
+pub fn canonicalize_source_files_by_purl(
+    components: &mut [ResolvedComponent],
+) {
+    use std::collections::BTreeSet;
+
+    // Phase 1: collect — walk every component, accumulate paths into a
+    // BTreeSet per canonical PURL. BTreeSet gives sort + dedupe for free
+    // and guarantees idempotence under repeat application.
+    let mut paths_by_purl: HashMap<String, BTreeSet<String>> = HashMap::new();
+    for c in components.iter() {
+        paths_by_purl
+            .entry(c.purl.as_str().to_string())
+            .or_default()
+            .extend(c.evidence.source_file_paths.iter().cloned());
+    }
+
+    // Phase 2: write back — replace each entry's source_file_paths with
+    // the alphabetically-sorted union for its PURL. Iteration over a
+    // BTreeSet yields keys in lex-ascending order, so the resulting Vec
+    // is naturally sorted.
+    for c in components.iter_mut() {
+        if let Some(union) = paths_by_purl.get(c.purl.as_str()) {
+            c.evidence.source_file_paths = union.iter().cloned().collect();
+        }
+    }
+}
+
 #[cfg(test)]
 #[cfg_attr(test, allow(clippy::unwrap_used))]
 mod tests {
@@ -1146,5 +1212,343 @@ mod tests {
                 .contains_key("mikebom:component-role"),
             "application paths must NOT carry the role annotation",
         );
+    }
+
+    // ============================================================
+    // Milestone 148: canonicalize_source_files_by_purl tests
+    // ============================================================
+
+    /// Build a `ResolvedComponent` with an explicit `parent_purl`. The
+    /// existing `make_component` helper hardcodes `parent_purl: None`,
+    /// which doesn't exercise the Maven nested-coord same-PURL multi-
+    /// entry shape this milestone targets.
+    fn make_component_with_parent(
+        purl_str: &str,
+        parent_purl: Option<&str>,
+        file_paths: Vec<&str>,
+    ) -> ResolvedComponent {
+        let mut c = make_component(
+            purl_str,
+            ResolutionTechnique::FilePathPattern,
+            0.90,
+            vec![],
+            file_paths,
+        );
+        c.parent_purl = parent_purl.map(String::from);
+        c
+    }
+
+    /// Milestone 148 T004 — SC-004 + FR-001 + FR-002 + FR-006.
+    /// Two ResolvedComponent instances sharing a Maven PURL but with
+    /// different parent_purl values get the alphabetically-sorted union
+    /// of all observed paths on BOTH entries. Topology (parent_purl) is
+    /// preserved verbatim.
+    #[test]
+    fn canonicalize_source_files_by_purl_same_purl_different_parent_unions_paths_md148() {
+        let mut components = vec![
+            make_component_with_parent(
+                "pkg:maven/com.example/foo@1.0",
+                None,
+                vec!["root/.m2/repository/.../foo-1.0.jar"],
+            ),
+            make_component_with_parent(
+                "pkg:maven/com.example/foo@1.0",
+                Some("pkg:maven/com.example/fat-bundle@1.0"),
+                vec!["tmp/extract/fat-bundle.jar!.../foo-1.0.jar"],
+            ),
+        ];
+        canonicalize_source_files_by_purl(&mut components);
+
+        // Alphabetical sort: "root/..." < "tmp/..." lex-ascending.
+        let expected = vec![
+            "root/.m2/repository/.../foo-1.0.jar".to_string(),
+            "tmp/extract/fat-bundle.jar!.../foo-1.0.jar".to_string(),
+        ];
+        assert_eq!(
+            components[0].evidence.source_file_paths, expected,
+            "FR-001 + FR-002: standalone entry MUST carry the alphabetically-sorted union",
+        );
+        assert_eq!(
+            components[1].evidence.source_file_paths, expected,
+            "FR-001 + FR-002: nested entry MUST carry the SAME alphabetically-sorted union",
+        );
+        // FR-006: parent_purl topology preserved verbatim.
+        assert_eq!(components[0].parent_purl, None);
+        assert_eq!(
+            components[1].parent_purl,
+            Some("pkg:maven/com.example/fat-bundle@1.0".to_string())
+        );
+    }
+
+    /// Milestone 148 T005 — FR-007 (content-preserving no-op for
+    /// single-entry PURLs). The SET of paths is unchanged; wire-order
+    /// MAY canonicalize to alphabetical via the BTreeSet collection
+    /// semantic — that's explicitly allowed by the FR-007 wording.
+    /// This test asserts set-equality only.
+    #[test]
+    fn canonicalize_source_files_by_purl_single_entry_is_content_preserving_md148() {
+        use std::collections::BTreeSet;
+        // Deliberately NOT alphabetical to exercise the wire-order
+        // canonicalization semantic.
+        let original_paths = [
+            "node_modules/example/package.json".to_string(),
+            "node_modules/example/index.js".to_string(),
+        ];
+        let mut components = vec![make_component_with_parent(
+            "pkg:npm/example@1.0.0",
+            None,
+            vec![
+                "node_modules/example/package.json",
+                "node_modules/example/index.js",
+            ],
+        )];
+        canonicalize_source_files_by_purl(&mut components);
+
+        // FR-007 (content-preserving): set of paths is unchanged.
+        let pre_set: BTreeSet<String> = original_paths.iter().cloned().collect();
+        let post_set: BTreeSet<String> =
+            components[0].evidence.source_file_paths.iter().cloned().collect();
+        assert_eq!(
+            pre_set, post_set,
+            "FR-007: single-entry PURL's path-SET MUST be preserved",
+        );
+    }
+
+    /// Milestone 148 T006 — FR-004 + SC-005 (idempotence). Two
+    /// consecutive passes produce byte-identical output.
+    #[test]
+    fn canonicalize_source_files_by_purl_is_idempotent_md148() {
+        let mut components = vec![
+            make_component_with_parent(
+                "pkg:maven/com.example/foo@1.0",
+                None,
+                vec!["b/path"],
+            ),
+            make_component_with_parent(
+                "pkg:maven/com.example/foo@1.0",
+                Some("pkg:maven/com.example/parent@1.0"),
+                vec!["a/path", "c/path"],
+            ),
+        ];
+        canonicalize_source_files_by_purl(&mut components);
+        let after_first: Vec<Vec<String>> = components
+            .iter()
+            .map(|c| c.evidence.source_file_paths.clone())
+            .collect();
+        canonicalize_source_files_by_purl(&mut components);
+        let after_second: Vec<Vec<String>> = components
+            .iter()
+            .map(|c| c.evidence.source_file_paths.clone())
+            .collect();
+        assert_eq!(
+            after_first, after_second,
+            "FR-004: canonicalize_source_files_by_purl MUST be idempotent",
+        );
+    }
+
+    /// Milestone 148 T007 — FR-005 (preserves all other fields). Only
+    /// `evidence.source_file_paths` is touched; every other named field
+    /// on `ResolvedComponent` MUST be preserved verbatim.
+    #[test]
+    fn canonicalize_source_files_by_purl_preserves_other_fields_md148() {
+        use mikebom_common::resolution::LifecycleScope;
+
+        let mut component = make_component_with_parent(
+            "pkg:maven/com.example/foo@1.0",
+            Some("pkg:maven/com.example/parent@1.0"),
+            vec!["original/path.jar"],
+        );
+        // Populate rich non-default values across the field surface.
+        component.lifecycle_scope = Some(LifecycleScope::Runtime);
+        component.sbom_tier = Some("source".to_string());
+        component.evidence.confidence = 0.9;
+        component.evidence.source_connection_ids = vec!["conn-42".to_string()];
+        component.extra_annotations.insert(
+            "mikebom:test-key".to_string(),
+            serde_json::json!("test-value"),
+        );
+        let snapshot = component.clone();
+
+        // Pair with a second same-PURL entry so the union pass fires (non-no-op).
+        let mut components = vec![
+            component,
+            make_component_with_parent(
+                "pkg:maven/com.example/foo@1.0",
+                None,
+                vec!["other/path.jar"],
+            ),
+        ];
+        canonicalize_source_files_by_purl(&mut components);
+
+        // FR-005: every non-source_file_paths field on the first entry
+        // MUST be preserved verbatim.
+        assert_eq!(components[0].purl, snapshot.purl);
+        assert_eq!(components[0].name, snapshot.name);
+        assert_eq!(components[0].version, snapshot.version);
+        assert_eq!(components[0].parent_purl, snapshot.parent_purl);
+        assert_eq!(components[0].lifecycle_scope, snapshot.lifecycle_scope);
+        assert_eq!(components[0].sbom_tier, snapshot.sbom_tier);
+        assert_eq!(components[0].hashes, snapshot.hashes);
+        assert_eq!(components[0].evidence.confidence, snapshot.evidence.confidence);
+        assert_eq!(components[0].evidence.technique, snapshot.evidence.technique);
+        assert_eq!(
+            components[0].evidence.source_connection_ids,
+            snapshot.evidence.source_connection_ids
+        );
+        assert_eq!(components[0].extra_annotations, snapshot.extra_annotations);
+        // The union pass IS expected to change source_file_paths in the
+        // multi-entry case — that's the whole point of the milestone.
+        assert_ne!(
+            components[0].evidence.source_file_paths,
+            snapshot.evidence.source_file_paths,
+            "the union pass IS expected to change source_file_paths in the multi-entry case",
+        );
+    }
+
+    /// Milestone 148 T009b — analyze-finding-H1 fallback: code-shape
+    /// regression guard asserting `mikebom:source-files` remains the
+    /// single-source-of-truth field-owned key. Combined with
+    /// `canonicalize_source_files_by_purl_same_purl_*` (asserting
+    /// post-pass Vec content equality across same-PURL entries), this
+    /// transitively guarantees cross-format wire-side equality
+    /// (CDX 1.6 / SPDX 2.3 / SPDX 3) of the `mikebom:source-files`
+    /// annotation WITHOUT requiring a synthetic Maven fixture or full
+    /// per-format emitter invocation. This closes SC-003 / FR-009 in
+    /// CI even when T008 + T009 are deferred.
+    #[test]
+    fn source_files_single_source_of_truth_invariant_md148() {
+        use crate::generate::root_selector::is_field_owned_annotation_key;
+        // FR-008 + milestone-145 US3 invariant: `mikebom:source-files`
+        // is field-owned. All three SBOM emitters consume it from
+        // `c.evidence.source_file_paths` exclusively; the
+        // `extra_annotations` bag-stamped duplicate is filtered out
+        // at every emitter iteration site via
+        // `is_field_owned_annotation_key`. Any new emitter MUST NOT
+        // bypass this filter; any new reader MUST NOT stamp the
+        // bag-keyed duplicate (the Maven reader's renamed key is
+        // `mikebom:source-files-nested-url` post-145 specifically to
+        // avoid this collision).
+        assert!(
+            is_field_owned_annotation_key("mikebom:source-files"),
+            "FR-008 + milestone-145 US3 invariant: mikebom:source-files MUST remain \
+             field-owned (drives single-source-of-truth across CDX/SPDX2.3/SPDX3 emitters)",
+        );
+        assert!(
+            !is_field_owned_annotation_key("mikebom:source-files-nested-url"),
+            "the renamed Maven-reader key is NOT field-owned — it ships through \
+             extra_annotations as a distinct annotation",
+        );
+    }
+
+    /// Milestone 148 T009b — analyze-finding-H1 fallback: behavioral
+    /// assertion that the canonicalize pass produces a Vec the three
+    /// SBOM emitters consume identically. After the pass, all same-PURL
+    /// entries carry byte-identical `source_file_paths` Vecs — which,
+    /// combined with the single-source-of-truth invariant from
+    /// `source_files_single_source_of_truth_invariant_md148`, transitively
+    /// guarantees cross-format byte-equality of the wire-side
+    /// `mikebom:source-files` annotation.
+    #[test]
+    fn canonicalize_produces_emitter_ready_vec_across_formats_md148() {
+        let mut components = vec![
+            make_component_with_parent(
+                "pkg:maven/com.example/foo@1.0",
+                None,
+                vec!["target/primary.jar"],
+            ),
+            make_component_with_parent(
+                "pkg:maven/com.example/foo@1.0",
+                Some("pkg:maven/com.example/fat-bundle@1.0"),
+                vec!["target/fat-bundle.jar!foo-1.0.jar"],
+            ),
+        ];
+        canonicalize_source_files_by_purl(&mut components);
+
+        // SC-003 invariant: post-canonicalize, all same-PURL entries
+        // carry identical source_file_paths Vec. Combined with the
+        // single-source-of-truth invariant asserted by
+        // source_files_single_source_of_truth_invariant_md148, this
+        // is sufficient to guarantee cross-format wire-side equality
+        // of `mikebom:source-files` without instantiating the per-format
+        // emitters (which require full ScanResult plumbing the unit
+        // test cannot easily reproduce).
+        assert_eq!(
+            components[0].evidence.source_file_paths,
+            components[1].evidence.source_file_paths,
+            "SC-003: post-canonicalize, all same-PURL entries MUST carry identical \
+             source_file_paths Vec — this transitively guarantees cross-format \
+             mikebom:source-files equality because all three emitters read from \
+             this field exclusively (FR-008 + 145-US3 single-source-of-truth invariant)",
+        );
+    }
+
+    /// Milestone 148 T010 — FR-003 + Edge Case 7 (cross-ecosystem
+    /// isolation). Two PURLs that share name + version but differ in
+    /// ecosystem MUST NOT cross-pollinate paths.
+    #[test]
+    fn canonicalize_source_files_by_purl_cross_ecosystem_isolation_md148() {
+        let mut components = vec![
+            make_component_with_parent(
+                "pkg:maven/com.example/foo@1.0",
+                None,
+                vec!["target/foo-1.0.jar"],
+            ),
+            make_component_with_parent(
+                "pkg:npm/example@1.0",
+                None,
+                vec!["node_modules/example/index.js"],
+            ),
+        ];
+        canonicalize_source_files_by_purl(&mut components);
+
+        // FR-003 + Edge Case 7: each ecosystem's paths stay isolated.
+        assert_eq!(
+            components[0].evidence.source_file_paths,
+            vec!["target/foo-1.0.jar".to_string()],
+            "FR-003: Maven component MUST NOT pick up npm paths",
+        );
+        assert_eq!(
+            components[1].evidence.source_file_paths,
+            vec!["node_modules/example/index.js".to_string()],
+            "FR-003: npm component MUST NOT pick up Maven paths",
+        );
+    }
+
+    /// Milestone 148 T011 — Edge Case 1 (three-or-more same-PURL
+    /// entries). When 3+ entries share a PURL (e.g., one standalone +
+    /// two different fat-jar nestings), all three entries get the
+    /// full N-way alphabetically-sorted union.
+    #[test]
+    fn canonicalize_source_files_by_purl_three_entries_full_union_md148() {
+        let mut components = vec![
+            make_component_with_parent(
+                "pkg:maven/com.example/foo@1.0",
+                None,
+                vec!["root/standalone.jar"],
+            ),
+            make_component_with_parent(
+                "pkg:maven/com.example/foo@1.0",
+                Some("pkg:maven/com.example/bundle-a@1.0"),
+                vec!["root/bundle-a.jar!foo-1.0.jar"],
+            ),
+            make_component_with_parent(
+                "pkg:maven/com.example/foo@1.0",
+                Some("pkg:maven/com.example/bundle-b@1.0"),
+                vec!["root/bundle-b.jar!foo-1.0.jar"],
+            ),
+        ];
+        canonicalize_source_files_by_purl(&mut components);
+
+        let expected = vec![
+            "root/bundle-a.jar!foo-1.0.jar".to_string(),
+            "root/bundle-b.jar!foo-1.0.jar".to_string(),
+            "root/standalone.jar".to_string(),
+        ];
+        for (i, c) in components.iter().enumerate() {
+            assert_eq!(
+                c.evidence.source_file_paths, expected,
+                "Edge Case 1: entry {i} MUST carry the full 3-path alphabetically-sorted union",
+            );
+        }
     }
 }

--- a/mikebom-cli/src/scan_fs/mod.rs
+++ b/mikebom-cli/src/scan_fs/mod.rs
@@ -38,7 +38,7 @@ use mikebom_common::resolution::{
 };
 
 use crate::generate::cpe::synthesize_cpes;
-use crate::resolve::deduplicator::deduplicate;
+use crate::resolve::deduplicator::{canonicalize_source_files_by_purl, deduplicate};
 use crate::resolve::path_resolver::resolve_path_with_context;
 
 /// Confidence assigned to components discovered by a filesystem walk.
@@ -748,6 +748,22 @@ pub fn scan_path(root: &Path, deb_codename: Option<&str>, size_cap: u64, read_pa
     apply_lifecycle_scope_to_edges(&components, &mut relationships);
 
     let mut components = deduplicate(components);
+    // Milestone 148: cross-PURL canonicalization. Some ecosystems (Maven
+    // nested-coord case at scan_fs/package_db/maven.rs:3429-3457, Cargo
+    // workspace vendoring, Go vendored modules) intentionally retain
+    // multiple ResolvedComponent instances sharing the same Purl::as_str()
+    // value but differing in parent_purl — the CDX nested-components
+    // topology depends on this. Pre-148 each surviving entry carried its
+    // own single-path source_file_paths Vec, and per-emitter iteration-
+    // order differences produced cross-format divergence on the
+    // mikebom:source-files annotation (51 polyglot-builder-image audit
+    // findings, 2026-06-28). The canonicalize pass writes the alphabetically-
+    // sorted union of all observed paths onto every same-PURL entry so
+    // every emitter sees the same Vec content and emits the same
+    // mikebom:source-files value regardless of which entry the harness
+    // picks first. Idempotent; preserves all other fields including
+    // parent_purl topology. See specs/148-source-files-union/ for details.
+    canonicalize_source_files_by_purl(&mut components);
     // Post-dedup CPE synthesis — runs on the merged set so a component
     // that exists in both the filename pass and the dpkg pass gets one
     // set of CPEs (attached to the single winning entry) instead of two.

--- a/specs/148-source-files-union/checklists/requirements.md
+++ b/specs/148-source-files-union/checklists/requirements.md
@@ -1,0 +1,53 @@
+# Specification Quality Checklist: source-files cross-emitter divergence — union evidence across same-PURL entries
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+  - Spec names specific file paths + line numbers (`scan_fs/mod.rs:750`, `resolve/deduplicator.rs:34-46`, `maven.rs:3429-3457`) as scope-bounding anchors. No control flow, function signatures, or Rust syntax in the spec body.
+- [X] Focused on user value and business needs
+  - US1 framed around compliance engineer + cross-format reconciliation tooling. US2 framed around cross-ecosystem invariant for future ecosystem readers.
+- [X] Written for non-technical stakeholders
+  - Origin & Context section walks through the bug discovery + root-cause in plain language. Concrete numerical SC-001 (51 → 0) anchors the outcome.
+- [X] All mandatory sections completed
+  - Origin & Context, User Scenarios & Testing, Requirements, Success Criteria, Assumptions, Out of Scope, Constitution V audit all present.
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+  - Zero markers. All design decisions documented in Assumptions.
+- [X] Requirements are testable and unambiguous
+  - FR-001 to FR-010 each name a specific behavior with verifiable assertions. Example: FR-005 lists every field that MUST be preserved; the negative-space contract is explicit.
+- [X] Success criteria are measurable
+  - SC-001 names a specific count delta (51 → 0). SC-002 names specific CI test names. SC-003/SC-004/SC-005 name specific unit-test placements + assertions. SC-006 names the pre-PR gate. SC-007 names the operator-cadence harness re-run.
+- [X] Success criteria are technology-agnostic (no implementation details)
+  - SCs describe observable outcomes (audit-finding counts, byte-equality assertions, test pass/fail). The only "technology" references are the three SBOM formats (CDX 1.6, SPDX 2.3, SPDX 3) which are spec-bounded artifact formats.
+- [X] All acceptance scenarios are defined
+  - US1 has 5 scenarios covering the union-with-self degenerate cases (top-level-only, nested-only) plus the multi-entry union case. US2 has 3 scenarios for cross-ecosystem coverage.
+- [X] Edge cases are identified
+  - 7 distinct edge cases covered: three-or-more-entry case, empty-vec case, single-entry case, file-tier case, all-empty case, cross-ecosystem collision case.
+- [X] Scope is clearly bounded
+  - Out of Scope section lists 9 explicit exclusions (CDX bom-ref uniqueness, per-emitter dedup, new annotations, milestone 145 US3 changes, deduplicator group-key changes, other evidence fields, issues #1 and #2 from the triage thread, file-tier components, new parity-catalog row).
+- [X] Dependencies and assumptions identified
+  - Assumptions section names 8 explicit assumptions including Maven-dominance, deduplicator-key-preservation, source_file_paths-only scope, CDX-bom-ref-out-of-scope, no-new-deps, no-new-annotations, operator-cadence-sufficient, Maven-reader-unchanged.
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+  - FR-001 ↔ US1 scenario 5. FR-002 ↔ SC-004. FR-003 ↔ Edge Case 7. FR-004 ↔ SC-005. FR-005 ↔ SC-004. FR-006 ↔ US1 scenarios 3 + 4 + 5. FR-007 ↔ US1 scenarios 3 + 4 + US2 scenario 3. FR-008 ↔ Constitution V audit. FR-009 ↔ SC-002. FR-010 ↔ SC-002.
+- [X] User scenarios cover primary flows
+  - US1 covers the singular value-add (cross-format `mikebom:source-files` parity on Maven nested-coords) + degenerate cases (single-entry, top-level-only, nested-only). US2 covers cross-ecosystem coverage as a free side-effect.
+- [X] Feature meets measurable outcomes defined in Success Criteria
+  - Every SC is achievable purely via the FR set.
+- [X] No implementation details leak into specification
+  - File paths and line numbers are scope anchors only. No function signatures or Rust syntax in spec body.
+
+## Notes
+
+- All checklist items pass on first iteration.
+- The spec deliberately names `mikebom-cli/src/scan_fs/mod.rs` and `mikebom-cli/src/resolve/deduplicator.rs` as the fix site. The fix is post-dedup and cross-cutting across all ecosystem readers; placing it elsewhere would scatter the logic across readers (unnecessary fanout).
+- The Constitution V audit (FR-008 + Constitution V audit section) deliberately documents the no-new-annotation claim — preventing future contributors from second-guessing the absence of a `mikebom:*` carry-out.
+- Ready for `/speckit-clarify` (probably zero questions; spec is self-contained) or directly for `/speckit-plan`.

--- a/specs/148-source-files-union/contracts/source-files-union.md
+++ b/specs/148-source-files-union/contracts/source-files-union.md
@@ -1,0 +1,116 @@
+# Contract — `canonicalize_source_files_by_purl` pass
+
+Phase 1 output. Defines the pure-function contract for the new post-dedup canonicalization pass.
+
+## Function signature
+
+```rust
+/// Milestone 148: cross-PURL canonicalization of evidence.source_file_paths.
+///
+/// After the existing `deduplicate()` pass merges same-(ecosystem,name,version,
+/// parent_purl)-key groups, some ecosystems (Maven nested-coord case at
+/// `scan_fs/package_db/maven.rs:3429-3457`, Cargo workspace vendoring, Go
+/// vendored modules) intentionally retain multiple `ResolvedComponent` instances
+/// sharing the same `Purl::as_str()` value but differing in `parent_purl`. The
+/// CDX nested-components topology depends on this two-entry shape.
+///
+/// Each entry carries its own `evidence.source_file_paths` Vec (one observed
+/// path from the standalone reader pass, one observed path from the nested
+/// reader pass). Per-emitter iteration-order differences (CDX `builder.rs:619`,
+/// SPDX 2.3 `annotations.rs:302`, SPDX 3 `v3_annotations.rs:267`) cause the
+/// audit harness to observe cross-format divergence on the `mikebom:source-files`
+/// annotation for what the harness treats as the same PURL (51 polyglot-builder-
+/// image findings, 2026-06-28 audit).
+///
+/// This pass, keyed on the full canonical `Purl::as_str()` string, replaces
+/// each same-PURL entry's `source_file_paths` Vec with the alphabetically-
+/// sorted UNION of paths observed across all same-PURL entries. After the
+/// pass, every emitter sees the same Vec content for every same-PURL pair,
+/// so the wire-side `mikebom:source-files` annotation is identical across
+/// formats regardless of which entry the harness happens to pick.
+///
+/// **Idempotent** — running twice produces byte-identical output.
+/// **Topology-preserving** — does NOT modify `parent_purl` or any other field.
+/// **No-op for single-entry PURLs** — the common case is unchanged.
+pub fn canonicalize_source_files_by_purl(components: &mut Vec<ResolvedComponent>);
+```
+
+## Contract requirements
+
+| Requirement | Source spec | Test |
+|---|---|---|
+| Same-PURL multi-entry: all entries get the same alphabetically-sorted union Vec | FR-001 + FR-002 | SC-004 unit test (two entries) + SC-003 integration test (cross-format) |
+| Single-entry PURL: no-op (byte-identical Vec pre/post) | FR-007 | Dedicated unit test in `deduplicator.rs#mod tests` |
+| Keyed on full canonical PURL string (`Purl::as_str()`) | FR-003 | Edge Case 7 cross-ecosystem isolation unit test |
+| Idempotent (two passes produce identical output) | FR-004 | SC-005 unit test |
+| Preserves all other `ResolvedComponent` fields verbatim | FR-005 | SC-004 unit test asserts every named field unchanged |
+| Preserves `parent_purl` specifically (topology intact) | FR-006 | SC-004 unit test |
+| Preserves `evidence.source_connection_ids`, `evidence.hashes`, `evidence.technique`, `evidence.confidence`, `evidence.deps_dev_match` | FR-005 + Assumption 3 | SC-004 unit test |
+| Three-or-more-entries case: full N-way union | Edge Case 1 | Optional N=3 unit test |
+| Empty Vec on every same-PURL entry: empty union (annotation stays absent) | Edge Case 3 | Unit test |
+| File-tier components: no-op (file_tier walker already aggregates) | Edge Case 5 + Out of Scope §8 | Implicit — file-tier PURLs are content-hash-unique, can't have multi-entry shape |
+| No new Cargo dependencies | Assumption 5 | Cargo.toml diff review |
+| No new `mikebom:*` annotation | FR-008 + Constitution V audit | docs/reference/sbom-format-mapping.md diff review |
+
+## Algorithm sketch (illustrative; not normative)
+
+```rust
+use std::collections::{BTreeSet, HashMap};
+
+pub fn canonicalize_source_files_by_purl(components: &mut Vec<ResolvedComponent>) {
+    // Phase 1: collect — walk every component, accumulate paths by canonical PURL.
+    let mut paths_by_purl: HashMap<String, BTreeSet<String>> = HashMap::new();
+    for c in components.iter() {
+        paths_by_purl
+            .entry(c.purl.as_str().to_string())
+            .or_default()
+            .extend(c.evidence.source_file_paths.iter().cloned());
+    }
+
+    // Phase 2: write back — replace each entry's source_file_paths with the
+    // alphabetically-sorted union for its PURL. Single-entry PURLs are a no-op
+    // because the BTreeSet collected from one Vec roundtrips to an
+    // equal-content Vec (modulo sort order; insertion-ordered single-entry
+    // Vecs that happen to be already-sorted are byte-identical post-pass).
+    for c in components.iter_mut() {
+        if let Some(union) = paths_by_purl.get(c.purl.as_str()) {
+            c.evidence.source_file_paths = union.iter().cloned().collect();
+        }
+    }
+}
+```
+
+## Negative-space contract (what MUST NOT happen)
+
+- The pass MUST NOT add new components.
+- The pass MUST NOT remove components.
+- The pass MUST NOT reorder components within the input Vec.
+- The pass MUST NOT mutate `purl`, `name`, `version`, `parent_purl`, `hashes`, `lifecycle_scope`, `extra_annotations`, `sbom_tier`, `binary_role`, `binary_stripped`, `linkage_kind`, `confidence`, `requirement_range`, `source_type`, `co_owned_by`, `npm_role`, `raw_version`, `licenses`, `concluded_licenses`, `supplier`, `cpes`, `advisories`, `occurrences`, `buildinfo_status`, `evidence_kind`, `binary_class`, `binary_packed`, `detected_go`, `shade_relocation`, `build_inclusion`, or any other field on `ResolvedComponent`.
+- The pass MUST NOT mutate `evidence.technique`, `evidence.confidence`, `evidence.source_connection_ids`, `evidence.deps_dev_match`. ONLY `evidence.source_file_paths` is touched.
+- The pass MUST NOT introduce duplicate entries within the per-PURL union Vec (BTreeSet semantic guarantees uniqueness).
+- The pass MUST NOT cross-pollinate paths across different ecosystems (FR-003 guards via `Purl::as_str()` keying — the ecosystem segment is part of the canonical string).
+
+## Call-site contract
+
+The function MUST be called from `mikebom-cli/src/scan_fs/mod.rs` immediately after the existing `let mut components = deduplicate(components);` call at line 750:
+
+```rust
+let mut components = deduplicate(components);
+canonicalize_source_files_by_purl(&mut components);
+// ... existing post-dedup passes (synthesize_cpes, etc.) ...
+```
+
+The placement is justified by research §A: no existing post-dedup pass touches `evidence.source_file_paths`, so ordering between the union pass and the subsequent CPE synthesis / scan-target-coord suppression / main-module tagging is non-load-bearing.
+
+## Test surface
+
+| Test | Asserts | Location |
+|---|---|---|
+| `canonicalize_source_files_by_purl_same_purl_different_parent_unions_paths_md148` | FR-001 + FR-002 + FR-006 | `deduplicator.rs#mod tests` |
+| `canonicalize_source_files_by_purl_single_entry_is_noop_md148` | FR-007 | `deduplicator.rs#mod tests` |
+| `canonicalize_source_files_by_purl_is_idempotent_md148` | FR-004 | `deduplicator.rs#mod tests` |
+| `canonicalize_source_files_by_purl_preserves_other_fields_md148` | FR-005 | `deduplicator.rs#mod tests` (asserts every named field unchanged) |
+| `canonicalize_source_files_by_purl_three_entries_full_union_md148` | Edge Case 1 | `deduplicator.rs#mod tests` |
+| `canonicalize_source_files_by_purl_cross_ecosystem_isolation_md148` | Edge Case 7 + FR-003 | `deduplicator.rs#mod tests` |
+| `same_purl_maven_nested_coord_emits_byte_identical_source_files_across_formats_md148` | SC-003 (cross-format invariance on synthetic Maven fixture) | `mikebom-cli/tests/source_files_purl_union_md148.rs` |
+| Existing C18 parity-catalog row tests | SC-002 — `Directionality::SymmetricEqual` continues to hold | `mikebom-cli/tests/cross_format_byte_identity.rs`, `holistic_parity.rs` |

--- a/specs/148-source-files-union/data-model.md
+++ b/specs/148-source-files-union/data-model.md
@@ -1,0 +1,68 @@
+# Data Model — milestone 148
+
+Phase 1 output. No new types introduced; this document describes the existing `ResolvedComponent.evidence.source_file_paths` semantic and the pre/post behavior table for affected components.
+
+## Modified field
+
+### `mikebom_common::resolution::ResolvedComponent.evidence.source_file_paths`
+
+| Aspect | Value |
+|---|---|
+| Type | `Vec<String>` (unchanged) |
+| Population sites (read-only context) | Artefact walker at `scan_fs/mod.rs:207`, Package-DB reader at `scan_fs/mod.rs:649`, and per-reader `PackageDbEntry::source_path` flows via `normalize_sbom_path_relative` (milestone 133 normalization pipeline) |
+| **Existing** within-group merge | At `resolve/deduplicator.rs:74-78` — insertion-ordered `.contains()` dedupe within each `(ecosystem, name, version, parent_purl)` group (unchanged) |
+| **New** cross-PURL union pass (milestone 148) | At `resolve/deduplicator.rs::canonicalize_source_files_by_purl` — alphabetically-sorted `BTreeSet<String>` union across all entries sharing a `Purl::as_str()` value (NEW) |
+| Idempotence | Guaranteed by `BTreeSet` set-union semantics (research §C). Running the canonicalize pass twice on the same input produces byte-identical output. |
+| Cross-ecosystem isolation | Guaranteed by `Purl::as_str()` keying — the canonical PURL string includes the ecosystem segment (research §D). |
+| Wire surface | Consumed by all three emitters: CDX `cyclonedx/builder.rs:830-839` via `source_files_as_json_array`; SPDX 2.3 `spdx/annotations.rs:302-308` via `json!(c.evidence.source_file_paths)`; SPDX 3 `spdx/v3_annotations.rs:267-273` via `json!(c.evidence.source_file_paths)`. **No emitter-side change** in milestone 148. |
+
+## New public function
+
+### `canonicalize_source_files_by_purl(components: &mut Vec<ResolvedComponent>)`
+
+| Aspect | Value |
+|---|---|
+| Location | `mikebom-cli/src/resolve/deduplicator.rs` (new sibling of `deduplicate`) |
+| Visibility | `pub` (called from `scan_fs/mod.rs:751`) |
+| Signature | `pub fn canonicalize_source_files_by_purl(components: &mut Vec<ResolvedComponent>)` |
+| Return | `()` — mutates in place |
+| Side effects | Replaces each entry's `evidence.source_file_paths` Vec with the alphabetically-sorted union of paths observed across all same-`Purl::as_str()` entries. No other field touched (FR-005). |
+| Complexity | O(N · log K + N · P) where N = component count, K = unique-PURL count, P = avg paths per PURL. Dominant term in practice: O(N). |
+| Allocations | Two `HashMap<&str, BTreeSet<String>>` (one for accumulating, one is the per-PURL Vec output via `.into_iter().collect()`). |
+| Test fixture | `mikebom-cli/tests/fixtures/source_files_union/` — synthetic Maven nested-coord case per research §F. |
+
+## Pre/post behavior table
+
+| Component shape | Pre-148 `evidence.source_file_paths` | Post-148 `evidence.source_file_paths` |
+|---|---|---|
+| Single-entry-per-PURL (common case) | `["path/to/foo.jar"]` (within-group merge result, possibly multi-element if multiple readers detected the same path-context) | **Content-preserving no-op** per FR-007 — set of paths unchanged; wire-order MAY be canonicalized to alphabetical (matters only for multi-element single-entry Vecs whose pre-148 order was insertion-order, not alphabetical) |
+| Same Maven coord, standalone + nested under fat-jar (two entries, different `parent_purl`) | Entry A: `["root/.m2/repo/.../foo.jar"]`; Entry B: `["tmp/extract/.../foo.jar"]` | Entry A: `["root/.m2/repo/.../foo.jar", "tmp/extract/.../foo.jar"]` (alphabetically sorted); Entry B: SAME value (alphabetically sorted union) |
+| File-tier component (PURL = `pkg:generic/file-tier?content-sha256=<hex>`) | `["path/A", "path/B"]` (already aggregated via `file_tier/walker.rs::push_path`) | UNCHANGED — union-with-self is identity (file-tier components never have same-PURL multi-entry shape; the content-sha256-keyed PURL guarantees uniqueness per scan) |
+| Same PURL with empty `source_file_paths` on every entry | `[]` (empty Vec on each entry) | UNCHANGED — empty union, every entry keeps the empty Vec |
+| Three entries sharing a PURL (e.g., one standalone + two different fat-jar nestings) | Three different single-path Vecs | All three entries get the same alphabetically-sorted three-element Vec |
+
+## Validation rules (consolidated from spec FRs)
+
+| Input | Rule | Source |
+|---|---|---|
+| `components: Vec<ResolvedComponent>` | The pass MUST NOT add, remove, or reorder components. It only mutates `evidence.source_file_paths` on each entry. | FR-005 + FR-006 |
+| Component with single-entry PURL | The *set* of paths MUST be unchanged pre/post the pass. Wire-order MAY canonicalize to alphabetical (FR-007 explicitly allows the BTreeSet sort). | FR-007 |
+| Component shares PURL with N>1 other components | All N+1 components MUST have `source_file_paths` set to the alphabetically-sorted union of all observed paths across the N+1 entries. | FR-001 + FR-002 |
+| PURL keying basis | `c.purl.as_str()` (full canonical PURL string) | FR-003 |
+| Cross-ecosystem entries that share `(name, version)` but differ in ecosystem | MUST remain isolated — no path cross-pollination | FR-003 + Edge Case 7 |
+| Idempotence | Two consecutive passes MUST yield byte-identical output | FR-004 |
+| Fields other than `source_file_paths` | Every other field of `ResolvedComponent` MUST be preserved verbatim | FR-005 |
+| `parent_purl` field | Specifically MUST NOT be modified — the dep-graph topology stays intact | FR-006 |
+| `mikebom:*` annotation surface | NO new key introduced; existing `mikebom:source-files` value-content may change for affected components only | FR-008 |
+| Cross-format byte-equivalence on emitted output | C18 parity-catalog row's `Directionality::SymmetricEqual` MUST hold on every byte-identity golden | FR-009 |
+| Golden refresh scope | Maven-bearing goldens may experience `mikebom:source-files` value changes; NO unrelated drift permitted | FR-010 |
+
+## Out of model
+
+- **No new types**: no structs/enums/newtypes introduced.
+- **No public API surface changes** outside the new `canonicalize_source_files_by_purl` function (additive only).
+- **No call-site changes elsewhere**: emitters consume `c.evidence.source_file_paths` transparently via their existing reads.
+- **No changes to `deduplicate()`** itself: the within-group merge stays unchanged (research §E).
+- **No changes to any ecosystem reader**: Maven, Cargo, Go all stay as-is (FR-006 + Out of Scope §5).
+- **No changes to any emitter**: CDX/SPDX 2.3/SPDX 3 stay as-is.
+- **No changes to `evidence.source_connection_ids`, `evidence.hashes`, or any other field** (Out of Scope §6 + Assumption 3).

--- a/specs/148-source-files-union/plan.md
+++ b/specs/148-source-files-union/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: source-files cross-emitter divergence — union evidence across same-PURL entries
+
+**Branch**: `148-source-files-union` | **Date**: 2026-06-28 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/148-source-files-union/spec.md`
+
+## Summary
+
+Close the last cluster of cross-format `mikebom:source-files` value divergence on the polyglot-builder-image audit corpus (51 → 0). The Maven nested-JAR walker intentionally creates two `PackageDbEntry` instances for the same Maven coord when it appears both standalone (`parent_purl = None`) AND vendored inside a fat-jar (`parent_purl = Some(...)`). The deduplicator at `mikebom-cli/src/resolve/deduplicator.rs:34-46` correctly preserves both entries (CDX nested-components model requires it). The bug: each entry carries its own single-path `evidence.source_file_paths` Vec, so per-emitter iteration-order differences produce a harness-visible divergence on the otherwise-same PURL.
+
+**Fix**: a post-dedup canonicalization pass that, for every PURL appearing on multiple `ResolvedComponent` instances, replaces each instance's `evidence.source_file_paths` Vec with the alphabetically-sorted **union** of paths observed across all same-PURL entries. The pass is keyed on `Purl::as_str()` (full canonical PURL string including ecosystem segment) per FR-003 — preserving cross-ecosystem isolation. It's idempotent (FR-004), preserves every other field (FR-005), and preserves the dep-graph topology that the deduplicator's `parent_purl` group-key intentionally retains (FR-006).
+
+Phase 0 research (§A through §D below) confirmed three load-bearing assumptions:
+1. **No existing post-dedup pass touches `evidence.source_file_paths`** — `synthesize_cpes` at line 754-756 only writes `c.cpes`; `maybe_suppress_scan_target_coord` at line 763-764 returns a new `scan_target_coord` value; `tag_main_modules_with_workspace_root` at line 773 only writes the `mikebom:is-workspace-root` extra_annotation. Order-of-operations is not load-bearing; the union pass can land anywhere after `deduplicate()` and before `ScanResult` construction.
+2. **The deduplicator's within-group merge at lines 74-78 uses insertion-order `.contains()` semantics** — not alphabetically sorted. For PURLs that survive as a single entry post-dedup (the common case), the cross-PURL union is identity and the within-group merge result reaches emit unchanged. For PURLs with multi-entry survival (cross-`parent_purl` shape), the cross-PURL union OVERWRITES the within-group result with the alphabetically-sorted superset — both unions are doing the same logical operation (set union), the cross-PURL pass is just more inclusive.
+3. **`Purl::as_str()` includes the ecosystem segment** (verified at `mikebom-common/src/types/purl.rs`), so cross-ecosystem isolation (Edge Case 7) is automatic.
+
+Total code surface estimate: ~15 LOC for the new pass in `mikebom-cli/src/resolve/deduplicator.rs` (or a sibling `source_files_union.rs` module — research §B decision below), ~60 LOC of unit tests (SC-004 + SC-005 + a same-PURL-different-`parent_purl` regression test), ~80 LOC of in-tree integration test (SC-003: synthetic Maven fixture asserting cross-format `mikebom:source-files` invariance). Zero new Cargo dependencies. No changes to any per-format emitter, no changes to any ecosystem reader, no new annotation. One additive function call at `scan_fs/mod.rs:750-751`.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–147; no nightly required for this user-space-only work).
+**Primary Dependencies**: Existing only — `std::collections::HashMap` + `std::collections::BTreeSet` (both pervasive in the codebase, no new use). The pass operates on `mikebom_common::resolution::ResolvedComponent` (already a workspace type). **No new Cargo dependencies.**
+**Storage**: N/A — purely in-process per-scan transformation; no persistence.
+**Testing**: `cargo +stable test --workspace`. New unit tests in `mikebom-cli/src/resolve/deduplicator.rs#mod tests` (or in a new `source_files_union.rs#mod tests` if research §B picks the sibling-module placement). New in-tree integration test at `mikebom-cli/tests/source_files_purl_union_md148.rs` covering the SC-003 cross-format byte-equality assertion on a synthetic Maven nested-coord fixture.
+**Target Platform**: Linux x86_64 + macOS arm64 + Windows (CI lanes). Pure-Rust pure-data-transform; no platform-specific behavior.
+**Project Type**: Library/post-processor — touches `mikebom-cli`'s post-dedup pipeline. Downstream consumers (CDX builder, SPDX 2.3 emitter, SPDX 3 emitter) consume the `ResolvedComponent.evidence.source_file_paths` field transparently with **zero call-site changes**.
+**Performance Goals**: One-pass O(N) over the post-dedup `Vec<ResolvedComponent>` (N = component count, typically 100s–10Ks). Two HashMap+BTreeSet builds (one for path-collection, one for write-back). Cost is comparable to the existing `synthesize_cpes` loop at lines 754-756; no measurable perf impact on any realistic scan.
+**Constraints**:
+- **Constitution V (standards-native > `mikebom:*`)**: This milestone introduces NO new `mikebom:*` annotation (FR-008). The fix is a value-canonicalization operation on the in-process `evidence.source_file_paths` field that all three emitters already consume. The existing C18 parity-catalog row's audit is unchanged. Constitution V is satisfied vacuously.
+- **Constitution IV (Type-Driven Correctness)**: The pass operates entirely on already-typed values (`Purl` newtype for keying, `String` for path values which is the existing field type). No new `.unwrap()` in production paths; tests guarded with `#[cfg_attr(test, allow(clippy::unwrap_used))]` per existing convention.
+- **No subprocess calls**: pure-Rust HashMap + BTreeSet operations.
+- **Pre-PR gate**: `./scripts/pre-pr.sh` (clippy `-D warnings` + `cargo test --workspace`) MUST exit 0 before PR open. The pre-existing local `sbomqs_parity` env-only failure documented in milestone 144 T001 still applies; CI on a clean runner validates.
+**Scale/Scope**: 51 polyglot-builder-image Maven cases → 0 post-fix. Across the full mikebom test fixture set, the union pass is a no-op for the overwhelming majority of components (single-entry PURLs); only components with multi-entry shape (Maven nested-coords, theoretical Cargo workspace vendor-cases, theoretical Go vendor-cases) experience the canonical-union write-back.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| # | Principle / Boundary | Status | Note |
+|---|---|---|---|
+| I | Pure Rust, Zero C | ✅ PASS | No new Cargo dependencies; uses stdlib `HashMap` + `BTreeSet`. |
+| II | eBPF-Only Observation | ✅ N/A | Pure post-dedup canonicalization; eBPF discovery untouched. |
+| III | Fail Closed | ✅ PASS | No change to scan-failure semantics; the union pass is an idempotent transformation on an existing Vec. |
+| IV | Type-Driven Correctness | ✅ PASS | Operates on existing typed values; no new `.unwrap()` in production paths. |
+| V | Specification Compliance | ✅ PASS (no new annotation) | Per FR-008. The fix changes VALUES of the existing `mikebom:source-files` annotation but introduces no new key. The existing C18 row's audit is unchanged. **Constitution V satisfied vacuously** — no annotation added → no audit needed. |
+| VI | Three-Crate Architecture | ✅ PASS | All change in `mikebom-cli`. |
+| VII | Test Isolation | ✅ PASS | New tests are pure-logic unit tests + an integration test that runs the binary against a synthetic fixture; no eBPF privilege requirements. |
+| VIII | Completeness | ✅ IMPROVES | The cross-format `mikebom:source-files` divergence was effectively a transparency gap — auditors couldn't trust the field to be stable across formats. Closing the divergence improves the downstream completeness signal. |
+| IX | Accuracy | ✅ IMPROVES | After the union pass, every consumer that reads `mikebom:source-files` for a given PURL gets the SAME set of observed paths regardless of format — more accurate than the pre-148 first-match-wins divergent behavior. |
+| X | Transparency | ✅ PASS | The path superset is more informative than the per-entry single path; auditors get the complete observed-paths picture for any same-PURL multi-entry component. |
+| XI | Enrichment | ✅ N/A | No enrichment-source changes. |
+| XII | External Data Source Enrichment | ✅ N/A | No external sources consulted. |
+| SB-1 | No lockfile-based discovery | ✅ N/A | The pass operates on already-discovered components. |
+| SB-2 | No MITM proxy | ✅ N/A | |
+| SB-3 | No C code | ✅ N/A | |
+| SB-4 | No `.unwrap()` in production | ✅ PASS | New tests guarded with `#[cfg_attr(test, allow(clippy::unwrap_used))]`. |
+| SB-5 | No file-tier duplicates in default mode | ✅ N/A | File-tier components already aggregate paths via `file_tier/walker.rs::push_path`; the union pass is idempotent for them. |
+
+**All gates pass.** Principle V is satisfied vacuously (no new annotation introduced); no Complexity Tracking entry needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/148-source-files-union/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (placement decision + idempotence-strategy + cross-ecosystem coverage audit + perf cost sketch)
+├── data-model.md        # Phase 1 output (no new types — describes the existing ResolvedComponent.evidence.source_file_paths semantic + pre/post behavior table)
+├── quickstart.md        # Phase 1 output (operator-facing verification — re-run polyglot-builder-image harness; expect 51 → 0)
+├── contracts/
+│   └── source-files-union.md   # Pure-function contract for the union pass
+└── checklists/
+    └── requirements.md  # Already exists from /speckit-specify (all items ✅)
+```
+
+### Source Code (repository root)
+
+Touched files (narrow scope):
+
+```text
+mikebom-cli/
+├── (no Cargo.toml change)
+└── src/
+    ├── resolve/
+    │   └── deduplicator.rs                      # OR a new sibling source_files_union.rs (research §B decision)
+    └── scan_fs/
+        └── mod.rs                               # ONE additive call at line ~751 invoking the union pass
+mikebom-cli/
+└── tests/
+    ├── source_files_purl_union_md148.rs        # NEW — SC-003 in-tree integration test (synthetic Maven nested-coord fixture)
+    └── fixtures/
+        └── source_files_union/                  # NEW — synthetic fixture with one Maven coord appearing both standalone + nested
+            ├── (minimal pom.xml + nested fat-jar synth structure)
+            └── README.md                        # Fixture-shape documentation
+mikebom-cli/
+└── tests/
+    └── fixtures/
+        └── golden/                              # Maven-bearing CDX/SPDX 2.3/SPDX 3 goldens may refresh (existing maven fixture: pom-three-deps)
+```
+
+**Structure Decision**: Single-file change at `mikebom-cli/src/resolve/deduplicator.rs` (research §B picks the in-deduplicator-module placement over a sibling source_files_union.rs module — the pass is conceptually a post-dedup canonicalization step belonging to the deduplicator's domain). One additive call at `scan_fs/mod.rs:751` (immediately after the existing `let mut components = deduplicate(components);`). Synthetic test fixture under `mikebom-cli/tests/fixtures/source_files_union/`. Zero new modules, zero signature changes to public APIs, zero call-site changes elsewhere.
+
+## Complexity Tracking
+
+*Not applicable.* All Constitution gates pass cleanly. No new annotation introduced (Principle V satisfied vacuously per FR-008). No new dependencies. No structural deviation from existing post-dedup pass pattern.

--- a/specs/148-source-files-union/quickstart.md
+++ b/specs/148-source-files-union/quickstart.md
@@ -1,0 +1,173 @@
+# Quickstart — milestone 148 source-files cross-emitter union
+
+Operator-facing walkthrough.
+
+## Scenario 1 — Reproduce the 51 → 0 audit drop on polyglot-builder-image
+
+The motivating use case: the polyglot-builder-image fixture surfaced 51 cross-format `mikebom:source-files` divergence findings in the 2026-06-28 audit harness run (post-145).
+
+```bash
+# Pre-148: 51 Maven PURLs with divergent mikebom:source-files across CDX vs SPDX 3
+mikebom sbom scan --path /path/to/polyglot-builder-image \
+    --format cyclonedx-json --output /tmp/mb-pre.cdx.json
+mikebom sbom scan --path /path/to/polyglot-builder-image \
+    --format spdx-3-json --output /tmp/mb-pre.spdx3.json
+
+# Compare mikebom:source-files values for every shared Maven PURL.
+# Pre-148: ~51 PURLs with divergent values; post-148: 0 (or near-zero).
+python3 - <<'PY'
+import json, sys
+
+cdx = json.load(open("/tmp/mb-pre.cdx.json"))
+spdx = json.load(open("/tmp/mb-pre.spdx3.json"))
+
+def cdx_source_files(comp):
+    for p in comp.get("properties", []):
+        if p.get("name") == "mikebom:source-files":
+            return frozenset(json.loads(p["value"]) if isinstance(p["value"], str) else p["value"])
+    return None
+
+def spdx_source_files(elem):
+    for a in elem.get("annotation", []):
+        try:
+            env = json.loads(a.get("statement", "{}"))
+            if env.get("field") == "mikebom:source-files":
+                return frozenset(env.get("value", []))
+        except (ValueError, AttributeError):
+            continue
+    return None
+
+cdx_by_purl = {c["purl"]: cdx_source_files(c) for c in cdx.get("components", []) if c.get("purl")}
+spdx_by_purl = {e["software_packageUrl"]: spdx_source_files(e)
+                for e in spdx.get("@graph", [])
+                if e.get("type") == "software_Package" and e.get("software_packageUrl")}
+
+shared = set(cdx_by_purl) & set(spdx_by_purl)
+diverge = [p for p in shared
+           if cdx_by_purl[p] is not None
+           and spdx_by_purl[p] is not None
+           and cdx_by_purl[p] != spdx_by_purl[p]
+           and "pkg:maven/" in p]
+print(f"Divergent Maven PURLs: {len(diverge)}")
+# Pre-148: ~51
+# Post-148: 0
+PY
+```
+
+## Scenario 2 — Verify single-entry PURLs are unchanged (FR-007)
+
+```bash
+# Scan a non-Maven fixture (npm, Cargo, etc.) where no same-PURL multi-entry
+# shape exists. Compare pre/post-148 mikebom:source-files values.
+
+mikebom sbom scan --path /path/to/npm-fixture \
+    --format cyclonedx-json --output /tmp/mb.cdx.json
+
+# Every component's mikebom:source-files value MUST be byte-identical to its
+# pre-148 emission. The union-with-self degenerates to identity (FR-007).
+
+# Confirm via golden diff (see Verification Commands below for the trifecta).
+```
+
+## Scenario 3 — Verify the synthetic Maven nested-coord fixture
+
+```bash
+# The SC-003 in-tree integration test exercises a minimal synthetic fixture:
+mikebom sbom scan --path mikebom-cli/tests/fixtures/source_files_union/ \
+    --format cyclonedx-json --output /tmp/syn.cdx.json
+
+# Inspect the foo coord: pre-148 it had ONE path per entry; post-148 it has
+# BOTH paths (alphabetically sorted) on every entry.
+jq '
+  .components[]
+  | select(.purl == "pkg:maven/com.example/foo@1.0")
+  | .properties[]
+  | select(.name == "mikebom:source-files")
+' /tmp/syn.cdx.json
+# Post-148: {"name": "mikebom:source-files",
+#            "value": "[\"target/fat-bundle.jar!com/example/foo-1.0.jar\",
+#                      \"target/primary.jar\"]"}
+# (Both paths, alphabetically sorted, on the entry's mikebom:source-files
+# annotation. Same value appears on the nested-under-fat-jar entry too.)
+
+# Same query against SPDX 3:
+mikebom sbom scan --path mikebom-cli/tests/fixtures/source_files_union/ \
+    --format spdx-3-json --output /tmp/syn.spdx3.json
+
+jq '
+  .["@graph"][]
+  | select(.software_packageUrl == "pkg:maven/com.example/foo@1.0")
+  | .annotation[]?
+  | .statement
+  | fromjson
+  | select(.field == "mikebom:source-files")
+' /tmp/syn.spdx3.json
+# Post-148: identical {"field":"mikebom:source-files",
+#                      "value":["target/fat-bundle.jar!.../foo-1.0.jar",
+#                               "target/primary.jar"]}
+# byte-equal to the CDX value above.
+```
+
+## Verification commands (in-tree, CI-binding)
+
+```bash
+# New unit tests in deduplicator.rs:
+cargo test -p mikebom canonicalize_source_files_by_purl
+
+# New in-tree integration test:
+cargo test --test source_files_purl_union_md148
+
+# Parity catalog row C18 (mikebom:source-files SymmetricEqual):
+cargo test -p mikebom parity::extractors::tests::c18_
+
+# Pre-PR gate:
+./scripts/pre-pr.sh
+```
+
+## Golden refresh (post-fix, before commit)
+
+```bash
+# Maven-bearing goldens may be affected:
+MIKEBOM_UPDATE_CDX_GOLDENS=1   cargo test --test cdx_regression cdx_regression_maven
+MIKEBOM_UPDATE_SPDX_GOLDENS=1  cargo test --test spdx_regression maven_byte_identity
+MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo test --test spdx3_regression maven_byte_identity
+
+# Inspect:
+git diff --stat -- mikebom-cli/tests/fixtures/golden/cyclonedx/maven.cdx.json \
+                   mikebom-cli/tests/fixtures/golden/spdx-2.3/maven.spdx.json \
+                   mikebom-cli/tests/fixtures/golden/spdx-3/maven.spdx3.json
+
+# Acceptance: any diff line MUST be either:
+#   (a) a mikebom:source-files value change on a Maven component that previously
+#       carried a non-canonical single-path Vec, OR
+#   (b) the new alphabetically-sorted union content
+# NO unrelated drift permitted (FR-010).
+#
+# NOTE: if the pom-three-deps fixture doesn't exercise the multi-entry shape
+# (likely — it's a simple POM fixture), the diffs will be empty and the
+# synthetic fixture from SC-003 is the only exercise of the new code path.
+```
+
+## Cross-tool comparison (operator-cadence per SC-007)
+
+```bash
+# Re-run the sbom-conformance audit harness on polyglot-builder-image post-merge:
+# (operator-specific tooling; not in mikebom's CI)
+sbom-conformance-audit \
+    --formats cdx,spdx-2.3,spdx-3 \
+    --target polyglot-builder-image \
+    --filter mikebom:source-files
+
+# Expected: pre-148 51 findings → post-148 0 findings (or near-zero residuals
+# from a different bug class, documented in the audit report).
+```
+
+## Known deferrals (spec Out of Scope)
+
+- CDX `bom-ref` uniqueness enforcement (two same-PURL `parent_purl=None` components both get bom-ref = plain PURL string, a CDX 1.6 spec violation that's pre-existing; not addressed by this milestone).
+- Per-emitter component-instance dedup (some emitters might benefit from collapsing two same-PURL components into one wire entry; out of scope — this milestone only canonicalizes the `evidence.source_file_paths` Vec).
+- New `mikebom:source-files-*` annotations — none introduced (FR-008).
+- Investigation of the JVM symlink paths issue (#1 from the 2026-06-28 triage) — needs operator-cadence raw-output diagnostic first.
+- The SPDX 3 lifecycle-scope harness finding (#2 from the 2026-06-28 triage) — deliberate Principle V decision; not a mikebom bug.
+- File-tier components — file_tier walker already aggregates per-hash; the union pass is idempotent for them.
+- Cross-ecosystem same-PURL multi-entry cases beyond Maven (Cargo workspace vendor, Go vendor) — fix applies generically, but SC-001 metric is Maven-specific.

--- a/specs/148-source-files-union/research.md
+++ b/specs/148-source-files-union/research.md
@@ -1,0 +1,166 @@
+# Research — milestone 148 (source-files cross-emitter divergence — union evidence across same-PURL entries)
+
+Phase 0 output. Resolves four implementation-affecting design questions before Phase 1.
+
+## §A — Order-of-operations with existing post-dedup passes (no conflict)
+
+**Decision**: The union pass can land immediately after `deduplicate()` at `scan_fs/mod.rs:750`. No existing post-dedup pass touches `evidence.source_file_paths`; ordering is not load-bearing.
+
+**Verification**: read `mikebom-cli/src/scan_fs/mod.rs:750-773`:
+
+| Line | Pass | Reads `source_file_paths`? | Writes `source_file_paths`? |
+|---|---|---|---|
+| 750 | `deduplicate(components)` | yes (within-group merge) | yes (within-group merge) |
+| 754-756 | `synthesize_cpes(c)` loop | no | no — writes `c.cpes` |
+| 763-764 | `maybe_suppress_scan_target_coord` | no | no — returns new `scan_target_coord` value |
+| 773 | `tag_main_modules_with_workspace_root` | no | no — writes `c.extra_annotations["mikebom:is-workspace-root"]` |
+
+**Implication**: the union pass landing at lines 751-752 (immediately after `deduplicate()`) is structurally clean. CPE synthesis at lines 754-756 reads `c` mutably but writes only `c.cpes`, which is independent of the canonicalized `source_file_paths` Vec. No reordering risk.
+
+**Alternatives considered**:
+- **Land the union pass INSIDE `deduplicate()`** as a second cross-group phase — rejected: muddles the deduplicator's per-group merge semantic with a global cross-group pass. Two distinct algorithms, one function ⇒ harder to test in isolation.
+- **Land the union pass at the end of the scan_fs pipeline (after line 773)** — neutral choice. Slightly later than necessary but no functional difference. Preferring the earlier site (line 751) for proximity to the dedup it complements.
+
+## §B — Code-location decision: in-deduplicator-module vs sibling source_files_union.rs
+
+**Decision**: place the union pass as a new `pub fn canonicalize_source_files_by_purl()` in `mikebom-cli/src/resolve/deduplicator.rs`. NOT a sibling module.
+
+**Rationale**:
+- The pass is conceptually a **second phase of deduplication** — same domain as the existing `deduplicate()` function, just with a different group-key (full canonical PURL vs the deduplicator's `(ecosystem, name, version, parent_purl)` 4-tuple).
+- Co-locating the two passes makes the relationship explicit: a reader landing on the file sees the within-group merge AND the cross-PURL union together, with both doc-comments visible.
+- The existing test module at `mikebom-cli/src/resolve/deduplicator.rs#mod tests` provides the test infrastructure (helper component-construction functions, the `#[cfg_attr(test, allow(clippy::unwrap_used))]` convention) without duplication.
+- A sibling module would force `pub(super)` exports on the helper helpers (or `pub(crate)` exposure), inflating the module surface area for no functional benefit.
+
+**Alternatives considered**:
+- **Sibling module `source_files_union.rs`** — rejected: see above; conceptually duplicates the deduplicator's domain.
+- **Inline at `scan_fs/mod.rs:751` as a closure or local block** — rejected: 15+ LOC is over the inline threshold; the helper functions need to be unit-testable in isolation (SC-004 + SC-005).
+
+## §C — Idempotence strategy
+
+**Decision**: idempotence is automatic via the choice of `BTreeSet<String>` as the union-collection type. The set-union of any Vec with itself returns the original set; converting back to `Vec<String>` via `.into_iter().collect()` yields the same sorted Vec byte-for-byte.
+
+**Verification** (illustrative; not normative):
+
+```rust
+let original: BTreeSet<String> = ["a", "b", "c"].into_iter().map(String::from).collect();
+let vec1: Vec<String> = original.iter().cloned().collect();
+
+// Second pass: rebuild from vec1
+let second: BTreeSet<String> = vec1.iter().cloned().collect();
+let vec2: Vec<String> = second.iter().cloned().collect();
+
+assert_eq!(vec1, vec2);  // byte-identical
+```
+
+**Test (SC-005)**: in `deduplicator.rs#mod tests`, construct two `ResolvedComponent` instances sharing a PURL with different paths. Run the canonicalize pass twice. Assert byte-equality of the post-second-pass output against the post-first-pass output.
+
+**Alternatives considered**:
+- **HashSet + sort** — rejected: same logical result but the sort step is now a manual operation, and the test assertions need to call `.sort()` to compare. BTreeSet collapses both concerns into the type.
+- **Vec + manual sort + dedup_consecutive** — rejected: requires two passes (sort, then dedup_consecutive), more LOC, harder to read.
+
+## §D — Cross-ecosystem coverage audit
+
+**Decision**: the union pass operates on `c.purl.as_str()` keying and is ecosystem-agnostic by construction. No ecosystem-specific code paths needed.
+
+**Audit of `parent_purl`-setting readers** (to identify all ecosystems where the same-PURL multi-entry shape can arise):
+
+```bash
+$ grep -rn "parent_purl: Some\|parent_purl:.*Some" mikebom-cli/src/scan_fs/package_db/ | grep -v tests
+```
+
+Returns (verified at plan-phase via the read of `maven.rs:3429-3457` + grep):
+- **Maven** (`maven.rs:1795`, `:3432-3436`): nested-coord case — `parent_purl = Some(enclosing_purl)` when the coord is vendored inside a fat-jar.
+- **Cargo** (`cargo.rs` ~similar): workspace member case — `parent_purl = Some(workspace-root)` when crate is a workspace member.
+- **Go** (`golang.rs` ~similar): module vendored under `vendor/` case — `parent_purl = Some(main-module-purl)`.
+
+**For each ecosystem**: when the same PURL appears BOTH as a top-level entry (parent_purl = None) AND as a nested-under-parent entry, the deduplicator's `(ecosystem, name, version, parent_purl)` group-key keeps them as separate groups → same-PURL multi-entry shape → the union pass canonicalizes their `source_file_paths` Vecs.
+
+**Implication**: US2 (cross-ecosystem coverage) gets satisfied for free. The Maven case is the only one explicitly tested in this milestone (SC-003 synthetic fixture); future ecosystem-specific tests can be added without re-touching the union pass logic.
+
+**Out-of-audit-scope**: the user's harness focused on the polyglot-builder-image corpus where Maven is the dominant ecosystem. Cross-ecosystem follow-ups (Cargo workspace vendoring, Go vendor) are out of scope for SC-001 (which is Maven-specific); they may produce additional fix-receipt counts on other audit corpora but those are operator-cadence verification.
+
+## §E — Pre-existing within-group merge behavior
+
+**Decision**: leave the deduplicator's within-group merge at lines 74-78 unchanged. The cross-PURL union OVERWRITES the within-group merge result for any same-PURL multi-entry case; for single-entry cases the within-group merge is the only operation and it stays as-is.
+
+**Verification** of the within-group merge:
+
+```rust
+// From deduplicator.rs:74-78
+for file_path in other.evidence.source_file_paths {
+    if !best.evidence.source_file_paths.contains(&file_path) {
+        best.evidence.source_file_paths.push(file_path);
+    }
+}
+```
+
+The within-group merge collects paths in insertion-order (not sorted). For same-`(ecosystem, name, version, parent_purl)`-key components (e.g., the same package detected by two different readers at the same path-context), this produces an insertion-ordered Vec of unique paths.
+
+**Why no harmonization needed**:
+- The within-group merge happens WITHIN a deduplicator group. The cross-PURL union happens ACROSS deduplicator groups that happen to share a PURL.
+- The cross-PURL union's BTreeSet collapses BOTH layers' contributions into one alphabetically-sorted Vec. The within-group insertion-order is irrelevant once the cross-PURL union writes back.
+- For single-entry-per-PURL components (the common case — within-group merge has nothing to merge, OR merges items into a single group), the cross-PURL union is identity. The within-group merge result reaches emit unchanged.
+
+**Net effect**: post-148, the emitted `evidence.source_file_paths` Vec on every component is either:
+- (a) The within-group merge result (insertion-ordered) — for single-entry-per-PURL components where the cross-PURL union is identity.
+- (b) The cross-PURL union (alphabetically-sorted) — for same-PURL multi-entry components where the cross-PURL union writes back over the within-group merge.
+
+This is acceptable because path-order in `mikebom:source-files` has no documented semantic — consumers parse it as a set. The shift from insertion-order to alphabetical-order on a subset of components is non-breaking (and arguably improves auditability — alphabetical sort is more predictable for diffing).
+
+**Test for the cross-pass invariant (SC-004)**: a unit test asserting that, for a single-entry PURL, the post-148 `source_file_paths` is byte-identical to the pre-148 within-group merge result. FR-007 codifies this no-op invariant.
+
+## §F — Synthetic fixture shape for SC-003
+
+**Decision**: construct a minimal Maven-shaped fixture at `mikebom-cli/tests/fixtures/source_files_union/` that exercises the same-PURL multi-entry shape WITHOUT requiring a real OCI image:
+
+```text
+source_files_union/
+├── pom.xml                   # declares one dep: pkg:maven/com.example:foo@1.0
+├── target/
+│   ├── primary.jar           # standalone com.example:foo@1.0.jar at top-level
+│   └── fat-bundle.jar        # fat-jar that vendors com.example:foo@1.0 internally
+└── README.md                  # documents the shape: one Maven coord, two paths
+```
+
+The Maven reader at `scan_fs/package_db/maven.rs:3429-3457` will:
+1. Detect `target/primary.jar` as standalone → emit one `PackageDbEntry` for `pkg:maven/com.example:foo@1.0` with `parent_purl = None`.
+2. Detect `target/fat-bundle.jar` and walk into it → detect the nested `com.example:foo@1.0` inside → emit one `PackageDbEntry` with `parent_purl = Some(pkg:maven/com.example:fat-bundle@...)`.
+
+Both entries pass through `deduplicate()` (different `parent_purl` → different groups → not merged) and reach the union pass with different single-element `source_file_paths` Vecs. Post-148 the union pass writes the alphabetically-sorted union onto BOTH entries' Vecs.
+
+The integration test runs `mikebom sbom scan --path <fixture> --format <each>` three times (one per format) and asserts that the `mikebom:source-files` value for `pkg:maven/com.example:foo@1.0` is bytewise-identical across all three format outputs (per US1 acceptance scenarios 1+2).
+
+**Alternative considered**:
+- **Reuse the polyglot-builder-image fixture from the audit corpus** — rejected: that fixture is a real OCI image, large + slow + opaque. The synthetic fixture is small + fast + intent-documented.
+
+## §G — Golden-refresh scope estimation
+
+**Decision**: existing Maven-bearing CDX/SPDX 2.3/SPDX 3 goldens may experience small `mikebom:source-files` value changes. Specifically: the `pom-three-deps` fixture under `mikebom-cli/tests/fixtures/maven/` may have any same-PURL multi-entry shape (unlikely — it's a simple POM-only fixture); if not, the goldens are unchanged.
+
+**Verification action for Phase 5 (tasks.md)**:
+```bash
+MIKEBOM_UPDATE_CDX_GOLDENS=1   cargo test --test cdx_regression cdx_regression_maven
+MIKEBOM_UPDATE_SPDX_GOLDENS=1  cargo test --test spdx_regression maven_byte_identity
+MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo test --test spdx3_regression maven_byte_identity
+
+# Inspect:
+git diff --stat -- mikebom-cli/tests/fixtures/golden/{cyclonedx,spdx-2.3,spdx-3}/maven.*.json
+```
+
+**Acceptance**: any drift MUST be limited to:
+- (a) `mikebom:source-files` value changes on components that previously carried a non-canonical single-path Vec (Maven nested-coord components specifically).
+- (b) New canonical-union Vec contents that include both the standalone path AND the nested path for each affected component.
+
+Reject any drift outside these two patterns (FR-010).
+
+## Summary of decisions feeding Phase 1
+
+- **§A**: Union pass lands at `scan_fs/mod.rs:751` immediately after `deduplicate()`. Order with subsequent passes is not load-bearing (none touch `source_file_paths`).
+- **§B**: Implementation lives in `mikebom-cli/src/resolve/deduplicator.rs` as a new `pub fn canonicalize_source_files_by_purl()`. NOT a sibling module.
+- **§C**: Idempotence via `BTreeSet<String>` collection type (set-union is idempotent by definition; conversion to sorted Vec is deterministic).
+- **§D**: Cross-ecosystem coverage automatic via `Purl::as_str()` keying. Maven is the only ecosystem with confirmed audit findings (51 polyglot-builder-image cases); Cargo workspace + Go vendor cases potentially covered for free.
+- **§E**: Existing within-group merge at deduplicator.rs:74-78 stays unchanged. The two passes compose — within-group merge runs first, cross-PURL union writes back over multi-entry results.
+- **§F**: Synthetic SC-003 fixture at `mikebom-cli/tests/fixtures/source_files_union/` with one Maven coord appearing both standalone + nested inside a fat-jar.
+- **§G**: Golden-refresh scope: 3 maven-bearing goldens (`cyclonedx/maven.cdx.json`, `spdx-2.3/maven.spdx.json`, `spdx-3/maven.spdx3.json`); likely empty diff unless the `pom-three-deps` fixture happens to exercise the multi-entry shape.
+- **No new Cargo dependencies.**
+- **No new `mikebom:*` annotation** (FR-008 + Constitution V satisfied vacuously).

--- a/specs/148-source-files-union/spec.md
+++ b/specs/148-source-files-union/spec.md
@@ -1,0 +1,168 @@
+# Feature Specification: source-files cross-emitter divergence — union evidence across same-PURL entries
+
+**Feature Branch**: `148-source-files-union`
+**Created**: 2026-06-28
+**Status**: Draft
+**Input**: User description: "milestone 148: source-files cross-emitter divergence — union evidence.source_file_paths across same-PURL entries after dedup to fix the Maven nested-coord audit finding (51 polyglot-builder-image cases)"
+
+## Origin & Context
+
+The sbom-conformance audit harness (operator-cadence; not a CI gate) compared mikebom-emitted CDX 1.6 / SPDX 2.3 / SPDX 3 documents for the `polyglot-builder-image` fixture on 2026-06-28 (post-merge of milestone 145's annotation-emission parity fixes in `8a0660b`). The harness reported that 51 components carry a `mikebom:source-files` value that differs across CDX and SPDX 3 outputs for what the harness treats as the SAME component PURL (matched by `pkg:maven/<groupId>:<artifactId>@<version>` identity).
+
+Investigation in the conversation thread leading to this milestone established:
+
+1. **Where it lives**: the Maven nested-JAR walker at `mikebom-cli/src/scan_fs/package_db/maven.rs:3429-3457` intentionally creates **two `PackageDbEntry` instances** for the same Maven coord when that coord appears both standalone (e.g., at `/root/.m2/repository/.../surefire-3.2.2.jar`) AND nested inside a fat-jar (e.g., extracted from `/tmp/extract-XXX/some-fat.jar!surefire-3.2.2.jar`). The two entries differ only in their `parent_purl` field — one is `None` (standalone), the other is `Some(fat-jar-purl)` (nested).
+
+2. **Why dedup doesn't merge them**: the deduplicator at `mikebom-cli/src/resolve/deduplicator.rs:34-46` groups components by `(ecosystem, name, version, parent_purl)`. Different `parent_purl` values → different groups → never merged. The CDX nested-components model (a child can appear under multiple parents) DEPENDS on this — collapsing by PURL alone would destroy the dep-graph topology.
+
+3. **Why the audit harness sees a divergence**: both entries survive into the per-format emit pipeline. Each entry carries its own `evidence.source_file_paths` Vec (one points at the standalone JAR path; the other at the extract-tempdir path). Each format emitter (CDX `builder.rs:619` iteration, SPDX 2.3 `annotations.rs:302`, SPDX 3 `v3_annotations.rs:267`) emits BOTH entries as separate components, each with its own `mikebom:source-files` value. The user's harness then groups by PURL on the audit side and observes "same PURL, different source-files values across formats" — the values it picks per format depend on whichever entry happens to be the first or last match in its post-processing pipeline, which differs by format because the wire surface presents the entries in different orders.
+
+4. **Why milestone 145's US3 fix didn't move these 51 findings**: 145 US3 addressed a DIFFERENT case — the same component's `mikebom:source-files` annotation was being double-emitted (once from `evidence.source_file_paths` field, once from `extra_annotations["mikebom:source-files"]` bag stamped by the Maven reader). The fix renamed the bag-stamped key to `mikebom:source-files-nested-url` (eliminating the within-component drift). The 51 polyglot-builder-image cases are a DIFFERENT shape: cross-`PackageDbEntry`-instance drift on the field-derived source itself.
+
+The remediation should preserve the topology-bearing two-entry shape while making the `evidence.source_file_paths` Vec carry the SAME content on every entry that shares a PURL. Once every same-PURL entry's Vec contains the union of all observed paths, the emitter-iteration-order-dependent harness divergence dissolves: regardless of which entry the harness picks per format, the `mikebom:source-files` value is identical.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Same-PURL `mikebom:source-files` values match across CDX and SPDX 3 emissions (Priority: P1)
+
+A compliance engineer runs `mikebom sbom scan` on `polyglot-builder-image` and emits both CDX 1.6 and SPDX 3 outputs. They run a cross-format audit query that, for every Maven coord PURL appearing in both documents, compares the `mikebom:source-files` annotation values. Today (post-145) the query reports 51 PURLs with cross-format divergence. After this milestone, the count drops to 0 (or near-zero) — every PURL's `mikebom:source-files` value contains the SAME union of observed paths regardless of whether the auditor reads the CDX or SPDX 3 view.
+
+**Why this priority**: this is the singular value-add of this milestone — closing the last cluster of cross-format `mikebom:source-files` divergence on the polyglot-builder-image audit corpus. Without it, downstream compliance tooling that does cross-format reconciliation continues to report 51 false-divergence findings, masking real cross-format issues.
+
+**Independent Test**: scan the polyglot-builder-image fixture in both CDX and SPDX 3 formats; for every shared Maven PURL, assert the `mikebom:source-files` value parsed as a sorted set is bytewise-identical across the two formats. SC-001 captures the expected count delta (51 → 0 or near-zero on the audit corpus).
+
+**Acceptance Scenarios**:
+
+1. **Given** the polyglot-builder-image fixture is scanned and produces both CDX 1.6 and SPDX 3 outputs, **When** the auditor extracts `mikebom:source-files` values from every Maven coord PURL that appears in both documents, **Then** every same-PURL pair carries the SAME set of file paths (as parsed alphabetically-sorted sets).
+
+2. **Given** the same fixture is scanned and produces both CDX 1.6 and SPDX 2.3 outputs, **When** the auditor performs the equivalent cross-format comparison, **Then** every same-PURL pair carries the SAME set of file paths. (SPDX 2.3 is structurally identical to SPDX 3 for this annotation; the parity must hold across all three formats.)
+
+3. **Given** a Maven coord that exists ONLY as a top-level entry (no fat-jar nesting), **When** the scan emits all three formats, **Then** the `mikebom:source-files` value continues to contain the single rootfs-relative path it carried pre-148 — the union-with-self degenerates to the identity case.
+
+4. **Given** a Maven coord that exists ONLY as a nested entry under a fat-jar (no standalone counterpart in the rootfs), **When** the scan emits all three formats, **Then** the `mikebom:source-files` value carries the single extract-tempdir path it carried pre-148 — the union-with-self again degenerates to the identity case.
+
+5. **Given** a Maven coord that exists in BOTH shapes (standalone + nested under a fat-jar), **When** the scan emits all three formats, **Then** EVERY surviving entry's `mikebom:source-files` value contains the FULL union of both paths (standalone AND nested), sorted alphabetically.
+
+---
+
+### User Story 2 - Cross-ecosystem coverage (non-Maven same-PURL multi-entry cases) (Priority: P2)
+
+The Maven nested-coord pattern is the most prominent same-PURL multi-entry case in the polyglot-builder-image audit corpus, but the deduplicator's `(ecosystem, name, version, parent_purl)` group-key admits the same shape for ANY ecosystem where a reader sets `parent_purl` on some entries and leaves it `None` on others for what the wire surface treats as the same component PURL. After this milestone, cross-format `mikebom:source-files` divergence MUST be zero for any such ecosystem (npm peer-dep edge cases, Go vendored module cases, Rust workspace cargo-vendored cases — wherever the same coord can survive both as top-level AND under a parent_purl).
+
+**Why this priority**: the fix lands in the cross-ecosystem post-dedup pipeline (not in the Maven reader specifically), so coverage of non-Maven ecosystems comes for free. Documenting it as a separate user story ensures the success criteria call out the cross-ecosystem invariant explicitly so future ecosystem readers can rely on it.
+
+**Independent Test**: enumerate every (ecosystem, PURL) combination in the polyglot-builder-image fixture; for each ecosystem that has ≥1 PURL with >1 surviving `ResolvedComponent` instance post-dedup, assert the same cross-format `mikebom:source-files` invariant from US1 scenario 1 holds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fixture contains a Cargo crate that exists both as a top-level workspace member AND as a vendored sub-crate under a workspace parent, **When** the scan emits all three formats, **Then** the crate's `mikebom:source-files` value carries the union of both paths across all three formats.
+
+2. **Given** a fixture contains a Go module that exists both as a `go.mod`-tracked direct dep AND as a vendored copy under `vendor/` (with `parent_purl` set on the vendored entry), **When** the scan emits all three formats, **Then** the module's `mikebom:source-files` value carries the union of both observed paths.
+
+3. **Given** a fixture has no ecosystem with same-PURL multi-entry shape, **When** the scan emits all three formats, **Then** no component's `mikebom:source-files` value changes from its pre-148 emission — the union-with-self degenerates to identity for every component.
+
+---
+
+### Edge Cases
+
+- **Same PURL, three or more surviving entries**: e.g., one standalone + two nested under different fat-jars. The union pass MUST merge across all three (and N more for general cases), producing a single alphabetically-sorted union Vec.
+
+- **Same PURL, same `source_file_paths` content on every entry**: union-with-self produces an unchanged Vec (the dedup-by-content set semantic guarantees no duplicate paths appear).
+
+- **Same PURL where one entry has empty `source_file_paths`**: the union still works — empty Vec contributes no elements, the merged Vec equals the non-empty entry's content.
+
+- **PURL that survives dedup as a single entry**: union-with-self is identity; the Vec content is unchanged byte-for-byte from pre-148.
+
+- **File-tier components** (PURL = `pkg:generic/file-tier?content-sha256=<hex>`): out of scope for this milestone. File-tier components already carry the FULL multi-path union via the existing `push_path` aggregation in `file_tier/walker.rs`; the union pass is an idempotent no-op for them (the dedup-by-content `BTreeSet` collapses the input back to the same set).
+
+- **Components where `evidence.source_file_paths` is empty on every same-PURL entry**: union produces empty Vec; the existing `if !c.evidence.source_file_paths.is_empty()` emission gates at each emitter site keep the annotation absent.
+
+- **PURL collision across ECOSYSTEMS** (theoretical — e.g., a `pkg:pypi/<name>@<v>` and a `pkg:maven/<name>@<v>` happening to share the bare-PURL string after some normalization step): MUST NOT cross-pollinate paths. The union pass MUST key on the full canonical PURL string (`Purl::as_str()`), which includes the ecosystem segment — preserving ecosystem isolation.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: After the existing `deduplicate()` pass at `scan_fs/mod.rs:750`, mikebom MUST run a post-dedup canonicalization pass that, for every PURL appearing on multiple `ResolvedComponent` instances, replaces each instance's `evidence.source_file_paths` Vec with the **union** of paths observed across all same-PURL entries.
+
+- **FR-002**: The union MUST be a set (no duplicate paths) collected in alphabetical (lex-ascending) order. This matches the milestone-145 `mikebom:file-paths` precedent (`paths_str.sort()` at `file_tier/mod.rs:230`).
+
+- **FR-003**: The union pass MUST key on the canonical PURL string (`component.purl.as_str()`), NOT on `(name, version)` or `(ecosystem, name, version, parent_purl)`. The canonical PURL string includes the ecosystem segment, preventing cross-ecosystem path cross-pollination per Edge Case 7.
+
+- **FR-004**: The union pass MUST be IDEMPOTENT. Running it twice on the same input produces byte-identical output. Specifically: every entry that already carries the canonical union Vec is unchanged after the second pass.
+
+- **FR-005**: The union pass MUST NOT alter ANY field of `ResolvedComponent` other than `evidence.source_file_paths`. Specifically: `purl`, `name`, `version`, `parent_purl`, `hashes`, `lifecycle_scope`, `extra_annotations`, the rest of `evidence.*` (technique, confidence, source_connection_ids, deps_dev_match), and every other field MUST be preserved verbatim.
+
+- **FR-006**: The fix MUST preserve the dep-graph topology that the deduplicator INTENTIONALLY retains via the `parent_purl` group-key. Specifically: the two entries for `pkg:maven/<groupId>:<artifactId>@<version>` (one with `parent_purl = None`, one with `parent_purl = Some(fat-jar-purl)`) MUST both continue to exist post-148; only their `evidence.source_file_paths` Vecs are touched.
+
+- **FR-007**: When a component's PURL appears as the only entry post-dedup (the common case — single-entry PURLs are the overwhelming majority of every scan), the union pass MUST be a **content-preserving no-op** for that entry: the *set* of paths MUST be unchanged. The wire-order MAY be canonicalized to alphabetical (lex-ascending) — the union pass uses a `BTreeSet<String>` collection, so an insertion-ordered single-entry Vec that wasn't already alphabetically sorted pre-148 will be sorted post-148. This is non-breaking because `mikebom:source-files` value-order has no documented semantic and consumers parse the value as a set. (The implementer MAY tighten the no-op to *byte-identical* by skipping write-back when the BTreeSet content equals the existing Vec content — purely an optimization; the spec requirement is content-preservation only.)
+
+- **FR-008**: The fix MUST NOT introduce any new `mikebom:*` annotation key. The existing `mikebom:source-files` (field-derived) and `mikebom:source-files-nested-url` (Maven-reader-stamped) keys cover the wire surface. The fix operates entirely on the in-process `evidence.source_file_paths` field; no wire-level addition.
+
+- **FR-009**: Cross-format byte-equivalence MUST hold for the `mikebom:source-files` annotation across all three formats (CDX 1.6, SPDX 2.3, SPDX 3) on every test fixture that exercises the same-PURL multi-entry case. The parity-catalog row C18 (`mikebom:source-files`, `Directionality::SymmetricEqual`) MUST continue to pass on all existing byte-identity goldens AND on any new fixture that exercises the post-148 union pass.
+
+- **FR-010**: Existing byte-identity goldens under `mikebom-cli/tests/fixtures/golden/` (CDX + SPDX 2.3 + SPDX 3) MUST refresh through the standard env-var trifecta (`MIKEBOM_UPDATE_CDX_GOLDENS=1`, `MIKEBOM_UPDATE_SPDX_GOLDENS=1`, `MIKEBOM_UPDATE_SPDX3_GOLDENS=1`). Any golden drift MUST be limited to `mikebom:source-files` value changes on components that previously carried a non-canonical single-path Vec (specifically: the Maven nested-coord components in the maven-bearing fixtures). NO unrelated field MUST drift.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On the polyglot-builder-image audit corpus (per the 2026-06-28 harness run), the count of Maven PURLs reporting cross-format `mikebom:source-files` divergence drops from **51 → 0** (or near-zero — single-digit residuals are acceptable only if they come from a different bug class, documented post-merge by the operator-cadence harness re-run).
+
+- **SC-002**: The C18 parity-catalog row's `Directionality::SymmetricEqual` invariant continues to hold on every byte-identity golden under `mikebom-cli/tests/fixtures/golden/`. The CI-binding `cross_format_byte_identity` and `holistic_parity` tests MUST pass.
+
+- **SC-003**: A new in-source integration test (placed in `mikebom-cli/tests/source_files_purl_union_md148.rs` or similar) MUST exercise a fixture with ≥1 known same-PURL multi-entry shape (Maven nested-coord) and assert the cross-format invariant from US1 acceptance scenario 1 — same PURL → same `mikebom:source-files` value across all three formats. The test MUST fail on the pre-148 codebase and pass post-148.
+
+- **SC-004**: A new unit test in the deduplicator module (`mikebom-cli/src/resolve/deduplicator.rs#mod tests`) MUST construct two `ResolvedComponent` instances sharing a PURL but differing in `parent_purl`, with different `evidence.source_file_paths` content, and assert that after the union pass both entries carry the same alphabetically-sorted union Vec. The test MUST cover FR-001 + FR-002 + FR-005 + FR-006.
+
+- **SC-005**: An idempotence unit test MUST run the union pass twice on the same input and assert byte-equality of the output (FR-004).
+
+- **SC-006**: The full pre-PR gate (`./scripts/pre-pr.sh`) MUST pass — both `cargo +stable clippy --workspace --all-targets -- -D warnings` and `cargo +stable test --workspace` — except the documented pre-existing `sbomqs_parity` env-only failure per memory `feedback_prepr_gate_full_output.md` + milestone-144 T001 note.
+
+- **SC-007**: Operator-cadence verification (post-merge, not CI-gated): the operator re-runs the sbom-conformance audit harness on the polyglot-builder-image fixture and confirms the 51 findings are gone. Documented in the PR description as a manual follow-up.
+
+## Assumptions
+
+1. **The Maven nested-coord pattern is the dominant same-PURL multi-entry shape on the polyglot-builder-image audit corpus.** Per the diagnostic in the conversation thread, all 51 audit findings cluster on Maven coords. Other ecosystems may also exhibit the pattern; the fix's cross-ecosystem coverage (US2) addresses them generically, but the SC-001 51 → 0 metric is Maven-specific.
+
+2. **The deduplicator's `(ecosystem, name, version, parent_purl)` group-key is correct and must NOT be changed.** Collapsing the group-key to `(ecosystem, name, version)` would destroy the CDX nested-components topology that Maven shade-plugin fat-jar handling depends on (per the doc-comment at `maven.rs:3450`). The fix MUST be additive: a post-dedup union pass that leaves the dedup logic untouched.
+
+3. **`source_file_paths` is the only `evidence.*` field that needs cross-entry union.** Other fields like `source_connection_ids` and `hashes` are MERGED by the deduplicator's existing logic (lines 69-83) WITHIN each `(ecosystem, name, version, parent_purl)` group. They don't need cross-`parent_purl` union because their semantics are per-instance (a hash measured at this specific path; a connection-id from this specific reader).
+
+4. **The CDX `bom-ref` uniqueness concern is out of scope.** When two same-PURL entries with `parent_purl = None` both reach the CDX builder, they both get bom-ref = plain PURL string, which violates CDX 1.6's bom-ref uniqueness spec. This is a SEPARATE issue (not introduced by this milestone) and the harness in the audit thread doesn't flag it. Future milestone N+M can address it; this milestone scope is the `mikebom:source-files` value-drift fix only.
+
+5. **No new Cargo dependencies.** The fix uses `std::collections::HashMap` + `std::collections::BTreeSet` (both pervasive in the codebase). No new crate additions.
+
+6. **No new `mikebom:*` annotation.** Per FR-008. The fix is purely an in-process evidence-merge operation; the wire surface is unchanged at the annotation key level (values change for affected components).
+
+7. **Operator-cadence audit re-run is sufficient SC-007 verification.** Per the existing project convention (milestones 144 / 145 / 147 all rely on operator-cadence re-runs of the harness as the post-merge confirmation; the in-tree integration test SC-003 is the CI-binding signal).
+
+8. **The Maven reader stays unchanged.** Per FR-006 — the Maven reader's two-entry intent is preserved. The fix lands in `scan_fs/mod.rs` (or a sibling module under `mikebom-cli/src/resolve/`), NOT in `mikebom-cli/src/scan_fs/package_db/maven.rs`.
+
+## Out of Scope
+
+1. **CDX `bom-ref` uniqueness enforcement.** Two same-PURL components both ending up with the same bom-ref is a CDX 1.6 spec violation but is NOT introduced by this milestone — it's pre-existing. Out of scope; a separate issue can track the fix.
+
+2. **Per-emitter component-instance dedup.** Some emitters might benefit from collapsing two same-PURL components into one wire entry (CDX nested-components vs SPDX 2.3 flat Packages vs SPDX 3 `software:Package` elements). This milestone does NOT change per-emitter dedup; it only canonicalizes the `evidence.source_file_paths` Vec across same-PURL entries so the emitted values agree.
+
+3. **New `mikebom:source-files-*` annotations.** Per FR-008 — no new annotation. The fix is the value canonicalization; the wire surface key set is unchanged.
+
+4. **Changes to milestone 145's US3 fix.** That fix (renaming the Maven bag-stamped key to `mikebom:source-files-nested-url`) stays as-is. This milestone is additive — different code path, different bug class.
+
+5. **Changes to the deduplicator's group-key.** Per Assumption 2 — the deduplicator stays untouched. This milestone is a post-dedup pass.
+
+6. **Changes to `evidence.source_connection_ids`, `evidence.hashes`, or any other `evidence.*` field.** Per Assumption 3 — only `source_file_paths` needs the cross-entry union.
+
+7. **Investigation of issue #1 (JVM symlink paths) or issue #2 (SPDX 3 lifecycle-scope).** Per the conversation triage:
+   - Issue #1 needs an operator-cadence raw-output diagnostic before scoping a fix; the hypothesis (harness shows only first array element) is plausible but unconfirmed.
+   - Issue #2 is a deliberate Principle V decision (SPDX 3's native `LifecycleScopedRelationship.scope` is the carrier); not a mikebom bug. Future harness updates should look at the relationship-side, not the package annotation.
+
+8. **File-tier components.** Per Edge Case 5, the file-tier walker already aggregates per-hash. The union pass is idempotent for them; no change in behavior.
+
+9. **A new parity-catalog row.** The C18 row already covers `mikebom:source-files` with `Directionality::SymmetricEqual`. SC-002 reuses the existing row.
+
+## Constitution V audit
+
+This milestone introduces NO new `mikebom:*` annotation (FR-008). The fix is purely a value-canonicalization operation on the in-process `evidence.source_file_paths` field that ALL three emitters already consume via their existing `c.evidence.source_file_paths` reads. The C18 parity-catalog row's audit (recorded at `docs/reference/sbom-format-mapping.md` C18) is unchanged.
+
+Constitution Principle V (standards-native > `mikebom:*`) is satisfied vacuously: no annotation is added; the existing `mikebom:source-files` annotation's parity-bridging rationale is unaffected.

--- a/specs/148-source-files-union/tasks.md
+++ b/specs/148-source-files-union/tasks.md
@@ -1,0 +1,604 @@
+---
+description: "Task list for milestone 148 — source-files cross-emitter divergence — union evidence.source_file_paths across same-PURL entries after dedup"
+---
+
+# Tasks: milestone 148 — source-files cross-emitter divergence — union evidence across same-PURL entries
+
+**Input**: Design documents from `/specs/148-source-files-union/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+**Tests**: Spec mandates tests via SC-002 + SC-003 + SC-004 + SC-005. Test tasks are included inline alongside implementation tasks (per the project's existing Rust convention of in-file `#[cfg(test)] mod tests` for unit tests + `mikebom-cli/tests/*.rs` for integration tests).
+
+**Organization**: US1 (cross-format value match) and US2 (cross-ecosystem coverage) share the SAME implementation — the `canonicalize_source_files_by_purl` pass keyed on `Purl::as_str()` is ecosystem-agnostic by construction (research §D). Phase 3 ships US1 + the implementation; Phase 4 ships US2 as additional cross-ecosystem assertions over the same code path. No foundational types or signature plumbing needed (zero new types per data-model.md).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Maps to user story from spec.md (US1, US2)
+- Paths absolute under repo root `/Users/mlieberman/Projects/mikebom/`
+
+## Path Conventions
+
+Two Rust source files touched: `mikebom-cli/src/resolve/deduplicator.rs` (NEW `canonicalize_source_files_by_purl` function + unit tests) and `mikebom-cli/src/scan_fs/mod.rs` (ONE additive call at line ~751). One new integration test at `mikebom-cli/tests/source_files_purl_union_md148.rs`. One new synthetic test fixture at `mikebom-cli/tests/fixtures/source_files_union/`. Three potential golden refreshes under `mikebom-cli/tests/fixtures/golden/{cyclonedx,spdx-2.3,spdx-3}/maven.*.json`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify baseline before any code change.
+
+- [ ] T001 Confirm baseline pre-PR gate is green on branch `148-source-files-union`. Run `./scripts/pre-pr.sh` from repo root. Expected: clippy `--workspace --all-targets -- -D warnings` clean; `cargo test --workspace` passes except for the pre-existing local-environment `sbomqs_parity::sbomqs_spdx_score_meets_or_beats_cdx_across_ecosystems` failure documented in milestone-144 T001. If anything ELSE fails, halt and investigate before proceeding.
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: None required for this milestone. Zero new types, zero new Cargo dependencies (per data-model.md). The new function is purely additive in an existing module.
+
+(No tasks in this phase. Proceed directly to Phase 3.)
+
+---
+
+## Phase 3: User Story 1 - Same-PURL `mikebom:source-files` values match across CDX and SPDX 3 emissions (Priority: P1) 🎯 MVP
+
+**Goal**: Implement `canonicalize_source_files_by_purl()` post-dedup pass; wire it into the scan pipeline; cover with unit tests + a synthetic-fixture integration test asserting cross-format byte-equality of `mikebom:source-files` on a Maven nested-coord PURL.
+
+**Independent Test**: Build a synthetic Maven fixture where one coord appears both standalone AND nested inside a fat-jar. Scan three times (CDX, SPDX 2.3, SPDX 3). Assert the `mikebom:source-files` value for that coord PURL is bytewise-identical across all three formats.
+
+### Implementation for User Story 1
+
+- [ ] T002 [US1] Add `pub fn canonicalize_source_files_by_purl(components: &mut Vec<ResolvedComponent>)` to `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/resolve/deduplicator.rs` immediately after the existing `pub fn deduplicate(...)` function. Per contracts/source-files-union.md algorithm sketch:
+
+  ```rust
+  /// Milestone 148: cross-PURL canonicalization of evidence.source_file_paths.
+  ///
+  /// After the existing `deduplicate()` pass merges same-(ecosystem,name,version,
+  /// parent_purl)-key groups, some ecosystems (Maven nested-coord case at
+  /// `scan_fs/package_db/maven.rs:3429-3457`, Cargo workspace vendoring, Go
+  /// vendored modules) intentionally retain multiple `ResolvedComponent` instances
+  /// sharing the same `Purl::as_str()` value but differing in `parent_purl`. The
+  /// CDX nested-components topology depends on this two-entry shape.
+  ///
+  /// Each entry carries its own `evidence.source_file_paths` Vec (one observed
+  /// path from the standalone reader pass, one observed path from the nested
+  /// reader pass). Per-emitter iteration-order differences (CDX `builder.rs:619`,
+  /// SPDX 2.3 `annotations.rs:302`, SPDX 3 `v3_annotations.rs:267`) cause the
+  /// audit harness to observe cross-format divergence on the `mikebom:source-files`
+  /// annotation for what the harness treats as the same PURL (51 polyglot-builder-
+  /// image findings, 2026-06-28 audit).
+  ///
+  /// This pass, keyed on the full canonical `Purl::as_str()` string, replaces
+  /// each same-PURL entry's `source_file_paths` Vec with the alphabetically-
+  /// sorted UNION of paths observed across all same-PURL entries. After the
+  /// pass, every emitter sees the same Vec content for every same-PURL pair,
+  /// so the wire-side `mikebom:source-files` annotation is identical across
+  /// formats regardless of which entry the harness happens to pick.
+  ///
+  /// **Idempotent** — running twice produces byte-identical output (FR-004).
+  /// **Topology-preserving** — does NOT modify `parent_purl` or any other
+  /// field (FR-005 + FR-006).
+  /// **No-op for single-entry PURLs** — the common case is unchanged (FR-007).
+  pub fn canonicalize_source_files_by_purl(
+      components: &mut Vec<ResolvedComponent>,
+  ) {
+      use std::collections::{BTreeSet, HashMap};
+
+      // Phase 1: collect — walk every component, accumulate paths by canonical PURL.
+      let mut paths_by_purl: HashMap<String, BTreeSet<String>> = HashMap::new();
+      for c in components.iter() {
+          paths_by_purl
+              .entry(c.purl.as_str().to_string())
+              .or_default()
+              .extend(c.evidence.source_file_paths.iter().cloned());
+      }
+
+      // Phase 2: write back — replace each entry's source_file_paths with the
+      // alphabetically-sorted union for its PURL.
+      for c in components.iter_mut() {
+          if let Some(union) = paths_by_purl.get(c.purl.as_str()) {
+              c.evidence.source_file_paths = union.iter().cloned().collect();
+          }
+      }
+  }
+  ```
+
+  Per research §B the function lives IN the existing `deduplicator.rs` (NOT a sibling `source_files_union.rs` module) since it's conceptually a second-phase cross-PURL union over the same domain as `deduplicate()`.
+
+- [ ] T003 [US1] Wire the new pass at `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/mod.rs` immediately after the existing `let mut components = deduplicate(components);` at line 750. Add the import at the top of the file if not already present (`use crate::resolve::deduplicator::canonicalize_source_files_by_purl;` or extend the existing `use crate::resolve::deduplicator::deduplicate;` import). The call:
+
+  ```rust
+  let mut components = deduplicate(components);
+  // Milestone 148: cross-PURL canonicalization. When the same PURL survives
+  // dedup as multiple entries (Maven nested-coord case where standalone +
+  // nested-under-fat-jar both exist with different parent_purl values), all
+  // surviving entries get the SAME alphabetically-sorted source_file_paths
+  // Vec — closes the 51 polyglot-builder-image audit findings on cross-format
+  // `mikebom:source-files` divergence.
+  canonicalize_source_files_by_purl(&mut components);
+  // ... existing CPE synthesis loop at lines 754-756 (unchanged) ...
+  ```
+
+  Per research §A this placement is structurally clean — no existing post-dedup pass touches `evidence.source_file_paths`.
+
+- [ ] T004 [US1] Add unit test `canonicalize_source_files_by_purl_same_purl_different_parent_unions_paths_md148` in `mikebom-cli/src/resolve/deduplicator.rs#mod tests`. Constructs two `ResolvedComponent` instances sharing `pkg:maven/com.example:foo@1.0` but with different `parent_purl` values + different `source_file_paths` content. Asserts both entries carry the alphabetically-sorted union Vec after the pass. Pattern:
+
+  ```rust
+  #[test]
+  fn canonicalize_source_files_by_purl_same_purl_different_parent_unions_paths_md148() {
+      use mikebom_common::types::purl::Purl;
+      let purl = Purl::new("pkg:maven/com.example/foo@1.0").unwrap();
+      let mut components = vec![
+          // Standalone entry (parent_purl = None).
+          make_test_component(
+              purl.clone(),
+              None,
+              vec!["root/.m2/repository/.../foo-1.0.jar".to_string()],
+          ),
+          // Nested-under-fat-jar entry (parent_purl = Some(...)).
+          make_test_component(
+              purl.clone(),
+              Some("pkg:maven/com.example/fat-bundle@1.0".to_string()),
+              vec!["tmp/extract/fat-bundle.jar!.../foo-1.0.jar".to_string()],
+          ),
+      ];
+      canonicalize_source_files_by_purl(&mut components);
+      let expected = vec![
+          "root/.m2/repository/.../foo-1.0.jar".to_string(),
+          "tmp/extract/fat-bundle.jar!.../foo-1.0.jar".to_string(),
+      ];
+      // Wait — alphabetical sort: "root/..." < "tmp/..." per lex. Confirm.
+      assert_eq!(components[0].evidence.source_file_paths, expected,
+          "FR-001 + FR-002: standalone entry MUST carry the alphabetically-sorted union");
+      assert_eq!(components[1].evidence.source_file_paths, expected,
+          "FR-001 + FR-002: nested entry MUST carry the SAME alphabetically-sorted union");
+      // FR-006: parent_purl topology preserved.
+      assert_eq!(components[0].parent_purl, None);
+      assert_eq!(components[1].parent_purl, Some("pkg:maven/com.example/fat-bundle@1.0".to_string()));
+  }
+  ```
+
+  Requires a `make_test_component` helper (define locally in the test module if not already present); pattern: minimal `ResolvedComponent` with the supplied purl/parent_purl/source_file_paths and reasonable defaults for the other fields. Covers FR-001 + FR-002 + FR-006 (topology preservation) + SC-004.
+
+- [ ] T005 [P] [US1] Add unit test `canonicalize_source_files_by_purl_single_entry_is_content_preserving_md148` in the same `mod tests` block. Tests FR-007: when a component's PURL appears as the only entry, the pass is a content-preserving no-op (set of paths unchanged; wire-order MAY canonicalize to alphabetical per the BTreeSet collection semantic). Pattern:
+
+  ```rust
+  #[test]
+  fn canonicalize_source_files_by_purl_single_entry_is_content_preserving_md148() {
+      use mikebom_common::types::purl::Purl;
+      use std::collections::BTreeSet;
+      let purl = Purl::new("pkg:npm/example@1.0.0").unwrap();
+      // Deliberately NOT alphabetical to exercise the wire-order canonicalization.
+      let original_paths = vec![
+          "node_modules/example/package.json".to_string(),
+          "node_modules/example/index.js".to_string(),
+      ];
+      let mut components = vec![make_test_component(
+          purl,
+          None,
+          original_paths.clone(),
+      )];
+      canonicalize_source_files_by_purl(&mut components);
+
+      // FR-007 (content-preserving no-op): the SET of paths is unchanged.
+      let pre_set: BTreeSet<&String> = original_paths.iter().collect();
+      let post_set: BTreeSet<&String> =
+          components[0].evidence.source_file_paths.iter().collect();
+      assert_eq!(pre_set, post_set,
+          "FR-007: single-entry PURL's path-SET MUST be preserved");
+      // Wire-order MAY be alphabetical per the BTreeSet collection semantic.
+      // We do NOT assert byte-identical wire order — that's an optimization
+      // an implementer may choose to add but the spec does not require.
+  }
+  ```
+
+  Covers FR-007 (content-preserving no-op). Per the spec's explicit allowance, wire-order canonicalization to alphabetical is permitted (BTreeSet collection semantic). This test deliberately asserts set-equality only — implementations that skip write-back for single-entry PURLs (preserving byte-order) and implementations that always write back (canonicalizing to alphabetical) both pass.
+
+- [ ] T006 [P] [US1] Add unit test `canonicalize_source_files_by_purl_is_idempotent_md148` in the same `mod tests` block. Tests FR-004: two consecutive passes produce byte-identical output. Pattern:
+
+  ```rust
+  #[test]
+  fn canonicalize_source_files_by_purl_is_idempotent_md148() {
+      use mikebom_common::types::purl::Purl;
+      let purl = Purl::new("pkg:maven/com.example/foo@1.0").unwrap();
+      let mut components = vec![
+          make_test_component(
+              purl.clone(),
+              None,
+              vec!["b/path".to_string()],
+          ),
+          make_test_component(
+              purl.clone(),
+              Some("pkg:maven/com.example/parent@1.0".to_string()),
+              vec!["a/path".to_string(), "c/path".to_string()],
+          ),
+      ];
+      canonicalize_source_files_by_purl(&mut components);
+      let after_first: Vec<Vec<String>> = components
+          .iter()
+          .map(|c| c.evidence.source_file_paths.clone())
+          .collect();
+      canonicalize_source_files_by_purl(&mut components);
+      let after_second: Vec<Vec<String>> = components
+          .iter()
+          .map(|c| c.evidence.source_file_paths.clone())
+          .collect();
+      assert_eq!(after_first, after_second,
+          "FR-004: canonicalize_source_files_by_purl MUST be idempotent");
+  }
+  ```
+
+  Covers FR-004 + SC-005.
+
+- [ ] T007 [P] [US1] Add unit test `canonicalize_source_files_by_purl_preserves_other_fields_md148` in the same `mod tests` block. Tests FR-005: the pass MUST NOT alter any field other than `evidence.source_file_paths`. Construct two same-PURL entries with rich non-default values on `name`, `version`, `parent_purl`, `lifecycle_scope`, `hashes`, `sbom_tier`, `extra_annotations`, `evidence.confidence`, `evidence.technique`, `evidence.source_connection_ids`. Assert every named field is byte-identical pre/post the pass.
+
+  ```rust
+  #[test]
+  fn canonicalize_source_files_by_purl_preserves_other_fields_md148() {
+      use mikebom_common::types::purl::Purl;
+      use mikebom_common::resolution::{LifecycleScope, ResolutionTechnique};
+      let purl = Purl::new("pkg:maven/com.example/foo@1.0").unwrap();
+      let mut component = make_test_component(
+          purl.clone(),
+          Some("pkg:maven/com.example/parent@1.0".to_string()),
+          vec!["original/path.jar".to_string()],
+      );
+      component.lifecycle_scope = Some(LifecycleScope::Runtime);
+      component.sbom_tier = Some("source".to_string());
+      component.evidence.confidence = 0.9;
+      component.evidence.source_connection_ids = vec![42];
+      component.extra_annotations.insert(
+          "mikebom:test-key".to_string(),
+          serde_json::json!("test-value"),
+      );
+      let snapshot = component.clone();
+
+      // Pair with a second entry sharing PURL (different parent_purl) so the
+      // union pass actually fires (non-no-op case).
+      let mut components = vec![
+          component,
+          make_test_component(
+              purl.clone(),
+              None,
+              vec!["other/path.jar".to_string()],
+          ),
+      ];
+      canonicalize_source_files_by_purl(&mut components);
+
+      // FR-005: every non-source_file_paths field MUST be preserved verbatim.
+      assert_eq!(components[0].purl, snapshot.purl);
+      assert_eq!(components[0].name, snapshot.name);
+      assert_eq!(components[0].version, snapshot.version);
+      assert_eq!(components[0].parent_purl, snapshot.parent_purl);
+      assert_eq!(components[0].lifecycle_scope, snapshot.lifecycle_scope);
+      assert_eq!(components[0].sbom_tier, snapshot.sbom_tier);
+      assert_eq!(components[0].hashes, snapshot.hashes);
+      assert_eq!(components[0].evidence.confidence, snapshot.evidence.confidence);
+      assert_eq!(components[0].evidence.technique, snapshot.evidence.technique);
+      assert_eq!(components[0].evidence.source_connection_ids,
+                 snapshot.evidence.source_connection_ids);
+      assert_eq!(components[0].extra_annotations, snapshot.extra_annotations);
+      // ONLY source_file_paths is allowed to change.
+      assert_ne!(components[0].evidence.source_file_paths,
+                 snapshot.evidence.source_file_paths,
+                 "the union pass IS expected to change source_file_paths in the multi-entry case");
+  }
+  ```
+
+  Covers FR-005.
+
+- [ ] T008 [US1] Create the synthetic test fixture at `/Users/mlieberman/Projects/mikebom/mikebom-cli/tests/fixtures/source_files_union/` per research §F. The fixture MUST exercise the Maven nested-coord same-PURL multi-entry shape WITHOUT requiring a real OCI image. Files:
+  - `pom.xml` — minimal POM declaring one dep `pkg:maven/com.example:foo@1.0`. Standard Maven POM format; pattern modeled on `mikebom-cli/tests/fixtures/maven/pom-three-deps/pom.xml`.
+  - `target/primary.jar` — synthetic JAR containing one class file for `com.example:foo@1.0` standalone. Use the helper that produces synthetic JARs in `mikebom-cli/tests/common/maven_jar_builder.rs` if available, otherwise hand-craft a minimal ZIP using `zip` shell tool or `tar`. The JAR MUST be readable by the Maven reader's nested-JAR walker at `maven.rs:3429-3457` AND MUST produce a `PackageDbEntry` with PURL `pkg:maven/com.example/foo@1.0` and `parent_purl = None`.
+  - `target/fat-bundle.jar` — synthetic fat-jar that vendors `com.example:foo@1.0` inside. The Maven reader's nested walker MUST detect the inner POM/manifest and produce a SECOND `PackageDbEntry` with the SAME PURL but `parent_purl = Some("pkg:maven/com.example:fat-bundle@...")`.
+  - `README.md` — documents the fixture's intent: "synthetic Maven nested-coord fixture for milestone-148 source-files cross-PURL union test. The dep `pkg:maven/com.example/foo@1.0` exists at TWO paths: `target/primary.jar` (standalone) and inside `target/fat-bundle.jar`. The milestone-148 union pass MUST emit BOTH paths on the `mikebom:source-files` annotation of the surviving `com.example/foo` component(s) regardless of output format."
+
+  If constructing the synthetic JARs is non-trivial in the implement phase (Maven JAR shape is intricate — requires META-INF/MANIFEST.MF, optionally pom.properties, and the actual class structure), consider deferring T008/T009 to a follow-up PR and rely solely on the unit tests T004-T007 + the existing transitive_parity_maven test for CI signal. Document the deferral in the PR description if applied. The 51-finding fix lands either way; the synthetic fixture is the in-tree validation surface, not the production verification (SC-007 operator-cadence harness re-run is the production verification).
+
+- [ ] T009 [US1] Create the in-tree integration test at `/Users/mlieberman/Projects/mikebom/mikebom-cli/tests/source_files_purl_union_md148.rs`. The test runs `mikebom sbom scan` against the synthetic fixture from T008 in all three formats and asserts the `mikebom:source-files` value for `pkg:maven/com.example/foo@1.0` is bytewise-identical across the three formats. Pattern (mirroring `mikebom-cli/tests/cdx_regression.rs` runner shape):
+
+  ```rust
+  //! Milestone 148 SC-003 — same-PURL multi-entry Maven coord emits
+  //! byte-identical mikebom:source-files across CDX 1.6 / SPDX 2.3 / SPDX 3.
+
+  use std::process::Command;
+
+  mod common;
+  use common::normalize::apply_fake_home_env;
+
+  #[test]
+  fn same_purl_maven_nested_coord_emits_byte_identical_source_files_across_formats_md148() {
+      let fx = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+          .join("tests/fixtures/source_files_union");
+      // Three scans, one per format. Capture output to tempfiles, parse,
+      // extract mikebom:source-files for pkg:maven/com.example/foo@1.0,
+      // assert bytewise-identical set semantics across the three formats.
+      let cdx_paths = extract_source_files_cdx(&fx);
+      let spdx_paths = extract_source_files_spdx23(&fx);
+      let spdx3_paths = extract_source_files_spdx3(&fx);
+      assert_eq!(cdx_paths, spdx_paths, "SC-003: CDX vs SPDX 2.3 source-files MUST match");
+      assert_eq!(cdx_paths, spdx3_paths, "SC-003: CDX vs SPDX 3 source-files MUST match");
+      // Sanity: the value MUST contain BOTH paths (standalone + nested),
+      // confirming the union pass actually fired.
+      assert!(cdx_paths.len() >= 2, "expected ≥2 paths in the union; got: {cdx_paths:?}");
+  }
+  ```
+
+  Implementation details:
+  - Use `env!("CARGO_BIN_EXE_mikebom")` to locate the test binary.
+  - `apply_fake_home_env` (existing helper in `common/normalize.rs`) for hermetic home-dir isolation.
+  - Helper functions `extract_source_files_cdx(&fx) -> BTreeSet<String>`, `extract_source_files_spdx23(...)`, `extract_source_files_spdx3(...)` each (a) run the scan in their target format to a tempfile, (b) parse the resulting JSON, (c) walk the document to find `pkg:maven/com.example/foo@1.0`, (d) extract its `mikebom:source-files` annotation value, (e) parse as a JSON array of strings and return a `BTreeSet<String>` for set-equality semantics.
+
+  If T008 was deferred (synthetic fixture construction non-trivial), defer this test too with the same rationale. **However**, T009b (below) provides a CI-binding fallback that covers SC-003's cross-format invariance without requiring a synthetic Maven fixture, so the analyze-finding-H1 coverage gap is closed regardless. Covers SC-003 (full-stack integration when not deferred).
+
+- [ ] T009b [P] [US1] Add cross-format `mikebom:source-files` parity unit test at `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/resolve/deduplicator.rs#mod tests` (NOT in the integration-test directory — this is a unit-level assertion that doesn't require a binary invocation). Provides a CI-binding fallback for SC-003 / FR-009 / analyze-finding-H1 when T008+T009 are deferred. The test asserts the single-source-of-truth invariant: ALL three SBOM emitters MUST read `mikebom:source-files` from `c.evidence.source_file_paths` (NOT from `c.extra_annotations["mikebom:source-files"]` — the milestone 145 US3 fix established this single-source contract via the `is_field_owned_annotation_key` filter). After the milestone-148 union pass canonicalizes `c.evidence.source_file_paths`, all three emitters therefore see the same value byte-for-byte. Two complementary assertion patterns:
+
+  ```rust
+  /// Milestone 148 SC-003 (analyze-finding-H1 fallback): assert that all
+  /// three SBOM emitters consume the same `c.evidence.source_file_paths`
+  /// field as the source of truth for `mikebom:source-files`. Combined with
+  /// the canonicalize pass guaranteeing same-PURL entries share an identical
+  /// Vec value, this transitively guarantees cross-format byte-equality of
+  /// the wire-side annotation — closing the cross-format invariance signal
+  /// in CI without requiring a synthetic Maven fixture.
+  ///
+  /// Pattern: code-shape grep assertion. The three emitter sites (CDX
+  /// `cyclonedx/builder.rs:830-839`, SPDX 2.3 `spdx/annotations.rs:302-308`,
+  /// SPDX 3 `spdx/v3_annotations.rs:267-273`) ALL read from
+  /// `c.evidence.source_file_paths`. The milestone-145 US3 filter at
+  /// `root_selector.rs::is_field_owned_annotation_key` prevents the
+  /// extra_annotations bag from re-emitting the same key. This test
+  /// asserts the filter still names `mikebom:source-files` AND the
+  /// expected emitter-side reads remain in place (code-shape regression
+  /// guard against accidental shape drift).
+  #[test]
+  fn source_files_single_source_of_truth_invariant_md148() {
+      use crate::generate::root_selector::is_field_owned_annotation_key;
+      // FR-008 + milestone-145 US3 invariant: `mikebom:source-files` is
+      // field-owned. Any new emitter MUST NOT bypass this filter, and
+      // any new reader MUST NOT stamp the bag-keyed duplicate (Maven
+      // reader's nested-URL key is `mikebom:source-files-nested-url`
+      // post-145 specifically to avoid this collision).
+      assert!(is_field_owned_annotation_key("mikebom:source-files"),
+          "FR-008 + 145-US3 invariant: mikebom:source-files MUST remain field-owned (drives single-source-of-truth across CDX/SPDX2.3/SPDX3)");
+      // Conditional: ensure no rename of the field-owned filter on the
+      // related milestone-145 nested-URL key (defense against the same
+      // class of regression).
+      assert!(!is_field_owned_annotation_key("mikebom:source-files-nested-url"),
+          "the renamed Maven-reader key is NOT field-owned — it ships through extra_annotations as a distinct annotation");
+  }
+  ```
+
+  Plus a behavioral assertion that the canonicalize pass actually produces a Vec the emitters will consume identically (this part is essentially a recap of T004 but framed as the cross-format-invariance assertion):
+
+  ```rust
+  #[test]
+  fn canonicalize_produces_emitter_ready_vec_across_formats_md148() {
+      use mikebom_common::types::purl::Purl;
+      // Construct two same-PURL entries (Maven nested-coord shape).
+      let purl = Purl::new("pkg:maven/com.example/foo@1.0").unwrap();
+      let mut components = vec![
+          make_test_component(purl.clone(), None,
+              vec!["target/primary.jar".to_string()]),
+          make_test_component(purl.clone(),
+              Some("pkg:maven/com.example/fat-bundle@1.0".to_string()),
+              vec!["target/fat-bundle.jar!foo-1.0.jar".to_string()]),
+      ];
+      canonicalize_source_files_by_purl(&mut components);
+      // SC-003 invariant: both entries' source_file_paths Vec is now
+      // byte-identical. Combined with the single-source-of-truth
+      // invariant above, this is sufficient to guarantee cross-format
+      // wire-side equality WITHOUT instantiating the per-format emitters
+      // (which require full ScanResult plumbing the unit test can't
+      // easily reproduce).
+      assert_eq!(
+          components[0].evidence.source_file_paths,
+          components[1].evidence.source_file_paths,
+          "SC-003: post-canonicalize, all same-PURL entries MUST carry identical source_file_paths Vec — this transitively guarantees cross-format mikebom:source-files equality because all three emitters read from this field exclusively (FR-008 + 145-US3 single-source-of-truth invariant asserted by source_files_single_source_of_truth_invariant_md148)"
+      );
+  }
+  ```
+
+  Covers SC-003 / FR-009 / analyze-finding-H1 as a CI-binding fallback regardless of whether T008+T009 land.
+
+**Checkpoint**: After Phase 3, US1 is fully functional. `cargo +stable test -p mikebom canonicalize_source_files_by_purl` shows 4 unit tests pass green; if T008+T009 landed, `cargo +stable test --test source_files_purl_union_md148` also passes. Manual smoke per quickstart §Scenario 1: the polyglot-builder-image audit count drops from 51 to 0.
+
+---
+
+## Phase 4: User Story 2 - Cross-ecosystem coverage (non-Maven same-PURL multi-entry cases) (Priority: P2)
+
+**Goal**: Add a unit test asserting that the union pass correctly isolates by full canonical PURL (`Purl::as_str()`), preventing cross-ecosystem path cross-pollination per FR-003 + Edge Case 7.
+
+**Independent Test**: Construct two `ResolvedComponent` instances with PURLs `pkg:maven/com.example:foo@1.0` and `pkg:npm/example@1.0` (same name+version, different ecosystem), each with distinct `source_file_paths`. After the pass, assert each component's `source_file_paths` contains ONLY its own original paths — no cross-pollination.
+
+### Implementation for User Story 2
+
+- [ ] T010 [P] [US2] Add unit test `canonicalize_source_files_by_purl_cross_ecosystem_isolation_md148` in `deduplicator.rs#mod tests`. Tests FR-003 + Edge Case 7:
+
+  ```rust
+  #[test]
+  fn canonicalize_source_files_by_purl_cross_ecosystem_isolation_md148() {
+      use mikebom_common::types::purl::Purl;
+      // Two PURLs that share name+version but differ in ecosystem. The union
+      // pass MUST NOT cross-pollinate paths between them.
+      let maven_purl = Purl::new("pkg:maven/com.example/foo@1.0").unwrap();
+      let npm_purl = Purl::new("pkg:npm/example@1.0").unwrap();
+      let mut components = vec![
+          make_test_component(maven_purl.clone(), None,
+              vec!["target/foo-1.0.jar".to_string()]),
+          make_test_component(npm_purl.clone(), None,
+              vec!["node_modules/example/index.js".to_string()]),
+      ];
+      canonicalize_source_files_by_purl(&mut components);
+
+      // FR-003 + Edge Case 7: each ecosystem's paths stay isolated to its own PURL.
+      assert_eq!(components[0].evidence.source_file_paths,
+                 vec!["target/foo-1.0.jar".to_string()],
+          "FR-003: Maven component MUST NOT pick up npm paths");
+      assert_eq!(components[1].evidence.source_file_paths,
+                 vec!["node_modules/example/index.js".to_string()],
+          "FR-003: npm component MUST NOT pick up Maven paths");
+  }
+  ```
+
+  Covers FR-003 + Edge Case 7.
+
+- [ ] T011 [P] [US2] Add unit test `canonicalize_source_files_by_purl_three_entries_full_union_md148` in `deduplicator.rs#mod tests`. Tests Edge Case 1: when 3+ entries share a PURL (one standalone + two different fat-jar nestings), all three get the alphabetically-sorted union of all three paths.
+
+  ```rust
+  #[test]
+  fn canonicalize_source_files_by_purl_three_entries_full_union_md148() {
+      use mikebom_common::types::purl::Purl;
+      let purl = Purl::new("pkg:maven/com.example/foo@1.0").unwrap();
+      let mut components = vec![
+          make_test_component(purl.clone(), None,
+              vec!["root/standalone.jar".to_string()]),
+          make_test_component(purl.clone(),
+              Some("pkg:maven/com.example/bundle-a@1.0".to_string()),
+              vec!["root/bundle-a.jar!foo-1.0.jar".to_string()]),
+          make_test_component(purl.clone(),
+              Some("pkg:maven/com.example/bundle-b@1.0".to_string()),
+              vec!["root/bundle-b.jar!foo-1.0.jar".to_string()]),
+      ];
+      canonicalize_source_files_by_purl(&mut components);
+      let expected = vec![
+          "root/bundle-a.jar!foo-1.0.jar".to_string(),
+          "root/bundle-b.jar!foo-1.0.jar".to_string(),
+          "root/standalone.jar".to_string(),
+      ];
+      for (i, c) in components.iter().enumerate() {
+          assert_eq!(c.evidence.source_file_paths, expected,
+              "Edge Case 1: entry {i} MUST carry the full 3-path alphabetically-sorted union");
+      }
+  }
+  ```
+
+  Covers Edge Case 1.
+
+**Checkpoint**: After Phase 4, US2 is fully covered. `cargo +stable test -p mikebom canonicalize_source_files_by_purl` shows 6 unit tests pass green (the 4 from Phase 3 + the 2 from Phase 4).
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Golden audit + refresh, pre-PR gate, commit.
+
+- [ ] T012 Audit existing Maven-bearing byte-identity goldens for `mikebom:source-files` drift potential. Run:
+
+  ```bash
+  grep -rl 'mikebom:source-files' \
+      /Users/mlieberman/Projects/mikebom/mikebom-cli/tests/fixtures/golden/{cyclonedx,spdx-2.3,spdx-3}/maven.*.json
+  ```
+
+  Per research §G the `pom-three-deps` fixture is unlikely to exercise the same-PURL multi-entry shape (it's a simple POM-only fixture). If the grep returns no matches OR the values don't change post-148, the refresh in T013 produces empty diffs. Document the finding (empty vs non-empty diff) for the PR description.
+
+- [ ] T013 Refresh affected goldens via the standard env-var trifecta:
+
+  ```bash
+  MIKEBOM_UPDATE_CDX_GOLDENS=1   cargo +stable test --test cdx_regression cdx_regression_maven
+  MIKEBOM_UPDATE_SPDX_GOLDENS=1  cargo +stable test --test spdx_regression maven_byte_identity
+  MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test --test spdx3_regression maven_byte_identity
+  ```
+
+  Inspect `git diff --stat -- mikebom-cli/tests/fixtures/golden/{cyclonedx,spdx-2.3,spdx-3}/maven.*.json`. Per FR-010, each affected line MUST be either (a) a `mikebom:source-files` value change on a Maven component that previously carried a non-canonical single-path Vec, OR (b) the new alphabetically-sorted union content. Reject any unrelated drift. If empty diff (`pom-three-deps` doesn't exercise the shape), that's expected per research §G and the synthetic fixture from T008/T009 is the sole CI-binding exercise of the new code path.
+
+- [ ] T014 Run mandatory pre-PR gate per Constitution Development Workflow + memory `feedback_prepr_gate_full_output.md`: `./scripts/pre-pr.sh` from repo root. Both clippy + test steps MUST pass clean (excepting the pre-existing local `sbomqs_parity` env-only failure documented in milestone-144 T001 — CI will validate on a clean runner). If any OTHER test fails, scan the FULL output (do NOT grep on `^test result: FAILED` — known to drop multi-test-suite summaries). Covers SC-006.
+
+- [ ] T015 Commit the milestone-148 changes. Per project convention (matching milestones 134/144/145/146/147), use the 4-commit chain:
+  - `spec(148): source-files cross-emitter divergence — union evidence across same-PURL entries` — spec.md + checklists/requirements.md
+  - `plan(148): canonicalize_source_files_by_purl post-dedup pass + design notes` — plan + research + data-model + contracts + quickstart + CLAUDE.md
+  - `tasks(148): 16 tasks across 5 phases for source-files cross-PURL union` — tasks.md
+  - `impl(148): canonicalize evidence.source_file_paths across same-PURL ResolvedComponent entries` — `mikebom-cli/src/resolve/deduplicator.rs` + `mikebom-cli/src/scan_fs/mod.rs` + (if T008+T009 landed) the synthetic fixture + integration test + any golden refresh from T013
+
+  Do NOT commit until T014 passes clean. Use `git add <specific paths>` (never `-A`). Each commit ends with the standard `Co-Authored-By` trailer.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies. Verifies baseline.
+- **Phase 2 (Foundational)**: EMPTY — no foundational work required.
+- **Phase 3 (US1)**: Depends on Phase 1. T002 (the function) + T003 (the call site wiring) IS the fix. T004-T007 are unit tests that can land in parallel after T002+T003. T009b (single-source-of-truth fallback) lands in parallel with T004-T007 and is MANDATORY (closes analyze-finding-H1 cross-format invariance coverage). T008 (synthetic fixture) + T009 (integration test) can land in parallel after T002+T003 and remain deferrable — T009b is the CI-binding fallback if they're deferred.
+- **Phase 4 (US2)**: Depends on Phase 3 — specifically T002 (the function). US2's tests assert additional properties of the same function. T010 + T011 can land in parallel after T002.
+- **Phase 5 (Polish)**: Depends on US1 + US2 being functionally complete.
+
+### User Story Dependencies
+
+- **US1 (P1, MVP)**: Standalone after Phase 1. Delivers the 51 → 0 audit drop. T002 + T003 + T004-T007 (4 unit tests) + T009b (single-source-of-truth + canonicalize-output cross-format-invariance assertions, MANDATORY) + optionally T008+T009 (synthetic fixture + full integration test).
+- **US2 (P2)**: Builds on US1's implementation. T010 + T011 add cross-ecosystem + three-entry assertions on the SAME function.
+
+### Within Each User Story
+
+- T002 + T003 are sequential (T002 defines the function; T003 wires the call site).
+- T004-T007 + T009b are tests and can land in parallel after T002+T003 (all in the same `mod tests` block in `deduplicator.rs`).
+- T008 + T009 can land in parallel after T002+T003 (different files: fixture + integration test). Both deferrable if fixture construction is non-trivial — T009b is the CI-binding fallback for SC-003 / FR-009.
+- T010 + T011 are tests and can land in parallel after T002.
+
+### Parallel Opportunities
+
+- Phase 3: T004 + T005 + T006 + T007 + T009b [P] (different tests, same `mod tests` block — landable in one editor pass).
+- Phase 3: T008 + T009 [P] (different files; landable independently of the unit tests).
+- Phase 4: T010 + T011 [P] (different tests, same `mod tests` block).
+
+---
+
+## Parallel Example: Phase 3 (after T002 + T003 land)
+
+```bash
+# Five unit tests + cross-format-invariance fallback can be added in one editor pass:
+Task T004:  canonicalize_source_files_by_purl_same_purl_different_parent_unions_paths_md148   (SC-004 + FR-001/002/006)
+Task T005:  canonicalize_source_files_by_purl_single_entry_is_content_preserving_md148        (FR-007)
+Task T006:  canonicalize_source_files_by_purl_is_idempotent_md148                             (FR-004 + SC-005)
+Task T007:  canonicalize_source_files_by_purl_preserves_other_fields_md148                    (FR-005)
+Task T009b: source_files_single_source_of_truth_invariant_md148 + canonicalize_produces_emitter_ready_vec_across_formats_md148   (SC-003 / FR-009 / analyze-finding-H1 fallback)
+
+# Optionally parallel (deferrable per T008/T009 notes):
+Task T008: synthetic fixture at mikebom-cli/tests/fixtures/source_files_union/
+Task T009: in-tree integration test at mikebom-cli/tests/source_files_purl_union_md148.rs
+```
+
+## Parallel Example: Phase 4 (after T002 lands)
+
+```bash
+Task T010: canonicalize_source_files_by_purl_cross_ecosystem_isolation_md148   (FR-003 + Edge Case 7)
+Task T011: canonicalize_source_files_by_purl_three_entries_full_union_md148    (Edge Case 1)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only — ships the 51 → 0 audit drop)
+
+1. Complete Phase 1: T001 baseline check.
+2. Complete Phase 3 unit-test path: T002 (function) + T003 (call site) + T004-T007 (4 unit tests) + T009b (cross-format-invariance fallback assertions, MANDATORY per analyze-finding-H1).
+3. **STOP and VALIDATE**: `./scripts/pre-pr.sh` clean. Manual smoke per quickstart §Scenario 1: polyglot-builder-image audit count drops from 51 to 0.
+4. This alone is a shippable PR. US2's cross-ecosystem assertions are additive defensive coverage on the SAME code; skipping them leaves the fix correct but with a smaller test surface.
+5. Defer T008+T009 (synthetic fixture + integration test) to a follow-up PR if synthetic Maven JAR construction is non-trivial — T009b's single-source-of-truth + canonicalize-output assertions cover the cross-format invariance signal in CI without the synthetic fixture; the operator-cadence harness re-run (SC-007) provides the production verification regardless.
+
+### Incremental / Recommended (single-PR delivery)
+
+1. Phase 1 (T001) baseline.
+2. Phase 3 (T002-T009 + T009b) US1 — orphan-divergence closes (51 → 0) + cross-format-invariance CI coverage.
+3. Phase 4 (T010-T011) US2 — cross-ecosystem + three-entry assertions.
+4. Phase 5 (T012-T015) polish — golden audit + refresh + pre-PR + commit.
+
+Total: 16 tasks (15 + T009b added per analyze-finding-H1 remediation). Estimated ~15 LOC of new function + ~80 LOC of unit tests + ~120 LOC of integration test + ~5 LOC of call-site wiring + synthetic fixture (variable, possibly deferred).
+
+### Single-developer Note
+
+This milestone is small enough that one developer can work through all phases in one session. The [P] markers exist primarily to signal "no cross-file write conflict" — useful for tooling that automates task execution but not load-bearing for a human implementer.
+
+---
+
+## Notes
+
+- Unit tests live in-file under `#[cfg(test)] mod tests` per the project's existing convention in `deduplicator.rs`. Integration test lives in `mikebom-cli/tests/source_files_purl_union_md148.rs` per the project's convention for cross-format byte-equality tests.
+- The `#[cfg_attr(test, allow(clippy::unwrap_used))]` convention applies to any test module per Constitution Principle IV (the existing `deduplicator.rs#mod tests` already has it; no change needed). The new integration test file MUST add the same guard at its `mod common` boundary.
+- Memory `feedback_prepr_gate_full_output.md` is directly relevant: when verifying T014, scan the FULL output rather than greping on `^test result: FAILED`.
+- Memory `feedback_dont_dismiss_test_failures.md` is relevant if any new test failures surface during golden refresh: verify reproducibility before calling anything "pre-existing flake".
+- The commit-message convention (T015) follows the milestone-134/144/145/146/147 precedent: `spec(148):` / `plan(148):` / `tasks(148):` / `impl(148):`.
+- Per spec SC-001 + SC-007 (operator-cadence cross-format harness re-run): document in the PR description that the operator should re-run the sbom-conformance audit harness on the polyglot-builder-image fixture post-merge to confirm the 51 findings drop to 0. The harness is NOT a CI gate; the in-tree unit tests T004-T007 + T010-T011 (and T009 if not deferred) are the CI-binding signals.
+- Per spec FR-008 + Constitution V audit in plan.md: NO new `mikebom:*` annotation introduced. The fix is purely a value-canonicalization on the existing `mikebom:source-files` annotation; the C18 parity-catalog row's audit at `docs/reference/sbom-format-mapping.md` C18 is unchanged.
+- The existing C18 row's `Directionality::SymmetricEqual` MUST continue to hold (SC-002). The CI-binding `cross_format_byte_identity` and `holistic_parity` tests provide this signal automatically post-implementation; no parity-catalog edits needed for this milestone.


### PR DESCRIPTION
## Summary

Closes the **51 Maven `mikebom:source-files` cross-format divergence findings** on the polyglot-builder-image audit corpus surfaced by the 2026-06-28 sbom-conformance harness re-run (post-merge of milestone 145 in `8a0660b`).

### Root cause

The Maven nested-JAR walker at `mikebom-cli/src/scan_fs/package_db/maven.rs:3429-3457` intentionally creates **two `PackageDbEntry` instances** for the same Maven coord when it appears both standalone (`parent_purl = None`) AND vendored inside a fat-jar (`parent_purl = Some(...)`). The deduplicator at `mikebom-cli/src/resolve/deduplicator.rs:34-46` groups by `(ecosystem, name, version, parent_purl)` so the two entries don't merge — the CDX nested-components topology depends on this. Each surviving entry carried its own single-path `evidence.source_file_paths` Vec, so per-emitter iteration-order differences produced cross-format `mikebom:source-files` divergence on what the audit harness treats as the same PURL.

Milestone 145 US3 fixed the within-component double-emission (renamed Maven's bag-stamped key to `mikebom:source-files-nested-url`). This milestone closes the **cross-`ResolvedComponent`-instance** divergence.

### Fix

New `pub fn canonicalize_source_files_by_purl(&mut [ResolvedComponent])` at `mikebom-cli/src/resolve/deduplicator.rs`, called once at `scan_fs/mod.rs:751` immediately after `deduplicate()`. The pass walks every component, accumulates paths into a `BTreeSet<String>` keyed on `Purl::as_str()`, then writes back the alphabetically-sorted union onto every same-PURL entry. After the pass, all same-PURL entries carry byte-identical `evidence.source_file_paths` Vec content — combined with the milestone-145 US3 single-source-of-truth invariant (all three emitters consume the field-derived source exclusively), this transitively guarantees cross-format wire-side `mikebom:source-files` equality.

Properties:
- **Idempotent** (FR-004): `BTreeSet` set-union is idempotent by construction
- **Topology-preserving** (FR-006): `parent_purl` and every other field unchanged
- **Content-preserving for single-entry PURLs** (FR-007): path set unchanged; wire-order MAY canonicalize to alphabetical
- **Cross-ecosystem isolated** (FR-003, Edge Case 7): `Purl::as_str()` includes the ecosystem segment
- **Constitution V satisfied vacuously** (FR-008): no new `mikebom:*` annotation introduced; existing C18 parity-catalog row audit unchanged

### Test plan

- [x] 8 new unit tests in `mikebom-cli/src/resolve/deduplicator.rs#mod tests` all pass:
  - `canonicalize_source_files_by_purl_same_purl_different_parent_unions_paths_md148` (FR-001+002+006)
  - `canonicalize_source_files_by_purl_single_entry_is_content_preserving_md148` (FR-007)
  - `canonicalize_source_files_by_purl_is_idempotent_md148` (FR-004)
  - `canonicalize_source_files_by_purl_preserves_other_fields_md148` (FR-005)
  - `canonicalize_source_files_by_purl_cross_ecosystem_isolation_md148` (FR-003, Edge Case 7)
  - `canonicalize_source_files_by_purl_three_entries_full_union_md148` (Edge Case 1)
  - `source_files_single_source_of_truth_invariant_md148` (T009b H1-fallback — code-shape regression guard)
  - `canonicalize_produces_emitter_ready_vec_across_formats_md148` (T009b H1-fallback — behavioral cross-format invariance proof)
- [x] Pre-PR gate (`./scripts/pre-pr.sh`) green except documented pre-existing `sbomqs_parity` env-only failure (matches milestone-144 T001 note)
- [x] Maven golden refresh produced zero drift — `pom-three-deps` fixture doesn't exercise the same-PURL multi-entry shape (matches research §G prediction). Cross-format invariance signal in CI comes from the T009b unit-test pair instead.

### Operator-cadence verification (post-merge)

Per SC-007 — the operator should re-run the sbom-conformance audit harness on `polyglot-builder-image` post-merge to confirm the 51 findings drop to 0. Documented in `specs/148-source-files-union/quickstart.md` §Scenario 1.

### Deferred (out of scope)

- T008 + T009 (synthetic Maven JAR fixture + full-stack integration test) — synthetic JAR construction is non-trivial; T009b's unit-test pair covers the CI-binding cross-format invariance signal without them
- CDX `bom-ref` uniqueness on two same-PURL `parent_purl=None` components (pre-existing spec violation; not introduced by this milestone)
- Per-emitter component-instance dedup
- The two sibling 2026-06-28 audit findings — issue #1 (JVM symlink paths) needs operator-cadence raw-output diagnostic first; issue #2 (SPDX 3 lifecycle-scope on npm dev-deps) is a deliberate Principle V decision per `v3_annotations.rs:266-275` (SPDX 3 uses native `LifecycleScopedRelationship.scope` natively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)