### PR TITLE
docs(reference): consumer-facing reading guide for mikebom SBOMs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-28
+Auto-generated from all feature plans. Last updated: 2026-06-29
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -172,6 +172,7 @@ Auto-generated from all feature plans. Last updated: 2026-06-28
 - Rust stable (workspace toolchain inherited from milestones 001–147; no nightly required for this user-space-only work). + Existing only — `std::collections::HashMap` + `std::collections::BTreeSet` (both pervasive in the codebase, no new use). The pass operates on `mikebom_common::resolution::ResolvedComponent` (already a workspace type). **No new Cargo dependencies.** (148-source-files-union)
 - N/A — purely in-process per-scan transformation; no persistence. (148-source-files-union)
 - Rust stable (workspace toolchain inherited from milestones 001–148; no nightly required for this user-space-only work). + Existing only — `clap` for the new boolean flag (via `Args`-derive — already used pervasively for milestones 077 / 081 / 119 / 134 flags), `serde`/`serde_json` for the annotation value, `tracing` for the INFO-level diagnostics on the no-op edge cases. `mikebom_common::resolution::ResolvedComponent` is the existing workspace type; `mikebom_common::types::purl::Purl` for the demoted entry's PURL (unchanged from pre-demote). **No new Cargo dependencies.** (149-demote-manifest-mainmod)
+- N/A — Markdown documentation. The mikebom binary is unchanged. + None. The doc is static reference Markdown. (150-sbom-consumer-guide)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -234,9 +235,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 150-sbom-consumer-guide: Added N/A — Markdown documentation. The mikebom binary is unchanged. + None. The doc is static reference Markdown.
 - 149-demote-manifest-mainmod: Added Rust stable (workspace toolchain inherited from milestones 001–148; no nightly required for this user-space-only work). + Existing only — `clap` for the new boolean flag (via `Args`-derive — already used pervasively for milestones 077 / 081 / 119 / 134 flags), `serde`/`serde_json` for the annotation value, `tracing` for the INFO-level diagnostics on the no-op edge cases. `mikebom_common::resolution::ResolvedComponent` is the existing workspace type; `mikebom_common::types::purl::Purl` for the demoted entry's PURL (unchanged from pre-demote). **No new Cargo dependencies.**
 - 148-source-files-union: Added Rust stable (workspace toolchain inherited from milestones 001–147; no nightly required for this user-space-only work). + Existing only — `std::collections::HashMap` + `std::collections::BTreeSet` (both pervasive in the codebase, no new use). The pass operates on `mikebom_common::resolution::ResolvedComponent` (already a workspace type). **No new Cargo dependencies.**
-- 147-npm-peer-edges: Added Rust stable (workspace toolchain inherited from milestones 001–146; no nightly required). + Existing only — `serde_json` (already pervasive in the npm reader), `BTreeMap` (already used at `package_lock.rs:166` for the existing `depends_set`), `BTreeSet` (for tracking peer-edge target uniqueness). **No new Cargo dependencies.**
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,11 @@ the way it did, or contribute to the pipeline.
   `verify-binding`, `trace-binding`, and the binding-hash-v1 algorithm.
 - [Cross-format SBOM mapping](reference/sbom-format-mapping.md) — per-feature
   carrier matrix across CDX 1.6, SPDX 2.3, and SPDX 3.
+- [Reading a mikebom SBOM](reference/reading-a-mikebom-sbom.md) — consumer-facing
+  guide to mikebom-emitted signals (what they mean, where to find them per
+  format, how to use them). Cross-references the
+  [SBOM format mapping](reference/sbom-format-mapping.md) catalog for full
+  per-row wire-shape detail.
 - [Conformance harness guide](reference/conformance-harness-guide.md) —
   per-format envelope-decode rules and the 7 inherent format-spec asymmetries.
 - [Ecosystems](ecosystems.md) — per-ecosystem coverage matrix for all nine

--- a/docs/reference/reading-a-mikebom-sbom.md
+++ b/docs/reference/reading-a-mikebom-sbom.md
@@ -1,0 +1,586 @@
+# Reading a mikebom SBOM
+
+**Audience**: anyone reading a mikebom-emitted CycloneDX 1.6 / SPDX 2.3 / SPDX 3.0.1 document — compliance engineers, vulnerability-scanner authors, SBOM-diff tool maintainers, auditors walking output for the first time.
+
+**What this doc is**: a consumer-facing tour of the signals mikebom makes available beyond the CDX/SPDX spec baseline — what they mean, where to find them per format, what to do with them, plus a complete index of every `mikebom:*` annotation key.
+
+**What this doc is NOT**: a complete wire-shape catalog (see [SBOM format mapping](sbom-format-mapping.md) for the 100+ row catalog that the emitters honor — that document is the authoritative wire-shape contract, structured for code-review depth). This guide is the onboarding surface; the catalog is the contract.
+
+---
+
+## Table of contents
+
+1. [Positioning — how mikebom uses spec-native fields](#1-positioning--how-mikebom-uses-spec-native-fields)
+2. [How to read this doc](#2-how-to-read-this-doc)
+3. [Signals mikebom makes available — by use case](#3-signals-mikebom-makes-available--by-use-case)
+   - 3.1 [Vulnerability scanning](#31-vulnerability-scanning)
+   - 3.2 [Compliance auditing](#32-compliance-auditing)
+   - 3.3 [Build provenance](#33-build-provenance)
+   - 3.4 [Transparency / completeness gaps](#34-transparency--completeness-gaps)
+4. [The `mikebom-annotation/v1` envelope](#4-the-mikebom-annotationv1-envelope)
+5. [Cross-format reading patterns](#5-cross-format-reading-patterns)
+6. [Stability](#6-stability)
+7. [For tool authors](#7-for-tool-authors)
+8. [Cross-references](#8-cross-references)
+- [Appendix A — Annotation key index](#appendix-a--annotation-key-index)
+- [Appendix B — Milestone-citation map](#appendix-b--milestone-citation-map)
+
+---
+
+## 1. Positioning — how mikebom uses spec-native fields
+
+mikebom strictly conforms to **CycloneDX 1.6**, **SPDX 2.3**, and **SPDX 3.0.1**. Most data in a mikebom-emitted SBOM lives in spec-native fields — PURL, name, version, supplier, licenses, hashes, CPEs, dependency edges. If you've parsed CDX or SPDX before, the bulk of a mikebom SBOM looks familiar.
+
+A small fraction of the data — currently 102 distinct keys at the time of writing — rides on `mikebom:*`-prefixed annotations. These are **parity-bridging annotations** introduced per [Constitution Principle V](../../.specify/memory/constitution.md): every spec proposing a new `mikebom:*` field must first audit the target formats for an existing native construct carrying the same semantic. Annotations are permitted only when (a) no native field exists across all three formats, or (b) one format has the native field but the others don't (parity-gap carve-out). Every `mikebom:*` annotation has a documented audit trail in the [SBOM format mapping](sbom-format-mapping.md) catalog naming the rejected native-field alternatives.
+
+The job of this doc is to tell consumers what each parity-bridging annotation means and how to use it. The framing is consumer-centric ("here's what mikebom emits and how to use it"), not competitive — we don't name specific competing SBOM tools or characterize their omissions. Consumers reading this guide already have an SBOM in hand; the question is "what's in it that I should care about?"
+
+---
+
+## 2. How to read this doc
+
+**Quick navigation by goal**:
+
+- Building a vulnerability scanner or fortifying CVE alerting → [§3.1](#31-vulnerability-scanning)
+- License audit or compliance workflow → [§3.2](#32-compliance-auditing)
+- Verifying build-time provenance (vs lockfile-derived enrichment) → [§3.3](#33-build-provenance)
+- Evaluating completeness or detecting gaps → [§3.4](#34-transparency--completeness-gaps)
+- Parsing the annotation envelope as a tool author → [§4](#4-the-mikebom-annotationv1-envelope) + [§7](#7-for-tool-authors)
+- Looking up an unfamiliar `mikebom:*` key seen in an SBOM → [Appendix A](#appendix-a--annotation-key-index)
+- Mapping a mikebom binary version to which signals are available → [Appendix B](#appendix-b--milestone-citation-map)
+
+**Full wire-shape detail**: every per-signal section links to the corresponding row in [`sbom-format-mapping.md`](sbom-format-mapping.md). That catalog is the contract; this guide is the orientation.
+
+---
+
+## 3. Signals mikebom makes available — by use case
+
+This section covers 12 signals depth-covered across 4 thematic clusters. Each signal follows the same rendering shape: plain-language description, per-format wire location, recommended consumer action, milestone introduced/stabilized, link to the catalog row, and a worked `jq` recipe.
+
+### 3.1 Vulnerability scanning
+
+Vulnerability scanners need to (a) suppress dev/test/build-only deps from production CVE alerting, (b) attribute findings to OCI layers for forensics and remediation prioritization, and (c) flag when the same package identity actually carries divergent content (so identical CVEs don't silently merge across distinct binaries). mikebom emits all three signals.
+
+#### `mikebom:lifecycle-scope`
+
+> **What it is**: the finer-grained dev / build / test / runtime distinction beyond CDX 1.6's 3-value `scope` enum. CDX 1.6's `component.scope` only carries `required`/`optional`/`excluded`; mikebom emits `excluded` for non-runtime deps and this annotation carries the finer split. SPDX 2.3 has native typed relationships (`DEV_DEPENDENCY_OF` / `BUILD_DEPENDENCY_OF` / `TEST_DEPENDENCY_OF`) used as the primary signal; this annotation also rides on the target Package so consumers walking only `DEPENDS_ON` still see the distinction. SPDX 3 carries the value natively in `LifecycleScopedRelationship.scope` AND omits the parity-bridging annotation (the native field is sufficient there).
+> **Where it lives**:
+> - **CDX 1.6**: `components[].properties[]` entry `{name: "mikebom:lifecycle-scope", value: "<scope>"}` on the target component. Native `component.scope: "excluded"` set alongside.
+> - **SPDX 2.3**: annotation envelope on the target Package — `{schema: "mikebom-annotation/v1", field: "mikebom:lifecycle-scope", value: "<scope>"}`. Plus native typed relationship `DEV_DEPENDENCY_OF` / `BUILD_DEPENDENCY_OF` / `TEST_DEPENDENCY_OF` reversed-direction edge under `--spdx2-relationship-compat=full` (the default).
+> - **SPDX 3**: NOT EMITTED as a per-package annotation. The value lives natively on the dep edge as `LifecycleScopedRelationship.scope` (`development` / `build` / `test`). Runtime edges omit `scope`.
+> **What to do with it**: filter your dep-graph walk to suppress non-runtime components from production-only CVE alerting. Common policy: alert on `runtime` (or absent scope, which means runtime) deps only; report dev/test/build hits as informational. Default mikebom scans INCLUDE dev/build/test-scoped components in `components[]`; the operator can drop them at scan time via `--exclude-scope dev,build,test` to produce the strict "what shipped to production" view.
+> **Milestone**: 052 — added; 228 — extended to SPDX 2.3 as parity-bridge.
+> **Catalog**: [C42](sbom-format-mapping.md#section-c--mikebom-specific-data-preserved-via-fallback)
+
+```jq
+# CDX 1.6 — list dev-scoped components by PURL:
+jq '.components[]
+    | select(.properties[]?
+             | .name == "mikebom:lifecycle-scope"
+             and .value == "development")
+    | .purl' your.cdx.json
+
+# SPDX 2.3 — same query via the annotation envelope:
+jq -r '.packages[]
+       | select(.annotations[]?
+                | .comment | fromjson?
+                | select(.field == "mikebom:lifecycle-scope" and .value == "development"))
+       | .name + " " + .versionInfo' your.spdx.json
+
+# SPDX 3 — read the relationship-scope natively:
+jq -r '.["@graph"][]
+       | select(.type == "Relationship"
+                and .relationshipType == "dependsOn"
+                and .scope == "development")
+       | .to[]' your.spdx3.json
+```
+
+#### `mikebom:layer-digest`
+
+> **What it is**: the OCI layer's compressed-blob `sha256:<hex>` digest (matches the `LayerDigest` semantic from OCI's image manifest — NOT the uncompressed `DiffID`). Tells you which layer in an OCI image first introduced the file backing this component. When a path is written by multiple layers, the LAST writer in the manifest's `Layers[]` array wins (OCI overlay semantics).
+> **Where it lives**: emitted ONLY for `--image` scans on every component whose source path resolves to an OCI layer.
+> - **CDX 1.6**: `components[].properties[]` entry `{name: "mikebom:layer-digest", value: "sha256:<hex>"}`.
+> - **SPDX 2.3**: annotation envelope on the Package.
+> - **SPDX 3**: annotation envelope on the `software_Package` element.
+> **What to do with it**: when a CVE fires for a component, look up its `mikebom:layer-digest` to find which layer to rebuild / replace / patch. Useful for differential rebuilds (only re-pull the affected layer), for forensics ("which build step introduced this vulnerable dep?"), and for layered remediation policies (e.g., "block deployment if a CVE-vulnerable component lives in the base layer").
+> **Milestone**: 133 (US2.2) — added.
+> **Catalog**: [C88](sbom-format-mapping.md#section-c--mikebom-specific-data-preserved-via-fallback)
+
+```jq
+# CDX — find every component that came from a specific layer digest:
+jq --arg layer "sha256:abc123..." '
+  .components[]
+  | select(.properties[]?
+           | .name == "mikebom:layer-digest" and .value == $layer)
+  | {purl, name, version}
+' your-image.cdx.json
+```
+
+#### `mikebom:duplicate-purl-divergent` + `mikebom:purl-collisions-detected`
+
+> **What they are**: when two Cargo `(name, version)` coords collide in a scan but their declared dep sets or hashes diverge, mikebom flags both the per-component (C99) and document-scope (C100) signals. Without these, a vulnerability scanner could silently merge two distinct binaries under one CVE assessment — masking that the actual code differs. The per-component annotation carries a `DivergenceRecord` envelope `{v, purl, reason, paths[], dep_sets_by_path?, hashes_by_path?}` where `reason` is `deps-differ` / `hashes-differ` / `both`. The document-scope summary aggregates every detected collision in one `jq`-queryable surface.
+> **Where it lives**:
+> - **CDX 1.6**: per-component `components[].properties[]` (C99) + document-scope `metadata.properties[]` (C100).
+> - **SPDX 2.3**: per-Package annotation envelope (C99) + document-scope annotation on `SpdxDocument` (C100).
+> - **SPDX 3**: per-`software_Package` annotation (C99) + document-scope annotation (C100).
+> **What to do with it**: when a CVE fires for `(name, version)`, check whether the component carries `mikebom:duplicate-purl-divergent` — if so, the CVE may not uniformly apply to all instances. Each `paths[]` entry shows where each diverging variant was found. For triage automation: when present, do NOT auto-suppress the CVE for any path; require per-path human review.
+> **Milestone**: 134 — added (Cargo only this milestone; detection logic structured for ecosystem-agnostic reuse).
+> **Catalog**: [C99](sbom-format-mapping.md) + [C100](sbom-format-mapping.md)
+
+```jq
+# CDX — list every divergent collision detected in this scan:
+jq '.metadata.properties[]?
+    | select(.name == "mikebom:purl-collisions-detected")
+    | .value
+    | fromjson
+    | .collisions[]' your.cdx.json
+```
+
+---
+
+### 3.2 Compliance auditing
+
+Compliance auditors need to (a) distinguish operator-asserted license conclusions from external-enrichment-derived ones, (b) account for unattributed content via file-tier components that fill the orphan-coverage gap, and (c) verify that operator overrides don't lose manifest-derived provenance.
+
+#### `mikebom:license-concluded-source`
+
+> **What it is**: identifies WHERE a component's `licenseConcluded` value came from. Initial value: `"operator-asserted"` — set when the operator passed `--conclude-licenses`, formally asserting they have reviewed the declared licenses and accept them as the analyst-verified conclusion. Future values may include `"clearly-defined"`, `"deps-dev"`, etc. for parallel external-enrichment provenance. Emitted ONLY on components whose `licenseConcluded` was populated by this mechanism; pre-existing `NOASSERTION` conclusions stay unannotated.
+> **Where it lives**:
+> - **CDX 1.6**: `components[].properties[]` entry `{name: "mikebom:license-concluded-source", value: "operator-asserted"}`.
+> - **SPDX 2.3**: annotation envelope on the Package.
+> - **SPDX 3**: annotation envelope on the `software_Package`.
+> **What to do with it**: distinguish license conclusions that carry a human-review claim (operator-asserted) from external-enrichment-derived ones. CDX 1.6's `component.licenses[].acknowledgement` enum is `"declared"` / `"concluded"` — it identifies the LICENSE TYPE, not the SOURCE of the conclusion. Use this annotation to filter your compliance dashboard: operator-asserted conclusions carry stronger provenance than auto-derived ones.
+> **Milestone**: 132 — added (issue #363).
+> **Catalog**: [C98](sbom-format-mapping.md)
+
+```jq
+# CDX — find every component with an operator-asserted license conclusion:
+jq '.components[]
+    | select(.properties[]?
+             | .name == "mikebom:license-concluded-source")
+    | {purl, licenseConcluded: (.licenses[]? | .license.id // .expression)}
+' your.cdx.json
+```
+
+#### `mikebom:component-tier` (specifically `"file"`)
+
+> **What it is**: marks components emitted by the file-tier walker — files surviving every package-DB reader + every binary-tier reader + every fingerprint matcher. File-tier components carry NO PURL; they identify content by SHA-256 + observed paths instead. This closes the unattributed-content gap that lockfile / package-DB-only scanners miss (Constitution VIII Completeness — vendored libraries with no manifest, custom binaries, embedded archives, etc.). Emitted by default under `--file-inventory=orphan` mode (the post-milestone-133 default); the override mode `--file-inventory=full` adds duplicate file-tier components to package/binary-attributed paths.
+> **Where it lives**:
+> - **CDX 1.6**: `components[].properties[]` entry `{name: "mikebom:component-tier", value: "file"}`. The component itself uses `type: "file"`, omits `purl`, and carries paths via `mikebom:file-paths` (C92).
+> - **SPDX 2.3**: annotation envelope on the Package (`filesAnalyzed: false`, no `externalRefs[purl]`).
+> - **SPDX 3**: annotation envelope on a `software_File` graph-element (the tier-shape change is the element type swap).
+> **What to do with it**: when a compliance auditor walks the dep tree for license attribution, file-tier components represent content with no manifest-declared license. Treat them as "needs human review" or "license: unknown" rather than skipping. Pair with `mikebom:file-paths` to see where each piece of unattributed content was found.
+> **Milestone**: 133 (US1.B) — added; 133 (US1.C) — default flip to `orphan` mode.
+> **Catalog**: [C91](sbom-format-mapping.md) (+ [C92](sbom-format-mapping.md) for the paths companion). See also [component-tiers.md](component-tiers.md) for the full tier model.
+
+```jq
+# CDX — list every file-tier component + its observed paths:
+jq '.components[]
+    | select(.properties[]?
+             | .name == "mikebom:component-tier" and .value == "file")
+    | {
+        name,
+        sha256: (.hashes[]? | select(.alg == "SHA-256") | .content),
+        paths: (.properties[]? | select(.name == "mikebom:file-paths") | .value | fromjson)
+      }
+' your.cdx.json
+```
+
+#### `mikebom:demoted-from-main-module`
+
+> **What it is**: marks a library-typed component in `components[]` as the manifest-derived main-module that was preserved (rather than dropped per the milestone-077 clean-replacement default) when the operator passed `--root-name` / `--root-version` / `--root-purl` together with the milestone-149 `--preserve-manifest-main-module` opt-in flag. The demoted entry retains its original ecosystem-derived PURL + name + version + license + hashes; the only differences vs the pre-override main-module are: (a) `component.type` changes from `application` → `library`; (b) this annotation is added; (c) the entry appears in `components[]` instead of at `metadata.component`.
+> **Where it lives**:
+> - **CDX 1.6**: `components[].properties[]` entry `{name: "mikebom:demoted-from-main-module", value: "true"}`.
+> - **SPDX 2.3**: annotation envelope on the Package.
+> - **SPDX 3**: annotation envelope on the `software_Package`, BUT the subject IRI routes to the synth-root rather than the demoted entry's own IRI (per `package_iri_by_purl` aliasing serving milestone-084 relationship re-anchoring). The annotation VALUE is byte-identical across all three formats; only the SPDX 3 SUBJECT differs. Consumers querying by annotation `field` key find the annotation regardless.
+> **What to do with it**: for compliance auditors verifying that operator overrides don't lose manifest provenance — surface demoted components separately in your audit dashboard. The demoted entry has its own ecosystem-derived PURL (e.g., `pkg:cargo/foo-internal@0.5.1`) usable for vulnerability lookups; the operator-override root carries the deployment-meaningful identity. Treat them as a paired set.
+> **Milestone**: 149 — added (closes issue #151).
+> **Catalog**: [C102](sbom-format-mapping.md)
+
+```jq
+# CDX — find demoted components + their original manifest identity:
+jq '.components[]
+    | select(.properties[]?
+             | .name == "mikebom:demoted-from-main-module" and .value == "true")
+    | {purl, name, version}
+' your.cdx.json
+```
+
+---
+
+### 3.3 Build provenance
+
+Consumers verifying build-time provenance need to (a) distinguish components observed during an actual build vs lockfile-derived enrichment, (b) understand the doc-level generation mode (eBPF trace vs source-tree scan vs image scan), and (c) follow cross-tier bindings from a build SBOM back to its source SBOM.
+
+#### `mikebom:source-type`
+
+> **What it is**: tags each component with its discovery provenance. Common values include `"trace-observed"` (eBPF-observed during a live build trace), `"declared-not-cached"` (declared in a lockfile but mikebom couldn't verify its presence on disk), `"transitive"` (added via transitive lockfile resolution from an observed component), `"package-database"` (read from a system package DB like dpkg/rpm/apk). Strong-vs-weak provenance markers.
+> **Where it lives**:
+> - **CDX 1.6**: `components[].properties[]` entry.
+> - **SPDX 2.3**: annotation envelope on the Package.
+> - **SPDX 3**: annotation envelope on the `software_Package`.
+> **What to do with it**: trace-observed components have stronger ground truth than enrichment-derived ones. For vulnerability scanning, you may want to weight CVEs against trace-observed components more heavily than declared-not-cached ones. For compliance audits, mark non-trace-observed components for additional review (their presence in the SBOM is from secondary signals, not direct observation).
+> **Milestone**: 002 — added; refined across milestones 049–055.
+> **Catalog**: [C1](sbom-format-mapping.md)
+
+```jq
+# CDX — list components grouped by source-type provenance:
+jq '[.components[]
+     | {purl, source_type: (.properties[]? | select(.name == "mikebom:source-type") | .value)}]
+    | group_by(.source_type)
+    | map({source_type: .[0].source_type, count: length, examples: [.[0:3][] | .purl]})
+' your.cdx.json
+```
+
+#### `mikebom:generation-context`
+
+> **What it is**: document-level signal carrying the generation mode metadata for the entire scan — e.g., source-tree scan vs image scan vs build trace. Useful for downstream tooling that processes SBOMs differently per generation context.
+> **Where it lives**:
+> - **CDX 1.6**: `metadata.properties[]` entry (document-scope).
+> - **SPDX 2.3**: document-scope annotation on `SpdxDocument` via `creationInfo.comment` aggregation.
+> - **SPDX 3**: document-scope annotation on the `SpdxDocument` element.
+> **What to do with it**: parse before walking components — different generation contexts imply different trust models. Build-trace SBOMs have strong observational provenance; static-scan SBOMs have lockfile-derived provenance; image-scan SBOMs have file-system-extracted provenance.
+> **Milestone**: 002 — added; refined across milestones 005, 047.
+> **Catalog**: search for "generation-context" in [sbom-format-mapping.md](sbom-format-mapping.md)
+
+```jq
+# CDX — read the doc-level generation context:
+jq '.metadata.properties[]?
+    | select(.name == "mikebom:generation-context")
+    | .value' your.cdx.json
+```
+
+#### `mikebom:source-document-binding`
+
+> **What it is**: cross-tier binding from a build-tier or analyzed-tier SBOM back to its source-tier SBOM via a content hash + optional IRI. Built using `--bind-to-source <path>` at scan time; verified with `mikebom sbom verify-binding`. Enables source ↔ build ↔ deploy correlation across the artifact lifecycle.
+> **Where it lives**: rides on spec-native carriers when available — CDX `metadata.component.externalReferences[type:bom]`, SPDX 2.3 `externalDocumentRefs` + `BUILT_FROM` relationship, SPDX 3 `import[]` ExternalMap + `Relationship[built_from]`. The annotation envelope carries the binding hash + identity metadata.
+> **What to do with it**: when auditing a deployment, follow the binding back to the source SBOM to verify what code was actually compiled. Useful for supply-chain attestations + SLSA-style provenance correlation.
+> **Milestone**: 072 — added.
+> **Catalog**: search for "source-document-binding" in [sbom-format-mapping.md](sbom-format-mapping.md). Full design in [cross-tier-binding.md](cross-tier-binding.md).
+
+```jq
+# CDX — extract the source-document binding hash:
+jq '.metadata.component.externalReferences[]?
+    | select(.type == "bom")
+    | .url' your-build.cdx.json
+```
+
+---
+
+### 3.4 Transparency / completeness gaps
+
+Consumers evaluating SBOM completeness need explicit signals when mikebom couldn't fully resolve the dep graph or when a non-default emission mode is in effect. mikebom is "fail loud" per Constitution Principle X (Transparency) — gaps are surfaced as annotations rather than silently omitted.
+
+#### `mikebom:file-inventory-mode`
+
+> **What it is**: document-scope marker emitted ONLY when the operator passed `--file-inventory=full` (the override mode that bypasses the milestone-133 hybrid dedup, producing file-tier components that may duplicate package/binary-attributed paths). The default `orphan` mode and the byte-identity-preserving `off` mode do NOT emit this marker. Per Constitution Strict Boundary §5, full-mode SBOMs MUST carry this marker so consumers can detect the override at parse time and filter the file-tier set when the duplication is unwanted.
+> **Where it lives**:
+> - **CDX 1.6**: `metadata.properties[]` entry (document-scope).
+> - **SPDX 2.3**: document-scope annotation on `SpdxDocument`.
+> - **SPDX 3**: document-scope annotation on the `SpdxDocument` element.
+> **What to do with it**: when present, your dep-graph walks will see duplicated entries (the file-tier component AND the package-tier component covering the same file). Either deduplicate by content hash on your side, or filter out file-tier entries (`mikebom:component-tier = "file"`) before counting components.
+> **Milestone**: 133 (US4) — added; codified in Constitution Strict Boundary §5.
+> **Catalog**: [C97](sbom-format-mapping.md). See also [component-tiers.md](component-tiers.md).
+
+```jq
+# CDX — detect full-mode emission:
+jq '.metadata.properties[]?
+    | select(.name == "mikebom:file-inventory-mode")
+    | .value' your.cdx.json
+# Output: "full" if the marker is present; null/empty otherwise.
+```
+
+#### `mikebom:graph-completeness` + `mikebom:graph-completeness-reason`
+
+> **What they are**: document-scope Go-graph-completeness signal — `Complete` (all observed Go components have full dep edges) or `Partial` (some edges couldn't be resolved). The companion `-reason` annotation enumerates the specific cause classes. Currently Go-only (the only ecosystem where mikebom can detect partial graph state explicitly); other ecosystems either complete or fail closed.
+> **Where it lives**:
+> - **CDX 1.6**: `metadata.properties[]` entries (document-scope).
+> - **SPDX 2.3**: document-scope annotations on `SpdxDocument`.
+> - **SPDX 3**: document-scope annotations on the `SpdxDocument` element.
+> **What to do with it**: when a Go-bearing SBOM reports `Partial`, surface the gap in your compliance dashboard or vulnerability scanner — the dep-graph view is incomplete. The reason string tells you whether the gap is recoverable (e.g., re-scan with `go.sum` present) or structural (e.g., cgo external refs).
+> **Milestone**: 061 — added (closes #119).
+> **Catalog**: search for "graph-completeness" in [sbom-format-mapping.md](sbom-format-mapping.md)
+
+```jq
+# CDX — check Go-graph completeness for this scan:
+jq '.metadata.properties[]?
+    | select(.name == "mikebom:graph-completeness" or .name == "mikebom:graph-completeness-reason")
+    | {name, value}' your.cdx.json
+```
+
+#### `mikebom:peer-edge-targets`
+
+> **What it is**: alphabetically-sorted array of PURL strings naming the peer-driven `dependsOn` edges from a given npm component. npm `peerDependencies` are install-time conventional (npm 7+ auto-installs them) but semantically declarative — different from regular `dependencies`. mikebom emits peer-edges as standard `dependsOn` (matching the npm install reality) AND tags the source component with this annotation so consumers can distinguish install-driven edges from functional-dep edges. Emitted only on npm components with ≥1 resolved peer-driven edge.
+> **Where it lives**:
+> - **CDX 1.6**: `components[].properties[]` entry — annotation VALUE is a JSON-encoded array of PURL strings.
+> - **SPDX 2.3**: annotation envelope on the Package — VALUE is a native JSON array (per the milestone-145 envelope-shape).
+> - **SPDX 3**: annotation envelope on the `software_Package` — VALUE is a native JSON array.
+> **What to do with it**: vulnerability scanners that want the install-only edge view (matching pre-milestone-147 mikebom behavior) can subtract this set from each component's `dependsOn`. License auditors who care about the functional-dep distinction can flag peer-edges separately.
+> **Milestone**: 147 — added (closes Trivy-comparison orphan gap on the looker-frontend lockfile: 5 orphans → 0).
+> **Catalog**: [C101](sbom-format-mapping.md)
+
+```jq
+# CDX — extract peer-edge targets for a specific component:
+jq --arg purl "pkg:npm/@react-native-async-storage/async-storage@1.24.0" '
+  .components[]
+  | select(.purl == $purl)
+  | .properties[]?
+  | select(.name == "mikebom:peer-edge-targets")
+  | .value
+  | fromjson
+' your.cdx.json
+```
+
+---
+
+## 4. The `mikebom-annotation/v1` envelope
+
+SPDX 2.3 and SPDX 3 don't have a native flat-string property carrier the way CycloneDX does (CDX's `properties[].{name, value}` accepts arbitrary string-typed values directly). Instead, mikebom uses a JSON envelope wrapped inside the format's native `Annotation` element. The envelope shape:
+
+```json
+{
+  "schema": "mikebom-annotation/v1",
+  "field": "<mikebom:* annotation key>",
+  "value": <payload — string OR JSON value, depending on the key>
+}
+```
+
+**Per-format examples** for a single signal (`mikebom:lifecycle-scope` = `"development"`):
+
+| Format | Carrier | Wire shape |
+|---|---|---|
+| CDX 1.6 | `components[i].properties[]` flat string | `{ "name": "mikebom:lifecycle-scope", "value": "development" }` |
+| SPDX 2.3 | `packages[i].annotations[].comment` envelope-as-string | `"comment": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:lifecycle-scope\",\"value\":\"development\"}"` |
+| SPDX 3 | `Annotation.statement` envelope-as-string | `"statement": "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:lifecycle-scope\",\"value\":\"development\"}"` |
+
+The envelope schema string `mikebom-annotation/v1` is the stability anchor — future envelope evolutions would bump the version (`mikebom-annotation/v2`) and provide a migration window. Consumers can safely match on `schema == "mikebom-annotation/v1"` to identify mikebom-emitted annotations.
+
+**Canonical Rust source references**:
+- Encoder: [`mikebom-cli/src/generate/spdx/annotations.rs`](../../mikebom-cli/src/generate/spdx/annotations.rs) — defines `ENVELOPE_SCHEMA_V1` constant + `MikebomAnnotationCommentV1` struct (lines ~31–67).
+- Decoder: [`mikebom-cli/src/parity/extractors/common.rs`](../../mikebom-cli/src/parity/extractors/common.rs) — verifies envelope `schema` + extracts `field` + `value` payload (line ~185).
+
+For SPDX 3 annotations: the `statement` field carries the envelope JSON-as-string. The `subject` field points at the SPDX 3 IRI of the element the annotation applies to — for most signals this is the relevant `software_Package` element; for document-scope signals it's the `SpdxDocument` element. **SPDX 3 subject-routing quirk**: a few annotations (notably `mikebom:demoted-from-main-module`) route to the synth-root IRI rather than the demoted entry's own IRI due to `package_iri_by_purl` aliasing serving milestone-084 relationship re-anchoring. The annotation VALUE remains byte-identical across formats; only the SPDX 3 SUBJECT differs. Consumers querying by annotation `field` key find the annotation regardless. See [C102](sbom-format-mapping.md) for the documented divergence.
+
+---
+
+## 5. Cross-format reading patterns
+
+The same `mikebom:*` signal lives in different per-format carriers. Here's a representative cross-format lookup table for 4 depth-covered signals:
+
+| Signal | CDX 1.6 | SPDX 2.3 | SPDX 3 |
+|---|---|---|---|
+| `mikebom:lifecycle-scope` | per-component `properties[]` flat string + native `component.scope: "excluded"` for non-runtime | per-Package annotation envelope + native typed relationships (`DEV/BUILD/TEST_DEPENDENCY_OF`) | NOT emitted as annotation — native `LifecycleScopedRelationship.scope` on the dep edge |
+| `mikebom:layer-digest` | per-component `properties[]` flat string | per-Package annotation envelope | per-`software_Package` annotation envelope |
+| `mikebom:source-type` | per-component `properties[]` flat string | per-Package annotation envelope | per-`software_Package` annotation envelope |
+| `mikebom:demoted-from-main-module` | per-component `properties[]` flat string | per-Package annotation envelope | per-`software_Package` annotation envelope, BUT subject routes to synth-root IRI (see [§4 subject-routing note](#4-the-mikebom-annotationv1-envelope)) |
+
+For the full per-row wire-shape detail across all 100+ catalog rows, see [`sbom-format-mapping.md`](sbom-format-mapping.md). That doc names the exact JSON Pointer paths, annotation subject rules, and per-format omissions for every signal.
+
+**Common pattern**: when a signal has a spec-native field in one or more formats AND only some formats need the parity-bridge, mikebom emits the native field where available + the annotation only where the native field is absent. This is Constitution Principle V in action — native first, annotation as a parity-bridge. SPDX 3's `LifecycleScopedRelationship.scope` is a representative example (SPDX 3 omits the parity-bridge annotation because the native field is sufficient there).
+
+---
+
+## 6. Stability
+
+**Catalog row numbers are durable identifiers**. Every `mikebom:*` annotation has a row in [`sbom-format-mapping.md`](sbom-format-mapping.md) numbered `C<N>`. The row number is the stable identifier — annotation key names and wire-shapes may evolve through documented migrations, but the row number identifies the signal's continuity across versions.
+
+**The `mikebom-annotation/v1` envelope shape is stable**. Future envelope evolutions would bump the version string (`mikebom-annotation/v2`) and provide a parallel-emission migration window so consumers can support both versions during the transition.
+
+**Opt-in / experimental flags affect which signals are emitted**:
+
+| Flag | Effect on emission |
+|---|---|
+| `--exclude-scope <dev,build,test>` | Default mikebom scans INCLUDE dev/build/test-scoped components (and emit `mikebom:lifecycle-scope` annotations for non-runtime entries). This flag DROPS the listed scopes from `components[]` — operator-side opt-out for production-only views. |
+| `--file-inventory=full` | Bypasses milestone-133 hybrid dedup; emits `mikebom:file-inventory-mode = "full"` as a transparency marker. Default `orphan` mode does not emit this marker. |
+| `--file-inventory=off` | Disables file-tier emission entirely. `mikebom:component-tier = "file"` components do not appear. |
+| `--preserve-manifest-main-module` | Enables `mikebom:demoted-from-main-module` annotations when used with `--root-name` / `--root-version` / `--root-purl` overrides. |
+| `--include-declared-deps` | Affects whether `declared-not-cached` `mikebom:source-type` components appear. |
+| `--no-deep-hash` | Skips per-file SHA-256 emission for binary-tier components. Affects whether content-hash signals are present. |
+| `--conclude-licenses` | Emits `mikebom:license-concluded-source = "operator-asserted"` on affected components. |
+
+**Versioning**: mikebom releases follow the `v*-alpha.*` tag sequence (currently in alpha; on `v0.1.0-alpha.52` as of milestone 149). Map binary version → signal availability via the milestone citations in [Appendix B](#appendix-b--milestone-citation-map).
+
+**Consumer-side compatibility**: consumers parsing a mikebom SBOM SHOULD treat unknown `mikebom:*` annotation keys as ignorable rather than as errors. The catalog is the canonical source-of-truth for which keys exist at any given mikebom version; consumers encountering an unknown key in real SBOM data should consult [Appendix A](#appendix-a--annotation-key-index) (this guide's snapshot) or the catalog directly.
+
+---
+
+## 7. For tool authors
+
+If you're building a tool that consumes mikebom SBOMs (vulnerability scanner, SBOM-diff tool, compliance dashboard, license auditor, custom remediation engine), this section is a quick integration checklist.
+
+**1. Decide your envelope-parse approach**. Per [§4](#4-the-mikebom-annotationv1-envelope), SPDX 2.3 + SPDX 3 ride the `mikebom-annotation/v1` envelope as a JSON-encoded string inside the format's native `Annotation`. You can either:
+- Match on the envelope `schema` field (`"mikebom-annotation/v1"`) to identify mikebom-emitted annotations.
+- Match directly on the envelope `field` field (e.g., `"mikebom:lifecycle-scope"`) to filter for a specific signal.
+
+CDX 1.6 has no envelope — the value is a flat string on `properties[].value`. Same `field` semantic; different carrier.
+
+**2. Use the catalog row numbers as the stability anchor**. Per [§6](#6-stability), `C<N>` row numbers in [`sbom-format-mapping.md`](sbom-format-mapping.md) are durable. If you depend on a specific annotation's semantic, reference its C-row number in your tool's docs so future mikebom version migrations remain trackable.
+
+**3. Suggested integration patterns**:
+
+| Goal | Pattern |
+|---|---|
+| Suppress dev-only deps from production CVE alerting | Filter components by `mikebom:lifecycle-scope` (CDX `properties[]` / SPDX 2.3+3 envelope) OR walk SPDX 2.3 typed `DEV_DEPENDENCY_OF` relationships OR walk SPDX 3 `LifecycleScopedRelationship.scope`. |
+| Attribute findings to OCI layers | Walk `mikebom:layer-digest` on every component; pair with the image manifest's `Layers[]` index to find the introducing layer. |
+| Flag divergent same-PURL collisions | Walk document-scope `mikebom:purl-collisions-detected` once; per-collision details on each affected component's `mikebom:duplicate-purl-divergent`. |
+| Recover orphan / unattributed content | Walk components with `mikebom:component-tier == "file"`; treat as identity-by-SHA-256 (no PURL); pair with `mikebom:file-paths` for path coverage. |
+| Detect full-mode duplicate file-tier coverage | Check document-scope `mikebom:file-inventory-mode == "full"`; if present, deduplicate file-tier vs package-tier components by content hash. |
+| Filter npm peer-edges separately | Walk `mikebom:peer-edge-targets` to extract install-driven edges; subtract from `dependsOn` for the functional-dep view. |
+| Verify build-time vs lockfile-derived provenance | Walk `mikebom:source-type`; weight `trace-observed` higher than `declared-not-cached` for CVE risk scoring. |
+| Cross-tier source ↔ build correlation | Follow `mikebom:source-document-binding` from build SBOM back to source SBOM; verify with `mikebom sbom verify-binding`. |
+
+**4. Report unexpected behavior**: if you encounter a signal that's not in the catalog, an annotation that doesn't match the documented envelope shape, or a behavior that contradicts this guide — file an issue at <https://github.com/kusari-oss/mikebom/issues> with the mikebom binary version + a minimal repro SBOM.
+
+---
+
+## 8. Cross-references
+
+| Doc | Purpose |
+|---|---|
+| [SBOM format mapping](sbom-format-mapping.md) | **The catalog.** Authoritative wire-shape contract — every emitted data element has a row naming its CDX 1.6 / SPDX 2.3 / SPDX 3 location. Code-review depth. |
+| [Identifiers](identifiers.md) | The four-layer identity model (`repo:` / `git:` / `image:` / `attestation:` / user-defined identifiers) — covers `mikebom:identifiers`, the `--repo` / `--git-ref` / `--image` / `--attestation` / `--id` CLI surface, and per-flag identity behavior. |
+| [SBOM types](sbom-types.md) | CISA SBOM Type signaling (Design / Source / Build / Analyzed / Deployed / Runtime), the four-column equivalence table, and the `--sbom-type` flag. Per-format mapping for `metadata.lifecycles[]` / `creationInfo.comment` / `software_Sbom.software_sbomType[]`. |
+| [Component tiers](component-tiers.md) | The package-tier vs binary-tier vs file-tier model — content-shape allowlist, full-mode override, behavior across `--file-inventory` modes. |
+| [Cross-tier binding](cross-tier-binding.md) | The `--bind-to-source` flag, `mikebom sbom verify-binding` CLI, the binding-hash-v1 algorithm, and source ↔ build ↔ deploy correlation patterns. |
+| [Conformance harness guide](conformance-harness-guide.md) | Per-format envelope-decode rules + the 7 inherent format-spec asymmetries (the structural reasons certain cross-format comparisons require canonicalization). |
+| [Ecosystems](../ecosystems.md) | Per-ecosystem coverage matrix for all supported ecosystems — what mikebom emits for each ecosystem, source-format detection rules, transitive-dep resolution patterns. |
+| [Changelog](../../CHANGELOG.md) | Milestone-by-milestone release history. Each released mikebom version maps to a milestone range; cross-reference with [Appendix B](#appendix-b--milestone-citation-map) to determine signal availability per binary version. |
+
+---
+
+## Appendix A — Annotation key index
+
+Snapshot at milestone-150 publication time (98 unique keys across the catalog). Future annotations land in [`sbom-format-mapping.md`](sbom-format-mapping.md) only; this index is best-effort current. When you encounter an unfamiliar `mikebom:*` key not listed here, search the catalog directly — its row contains the full wire-shape contract.
+
+Alphabetical order. Each entry links to the FIRST catalog row that mentions the key (some keys appear on multiple rows — e.g., per-component + document-scope variants — follow the linked row for cross-references to siblings).
+
+- **`mikebom:also-detected-via`** — when the deduplicator merges entries from multiple readers, lists the alternative reader sources for the surviving component. ([C56](sbom-format-mapping.md))
+- **`mikebom:assembly-version-informational`** — for .NET assemblies, the raw `AssemblyInformationalVersion` value extracted from the binary. ([catalog](sbom-format-mapping.md))
+- **`mikebom:assembly-version-informational-stripped`** — for .NET assemblies, the `AssemblyInformationalVersion` stripped of its build-metadata SemVer suffix (everything after `+`) for cross-tool comparison. ([C87](sbom-format-mapping.md))
+- **`mikebom:assertion-conflict`** — milestone-119 supplement-CDX merge: signals when a supplement file's assertion conflicts with auto-detected scan data. ([C67](sbom-format-mapping.md))
+- **`mikebom:bazel-archive-name`** — for Bazel-emitted components, the archive filename used in the BUILD/WORKSPACE rule. ([C54](sbom-format-mapping.md))
+- **`mikebom:bbappend-applied`** — Yocto: signals that a `.bbappend` recipe overlay was applied during build. ([C76](sbom-format-mapping.md))
+- **`mikebom:binary-class`** — binary-tier classification (`elf-executable` / `elf-shared-library` / `pe-executable` / `mach-o-binary` / etc.). ([C10](sbom-format-mapping.md))
+- **`mikebom:binary-packed`** — boolean signaling the binary file was detected as packed/compressed (UPX, similar). ([C15](sbom-format-mapping.md))
+- **`mikebom:binary-stripped`** — boolean signaling the binary has had its debug symbols stripped. ([C11](sbom-format-mapping.md))
+- **`mikebom:build-inclusion`** — milestone-112 Go build-inclusion classification (`tracked` / `not-tracked` / `unknown`). ([C60](sbom-format-mapping.md))
+- **`mikebom:build-inclusion-derivation`** — milestone-112 derivation reason for the build-inclusion classification above. ([C61](sbom-format-mapping.md))
+- **`mikebom:build-reference`** — links a build-tier component to its build-system reference (Bazel target, Maven coord, etc.). ([C57](sbom-format-mapping.md))
+- **`mikebom:buildinfo-status`** — Debian buildinfo-file presence + verification status (`present` / `absent` / `partial`). ([C13](sbom-format-mapping.md))
+- **`mikebom:co-owned-by`** — multi-source component co-ownership marker (e.g., Maven coord owned by both `groupA:artifact` and `groupB:artifact`). ([C7](sbom-format-mapping.md))
+- **`mikebom:component-role`** — milestone-127 role tag (`main-module` / `service` / etc.) for root-selection logic. Internal — filtered before emission. ([C40](sbom-format-mapping.md))
+- **`mikebom:component-tier`** — package-tier vs binary-tier vs file-tier classification. See [§3.2](#32-compliance-auditing) for depth coverage. ([C91](sbom-format-mapping.md))
+- **`mikebom:confidence`** — resolution-confidence score (0.0–1.0) for components identified via fuzzy matching. ([C16](sbom-format-mapping.md))
+- **`mikebom:cpe-candidates`** — when a component has multiple unresolved CPE candidates, the full set rides this annotation (resolved candidates ride native `externalRefs[cpe23Type]`). ([C19](sbom-format-mapping.md))
+- **`mikebom:demoted-from-main-module`** — milestone-149 marker for library entries preserved from the manifest-derived main-module after `--root-name` override + `--preserve-manifest-main-module` opt-in. See [§3.2](#32-compliance-auditing) for depth coverage. ([C102](sbom-format-mapping.md))
+- **`mikebom:depends-unresolved`** — for components with declared deps mikebom couldn't resolve, lists the unresolved dep names. ([C77](sbom-format-mapping.md))
+- **`mikebom:deps-dev-match`** — deps.dev enrichment match record (system + name + version triple). ([C3](sbom-format-mapping.md))
+- **`mikebom:detected-cargo-auditable`** — boolean signaling the binary embeds cargo-auditable JSON manifest data. ([C36](sbom-format-mapping.md))
+- **`mikebom:detected-go`** — Go-binary detection metadata (Go module path + version extracted from `runtime/debug.BuildInfo`). ([C14](sbom-format-mapping.md))
+- **`mikebom:download-url`** — recipe-declared download URL (Yocto / Bitbake `SRC_URI` variant). ([C53](sbom-format-mapping.md))
+- **`mikebom:duplicate-purl-divergent`** — milestone-134: per-component flag for divergent same-PURL collisions. See [§3.1](#31-vulnerability-scanning) for depth coverage. ([C99](sbom-format-mapping.md))
+- **`mikebom:elf-build-id`** — ELF binary's GNU build-ID hex string (from `.note.gnu.build-id` section). ([C24](sbom-format-mapping.md))
+- **`mikebom:elf-compiler-stamps`** — compiler-version strings extracted from ELF `.comment` / `.note.gnu` sections. ([C49](sbom-format-mapping.md))
+- **`mikebom:elf-debuglink`** — ELF `.gnu_debuglink` reference (path to debug-symbol companion file). ([C26](sbom-format-mapping.md))
+- **`mikebom:elf-runpath`** — ELF `DT_RPATH` / `DT_RUNPATH` colon-separated runpath entries. ([C25](sbom-format-mapping.md))
+- **`mikebom:evidence-kind`** — classification of evidence quality (`direct-observation` / `inference` / `enrichment`). ([C4](sbom-format-mapping.md))
+- **`mikebom:exclude-path`** — milestone-113 transparency annotation listing exclude-path patterns that suppressed file emission. ([C63](sbom-format-mapping.md))
+- **`mikebom:file-inventory-mode`** — milestone-133 marker emitted only when `--file-inventory=full` (override mode). See [§3.4](#34-transparency--completeness-gaps) for depth coverage. ([C97](sbom-format-mapping.md))
+- **`mikebom:file-inventory-skipped-oversize`** — milestone-133 transparency counter for files skipped during the file-tier walk due to size cap. ([C93](sbom-format-mapping.md))
+- **`mikebom:file-inventory-skipped-special-files`** — milestone-133 transparency counter for special-file skips during the file-tier walk. ([C94](sbom-format-mapping.md))
+- **`mikebom:file-inventory-unreadable`** — milestone-133 transparency counter for unreadable-file skips during the file-tier walk. ([C95](sbom-format-mapping.md))
+- **`mikebom:file-paths`** — milestone-133 file-tier component's path coverage list (every rootfs-relative path where the SHA-256 content was observed). ([C92](sbom-format-mapping.md))
+- **`mikebom:file-paths-truncated`** — boolean signaling the `mikebom:file-paths` array was truncated to the cap; some paths were dropped. ([C96](sbom-format-mapping.md))
+- **`mikebom:fingerprint-confidence`** — milestone-108 fingerprint-matcher confidence score (0.0–1.0). ([C59](sbom-format-mapping.md))
+- **`mikebom:fingerprint-corpus-sha`** — milestone-108 corpus identity SHA used for fingerprint matching (provenance). ([C58](sbom-format-mapping.md))
+- **`mikebom:generation-context`** — document-scope generation-mode metadata. See [§3.3](#33-build-provenance) for depth coverage. ([C21](sbom-format-mapping.md))
+- **`mikebom:go-vcs-modified`** — Go binary's `vcs.modified` flag from `runtime/debug.BuildInfo`. ([C29](sbom-format-mapping.md))
+- **`mikebom:go-vcs-revision`** — Go binary's `vcs.revision` (commit SHA) from `runtime/debug.BuildInfo`. ([C27](sbom-format-mapping.md))
+- **`mikebom:go-vcs-time`** — Go binary's `vcs.time` (commit timestamp) from `runtime/debug.BuildInfo`. ([C28](sbom-format-mapping.md))
+- **`mikebom:graph-completeness`** — milestone-061 document-scope signal for Go-graph completeness (`Complete` / `Partial`). See [§3.4](#34-transparency--completeness-gaps) for depth coverage. ([C44](sbom-format-mapping.md))
+- **`mikebom:graph-completeness-reason`** — milestone-061 companion enumerating the reason class for `Partial` Go-graph completeness. ([C44](sbom-format-mapping.md))
+- **`mikebom:identifiers`** — milestone-073 user-defined identifier envelope (`<scheme>:<value>` records beyond the built-in `repo:` / `git:` / `image:` / `attestation:` schemes). See [identifiers.md](identifiers.md). ([C47](sbom-format-mapping.md))
+- **`mikebom:kmp-source-set`** — milestone-122 Kotlin Multiplatform source-set names that declared each dep. ([C68](sbom-format-mapping.md))
+- **`mikebom:layer-digest`** — milestone-133 OCI layer-digest attribution. See [§3.1](#31-vulnerability-scanning) for depth coverage. ([C88](sbom-format-mapping.md))
+- **`mikebom:license-concluded-source`** — milestone-132 provenance marker for license conclusions. See [§3.2](#32-compliance-auditing) for depth coverage. ([C98](sbom-format-mapping.md))
+- **`mikebom:lifecycle-scope`** — milestone-052 finer-grained dev/build/test/runtime scope distinction. See [§3.1](#31-vulnerability-scanning) for depth coverage. ([C42](sbom-format-mapping.md))
+- **`mikebom:lifecycle-scope-derivation`** — milestone-062 reason-class for why a particular lifecycle-scope was chosen for a component. ([C62](sbom-format-mapping.md))
+- **`mikebom:linkage-kind`** — binary linkage classification (`statically-linked` / `dynamically-linked` / `cgo-import` / etc.). ([C12](sbom-format-mapping.md))
+- **`mikebom:macho-build-tools`** — Mach-O `LC_BUILD_VERSION` build-tools entries (clang/swift version + similar). ([C51](sbom-format-mapping.md))
+- **`mikebom:macho-build-version`** — Mach-O `LC_BUILD_VERSION` SDK + min-OS values. ([C50](sbom-format-mapping.md))
+- **`mikebom:macho-codesign-flags`** — Mach-O code-signature flags bitmask (hex). ([C38](sbom-format-mapping.md))
+- **`mikebom:macho-codesign-identifier`** — Mach-O code-signature identifier string. ([C37](sbom-format-mapping.md))
+- **`mikebom:macho-codesign-team-id`** — Mach-O code-signature team identifier (Apple developer team). ([C39](sbom-format-mapping.md))
+- **`mikebom:macho-min-os`** — Mach-O `LC_VERSION_MIN_*` minimum-OS version. ([C32](sbom-format-mapping.md))
+- **`mikebom:macho-rpath`** — Mach-O `LC_RPATH` runpath entries. ([C31](sbom-format-mapping.md))
+- **`mikebom:macho-uuid`** — Mach-O `LC_UUID` binary identifier. ([C30](sbom-format-mapping.md))
+- **`mikebom:not-linked`** — milestone-050 marker for Go components present in source but never linked into the binary output. ([C41](sbom-format-mapping.md))
+- **`mikebom:npm-role`** — npm-specific component role (e.g., `workspace-root` / `peer-dep`). ([C9](sbom-format-mapping.md))
+- **`mikebom:orphan-reason`** — when a component appears as a graph orphan (no inbound edges), enumerates the reason class. ([C45](sbom-format-mapping.md))
+- **`mikebom:os-release-missing-fields`** — document-scope transparency: lists `/etc/os-release` fields missing during distro detection. ([C22](sbom-format-mapping.md))
+- **`mikebom:pe-linker-version`** — PE binary's linker-version major/minor (from `IMAGE_OPTIONAL_HEADER`). ([C52](sbom-format-mapping.md))
+- **`mikebom:pe-machine`** — PE binary's machine architecture (x86 / x64 / ARM64). ([C34](sbom-format-mapping.md))
+- **`mikebom:pe-pdb-id`** — PE binary's PDB GUID + age (for symbol-file correlation). ([C33](sbom-format-mapping.md))
+- **`mikebom:pe-subsystem`** — PE binary's subsystem value (CLI / GUI / driver). ([C35](sbom-format-mapping.md))
+- **`mikebom:peer-edge-targets`** — milestone-147 npm peer-edge PURL list for install-vs-functional filtering. See [§3.4](#34-transparency--completeness-gaps) for depth coverage. ([C101](sbom-format-mapping.md))
+- **`mikebom:produces-binaries`** — milestone-116 marker for source components that produce binary outputs (cross-tier binding helper). ([C64](sbom-format-mapping.md))
+- **`mikebom:purl-collisions-detected`** — milestone-134 document-scope summary of divergent same-PURL collisions. See [§3.1](#31-vulnerability-scanning) for depth coverage. ([C100](sbom-format-mapping.md))
+- **`mikebom:raw-version`** — pre-canonicalization raw version string when canonicalization altered the value. ([C17](sbom-format-mapping.md))
+- **`mikebom:rdepends-unresolved`** — for components with declared runtime-deps mikebom couldn't resolve, lists the unresolved names. ([C78](sbom-format-mapping.md))
+- **`mikebom:requirement-range`** — the declared version-range constraint (e.g., `^1.2.0` / `>=2.0`) when known. ([C20](sbom-format-mapping.md))
+- **`mikebom:resolver-step`** — milestone-091 Go resolver: enumerates which resolution-ladder step produced a transitive component (e.g., `go-mod-graph` / `go-sum-fallback`). ([C48](sbom-format-mapping.md))
+- **`mikebom:root-selection-heuristic`** — milestone-127 document-scope: which heuristic selected the root component (per the [SBOM root-selection ladder](component-tiers.md)). ([C69](sbom-format-mapping.md))
+- **`mikebom:sbom-tier`** — per-component tier marker (`source` / `build` / `analyzed` / `deployed` — orthogonal to component-tier). ([C5](sbom-format-mapping.md))
+- **`mikebom:shade-relocation`** — Maven shade-plugin relocation rule that was applied to the vendored coord. ([C8](sbom-format-mapping.md))
+- **`mikebom:source-connection-ids`** — comma-separated list of eBPF source-connection identifiers that observed this component. ([C2](sbom-format-mapping.md))
+- **`mikebom:source-document-binding`** — milestone-072 cross-tier binding envelope. See [§3.3](#33-build-provenance) for depth coverage. ([C46](sbom-format-mapping.md))
+- **`mikebom:source-files`** — milestone-145 JSON-array of source file paths backing this component (canonicalized via `c.evidence.source_file_paths`). ([C18](sbom-format-mapping.md))
+- **`mikebom:source-mechanism`** — for cross-tier-attribution components, the mechanism used to bind source ↔ build (e.g., `cmake-fetchcontent-git` / `binary-symbol-fingerprint`). ([C55](sbom-format-mapping.md))
+- **`mikebom:source-tier`** — companion to `mikebom:sbom-tier` identifying the source-tier when relevant. ([C65](sbom-format-mapping.md))
+- **`mikebom:source-type`** — discovery-provenance tag. See [§3.3](#33-build-provenance) for depth coverage. ([C1](sbom-format-mapping.md))
+- **`mikebom:src-uri`** — Yocto / Bitbake recipe `SRC_URI` value carrying the upstream source URL(s). ([C71](sbom-format-mapping.md))
+- **`mikebom:src-uri-local-only`** — boolean signaling all `SRC_URI` entries were `file://` (no external upstream). ([C82](sbom-format-mapping.md))
+- **`mikebom:srcrev`** — Yocto recipe `SRCREV` value (commit SHA pin for source). ([C70](sbom-format-mapping.md))
+- **`mikebom:srcrev-by-machine`** — Yocto multi-machine builds: per-machine `SRCREV` override map. ([C72](sbom-format-mapping.md))
+- **`mikebom:supplement-cdx`** — milestone-119 supplement-CDX merge marker (which CDX entries came from supplement files vs scan output). ([C66](sbom-format-mapping.md))
+- **`mikebom:trace-integrity-*`** — milestone-002 family of eBPF trace-integrity counters + dropped-event diagnostics. ([C23](sbom-format-mapping.md))
+- **`mikebom:yocto-class-extend`** — Yocto `BBCLASSEXTEND` flavor list (e.g., `["native", "nativesdk"]`). ([C83](sbom-format-mapping.md))
+- **`mikebom:yocto-description`** — Yocto recipe `DESCRIPTION` when distinct from `SUMMARY` (added value vs the native `description` field). ([C81](sbom-format-mapping.md))
+- **`mikebom:yocto-layer`** — Yocto layer name owning the recipe (provenance for multi-layer builds). ([C73](sbom-format-mapping.md))
+- **`mikebom:yocto-layer-series`** — Yocto layer release series (e.g., `scarthgap` / `kirkstone`). ([C75](sbom-format-mapping.md))
+- **`mikebom:yocto-layer-version`** — Yocto layer's `LAYERVERSION` declaration. ([C74](sbom-format-mapping.md))
+- **`mikebom:yocto-layer-version-missing`** — Yocto transparency marker: signals that a layer's `LAYERVERSION` declaration was absent / unparseable. ([catalog](sbom-format-mapping.md))
+- **`mikebom:yocto-license-closed`** — boolean signaling the Yocto recipe declared `LICENSE_FLAGS = "commercial"` (CLOSED license). ([C80](sbom-format-mapping.md))
+- **`mikebom:yocto-overrides-merged`** — boolean signaling ≥1 override-syntax merge fired during Yocto recipe parsing (FR-016 union-merge approximation). ([C84](sbom-format-mapping.md))
+- **`mikebom:yocto-recipe-name`** — Yocto recipe filename-derived name (emitted when host-typed PURL fires per FR-002a). ([C85](sbom-format-mapping.md))
+- **`mikebom:yocto-recipe-version`** — Yocto recipe filename-derived version (companion to recipe-name). ([C86](sbom-format-mapping.md))
+- **`mikebom:yocto-unexpanded-vars`** — Yocto: transparency annotation listing variables that couldn't be expanded during recipe parsing. ([C79](sbom-format-mapping.md))
+- **`mikebom:vendored`** — marker for components detected as vendored into the source tree (e.g., `vendor/` for Go, Cargo workspace `vendor/`). ([catalog](sbom-format-mapping.md))
+
+---
+
+## Appendix B — Milestone-citation map
+
+Each depth-covered signal cites the milestone that introduced or stabilized it. Consumers comparing a mikebom binary version against signal availability can use this table to determine whether a specific signal is available in their pinned binary.
+
+| Signal | Milestone | Verb |
+|---|---|---|
+| `mikebom:lifecycle-scope` | 052 | added (Constitution V redesign: replaces an alpha-era custom annotation with native CDX `scope` + finer-grained annotation) |
+| `mikebom:lifecycle-scope` | 228 (issue) | extended to SPDX 2.3 as parity-bridge so `DEPENDS_ON`-walkers can recover the dev/build/test distinction |
+| `mikebom:layer-digest` | 133 (US2.2) | added |
+| `mikebom:duplicate-purl-divergent` | 134 | added (Cargo only this milestone; ecosystem-agnostic detection logic) |
+| `mikebom:purl-collisions-detected` | 134 | added (document-scope companion of `mikebom:duplicate-purl-divergent`) |
+| `mikebom:license-concluded-source` | 132 | added (issue #363) |
+| `mikebom:component-tier` (`file` value) | 133 (US1.B) | added; default flip to `orphan` mode in 133 (US1.C) |
+| `mikebom:demoted-from-main-module` | 149 | added (closes issue #151) |
+| `mikebom:source-type` | 002 | added |
+| `mikebom:source-type` | 049, 050, 052, 055 | refined / extended across multiple milestones |
+| `mikebom:generation-context` | 002 | added |
+| `mikebom:generation-context` | 005, 047 | refined |
+| `mikebom:source-document-binding` | 072 | added |
+| `mikebom:file-inventory-mode` | 133 (US4) | added; codified in Constitution Strict Boundary §5 |
+| `mikebom:graph-completeness` | 061 | added (closes #119) |
+| `mikebom:graph-completeness-reason` | 061 | added |
+| `mikebom:peer-edge-targets` | 147 | added (closes Trivy-comparison orphan gap on the looker-frontend npm lockfile) |
+
+mikebom releases follow the `v*-alpha.*` tag sequence. As of milestone 149, the released version is `v0.1.0-alpha.52`. To determine signal availability for a specific binary version, cross-reference the [CHANGELOG](../../CHANGELOG.md) for the release-to-milestone mapping.

--- a/specs/150-sbom-consumer-guide/checklists/requirements.md
+++ b/specs/150-sbom-consumer-guide/checklists/requirements.md
@@ -1,0 +1,55 @@
+# Specification Quality Checklist: SBOM consumer-facing reading guide
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+  - Spec names specific docs file paths (`docs/reference/reading-a-mikebom-sbom.md`, `sbom-format-mapping.md`) as deliverable + cross-reference anchors. No control flow or implementation specifics — this is a docs milestone.
+- [X] Focused on user value and business needs
+  - US1 framed around the compliance engineer onboarding case. US2 framed around vulnerability-scanner / tool-author leverage of mikebom signals.
+- [X] Written for non-technical stakeholders
+  - Origin & Context section walks through the consumer-onboarding gap in plain language. No mikebom-internal jargon without explanation.
+- [X] All mandatory sections completed
+  - Origin & Context, User Scenarios & Testing, Requirements, Success Criteria, Assumptions, Out of Scope, Key Entities all present.
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+  - Zero markers. All design decisions documented in Assumptions.
+- [X] Requirements are testable and unambiguous
+  - FR-001 to FR-013 each name a specific deliverable or contract. Example: FR-006 specifies the appendix index shape (flat alphabetical lookup table with direct anchor links to catalog rows) — directly testable.
+- [X] Success criteria are measurable
+  - SC-001 names a 5-question read-through audit. SC-002 names the catalog-coverage audit. SC-003 names the index.md link. SC-004 names a recipe-count threshold (≥5). SC-005 names a cluster-count threshold (≥4). SC-006 names tool-count + differentiator-count thresholds. SC-007 names the pre-PR gate. SC-008 names a reverse-link audit.
+- [X] Success criteria are technology-agnostic (no implementation details)
+  - SCs describe observable outcomes (questions answered, audits passing, links present). The doc IS a tech artifact but the SC measure is doc-quality, not impl-quality.
+- [X] All acceptance scenarios are defined
+  - US1 has 5 scenarios covering opening-section comprehension, lifecycle-scope lookup, unfamiliar-annotation lookup, build-provenance signals, phantom-component detection. US2 has 3 scenarios for tool-author needs.
+- [X] Edge cases are identified
+  - 6 distinct edge cases covered: outside-cluster use case, future-annotation drift, consumer disagreement with emission, appendix-staleness, single-file-self-contained guarantee, mikebom-version verification.
+- [X] Scope is clearly bounded
+  - Out of Scope section lists 10 explicit exclusions including emitter-behavior changes, new annotations, auto-generation of appendix, multi-language, per-annotation subdocs, interactive tooling, comparison benchmark suite, exhaustive C-row coverage, parser/linter tooling.
+- [X] Dependencies and assumptions identified
+  - Assumptions section names 9 explicit assumptions: docs-only, no emitter change, catalog stays canonical, appendix is snapshot, jq recipes illustrative, factual comparison, no new schema files, single file per Assumption 8, operator-cadence quality review.
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+  - FR-001 ↔ existence of the new doc file. FR-002 ↔ US1 scenario 1 (positioning understandable in 3 minutes). FR-003 ↔ US1 scenarios 2-5 + SC-005. FR-004 ↔ SC-004. FR-005 ↔ US2 scenario 1. FR-006 ↔ US1 scenario 3 + SC-002. FR-007 ↔ SC-008. FR-008 ↔ implicit (cross-ref pattern). FR-009 ↔ SC-003. FR-010 ↔ SC-006. FR-011 ↔ SC-004. FR-012 ↔ US2 scenario 2. FR-013 ↔ Edge Case 6.
+- [X] User scenarios cover primary flows
+  - US1 covers consumer onboarding (the singular value-add). US2 covers tool-author leverage as defensive coverage on the same artifact.
+- [X] Feature meets measurable outcomes defined in Success Criteria
+  - Every SC is achievable purely via the FR set.
+- [X] No implementation details leak into specification
+  - File paths and doc structure are deliverable definitions, not implementation specifics.
+
+## Notes
+
+- All checklist items pass on first iteration.
+- The spec is explicitly a DOCS-ONLY milestone (Assumption 1) — no Rust source code touched, no CLI flags, no test changes. The pre-PR gate (SC-007) is essentially a no-op formal check.
+- The single-file deliverable (Assumption 8) prioritizes consumer-grepability + bookmark-ability over multi-file navigation.
+- The appendix-as-snapshot decision (Assumption 4 + Edge Case 4 + FR-006) intentionally avoids the obligation to update the guide every time a new annotation lands — the catalog stays the canonical source-of-truth; the guide is the onboarding surface.
+- The factual-comparison decision (FR-010 + Assumption 6) is the key risk surface — comparison passages must be verifiable. Plan-phase should commit to a verification approach (operator-cadence read-through of representative SBOMs from each named tool, OR pinning to specific tool versions + dates).
+- Ready for `/speckit-clarify` (probably 1-2 questions about which specific tools to compare against + how exhaustively the appendix should cover the catalog) or directly for `/speckit-plan`.

--- a/specs/150-sbom-consumer-guide/contracts/doc-structure.md
+++ b/specs/150-sbom-consumer-guide/contracts/doc-structure.md
@@ -1,0 +1,181 @@
+# Contract — `reading-a-mikebom-sbom.md` document structure
+
+Phase 1 output. Defines the doc-structure contract that the implementer follows when authoring the new consumer-facing reference doc.
+
+## File location + naming
+
+| Aspect | Value |
+|---|---|
+| File path | `docs/reference/reading-a-mikebom-sbom.md` |
+| Visibility | Public (part of the published `docs/` tree) |
+| Format | GitHub-flavored Markdown |
+| Estimated size | 600–900 lines |
+| Linked from | `docs/index.md` Reference material section (one-line addition) |
+
+## Document outline (mandatory)
+
+The doc MUST contain the following top-level sections in this order. Section count = 8 + 2 appendices = 10 sections total.
+
+```text
+# Reading a mikebom SBOM
+
+1. Opening positioning (~30 lines)
+2. How to read this doc (~20 lines)
+3. Signals mikebom makes available — by use case (~400 lines, 12 depth-covered signals)
+   3.1 Vulnerability scanning (3 signals)
+   3.2 Compliance auditing (3 signals)
+   3.3 Build provenance (3 signals)
+   3.4 Transparency / completeness gaps (3 signals)
+4. The mikebom-annotation/v1 envelope (~40 lines)
+5. Cross-format reading patterns (~60 lines)
+6. Stability (~40 lines)
+7. For tool authors (~60 lines)
+8. Cross-references (~30 lines)
+Appendix A. Annotation key index (~200 lines for 102 entries)
+Appendix B. Milestone-citation map (~30 lines)
+```
+
+## Section content contracts
+
+### Section 1 — Opening positioning (~30 lines)
+
+MUST include:
+- Statement that mikebom strict-conforms to CDX 1.6 / SPDX 2.3 / SPDX 3.0.1.
+- Statement that most data lives in spec-native fields (not `mikebom:*` annotations).
+- Definition of "parity-bridging" — `mikebom:*` annotations are introduced ONLY when no native field in the target format(s) carries the signal, per Constitution Principle V.
+- One-sentence framing of the doc's job: "tell consumers what each parity-bridging annotation (and a few notable native-field-usage patterns) mean and how to use them".
+- Per the 2026-06-29 clarification (Q1 Option D): the doc focuses on what mikebom emits, NOT on comparing mikebom against named competing tools.
+
+MUST NOT include:
+- Names of specific competing SBOM tools (syft / trivy / cdxgen / snyk / anchore). Use phrasing like "the CDX/SPDX spec baseline" or "standard SBOM tool output" when contrast is needed.
+
+### Section 2 — How to read this doc (~20 lines)
+
+MUST include:
+- A "navigation map" — readers who want vulnerability-scanning signals jump to §3.1; compliance auditors jump to §3.2; tool authors jump to §7; etc.
+- A pointer to Appendix A for the full key index.
+- A pointer to `docs/reference/sbom-format-mapping.md` for full wire-shape catalog depth.
+
+### Section 3 — Signals by use case (~400 lines, 12 signals)
+
+4 subsections (3.1–3.4), each covering 3 signals per research §C cluster assignments. Each signal renders per the per-signal invariant in `data-model.md` §2:
+
+- "What it is" — plain-language description (1–2 sentences)
+- "Where it lives" — per-format wire-shape (CDX / SPDX 2.3 / SPDX 3)
+- "What to do with it" — action-oriented consumer guidance (1–3 sentences)
+- "Milestone" — milestone N (added/stabilized/extended)
+- "Catalog" — link to the corresponding C-row in `sbom-format-mapping.md`
+- A working `jq` recipe + its expected output
+
+12 depth-covered signals MUST appear (per research §C):
+- 3.1: `mikebom:lifecycle-scope`, `mikebom:layer-digest`, `mikebom:duplicate-purl-divergent` (+ `mikebom:purl-collisions-detected` mentioned as the document-scope companion)
+- 3.2: `mikebom:license-concluded-source`, `mikebom:component-tier` (file value), `mikebom:demoted-from-main-module`
+- 3.3: `mikebom:source-type`, `mikebom:generation-context`, `mikebom:source-document-binding`
+- 3.4: `mikebom:file-inventory-mode`, `mikebom:graph-completeness` (+ `mikebom:graph-completeness-reason`), `mikebom:peer-edge-targets`
+
+### Section 4 — The mikebom-annotation/v1 envelope (~40 lines)
+
+MUST include:
+- Envelope schema (3 fields: `schema`, `field`, `value`) shown inline.
+- One example per format showing the envelope embedded:
+  - CDX 1.6 `properties[]` entry: `{name: "mikebom:lifecycle-scope", value: "development"}` (envelope NOT used — CDX uses native `properties[].value` string carrier).
+  - SPDX 2.3 `annotations[]` entry: `{comment: "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:lifecycle-scope\",\"value\":\"development\"}", ...}`.
+  - SPDX 3 `Annotation` element: `{statement: "{\"schema\":\"mikebom-annotation/v1\",\"field\":\"mikebom:lifecycle-scope\",\"value\":\"development\"}", ...}`.
+- Pointers to canonical Rust sources:
+  - Encoder: `mikebom-cli/src/generate/spdx/annotations.rs:31-67` (ENVELOPE_SCHEMA_V1 constant + MikebomAnnotationCommentV1 struct).
+  - Decoder: `mikebom-cli/src/parity/extractors/common.rs:185` (envelope verification + payload extraction).
+- Statement that the envelope schema string `mikebom-annotation/v1` is the stability anchor — future envelope evolutions would bump the version (`v2`).
+
+### Section 5 — Cross-format reading patterns (~60 lines)
+
+MUST include:
+- Table or list showing the SAME signal in 3 formats for 4–5 representative depth-covered signals, demonstrating the per-format carrier shape.
+- Pointer to `sbom-format-mapping.md` as the canonical wire-shape source for the full 98-row catalog.
+- Note about SPDX 3 subject-routing quirks where applicable (e.g., `mikebom:demoted-from-main-module` routes to synth-root IRI per milestone-149 C102 docs).
+
+### Section 6 — Stability (~40 lines)
+
+MUST include:
+- Every `C*` row in the catalog is a stable wire shape; the row number is the durable identifier.
+- The `mikebom-annotation/v1` envelope shape is stable.
+- Opt-in / experimental flags affecting emission MUST be called out:
+  - `--file-inventory=full` (override marker via `mikebom:file-inventory-mode`)
+  - `--preserve-manifest-main-module` (milestone 149)
+  - `--include-dev` (affects which `mikebom:lifecycle-scope` values get emitted in `metadata.lifecycles[]`)
+  - Other opt-ins as authoring discovers them.
+- Versioning: mikebom emissions follow the `v*-alpha.*` tag sequence; consumers can map binary version → signal availability via the milestone citations in Appendix B.
+
+### Section 7 — For tool authors (~60 lines)
+
+MUST include:
+- Envelope schema location pointer (cross-ref to §4).
+- Per-format carrier-mapping table (cross-ref to §5 + catalog).
+- Stability statement (cross-ref to §6).
+- Suggested integration patterns:
+  - Filter dep-graph by `mikebom:lifecycle-scope` for production-vulnerability suppression.
+  - Walk `mikebom:layer-digest` for layer-attribution in OCI scans.
+  - Correlate `mikebom:duplicate-purl-divergent` for divergence-detection workflows.
+- Pointer to GitHub Issues for bug reports or signal-shape concerns.
+
+### Section 8 — Cross-references (~30 lines)
+
+MUST include links to:
+- `docs/reference/sbom-format-mapping.md` (the catalog — canonical wire-shape contract)
+- `docs/reference/identifiers.md` (identifier model)
+- `docs/reference/sbom-types.md` (CISA SBOM types)
+- `docs/reference/component-tiers.md` (package / binary / file tier model)
+- `docs/reference/cross-tier-binding.md` (source ↔ build ↔ deploy binding)
+- `../CHANGELOG.md` (milestone-by-milestone release history)
+
+### Appendix A — Annotation key index (~200 lines for 102 entries)
+
+Per `data-model.md` §3 invariant. Each entry: `- **\`mikebom:<key>\`** — <one-line description> ([C<row>](sbom-format-mapping.md#<anchor>))`. Alphabetically sorted.
+
+MUST cover all 102 unique `mikebom:*` keys present in `sbom-format-mapping.md` at milestone-150 ship time (per spec FR-006 + SC-002).
+
+### Appendix B — Milestone-citation map (~30 lines)
+
+MUST include a table mapping each depth-covered signal (the 12 from §3) to its introducing/stabilizing milestone number with a brief verb (`added` / `stabilized` / `extended`). Format:
+
+```text
+| Signal | Milestone | Verb |
+|---|---|---|
+| `mikebom:lifecycle-scope` | 052 | added |
+| ... | ... | ... |
+```
+
+Per spec FR-013 + Edge Case 6.
+
+## Index update contract
+
+`docs/index.md`'s **Reference material** section MUST add the following one-line entry (positioned to fit the existing list's alphabetical / topical ordering):
+
+```markdown
+- [Reading a mikebom SBOM](reference/reading-a-mikebom-sbom.md) — consumer-facing
+  guide to mikebom-emitted signals (what they mean, where to find them per format,
+  how to use them). Cross-references the [SBOM format mapping](reference/sbom-format-mapping.md)
+  catalog for full per-row wire-shape detail.
+```
+
+## Negative-space contract (what MUST NOT happen)
+
+- The doc MUST NOT name specific competing SBOM tools (syft / trivy / cdxgen / snyk / anchore). Per the 2026-06-29 clarification Q1 Option D.
+- The doc MUST NOT introduce new `mikebom:*` annotations. Pure docs milestone.
+- The doc MUST NOT change the wire format mikebom emits. Reads from existing catalog only.
+- The doc MUST NOT duplicate `sbom-format-mapping.md`'s per-row wire-shape detail at row-precision. Summary + link is the layered-docs approach.
+- The doc MUST NOT include marketing language or unverifiable claims about ecosystem positioning.
+- The doc MUST NOT include translations or non-English content.
+- The doc MUST NOT include implementation-specific Rust code paths (consumer-facing surface only).
+
+## Test surface
+
+| Test | Asserts |
+|---|---|
+| Operator-cadence read-through audit | SC-001 5-question test — the doc reader can answer all 5 questions without consulting other docs |
+| Appendix-coverage audit | SC-002 — every `mikebom:*` key in `sbom-format-mapping.md` is also in Appendix A |
+| `docs/index.md` linkback | SC-003 — the new doc is linked from index.md's Reference material section |
+| `jq` recipes runnable count | SC-004 — at least 5 recipes verified runnable at doc-authoring time |
+| Cluster coverage count | SC-005 — at least 4 distinct thematic clusters, each with at least 2 signals |
+| Depth-covered signal count | SC-006 — at least 8 signals depth-covered (12 chosen for headroom) |
+| Pre-PR gate | SC-007 — `./scripts/pre-pr.sh` passes (docs-only milestone; gate is essentially a no-op) |
+| Catalog reverse-link audit | SC-008 — `sbom-format-mapping.md` is linked from the new doc at least once |

--- a/specs/150-sbom-consumer-guide/data-model.md
+++ b/specs/150-sbom-consumer-guide/data-model.md
@@ -1,0 +1,83 @@
+# Data Model — milestone 150
+
+Phase 1 output. The "entities" here are documentation-structure entities — sections and per-signal rendering shape — rather than runtime data structures. No code changes; no Rust types introduced.
+
+## Doc-structure entities
+
+### 1. Top-level section TOC
+
+The new doc at `docs/reference/reading-a-mikebom-sbom.md` MUST contain the following sections in this order:
+
+| # | Section title | Purpose | Spec FR refs |
+|---|---|---|---|
+| 1 | Opening positioning | "mikebom strict-conforms to CDX/SPDX; `mikebom:*` annotations are parity-bridges per Constitution V; here's what they mean" | FR-002 |
+| 2 | How to read this doc | Reader-facing map of clusters + appendix + cross-refs | — |
+| 3 | Signals mikebom makes available — by use case | 4 thematic clusters with 12 depth-covered signals total | FR-003 + FR-004 + SC-005 |
+| 3.1 | Vulnerability scanning | 3 signals: `mikebom:lifecycle-scope`, `mikebom:layer-digest`, `mikebom:duplicate-purl-divergent` + `mikebom:purl-collisions-detected` | research §C cluster 1 |
+| 3.2 | Compliance auditing | 3 signals: `mikebom:license-concluded-source`, `mikebom:component-tier`, `mikebom:demoted-from-main-module` | research §C cluster 2 |
+| 3.3 | Build provenance | 3 signals: `mikebom:source-type`, `mikebom:generation-context`, `mikebom:source-document-binding` | research §C cluster 3 |
+| 3.4 | Transparency / completeness gaps | 3 signals: `mikebom:file-inventory-mode`, `mikebom:graph-completeness` + `mikebom:graph-completeness-reason`, `mikebom:peer-edge-targets` | research §C cluster 4 |
+| 4 | The `mikebom-annotation/v1` envelope | Envelope shape (3 fields) + per-format examples (CDX `properties[]` value, SPDX 2.3 annotation `comment`, SPDX 3 annotation `statement`) + canonical-source links | FR-005 |
+| 5 | Cross-format reading patterns | Same signal, where to look in each format (point to `sbom-format-mapping.md` for full wire-shape) | research §D |
+| 6 | Stability | Catalog C-row numbers are durable identifiers; envelope shape is stable; opt-in / experimental flags called out | FR-012 |
+| 7 | For tool authors | Tool-author-specific summary: envelope schema + carrier-mapping table + stability statement | US2 |
+| 8 | Cross-references | List of related docs (5 topical refs + catalog + changelog) | FR-007 + FR-008 |
+| Appendix A | Annotation key index | All 102 `mikebom:*` keys at milestone-150 ship time, alphabetical, with one-line descriptions + links to catalog C-rows | FR-006 + SC-002 |
+| Appendix B | Milestone-citation map | Each depth-covered signal cites the milestone that introduced or stabilized it | FR-013 + Edge Case 6 |
+
+### 2. Per-signal rendering invariant
+
+Each of the 12 depth-covered signals (sections 3.1–3.4) MUST follow this consistent rendering shape:
+
+```text
+### `<annotation-key>`
+
+> **What it is**: <plain-language description, 1-2 sentences>
+> **Where it lives**:
+> - CDX 1.6: <wire-shape — e.g., `component.properties[]` entry / `metadata.properties[]` / `metadata.lifecycles[]` ...>
+> - SPDX 2.3: <wire-shape — typically envelope annotation; or native field name>
+> - SPDX 3: <wire-shape>
+> **What to do with it**: <action-oriented consumer guidance, 1-3 sentences>
+> **Milestone**: <N — added/stabilized/extended>
+> **Catalog**: [<C-row>](sbom-format-mapping.md#<anchor>)
+
+```jq
+<verified-runnable jq recipe>
+```
+
+Expected output:
+```
+<the actual output the recipe produces against a real fixture>
+```
+```
+
+Every depth-covered signal MUST conform to this shape — same field order, same code-block formatting. Consumer can scan-read with predictable cadence.
+
+### 3. Appendix A entry invariant
+
+Each appendix entry MUST follow:
+
+```text
+- **`mikebom:<key>`** — <one-line description> ([C<row>](sbom-format-mapping.md#c<row>-mikebom-<key>))
+```
+
+Alphabetically sorted by `<key>`. Anchor format `c<row>-mikebom-<key>` matches GitHub's auto-generated heading anchors for the catalog table rows. Consumer encountering an unknown key in a real SBOM searches the appendix in O(log N) reading time and gets to the catalog row in one click.
+
+### 4. Cross-reference target shape
+
+Each section that touches a topic covered in depth by an existing ref doc MUST include a `> For full depth, see [<doc title>](<doc path>).` pointer. The summary in the new doc MUST be ~1 paragraph (5-8 sentences) — enough to set context, not enough to duplicate.
+
+### 5. `jq` recipe correctness invariant
+
+Per spec FR-011 + SC-004: each recipe MUST:
+- Be valid `jq` syntax (parseable by `jq` 1.6+)
+- Produce the documented "Expected output" when run against a real mikebom-emitted SBOM with the appropriate flags
+- Be verified at doc-authoring time per research §E
+
+## Out of model
+
+- **No new types**: docs-only milestone.
+- **No public API changes**: the mikebom binary is unchanged.
+- **No new schema files**: per spec Assumption 7, the doc cites existing canonical sources for the envelope schema.
+- **No multi-file split**: single deliverable file per spec Assumption 8.
+- **No translations or l10n**: per spec Out of Scope §5.

--- a/specs/150-sbom-consumer-guide/plan.md
+++ b/specs/150-sbom-consumer-guide/plan.md
@@ -1,0 +1,95 @@
+# Implementation Plan: SBOM consumer-facing reading guide — documenting mikebom annotations and differentiators
+
+**Branch**: `150-sbom-consumer-guide` | **Date**: 2026-06-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/150-sbom-consumer-guide/spec.md`
+
+## Summary
+
+Pure docs milestone. Deliverable is a single new file at `docs/reference/reading-a-mikebom-sbom.md` (~600–900 lines estimated) plus a one-line addition to `docs/index.md`'s **Reference material** list. No Rust source code change, no CLI flag change, no wire-format change. Per the 2026-06-29 clarification (Q1 Option D), the doc avoids naming specific competing SBOM tools — the framing is "what mikebom emits and how to use it" rather than competitive comparison. This sidesteps the verification burden of pinning external tool versions / behaviors AND keeps the doc evergreen against external-tool drift.
+
+Phase 0 research (§A through §D below) confirmed:
+1. **102 unique `mikebom:*` annotation keys** exist in the catalog at milestone-150 ship time (catalog spans C1–C102 plus a handful of duplicate-named annotations across catalog rows). The appendix index covers all 102. Depth coverage is reserved for a curated subset — the 8–15 most consumer-actionable signals per SC-006.
+2. **Envelope schema canonical location**: `mikebom-cli/src/generate/spdx/annotations.rs:31-67` defines `ENVELOPE_SCHEMA_V1 = "mikebom-annotation/v1"` + `MikebomAnnotationCommentV1` struct (fields `schema`, `field`, `value`). The decoder is at `mikebom-cli/src/parity/extractors/common.rs:185`. The doc links to BOTH as canonical references; no new JSON Schema artifact is published in this milestone.
+3. **Thematic clustering**: 4 clusters land naturally per spec FR-003 — (a) vulnerability scanning, (b) compliance auditing, (c) build provenance, (d) transparency/completeness gaps. Each cluster pulls 2–4 specific signals from the 102-key catalog.
+4. **Cross-references**: 5 existing reference docs get linked from the new doc — `sbom-format-mapping.md` (catalog), `identifiers.md` (`mikebom:identifiers` + `repo:`/`git:`/`image:`), `sbom-types.md` (`--sbom-type` + per-tier semantics), `component-tiers.md` (file-tier coverage + `mikebom:component-tier`), `cross-tier-binding.md` (`mikebom:source-document-binding`). The doc summarizes each topic in ~1 paragraph + delegates depth to the linked refs.
+
+Total code surface: zero Rust LOC. Two docs files touched (`reading-a-mikebom-sbom.md` NEW + `index.md` 1-line addition). Estimated effort: ~600–900 lines of Markdown across the new doc.
+
+## Technical Context
+
+**Language/Version**: N/A — Markdown documentation. The mikebom binary is unchanged.
+**Primary Dependencies**: None. The doc is static reference Markdown.
+**Storage**: N/A.
+**Testing**: `cargo +stable test --workspace` is a no-op for this milestone (no Rust source change), but the pre-PR gate (`./scripts/pre-pr.sh`) is still expected per project convention (SC-007). The `sbom_format_mapping_coverage` test continues to pass (it asserts every emitted `mikebom:*` field has a catalog row — the catalog itself is unchanged).
+**Target Platform**: Markdown rendering on GitHub + any standard Markdown renderer.
+**Project Type**: Documentation reference — consumer-onboarding surface for mikebom-emitted SBOMs.
+**Performance Goals**: N/A.
+**Constraints**:
+- **Per the 2026-06-29 clarification (Q1 Option D)**: the doc MUST NOT name specific competing SBOM tools. Framing is consumer-centric ("what mikebom emits") rather than competitive ("what other tools omit").
+- **Constitution Principle V** (standards-native > `mikebom:*`): the doc reinforces this in its opening positioning passage — `mikebom:*` annotations are parity-bridges introduced ONLY when no native field carries the signal. This positioning is critical for consumer trust.
+- **Single-file deliverable** (spec Assumption 8): one Markdown file at `docs/reference/reading-a-mikebom-sbom.md`. No multi-file split.
+- **Appendix-as-snapshot** (spec Assumption 4): the appendix index reflects the catalog at milestone-150 ship time. Future annotations land in the catalog only; the guide's appendix is best-effort current.
+- **`jq` recipes verified runnable** (spec FR-011 + SC-004): each recipe in the doc must produce the documented output against a real mikebom-emitted SBOM at doc-authoring time.
+- **Pre-PR gate**: `./scripts/pre-pr.sh` MUST exit 0 before PR open (modulo the documented pre-existing `sbomqs_parity` env-only failure).
+**Scale/Scope**: Reaches every external mikebom-SBOM consumer; reduces the cost of onboarding from "read mikebom source OR walk 102-row catalog" to "skim the new doc". Effort budget: ~600–900 lines of Markdown + 5–10 hours of authoring.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| # | Principle / Boundary | Status | Note |
+|---|---|---|---|
+| I | Pure Rust, Zero C | ✅ N/A | Documentation only. |
+| II | eBPF-Only Observation | ✅ N/A | |
+| III | Fail Closed | ✅ N/A | |
+| IV | Type-Driven Correctness | ✅ N/A | |
+| V | Specification Compliance | ✅ **REINFORCES** | The new doc's opening passage EXPLICITLY reinforces Principle V — strict spec conformance first, `mikebom:*` annotations only when no native field exists. This is part of mikebom's consumer-facing positioning. The doc IS a Principle V documentation artifact. |
+| VI | Three-Crate Architecture | ✅ N/A | |
+| VII | Test Isolation | ✅ N/A | |
+| VIII | Completeness | ✅ IMPROVES (indirectly) | The doc helps consumers find existing completeness signals (e.g., `mikebom:component-tier` for file-tier orphan coverage, `mikebom:file-inventory-mode` for override-mode awareness). Doesn't add new completeness signals; surfaces existing ones. |
+| IX | Accuracy | ✅ IMPROVES (indirectly) | Consumers reading the doc can identify mikebom's accuracy signals (`mikebom:confidence`, `mikebom:evidence-kind`, `mikebom:fingerprint-confidence`) and filter / threshold appropriately. |
+| X | Transparency | ✅ DIRECTLY ADVANCES | The doc IS a transparency artifact — it tells consumers exactly what every `mikebom:*` signal means and how to interpret it. Section dedicated to "transparency / completeness gaps" cluster. |
+| XI | Enrichment | ✅ N/A | |
+| XII | External Data Source Enrichment | ✅ N/A | |
+| SB-1 | No lockfile-based discovery | ✅ N/A | |
+| SB-2 | No MITM proxy | ✅ N/A | |
+| SB-3 | No C code | ✅ N/A | |
+| SB-4 | No `.unwrap()` in production | ✅ N/A | |
+| SB-5 | No file-tier duplicates in default mode | ✅ N/A | |
+
+**All gates pass.** Principle V is REINFORCED (not violated) — the doc's opening positioning passage is itself an expression of Principle V's consumer-facing implications. Constitution X (Transparency) is DIRECTLY ADVANCED by the milestone.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/150-sbom-consumer-guide/
+├── plan.md              # This file
+├── research.md          # Phase 0 — envelope schema location + key inventory + clustering rationale + jq-recipe-verification plan
+├── data-model.md        # Phase 1 — doc structure entities (sections + appendix-entry shape) + per-signal rendering invariants
+├── quickstart.md        # Phase 1 — operator-facing read-through walkthrough (5-question SC-001 audit reproduction)
+├── contracts/
+│   └── doc-structure.md # Phase 1 — TOC + per-section content contract for the new doc
+└── checklists/
+    └── requirements.md  # Already exists from /speckit-specify (all items ✅)
+```
+
+### Source Files (repository root)
+
+Touched files (narrow scope — docs-only):
+
+```text
+docs/
+├── reference/
+│   └── reading-a-mikebom-sbom.md            # NEW — single-file consumer-onboarding doc
+└── index.md                                   # Update — add 1-line entry in "Reference material" section
+```
+
+No code files touched. No fixtures. No test files. No parity-catalog rows. No CLI flag changes.
+
+**Structure Decision**: Single new Markdown file + one-line index update. The new doc lives at `docs/reference/reading-a-mikebom-sbom.md` (the same directory as the other reference docs — `identifiers.md`, `sbom-types.md`, `component-tiers.md`, `cross-tier-binding.md`, `sbom-format-mapping.md`, `conformance-harness-guide.md`). This placement signals it's a peer reference doc to those existing ones, not a new doc category.
+
+## Complexity Tracking
+
+*Not applicable.* All Constitution gates pass cleanly. Pure docs milestone — no design tradeoffs to track. The cross-tool-comparison-avoidance decision (Q1 Option D) is the only real design call; it's recorded in the spec's Clarifications + FR-010 + SC-006 + Assumption 6.

--- a/specs/150-sbom-consumer-guide/quickstart.md
+++ b/specs/150-sbom-consumer-guide/quickstart.md
@@ -1,0 +1,133 @@
+# Quickstart — milestone 150 consumer reading guide
+
+Operator-facing walkthrough for VALIDATING the new doc post-merge. This milestone's quality is fundamentally an operator-cadence read-through assessment (per spec SC-001) — there's no automated test that can verify "is this doc useful to a consumer?".
+
+## Scenario 1 — SC-001 5-question read-through audit
+
+After the doc ships, an operator (or external reviewer simulating a first-time mikebom-SBOM consumer) reads `docs/reference/reading-a-mikebom-sbom.md` end-to-end and must be able to answer all 5 questions WITHOUT consulting `sbom-format-mapping.md` or any other doc:
+
+1. **"What does `mikebom:lifecycle-scope` mean?"**
+   Expected answer: a parity-bridging annotation carrying the finer dev/build/test/runtime distinction beyond CDX 1.6's 3-value `scope` enum. The annotation lives on the dep target's `properties[]` in CDX, on the target Package's `annotations[]` envelope in SPDX 2.3 + SPDX 3.
+
+2. **"How do I find dev-only dependencies in a mikebom SPDX 2.3 SBOM?"**
+   Expected answer: use SPDX 2.3 typed relationships (`DEV_DEPENDENCY_OF`) for the spec-native expression, OR walk the target Package's `annotations[]` for `mikebom:lifecycle-scope = "development"`. The doc provides a `jq` recipe.
+
+3. **"Where do I find which OCI layer a binary came from?"**
+   Expected answer: the per-component `mikebom:layer-digest` annotation (CDX `properties[]` / SPDX 2.3 + SPDX 3 envelope). Emitted only for image scans.
+
+4. **"What's the difference between `mikebom:source-type = trace-observed` and `mikebom:source-type = declared-not-cached`?"**
+   Expected answer: trace-observed means mikebom's eBPF (or filesystem scan) saw the component as actually fetched/used; declared-not-cached means a lockfile or manifest declared it but mikebom couldn't verify its presence. Strong vs weak provenance.
+
+5. **"What's the `mikebom-annotation/v1` envelope shape?"**
+   Expected answer: a JSON object with 3 fields — `schema` (the literal string `"mikebom-annotation/v1"`), `field` (the `mikebom:*` key), `value` (the payload). Used in SPDX 2.3 + SPDX 3 to wrap annotation values; CDX uses a flat `properties[].value` string carrier instead.
+
+If all 5 answers come from the doc alone: ✅ SC-001 passes. If any answer requires reading `sbom-format-mapping.md` or another doc: the doc needs strengthening on that signal.
+
+## Scenario 2 — SC-002 appendix-coverage audit
+
+```bash
+# Extract all mikebom: keys present in the catalog at doc-ship time:
+grep -E "^\| C[0-9]+\b" /Users/mlieberman/Projects/mikebom/docs/reference/sbom-format-mapping.md \
+  | grep -oE "mikebom:[a-z0-9-]+" | sort -u > /tmp/catalog-keys.txt
+
+# Extract all mikebom: keys present in the new doc's Appendix A:
+grep -oE "mikebom:[a-z0-9-]+" /Users/mlieberman/Projects/mikebom/docs/reference/reading-a-mikebom-sbom.md \
+  | sort -u > /tmp/guide-keys.txt
+
+# Asymmetric diff: keys in the catalog but missing from the guide.
+diff /tmp/catalog-keys.txt /tmp/guide-keys.txt
+# Expected: empty (all 102 catalog keys are in the guide's appendix).
+# If ANY key is missing: the appendix has a coverage gap.
+```
+
+Per spec FR-006 + SC-002: every `mikebom:*` key in the catalog at milestone-150 ship time MUST be in Appendix A. The audit is mechanical.
+
+## Scenario 3 — SC-003 index.md linkback verification
+
+```bash
+# Confirm the new doc is linked from docs/index.md's Reference material section.
+grep -A 3 "Reference material" /Users/mlieberman/Projects/mikebom/docs/index.md \
+  | grep "reading-a-mikebom-sbom"
+# Expected: 1 match.
+```
+
+## Scenario 4 — SC-004 `jq` recipe verification (≥5 recipes)
+
+Run each `jq` recipe in the doc against a real mikebom-emitted SBOM and confirm the documented output matches. Authoring artifact at `specs/150-sbom-consumer-guide/verify-recipes.sh` (or inline in the doc's authoring notes) lists each scan-then-jq invocation.
+
+Example for the `mikebom:lifecycle-scope` recipe:
+
+```bash
+# Scan a fixture with dev deps included:
+cargo +stable run -q -p mikebom --bin mikebom -- sbom scan --offline \
+    --path /Users/mlieberman/.cache/mikebom/fixtures/<sha>/cargo/lockfile-v3 \
+    --include-dev \
+    --format spdx-2.3-json --output /tmp/spdx.json
+
+# Run the doc's recipe:
+jq -r '.packages[]
+       | select(.annotations[]?
+                | .comment
+                | fromjson?
+                | select(.field == "mikebom:lifecycle-scope" and .value == "development"))
+       | .name' /tmp/spdx.json
+# Expected output: dev-scoped package names, one per line.
+```
+
+If the recipe produces the documented output: ✅ SC-004 increments by 1 verified recipe. Repeat for ≥5 recipes total.
+
+## Scenario 5 — SC-005 cluster coverage audit
+
+```bash
+# Verify the doc has 4 thematic-cluster section headings:
+grep -E "^### 3\.[1-4]" /Users/mlieberman/Projects/mikebom/docs/reference/reading-a-mikebom-sbom.md
+# Expected: 4 matches (3.1 / 3.2 / 3.3 / 3.4).
+```
+
+Then visually inspect each cluster section to confirm ≥2 documented signals (per spec FR-003 + SC-005). The 12-signal target from research §C ensures ≥3 per cluster — 1.5× the minimum.
+
+## Scenario 6 — SC-006 depth-covered signal count
+
+```bash
+# Each depth-covered signal renders per the data-model §2 invariant — count
+# section headings at depth 4 (####) inside section 3:
+awk '/^### 3\./,/^### 4 /' /Users/mlieberman/Projects/mikebom/docs/reference/reading-a-mikebom-sbom.md \
+  | grep -cE "^#### "
+# Expected: ≥8 (target 12 per research §C).
+```
+
+## Scenario 7 — SC-007 pre-PR gate
+
+```bash
+./scripts/pre-pr.sh
+# Expected: green except documented pre-existing sbomqs_parity env failure.
+# This milestone is docs-only; the gate's clippy + test outcomes match pre-150 main.
+```
+
+## Scenario 8 — SC-008 reverse-link audit
+
+```bash
+# Verify the catalog is linked from the new doc at least once:
+grep -c "sbom-format-mapping.md" /Users/mlieberman/Projects/mikebom/docs/reference/reading-a-mikebom-sbom.md
+# Expected: ≥1 (likely much more — every depth-covered signal links to its C-row).
+```
+
+## Post-merge — operator-cadence external review
+
+Per spec Assumption 9, the doc's quality is assessed via an operator-cadence read-through (the 5-question SC-001 audit above), not via automated tests. After merge:
+
+1. The maintainer or an external reviewer sits down with a real mikebom-emitted SBOM (any format, any ecosystem) AND the new doc.
+2. They formulate a question relevant to their workflow ("how do I tell whether this package was actually built vs just declared in a lockfile?").
+3. They search the new doc for the answer.
+4. They report success / failure in a follow-up issue if the doc didn't help.
+
+This feedback loop drives future milestone updates to the doc — single-file deliverable means edits are surgical.
+
+## Known deferrals (spec Out of Scope)
+
+- No competitor comparison (per Q1 Option D — focus is consumer-centric on mikebom's emitted data).
+- No auto-generated appendix (manual maintenance at milestone-150 ship; future milestone could automate via a build-time script that diffs catalog ↔ guide).
+- No JSON Schema artifact for `mikebom-annotation/v1` (citing existing Rust source as canonical).
+- No per-annotation deep-dive subdocs (single-file deliverable).
+- No translations (English-only).
+- No interactive consumer tooling (static Markdown only).

--- a/specs/150-sbom-consumer-guide/research.md
+++ b/specs/150-sbom-consumer-guide/research.md
@@ -1,0 +1,142 @@
+# Research — milestone 150 (SBOM consumer-facing reading guide)
+
+Phase 0 output. Resolves five doc-structure design questions before Phase 1.
+
+## §A — Envelope schema canonical location
+
+**Decision**: link to TWO existing canonical sources from the new doc; publish NO new JSON Schema artifact in this milestone.
+
+**Verification** (grep at plan-phase time):
+
+- `mikebom-cli/src/generate/spdx/annotations.rs:31` defines `pub const ENVELOPE_SCHEMA_V1: &str = "mikebom-annotation/v1"`.
+- `mikebom-cli/src/generate/spdx/annotations.rs:44-67` defines `pub struct MikebomAnnotationCommentV1 { schema, field, value }` + a `new()` constructor + serialization helper.
+- `mikebom-cli/src/parity/extractors/common.rs:185` defines the symmetric decoder — verifies `v.get("schema")?.as_str()? != "mikebom-annotation/v1"` and extracts the `field` + `value` payload.
+
+The Rust source IS the canonical schema today. Both Rust files have clear doc-comments explaining the envelope shape. Linking to both lines from the new doc gives consumers a stable canonical reference + lets them inspect the exact (de)serialization round-trip.
+
+**Alternative considered**: publish a JSON Schema artifact at `docs/reference/mikebom-annotation-v1.schema.json` referenced from the new doc. **Rejected** for this milestone scope — would require defining the schema's authoritative location (this milestone is docs-only, no new schema files per spec Assumption 7), reviewing the schema's semantic version + extension policy, and ongoing maintenance of the JSON Schema alongside the Rust struct. A future milestone can promote the schema to a first-class artifact; out of scope here.
+
+**Doc treatment**: in the new doc's "Envelope schema" section, give the shape inline (3 fields with example), then cite both Rust file lines as the canonical references. ~10–15 lines of Markdown.
+
+## §B — Annotation key inventory + appendix-coverage decision
+
+**Decision**: appendix index covers all 102 unique `mikebom:*` keys present in the catalog at milestone-150 ship time. Each appendix entry has fields `{key, one-line-description, link-to-catalog-C-row}`. Sorted alphabetically.
+
+**Verification**: `grep -E "^\| C[0-9]+\b" docs/reference/sbom-format-mapping.md | grep -oE "mikebom:[a-z0-9-]+" | sort -u | wc -l` returns 102 keys.
+
+Representative key set (first 60 alphabetically):
+```
+mikebom:also-detected-via, mikebom:assembly-version-informational,
+mikebom:assembly-version-informational-stripped, mikebom:assertion-conflict,
+mikebom:bazel-archive-name, mikebom:bbappend-applied, mikebom:binary-class,
+mikebom:binary-packed, mikebom:binary-stripped, mikebom:build-inclusion,
+mikebom:build-inclusion-derivation, mikebom:build-reference,
+mikebom:buildinfo-status, mikebom:co-owned-by, mikebom:component-role,
+mikebom:component-tier, mikebom:confidence, mikebom:cpe-candidates,
+mikebom:demoted-from-main-module, mikebom:depends-unresolved,
+mikebom:deps-dev-match, mikebom:detected-cargo-auditable, mikebom:detected-go,
+mikebom:download-url, mikebom:duplicate-purl-divergent,
+mikebom:elf-build-id, mikebom:elf-compiler-stamps, mikebom:elf-debuglink,
+mikebom:elf-runpath, mikebom:evidence-kind, mikebom:exclude-path,
+mikebom:file-inventory-mode, mikebom:file-inventory-skipped-oversize,
+mikebom:file-inventory-skipped-special-files, mikebom:file-inventory-unreadable,
+mikebom:file-paths, mikebom:file-paths-truncated, mikebom:fingerprint-confidence,
+mikebom:fingerprint-corpus-sha, mikebom:generation-context,
+mikebom:go-vcs-modified, mikebom:go-vcs-revision, mikebom:go-vcs-time,
+mikebom:graph-completeness, mikebom:graph-completeness-reason,
+mikebom:identifiers, mikebom:kmp-source-set, mikebom:layer-digest,
+mikebom:license-concluded-source, mikebom:lifecycle-scope,
+mikebom:lifecycle-scope-derivation, mikebom:linkage-kind,
+mikebom:macho-build-tools, mikebom:macho-build-version,
+mikebom:macho-codesign-flags, mikebom:macho-codesign-identifier,
+mikebom:macho-codesign-team-id, mikebom:macho-min-os, mikebom:macho-rpath,
+mikebom:macho-uuid
+```
+
+Remaining 42 keys (alphabetical tail) covered in the appendix per the same shape.
+
+**Decision rationale**: per spec FR-006, the appendix is a flat alphabetical lookup table. Maintaining 102 entries at milestone-150 ship time is tractable manually. Per spec Assumption 4 the appendix is a snapshot — future milestones land new annotations in the catalog only, not in the guide's appendix. The catalog remains the canonical source-of-truth for new signals.
+
+**Alternative considered**: restrict appendix to only the parity-bridging `mikebom:*` annotations (skip Section A native-field rows). **Rejected** — Section A native fields don't have `mikebom:` prefixed keys (they map to spec-native fields like `component.name`, `package.versionInfo`); they wouldn't appear in the appendix anyway. The 102 keys ARE all parity-bridging or transparency-marker annotations.
+
+## §C — Depth-coverage signal selection (curated list)
+
+**Decision**: depth-cover ~12 signals across 4 thematic clusters per FR-003 + SC-005 + SC-006 (≥8 signals minimum, 12 chosen for headroom). The remaining ~90 keys ride the appendix index only.
+
+**Curated depth-coverage list** (organized by spec FR-003's thematic clusters):
+
+### Cluster 1 — Vulnerability scanning (3 signals)
+
+| Signal | Why a vulnerability scanner cares |
+|---|---|
+| `mikebom:lifecycle-scope` | Suppress dev/test/build-scoped deps from production-only CVE alerting. Native CDX `component.scope: excluded` is the coarse signal; this annotation carries the finer `development` / `build` / `test` split. |
+| `mikebom:layer-digest` | OCI image scans — correlate vulnerable component → which layer introduced it (forensics + remediation prioritization). |
+| `mikebom:duplicate-purl-divergent` + `mikebom:purl-collisions-detected` | When the same PURL maps to divergent content (Cargo `(name, version)` collision), surface it so the scanner doesn't silently merge into one vulnerability assessment. |
+
+### Cluster 2 — Compliance auditing (3 signals)
+
+| Signal | Why a compliance auditor cares |
+|---|---|
+| `mikebom:license-concluded-source` | Distinguish operator-asserted license conclusions (`--conclude-licenses`) from external-enrichment-derived ones (ClearlyDefined, deps.dev). Determines whether the conclusion carries a human-review claim or not. |
+| `mikebom:component-tier` (when `"file"`) | File-tier components carry no PURL; identify content by SHA-256 + observed paths. Closes the orphan / unattributed-content gap (Constitution VIII Completeness). |
+| `mikebom:demoted-from-main-module` (milestone 149) | When `--root-name` operator override is active + `--preserve-manifest-main-module` is set, marks the library entry as the demoted manifest-derived main-module. Auditors verify the operator-override doesn't lose manifest provenance. |
+
+### Cluster 3 — Build provenance (3 signals)
+
+| Signal | Why a build-provenance consumer cares |
+|---|---|
+| `mikebom:source-type` | Distinguishes `eBPF-traced` vs `lockfile-derived` vs `declared-not-cached` provenance. Trace-observed components have stronger ground truth than enrichment-only ones. |
+| `mikebom:generation-context` (document-scope) | Doc-level signal of whether the SBOM was generated from a build trace, source-tree scan, image scan, or hybrid. |
+| `mikebom:source-document-binding` (milestone 072) | Cross-tier binding from a build SBOM back to its source SBOM via content hash + IRI. Enables source ↔ build ↔ deploy correlation. |
+
+### Cluster 4 — Transparency / completeness gaps (3 signals)
+
+| Signal | Why a consumer evaluating completeness cares |
+|---|---|
+| `mikebom:file-inventory-mode` (document-scope) | Marks SBOMs scanned with `--file-inventory=full` so consumers know the file-tier set may duplicate package/binary tier coverage (Strict Boundary §5). Without this flag the SBOM is in default `orphan` mode. |
+| `mikebom:graph-completeness` + `mikebom:graph-completeness-reason` (document-scope) | Go dependency graph completeness signal — distinguishes `Complete` vs `Partial` graphs with reason codes for the latter. |
+| `mikebom:peer-edge-targets` (milestone 147) | npm peerDependency edges, with the install-vs-functional distinction preserved. Consumers can filter the dep graph by edge kind. |
+
+**12 signals total across 4 clusters.** Each gets full per-format wire-shape + plain-language meaning + `jq` recipe + action-oriented consumer guidance per FR-004.
+
+**Alternatives considered**:
+- **Cover 20+ signals in depth** — rejected: bloats the doc + duplicates catalog content. The 12-signal curated set is enough for SC-005 (≥4 clusters) + SC-006 (≥8 signals).
+- **Cover only the top 3 signals per cluster (12 signals)** — chosen. Tight focus.
+- **Defer per-cluster signal selection to authoring time** — rejected: tasks.md needs to enumerate the targets so an implementer can scope per-signal work.
+
+## §D — Cross-reference targets
+
+**Decision**: 5 existing reference docs get linked from the new doc; each gets a ~1-paragraph summary in the new doc + a "for full depth, see X" pointer.
+
+| Cross-ref target | New doc treatment | Why summary + link, not duplication |
+|---|---|---|
+| `docs/reference/sbom-format-mapping.md` | Linked from every depth-covered signal + the appendix index entries. THE canonical wire-shape catalog. | The catalog is exhaustive (98+ C-rows) and code-review-grade; duplicating it in the new doc defeats the layered-docs approach. |
+| `docs/reference/identifiers.md` | Linked from the `mikebom:identifiers` mention + the cross-tier identity discussion. Summary: "mikebom carries `repo:` / `git:` / `image:` / `attestation:` / user-defined identifiers via spec-native carriers + an annotation envelope". | Identifier model is rich (4-layer); a 1-paragraph summary directs the reader to the dedicated ref doc. |
+| `docs/reference/sbom-types.md` | Linked from the CISA SBOM Type discussion. Summary: "mikebom emits CISA SBOM Types via native `metadata.lifecycles[]` (CDX) / `creationInfo.comment` (SPDX 2.3) / `software_Sbom.software_sbomType[]` (SPDX 3) per the `--sbom-type` flag". | Type model has 6 enum values + emission semantics per format; dedicated ref doc covers depth. |
+| `docs/reference/component-tiers.md` | Linked from the `mikebom:component-tier` deep-dive + the file-tier orphan-coverage discussion. Summary: "mikebom classifies components into package-tier, binary-tier, and file-tier per the content-shape allowlist; file-tier components fill the unattributed-content gap". | Tier model has FR-011 hybrid dedup + 3 modes + content-shape allowlist; ref doc has the full taxonomy. |
+| `docs/reference/cross-tier-binding.md` | Linked from the `mikebom:source-document-binding` discussion + the `--bind-to-source` / `verify-binding` mention. | Binding-hash-v1 algorithm + verify CLI surface lives in the dedicated ref doc. |
+
+**Plus**: link to the CHANGELOG (`../../CHANGELOG.md`) for milestone-by-milestone signal-introduction history, per spec Edge Case 6 + FR-013.
+
+## §E — `jq` recipe verification plan
+
+**Decision**: each `jq` recipe in the new doc MUST be verified at doc-authoring time against a real mikebom-emitted SBOM. Verification approach:
+
+1. Run `mikebom sbom scan` against the existing `tests/fixtures/cargo/lockfile-v3` (or equivalent ecosystem fixture) with appropriate flags to trigger the signal (e.g., `--include-dev` for lifecycle-scope examples, `--root-name X --root-version Y --preserve-manifest-main-module` for the demote-from-main-module example).
+2. Pipe through the doc's exact `jq` recipe.
+3. Confirm the output matches the doc's claimed output (or update one to match the other).
+
+Per spec FR-011: each recipe MUST be correct as written. Per spec SC-004: at least 5 recipes verified runnable.
+
+**Authoring artifact**: a `verify-recipes.sh` shell script in the spec dir (or appendix to the doc itself) listing the exact scan-then-jq commands for each recipe. NOT shipped to the repo — kept in the spec dir as authoring evidence. Operator can re-run post-merge if doubt arises about a specific recipe.
+
+**Alternative considered**: ship the verification script as part of the doc itself (in a "Verifying recipes" appendix). **Rejected** — bloats the doc; the recipes-are-correct invariant is a doc-authoring quality check, not a consumer-facing surface. The doc text itself includes worked examples; the verification script is implementation detail.
+
+## Summary of decisions feeding Phase 1
+
+- **§A**: Envelope schema cited from two existing Rust locations (`spdx/annotations.rs:31-67` + `parity/extractors/common.rs:185`). No new JSON Schema artifact.
+- **§B**: Appendix indexes all 102 unique `mikebom:*` keys at milestone-150 ship time, alphabetical, snapshot.
+- **§C**: 12 signals depth-covered across 4 clusters (vulnerability scanning + compliance auditing + build provenance + transparency/completeness gaps).
+- **§D**: 5 cross-references to existing topical refs + CHANGELOG link.
+- **§E**: `jq` recipe verification via shell script in spec dir (authoring artifact, not shipped).
+- **No new Rust code, no new schema files, no wire-format changes.**

--- a/specs/150-sbom-consumer-guide/spec.md
+++ b/specs/150-sbom-consumer-guide/spec.md
@@ -1,0 +1,201 @@
+# Feature Specification: SBOM consumer-facing reading guide — documenting mikebom annotations and differentiators
+
+**Feature Branch**: `150-sbom-consumer-guide`
+**Created**: 2026-06-29
+**Status**: Draft
+**Input**: User description: "milestone 150: SBOM consumer-facing reading guide documenting mikebom annotations and differentiators (where to find non-standard signals, what they mean, how to interpret them across CDX/SPDX 2.3/SPDX 3)"
+
+## Origin & Context
+
+The mikebom project has accumulated ~98 `mikebom:*` annotations across 50+ milestones (C-rows C1 through C102 as of milestone 149). Every annotation is rigorously documented in `docs/reference/sbom-format-mapping.md` — the **emitter-side correctness contract** that the format serializers honor — but that document is structured for mikebom CODE reviewers (one giant 98-row table; one-line justifications scoped to "why this annotation exists at all" rather than "what should an SBOM consumer do with it"). It is dense, exhaustive, and intentionally written as a spec, not a guide.
+
+The consumer-facing surface is incomplete. Today an external user (a compliance engineer, a vulnerability scanner author, an SBOM-diff tool maintainer, an auditor walking an emitted SBOM) who picks up a mikebom-emitted CycloneDX 1.6 or SPDX 2.3 or SPDX 3 document can find:
+
+- ✅ Per-flag CLI docs in `docs/user-guide/cli-reference.md` (emit side)
+- ✅ Narrow topical reference docs (`identifiers.md`, `sbom-types.md`, `component-tiers.md`, `cross-tier-binding.md`) — each covers ONE conceptual area in depth
+- ✅ The catalog-style `sbom-format-mapping.md` — comprehensive but built for code-review depth
+- ❌ **NO** single doc that asks "what does mikebom emit beyond the SBOM standards' minimums, and how do you USE that data as a consumer?"
+
+The result: consumers either (a) reverse-engineer mikebom's value-adds by reading mikebom source, (b) miss them entirely and treat mikebom output as carrying only standard-baseline signals, or (c) walk the 98-row C-catalog row-by-row trying to assemble a mental model from one-line justifications scoped at "why this annotation exists" rather than "what should I do with it."
+
+This milestone closes the gap by publishing a new consumer-facing reference doc at `docs/reference/reading-a-mikebom-sbom.md` that:
+
+1. **Frames mikebom's positioning** — strict spec conformance first; `mikebom:*` annotations only when no native field exists (Constitution Principle V).
+2. **Highlights the data mikebom makes available** — the signals mikebom adds beyond the SBOM standards' minimum content, organized by consumer use case (vulnerability scanning / compliance auditing / build provenance / transparency). Per the 2026-06-29 clarification, the doc does NOT name specific competing SBOM tools — the framing is "here's what mikebom emits and how to use it", not "here's what mikebom emits that other tools don't".
+3. **For each non-standard signal**: explains what it means, where to find it in CDX 1.6 vs SPDX 2.3 vs SPDX 3 (with `jq` recipes), and what a consumer should do with it.
+4. **Cross-references** `sbom-format-mapping.md` for wire-shape depth when readers want the catalog-level detail.
+5. **Documents the `mikebom-annotation/v1` envelope shape** for SPDX 2.3 + SPDX 3 readers (today the envelope schema is recoverable from `mikebom-cli/src/parity/extractors/common.rs` and the per-spec contract files, but not from a single consumer-facing doc).
+6. **Provides an appendix index** mapping every `mikebom:*` annotation key to its row in `sbom-format-mapping.md`, so a consumer encountering an unknown key in a real SBOM can look it up in seconds.
+
+The new doc complements (not replaces) the existing `sbom-format-mapping.md` catalog — both files have distinct audiences. The catalog stays the canonical wire-shape contract; this guide is the consumer-onboarding surface.
+
+## Clarifications
+
+### Session 2026-06-29
+
+- Q: How exhaustive should the cross-tool comparison be (syft + trivy + cdxgen + snyk + anchore; subset; or none)? → A: Option D — don't name specific competing SBOM tools at all. Frame the doc around what mikebom MAKES AVAILABLE, not what others lack. Removes the cross-tool verification burden and keeps the focus on mikebom's emitted data as a self-contained reference. FR-010 + SC-006 + Assumption 6 updated to drop tool-naming; references throughout the spec rewritten to remove competitor mentions.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Compliance engineer reads a mikebom SBOM for the first time (Priority: P1)
+
+A compliance engineer at a downstream consumer organization receives a mikebom-emitted SPDX 2.3 SBOM for a vendor product. They want to quickly understand: (a) what's in this SBOM beyond the standard CDX/SPDX baseline they're used to, (b) which fields they can safely ignore vs which they should pay attention to, (c) what `mikebom:*` annotations actually mean.
+
+They open `docs/reference/reading-a-mikebom-sbom.md`, see a "Signals mikebom makes available" section organized by consumer use case (vulnerability scanning / compliance auditing / build provenance / transparency), find the one relevant to their license-audit workflow (e.g., `mikebom:license-concluded-source`), read what it means, copy the `jq` recipe for finding it in SPDX 2.3, and complete their audit task without reading mikebom source or other docs.
+
+**Why this priority**: this is the singular value-add of the milestone. Today's docs require the consumer to be a mikebom code reader OR a 98-row-catalog reader; both are barriers to adoption. Closing this gap is the only purpose of this milestone. The framing per the 2026-06-29 clarification focuses on what mikebom emits (consumer-centric "here's what's available and how to use it"), not on comparing mikebom against named competing tools.
+
+**Independent Test**: Have a person (or via documentation review) walk through the guide for the first time, find at least 3 signals relevant to their use case, and execute the `jq` recipes against a sample mikebom-emitted SBOM successfully without consulting any other doc.
+
+**Acceptance Scenarios**:
+
+1. **Given** an external consumer opens the new doc, **When** they read the opening section, **Then** they understand mikebom's positioning vs other SBOM tools within 3 minutes (mikebom strict-conforms to CDX/SPDX, `mikebom:*` annotations are parity-bridges, the doc tells them what each parity-bridge means).
+
+2. **Given** a consumer needs to find dev/test/build-scoped dependencies in a mikebom SPDX 2.3 SBOM, **When** they search the guide for "lifecycle-scope" or "test deps" or "dev deps", **Then** they find a section explaining the dual-carrier model (native SPDX 2.3 `DEV_DEPENDENCY_OF` / `BUILD_DEPENDENCY_OF` / `TEST_DEPENDENCY_OF` typed relationships AND the `mikebom:lifecycle-scope` annotation on the target Package) with a `jq` recipe that returns the filtered set.
+
+3. **Given** a consumer encounters an unfamiliar `mikebom:*` annotation in an SBOM, **When** they search the guide's appendix index for the key, **Then** they find a one-line description + a link to the corresponding C-row in `sbom-format-mapping.md` for wire-shape depth.
+
+4. **Given** a consumer wants to understand mikebom's build-trace provenance (the eBPF observation model), **When** they read the guide, **Then** they find a "Build provenance" section explaining `mikebom:source-type`, the doc-level `generation_context` signal, and how to filter components by trace-observed vs lockfile-enriched.
+
+5. **Given** a consumer wants to identify "phantom" components (declared in a manifest but not actually built), **When** they read the guide, **Then** they find the `mikebom:source-type` mapping (e.g., `"trace-observed"` vs `"declared-not-cached"`) with a `jq` recipe that surfaces declared-only entries.
+
+---
+
+### User Story 2 - Vulnerability scanner author integrates mikebom-specific signals (Priority: P2)
+
+A vulnerability-scanner maintainer (or any consumer-side tool author building on mikebom output) wants to extend their tool to leverage mikebom-specific signals — e.g., suppress dev-only deps from production-vulnerability alerts using `mikebom:lifecycle-scope`, or correlate divergent-PURL collisions surfaced by `mikebom:duplicate-purl-divergent`. They need machine-readable details on:
+
+- Annotation key names + value shapes (boolean string vs JSON-encoded array vs envelope-wrapped struct)
+- Which carrier each annotation rides in per format (CDX `properties[]` vs SPDX 2.3 envelope vs SPDX 3 envelope on a graph-element Annotation)
+- The `mikebom-annotation/v1` envelope schema for SPDX 2.3 + SPDX 3 readers
+- Stability guarantees (which signals are stable vs experimental, what changes when)
+
+**Why this priority**: enables third-party tool authors to build on mikebom's value-adds without reading mikebom source. Wider ecosystem leverage of mikebom's differentiators.
+
+**Independent Test**: A tool author reads the "for tool authors" section, codifies a filter or correlation rule using ONE mikebom-specific signal, and produces correct results against a real mikebom SBOM without consulting mikebom source.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tool author needs the `mikebom-annotation/v1` envelope JSON schema, **When** they search the guide, **Then** they find the envelope shape (fields `schema`, `field`, `value`) with at least one example per format AND a link to the canonical schema file location.
+
+2. **Given** a tool author needs to know which signals are stable vs experimental, **When** they read the guide, **Then** they find a stability statement (e.g., "all `C*` rows in the catalog are stable wire shapes; the catalog row number is the durable identifier") and a callout for any opt-in or experimental flags (`--file-inventory=full`, `--preserve-manifest-main-module`, etc.).
+
+3. **Given** a tool author wants to write a CDX-to-SPDX-3 normalizer that preserves mikebom value-adds, **When** they read the "Cross-format reading patterns" section, **Then** they find a per-signal carrier-mapping table (or pointer to `sbom-format-mapping.md`'s catalog) showing where the same signal lives in each format.
+
+---
+
+### Edge Cases
+
+- **A consumer reads the guide but their use case is NOT one of the documented thematic clusters**: the guide includes a "find by annotation key" appendix so the consumer can search for the specific `mikebom:*` key they encountered in an SBOM and get a one-line description + link to wire-shape details.
+
+- **An annotation is added to mikebom in a future milestone after the guide ships**: the guide MUST link to `sbom-format-mapping.md` as the source-of-truth catalog so consumers reading a future-mikebom SBOM with unknown annotations have a single canonical lookup destination. The guide's appendix index need not be exhaustively maintained at every annotation addition — only the catalog is mandatory to update.
+
+- **A consumer reads the guide and disagrees with mikebom's emission choice** (e.g., wants to suppress a `mikebom:*` annotation, or wants the demoted-from-main-module entry's outbound edges preserved): the guide MUST point at the relevant FILED ISSUE or accept-future-issue path (Constitution Principle V audit + `mikebom:*` annotation governance) rather than imply emission choices are non-negotiable.
+
+- **A consumer encounters a `mikebom:*` annotation NOT in the guide's appendix index** (because the guide is published at milestone-N but the annotation was added at milestone-N+M): they should still find the annotation in `sbom-format-mapping.md`'s catalog. The guide's appendix is best-effort current; the catalog is the canonical mandatory reference.
+
+- **A consumer wants to use the guide as a one-stop reference and does NOT want to drill into `sbom-format-mapping.md`**: the guide MUST be self-contained for the top ~10-15 differentiator signals — each gets a full explanation in the guide. Drilling into the catalog is for wire-shape edge cases and for the long tail of annotations.
+
+- **A consumer wants to verify the doc is current with the shipped binary**: the guide MUST cite specific milestone numbers (e.g., "added in milestone 134", "stabilized in milestone 145") so consumers comparing against a specific mikebom binary version can confirm coverage. mikebom versions correspond to the `v*-alpha.*` tag sequence; the guide's signal-by-signal milestone citations let consumers map binary-version → signal availability.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: mikebom MUST publish a new consumer-facing reference doc at `docs/reference/reading-a-mikebom-sbom.md` covering mikebom's value-add signals (annotations + native-field usage patterns that differ from other SBOM tools).
+
+- **FR-002**: The doc MUST open with a positioning section explaining: (a) mikebom strictly conforms to CDX 1.6 / SPDX 2.3 / SPDX 3.0.1 — most data lives in spec-native fields; (b) `mikebom:*` annotations are parity-bridges introduced per Constitution Principle V when no native field carries a particular signal; (c) the doc's job is to tell consumers what the parity-bridges (and a few other notable native-field-usage patterns) mean.
+
+- **FR-003**: The doc MUST organize differentiator signals into thematic clusters aligned with common consumer use cases — minimum: vulnerability scanning, compliance auditing, build provenance, transparency / completeness gaps. Each cluster MUST include at least 2 specific mikebom signals with worked examples.
+
+- **FR-004**: For each documented signal, the doc MUST provide: (a) plain-language description of what it means; (b) where to find it in CDX 1.6, SPDX 2.3, and SPDX 3 (with the per-format carrier shape); (c) a working `jq` recipe that returns the signal value or filters by it; (d) what a consumer should do with the signal (action-oriented guidance).
+
+- **FR-005**: The doc MUST document the `mikebom-annotation/v1` envelope shape (fields `schema`, `field`, `value`) with at least one example per format (CDX `properties[]` value, SPDX 2.3 annotation `comment`, SPDX 3 annotation `statement`). The doc MAY link to the canonical envelope-schema file at `mikebom-cli/src/parity/extractors/common.rs` (or wherever the envelope is defined) rather than re-state the schema in full.
+
+- **FR-006**: The doc MUST include an appendix index that maps every `mikebom:*` annotation key to its corresponding C-row in `sbom-format-mapping.md`. The index MUST be a flat alphabetical lookup table; entries MUST link directly to the C-row anchor in the catalog. The index covers all annotation keys present at the time of milestone-150 ship (a snapshot — future annotations land in the catalog, not in this guide's appendix; the guide's catalog link covers them).
+
+- **FR-007**: The doc MUST cross-reference `docs/reference/sbom-format-mapping.md` as the canonical wire-shape catalog whenever it discusses a specific signal — readers who want full per-format wire-shape detail follow the link. The guide is the consumer-onboarding surface; the catalog is the contract.
+
+- **FR-008**: The doc MUST cross-reference the narrow topical refs (`identifiers.md`, `sbom-types.md`, `component-tiers.md`, `cross-tier-binding.md`) when discussing signals covered in depth elsewhere. The guide names the signal + provides a one-paragraph summary + links out for depth.
+
+- **FR-009**: The doc MUST be linked from `docs/index.md` in the **Reference material** section, listed alongside the existing reference docs (`identifiers.md`, `sbom-types.md`, etc.), with a one-line description identifying it as the consumer-onboarding surface.
+
+- **FR-010**: The doc MUST frame its content around what mikebom EMITS rather than what other SBOM tools omit. Per the 2026-06-29 clarification (Q1 Option D), the doc MUST NOT name specific competing SBOM tools (no "syft does X but mikebom does Y" passages). The framing instead is "here's what mikebom makes available and how to use it" — consumer-centric, comparison-tool-agnostic. The doc MAY refer in passing to "standard SBOM tool output" or "the CDX/SPDX spec baseline" as shorthand for the reference behavior; it MUST NOT cite specific tool names or behaviors.
+
+- **FR-011**: Every `jq` recipe in the doc MUST be runnable against a real mikebom-emitted SBOM (verified at doc-authoring time) and MUST produce the documented output. The recipes are illustrative — they need not cover every variant — but each MUST be correct as written.
+
+- **FR-012**: The doc MUST include a "Stability" section covering: (a) every `C*` row in `sbom-format-mapping.md` is a stable wire shape — its row number is the durable identifier; (b) the `mikebom-annotation/v1` envelope shape is stable; (c) any opt-in or experimental flags that affect emission are called out (e.g., `--file-inventory=full`, `--preserve-manifest-main-module`).
+
+- **FR-013**: The doc MUST cite specific milestone numbers for each documented signal (e.g., "added in milestone 134", "stabilized in milestone 145") so consumers can map a mikebom binary version to signal availability.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A reviewer (operator-cadence — not a CI gate) reads the new doc end-to-end and confirms they can answer the following questions WITHOUT consulting `sbom-format-mapping.md` or any other doc: "What does `mikebom:lifecycle-scope` mean?", "How do I find dev-only dependencies in a mikebom SPDX 2.3 SBOM?", "Where do I find which OCI layer a binary came from?", "What's the difference between `mikebom:source-type = trace-observed` and `mikebom:source-type = declared-not-cached`?", "What's the `mikebom-annotation/v1` envelope shape?".
+
+- **SC-002**: The doc's appendix index lists every `mikebom:*` annotation key present in `sbom-format-mapping.md` at milestone-150 ship time. A test or audit can verify by comparing the index keys against the catalog's row labels.
+
+- **SC-003**: The doc is reachable from `docs/index.md`'s "Reference material" section with a one-line description.
+
+- **SC-004**: At least 5 `jq` recipes in the doc are verified runnable against a real mikebom-emitted SBOM at doc-authoring time. The recipes' expected outputs match the doc's claimed outputs.
+
+- **SC-005**: At least 4 distinct thematic clusters are present in the doc (vulnerability scanning / compliance auditing / build provenance / transparency / completeness gaps), each with at least 2 documented signals.
+
+- **SC-006**: The doc covers at least 8 distinct mikebom-emitted signals in depth (full per-format wire-shape + plain-language meaning + `jq` recipe + action-oriented consumer guidance per FR-004). Per the 2026-06-29 clarification (Q1 Option D), this metric replaces the original cross-tool comparison count — the doc focuses on signal coverage breadth rather than competitor-tool naming. An audit/reviewer can count documented signals to verify.
+
+- **SC-007**: The pre-PR gate (`./scripts/pre-pr.sh`) passes — clippy clean + `cargo test --workspace` clean (excepting the pre-existing `sbomqs_parity` env-only failure). Since this milestone is docs-only, the gate is essentially a no-op (no Rust source code change) but the convention is followed.
+
+- **SC-008**: A reverse-link test or audit confirms `docs/reference/sbom-format-mapping.md` is linked from the new doc at least once.
+
+## Assumptions
+
+1. **Docs-only milestone**: this milestone touches only Markdown files under `docs/`. No Rust source code changes, no CLI flag changes, no parity-catalog row additions, no test changes. The new doc is a published reference, not an emitted artifact.
+
+2. **No emitter-behavior change**: the wire format mikebom emits is unchanged. Consumers reading SBOMs against the existing mikebom binary (alpha.52 + this milestone's docs) see the same wire bytes as alpha.52 alone.
+
+3. **Catalog stays canonical**: `sbom-format-mapping.md` remains the source-of-truth wire-shape catalog. The new doc cross-references it; the new doc does NOT duplicate per-row wire-shape detail except for the top ~10-15 differentiator signals that get full inline coverage.
+
+4. **Appendix index is a snapshot**: the appendix maps every annotation key present at milestone-150 ship time. Future annotations (milestones N+M for N > 150) land in the catalog only; the guide's appendix is best-effort current but the catalog is the canonical mandatory reference for new signals.
+
+5. **`jq` recipes are illustrative**: the recipes cover the common case but not every variant. They MUST be correct as written; they need not be exhaustive.
+
+6. **No cross-tool comparison** (2026-06-29 clarification Q1 Option D): the doc does NOT name specific competing SBOM tools. Framing is consumer-centric ("here's what mikebom emits and how to use it"), not competitive ("here's what mikebom does that others don't"). Removes the verification burden of pinning specific tool versions / dates / license tiers, and keeps the doc evergreen against external-tool behavioral drift.
+
+7. **No new schema files**: the `mikebom-annotation/v1` envelope schema is already defined in mikebom code (`mikebom-cli/src/parity/extractors/common.rs` or similar canonical location). The new doc links to the existing canonical schema rather than duplicating it.
+
+8. **One file, one doc**: the deliverable is a SINGLE Markdown file at `docs/reference/reading-a-mikebom-sbom.md`. It MAY be long (the existing `sbom-format-mapping.md` is ~200 lines but ships as one file). A single file keeps the doc easy to grep + bookmark; multi-file splits add navigation friction.
+
+9. **Operator-cadence quality review**: the doc's quality is assessed via an operator-cadence read-through (per SC-001), not via automated tests. The doc cannot fail in CI; it can only fail an operator's "I read it and got my answer" check.
+
+## Out of Scope
+
+1. **Changes to `sbom-format-mapping.md`'s structure or content**. The existing catalog stays as-is. The new doc complements it.
+
+2. **Changes to the wire format mikebom emits**. Purely documentation.
+
+3. **New `mikebom:*` annotations**. No new annotations introduced — the doc covers what's already there as of milestone-150 ship.
+
+4. **Auto-generation of the appendix index from the catalog**. The index is hand-maintained at ship time (SC-002 audit confirms coverage). A future milestone could automate via a build-time script reading both files; out of scope here.
+
+5. **Translations or multi-language versions**. English-only.
+
+6. **Per-annotation deep-dive subdocs** (e.g., a separate file per `mikebom:*` key). Single-file deliverable per Assumption 8.
+
+7. **Interactive consumer tooling** (e.g., a web tool that parses an uploaded SBOM and explains mikebom signals). Static Markdown only.
+
+8. **Comparison-tool implementations**. The doc names other tools' behaviors descriptively; it does NOT include a benchmark suite or comparison-CI harness.
+
+9. **Coverage of every `C*` row in the catalog**. The guide covers the top ~10-15 differentiator signals in depth + the appendix lists every key. The long-tail catalog rows stay in the catalog.
+
+10. **Per-format SBOM viewers / parsers / linters**. Reference material only; no tooling.
+
+## Key Entities
+
+- **Consumer-guide document** (`docs/reference/reading-a-mikebom-sbom.md`): the new single-file reference. Sections: positioning, differentiator clusters by use case, envelope schema, stability statement, cross-tool comparison, milestone-citation pattern, appendix index. Cross-references the existing catalog + narrow topical refs.
+
+- **Appendix index entries**: each is a row `{annotation-key, one-line-description, link-to-C-row-in-catalog}`. Snapshot at milestone-150 ship; future entries land in catalog only.
+
+- **Cited milestones**: each documented signal cites the milestone that introduced or stabilized it. Format: `(milestone N — verb)`, e.g., `(milestone 134 — added)`, `(milestone 145 — stabilized envelope shape)`.
+
+- **Documented `mikebom:*` annotation set**: the union of all annotations covered in depth (the top ~10-15) PLUS the appendix index (all keys at ship time). The depth-covered subset is a curated choice; the appendix-listed subset is automatically determined from `sbom-format-mapping.md` snapshot at ship time.

--- a/specs/150-sbom-consumer-guide/tasks.md
+++ b/specs/150-sbom-consumer-guide/tasks.md
@@ -1,0 +1,209 @@
+---
+description: "Task list for milestone 150 — SBOM consumer-facing reading guide documenting mikebom annotations and differentiators"
+---
+
+# Tasks: milestone 150 — SBOM consumer-facing reading guide
+
+**Input**: Design documents from `/specs/150-sbom-consumer-guide/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+**Tests**: This is a pure-docs milestone. There are no Rust source code tests to write. Quality is validated via operator-cadence read-through audit (SC-001), mechanical audits for appendix coverage / index linkback / cluster count / signal count (SC-002 / SC-003 / SC-005 / SC-006), and jq-recipe verification at doc-authoring time (SC-004). The pre-PR gate (SC-007) is essentially a no-op since no Rust source changes. The reverse-link audit (SC-008) is mechanical.
+
+**Organization**: US1 (P1) ships the bulk of the doc — opening positioning + 12 depth-covered signals across 4 clusters + envelope + cross-format reading + cross-refs. US2 (P2) layers the "For tool authors" section on top. The appendix index (102 entries) is polish-phase since it's mechanical bulk after the depth-coverage signals stabilize.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different sections of the doc, no dependencies)
+- **[Story]**: Maps to user story from spec.md (US1, US2)
+- Paths absolute under repo root `/Users/mlieberman/Projects/mikebom/`
+
+## Path Conventions
+
+Touched files (docs-only milestone, narrow scope):
+
+- `docs/reference/reading-a-mikebom-sbom.md` — NEW single-file deliverable; every authoring task appends or edits this file
+- `docs/index.md` — ONE-line update in the Reference material section
+- `specs/150-sbom-consumer-guide/verify-recipes.sh` — NEW authoring artifact (not shipped to public docs); lists scan-then-jq invocations for SC-004 verification
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify baseline; create the new doc file skeleton.
+
+- [ ] T001 Confirm baseline pre-PR gate is green on branch `150-sbom-consumer-guide`. Run `./scripts/pre-pr.sh` from repo root. Expected: clippy `--workspace --all-targets -- -D warnings` clean; `cargo test --workspace` passes except for the pre-existing local-environment `sbomqs_parity::sbomqs_spdx_score_meets_or_beats_cdx_across_ecosystems` failure documented in milestone-144 T001. This milestone is docs-only so the gate is essentially a no-op for behavior validation — it's a smoke-test confirming nothing in the current main was broken by the branch creation. If anything ELSE fails, halt and investigate before proceeding.
+
+- [ ] T002 Create the new doc file at `/Users/mlieberman/Projects/mikebom/docs/reference/reading-a-mikebom-sbom.md` with the 10-section TOC scaffolding per `contracts/doc-structure.md`. Each section gets a placeholder header (`## 1. Opening positioning`, etc.) + a `[TODO: filled in by T0XX]` marker. The TOC at the top of the doc lists all 10 sections (with anchor links). After this task, subsequent authoring tasks fill in each section.
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: None required. This is a docs milestone — no foundational types, no shared infra to land first. The doc scaffold from T002 is the only prerequisite for authoring tasks.
+
+(No tasks in this phase. Proceed directly to Phase 3.)
+
+---
+
+## Phase 3: User Story 1 - Compliance engineer reads a mikebom SBOM for the first time (Priority: P1) 🎯 MVP
+
+**Goal**: Author all content needed for the SC-001 5-question read-through audit — opening positioning, 12 depth-covered signals across 4 thematic clusters, envelope schema documentation, cross-format reading patterns, stability statement, and cross-reference section. After this phase, an SBOM consumer can read the doc + answer all 5 SC-001 questions without consulting other docs.
+
+**Independent Test**: A reviewer reads the doc end-to-end and answers the 5 SC-001 questions (`mikebom:lifecycle-scope` meaning, finding dev-only deps in SPDX 2.3, finding OCI layer attribution, trace-observed vs declared-not-cached source-type, envelope shape) without opening any other file.
+
+### Implementation for User Story 1
+
+- [ ] T003 [US1] Author the Section 1 "Opening positioning" content (~30 lines) at `/Users/mlieberman/Projects/mikebom/docs/reference/reading-a-mikebom-sbom.md`. Per `contracts/doc-structure.md` §1 contract: state mikebom strict-conforms to CDX 1.6 / SPDX 2.3 / SPDX 3.0.1; most data lives in spec-native fields; `mikebom:*` annotations are parity-bridges per Constitution Principle V (introduced ONLY when no native field carries the signal); the doc's job is to tell consumers what each parity-bridge means and how to use it. Per the 2026-06-29 clarification (Q1 Option D) the section MUST NOT name specific competing SBOM tools — use phrasing like "the CDX/SPDX spec baseline" or "standard SBOM output" when contrast is needed.
+
+- [ ] T004 [US1] Author the Section 2 "How to read this doc" content (~20 lines). Reader-navigation map: vulnerability scanning → §3.1; compliance auditing → §3.2; tool authors → §7; appendix lookup for unknown keys → Appendix A; full per-format wire-shape catalog → `sbom-format-mapping.md`. Establishes the doc's flow + sets reader expectations.
+
+- [ ] T005 [P] [US1] Author Section 3.1 — Vulnerability scanning cluster (3 signals: `mikebom:lifecycle-scope`, `mikebom:layer-digest`, `mikebom:duplicate-purl-divergent` + `mikebom:purl-collisions-detected` as the document-scope companion). Each signal renders per the per-signal invariant in `data-model.md` §2 (5 fields + a verified `jq` recipe + expected output). Cluster intro (~5 lines) explains why these signals matter for vulnerability scanners. Total ~120 lines.
+
+- [ ] T006 [P] [US1] Author Section 3.2 — Compliance auditing cluster (3 signals: `mikebom:license-concluded-source`, `mikebom:component-tier` for file value, `mikebom:demoted-from-main-module`). Same per-signal rendering invariant. Cluster intro explains why these signals matter for license / compliance auditors. Total ~120 lines.
+
+- [ ] T007 [P] [US1] Author Section 3.3 — Build provenance cluster (3 signals: `mikebom:source-type`, `mikebom:generation-context`, `mikebom:source-document-binding`). Same rendering invariant. Cluster intro explains why these signals matter for consumers verifying build-time provenance vs lockfile-derived enrichment. Total ~120 lines.
+
+- [ ] T008 [P] [US1] Author Section 3.4 — Transparency / completeness gaps cluster (3 signals: `mikebom:file-inventory-mode`, `mikebom:graph-completeness` + `mikebom:graph-completeness-reason` paired, `mikebom:peer-edge-targets`). Same rendering invariant. Cluster intro explains why these signals matter for consumers evaluating SBOM completeness + provenance gaps. Total ~120 lines.
+
+- [ ] T009 [US1] Author Section 4 "The mikebom-annotation/v1 envelope" (~40 lines) per `contracts/doc-structure.md` §4. Include: the envelope schema (3 fields: `schema`, `field`, `value`) shown inline; one example per format embedded — CDX `properties[]` flat string carrier, SPDX 2.3 annotation `comment` envelope, SPDX 3 annotation `statement` envelope; pointer to canonical Rust sources (`mikebom-cli/src/generate/spdx/annotations.rs:31-67` encoder + `mikebom-cli/src/parity/extractors/common.rs:185` decoder); statement that the envelope schema string is the stability anchor (future evolutions would bump version to `mikebom-annotation/v2`).
+
+- [ ] T010 [US1] Author Section 5 "Cross-format reading patterns" (~60 lines) per `contracts/doc-structure.md` §5. Table or list showing the SAME signal in 3 formats for 4–5 representative depth-covered signals (recommended: `mikebom:lifecycle-scope`, `mikebom:layer-digest`, `mikebom:source-type`, `mikebom:demoted-from-main-module`); demonstrates the per-format carrier-shape variation. Pointer to `sbom-format-mapping.md` as the canonical wire-shape source. Note about SPDX 3 subject-routing quirks where applicable (e.g., `mikebom:demoted-from-main-module` routes to synth-root IRI per milestone-149 C102 docs).
+
+- [ ] T011 [US1] Author Section 6 "Stability" (~40 lines) per `contracts/doc-structure.md` §6. Cover: every `C*` row in the catalog is a stable wire shape; the row number is the durable identifier; the `mikebom-annotation/v1` envelope shape is stable; explicit list of opt-in / experimental flags affecting emission (`--file-inventory=full`, `--preserve-manifest-main-module`, `--include-dev`, etc.); versioning statement (mikebom emissions follow `v*-alpha.*` tag sequence; map binary version → signal availability via Appendix B milestone citations).
+
+- [ ] T012 [US1] Author Section 8 "Cross-references" (~30 lines) per `contracts/doc-structure.md` §8. Linked-list of related docs: `docs/reference/sbom-format-mapping.md` (catalog), `docs/reference/identifiers.md`, `docs/reference/sbom-types.md`, `docs/reference/component-tiers.md`, `docs/reference/cross-tier-binding.md`, `../../CHANGELOG.md`. Each link has a 1-line description of what the linked doc covers.
+
+**Checkpoint**: After Phase 3, US1 is fully covered. A reviewer can read sections 1–6 + 8 and answer all 5 SC-001 questions without consulting other docs. The 8-signal depth-covered floor (SC-006) is met with 12 signals; the 4-cluster floor (SC-005) is met. Appendix A (102 entries) is in Phase 5 since it's mechanical bulk after the depth-covered signals stabilize.
+
+---
+
+## Phase 4: User Story 2 - Vulnerability scanner author integrates mikebom-specific signals (Priority: P2)
+
+**Goal**: Author the Section 7 "For tool authors" section — tool-author-specific summary covering envelope schema location, carrier-mapping table, stability statement, and suggested integration patterns. After this phase, a downstream tool author can implement a mikebom-signal integration from the doc alone without reading mikebom source.
+
+**Independent Test**: A tool author reads Section 7 + the cross-referenced Sections 4 + 5 + 6 and can codify a filter or correlation rule using ONE mikebom-specific signal (e.g., suppress dev-deps from vulnerability alerts using `mikebom:lifecycle-scope`) without consulting mikebom source.
+
+### Implementation for User Story 2
+
+- [ ] T013 [US2] Author Section 7 "For tool authors" (~60 lines) per `contracts/doc-structure.md` §7. Include: envelope schema location pointer (cross-ref to §4); per-format carrier-mapping table (cross-ref to §5 + catalog); stability statement (cross-ref to §6); suggested integration patterns (filter dep-graph by `mikebom:lifecycle-scope` for production-vulnerability suppression / walk `mikebom:layer-digest` for layer-attribution in OCI scans / correlate `mikebom:duplicate-purl-divergent` for divergence-detection workflows / etc.); pointer to GitHub Issues for bug reports or signal-shape concerns.
+
+**Checkpoint**: After Phase 4, US2 is fully covered. The doc now serves both consumer-onboarding (US1 sections 1–6 + 8) and tool-author leverage (US2 section 7).
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Author the appendix index + milestone-citation map; update `docs/index.md`; verify jq recipes; pre-PR gate; commit chain.
+
+- [ ] T014 Author Appendix A "Annotation key index" (~200 lines for 102 entries) per `contracts/doc-structure.md` Appendix A. Generate the key list mechanically from `sbom-format-mapping.md`:
+
+  ```bash
+  grep -E "^\| C[0-9]+\b" /Users/mlieberman/Projects/mikebom/docs/reference/sbom-format-mapping.md \
+      | grep -oE "mikebom:[a-z0-9-]+" | sort -u
+  ```
+
+  Returns 102 keys at milestone-150 ship time. For each key, author one entry per the data-model §3 invariant: `- **\`mikebom:<key>\`** — <one-line description> ([C<row>](sbom-format-mapping.md#c<row>-mikebom-<key>))`. The one-line description comes from the catalog's row description (paraphrased to fit one line, ~10-15 words). Alphabetically sorted.
+
+- [ ] T015 [P] Author Appendix B "Milestone-citation map" (~30 lines) per `contracts/doc-structure.md` Appendix B. Table mapping each of the 12 depth-covered signals (from sections 3.1–3.4) to its introducing/stabilizing milestone with a brief verb. Lookup source: each signal's "Milestone" field from the per-signal rendering (filled in by T005–T008). Format: 3-column markdown table.
+
+- [ ] T016 [P] Update `/Users/mlieberman/Projects/mikebom/docs/index.md` per the "Index update contract" in `contracts/doc-structure.md`. Add the one-line entry in the **Reference material** section, positioned to fit the existing list's topical ordering (recommended: between the existing `sbom-format-mapping.md` entry and `conformance-harness-guide.md` entry — the new doc is the consumer-facing companion to the catalog). The one-line description identifies it as the consumer-onboarding surface and cross-references the catalog.
+
+- [ ] T017 [P] Create the jq-recipe verification artifact at `/Users/mlieberman/Projects/mikebom/specs/150-sbom-consumer-guide/verify-recipes.sh`. Per `quickstart.md` Scenario 4: for each `jq` recipe in the doc, list (a) the `mikebom sbom scan` command that produces the source SBOM, (b) the exact `jq` recipe from the doc, (c) the documented expected output. The script is an authoring artifact (lives in the spec dir, NOT shipped to `docs/`). Operator-cadence reviewer can re-run post-merge to confirm recipes still produce documented output if doubt arises.
+
+- [ ] T018 Run all jq recipes in the doc against real mikebom-emitted SBOMs and confirm outputs match the documented "Expected output" blocks. Per SC-004: at least 5 recipes verified runnable. Per FR-011: each recipe MUST be correct as written. Update the doc's "Expected output" blocks to match actual output where any mismatch is observed (or update the recipe — implementer's choice based on which is wrong). The verify-recipes.sh script from T017 makes this re-runnable.
+
+- [ ] T019 Run mandatory pre-PR gate per Constitution Development Workflow + memory `feedback_prepr_gate_full_output.md`: `./scripts/pre-pr.sh` from repo root. Both clippy + test steps MUST pass clean (excepting the pre-existing local `sbomqs_parity` env-only failure documented in milestone-144 T001 — CI will validate on a clean runner). Since this milestone is docs-only, the gate is essentially a smoke-test confirming no inadvertent Rust source-tree disruption. Covers SC-007.
+
+- [ ] T020 Verify the SC-002 appendix-coverage audit + SC-003 index-linkback audit + SC-005 cluster audit + SC-006 signal-count audit + SC-008 reverse-link audit per `quickstart.md` Scenarios 2 + 3 + 5 + 6 + 8 — mechanical shell-grep audits. All MUST pass before commit. Each audit's pass/fail outcome documented in the PR description.
+
+- [ ] T021 Commit the milestone-150 changes. Per project convention (matching milestones 134/144/145/146/147/148/149), use the 4-commit chain:
+  - `spec(150): SBOM consumer-facing reading guide — documenting mikebom annotations and differentiators` — spec.md + checklists/requirements.md
+  - `plan(150): docs-only milestone with 12 depth-covered signals across 4 clusters + 102-key appendix + cross-refs` — plan + research + data-model + contracts + quickstart + CLAUDE.md
+  - `tasks(150): 21 tasks across 5 phases for SBOM consumer guide` — tasks.md + verify-recipes.sh (the authoring artifact from T017 lives under the spec dir, ships with the spec)
+  - `docs(150): publish reading-a-mikebom-sbom.md consumer guide` — `docs/reference/reading-a-mikebom-sbom.md` + `docs/index.md`
+
+  Do NOT commit until T019 + T020 pass clean. Use `git add <specific paths>` (never `-A`). Each commit ends with the standard `Co-Authored-By` trailer.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: T001 baseline; T002 doc scaffold. T002 must complete before any authoring task starts.
+- **Phase 2 (Foundational)**: EMPTY — no foundational work required.
+- **Phase 3 (US1)**: Depends on T002. T003 (opening positioning) + T004 (navigation map) are sequential since they set the doc's tone + reader expectations. T005–T008 [P] are the 4 cluster sections — different file regions, landable in any order or in parallel. T009–T012 are subsequent independent sections that can follow T005–T008.
+- **Phase 4 (US2)**: Depends on Phase 3 — Section 7 cross-references Sections 4 + 5 + 6 which must exist first.
+- **Phase 5 (Polish)**: Depends on US1 + US2 being functionally complete. Within Phase 5: T014 (appendix) + T015 [P] (milestone map) + T016 [P] (index.md) + T017 [P] (verify-recipes.sh) can land in parallel; T018 (verify recipes) requires T005–T008 + T017; T019 + T020 are the gate audits; T021 is the commit chain.
+
+### User Story Dependencies
+
+- **US1 (P1, MVP)**: Standalone after Phase 1. Delivers the consumer-onboarding surface. T002–T012 (~11 tasks). After this phase the doc can be reviewed for SC-001 read-through audit.
+- **US2 (P2)**: Builds on US1 — T013 (Section 7) cross-references sections 4 + 5 + 6 from US1.
+
+### Within Each User Story
+
+- T003 → T004 → T005-T008 [P] → T009 → T010 → T011 → T012 (US1 sequential except for the 4 cluster sections which are [P]).
+- T013 (US2) lands after T009 + T010 + T011 (which it cross-refs).
+
+### Parallel Opportunities
+
+- Phase 3: T005 + T006 + T007 + T008 [P] — 4 cluster sections, ~120 lines each, landable in parallel.
+- Phase 5: T015 + T016 + T017 [P] — milestone-citation map + index.md update + verify-recipes.sh script (3 different files).
+
+---
+
+## Parallel Example: Phase 3 (after T002 + T003 + T004 land)
+
+```bash
+# Four cluster sections can be authored in parallel:
+Task T005: §3.1 Vulnerability scanning   (3 signals × ~40 lines + intro = ~120 lines)
+Task T006: §3.2 Compliance auditing      (3 signals × ~40 lines + intro = ~120 lines)
+Task T007: §3.3 Build provenance         (3 signals × ~40 lines + intro = ~120 lines)
+Task T008: §3.4 Transparency gaps        (3 signals × ~40 lines + intro = ~120 lines)
+```
+
+## Parallel Example: Phase 5
+
+```bash
+Task T015: Appendix B milestone-citation map  (specs/150-sbom-consumer-guide/... → docs/reference/...)
+Task T016: docs/index.md update               (one-line addition)
+Task T017: specs/150-sbom-consumer-guide/verify-recipes.sh   (authoring artifact)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only — ships the consumer-onboarding surface)
+
+1. Complete Phase 1: T001 baseline + T002 scaffold.
+2. Complete Phase 3: T003 (opening) + T004 (nav) + T005-T008 (4 cluster sections, [P]) + T009 (envelope) + T010 (cross-format) + T011 (stability) + T012 (cross-refs).
+3. **STOP and VALIDATE** with operator-cadence reviewer running the SC-001 5-question audit per `quickstart.md` Scenario 1.
+4. This is a shippable PR. Appendix A + milestone-citation map + tool-author section can land in a follow-up PR if the operator-cadence review surfaces structural concerns.
+
+### Incremental / Recommended (single-PR delivery)
+
+1. Phase 1 (T001-T002) setup.
+2. Phase 3 (T003-T012) US1 sections.
+3. Phase 4 (T013) US2 tool-author section.
+4. Phase 5 (T014-T021) polish: appendix + milestone map + index update + jq verification + pre-PR + commit chain.
+
+Total: 21 tasks. Estimated ~600–900 lines of Markdown + 1-line `docs/index.md` update + ~50 lines of `verify-recipes.sh` script (authoring artifact, lives in spec dir).
+
+### Single-developer Note
+
+This milestone is bulk-authoring rather than chunked implementation. One developer can work through all phases in one session if focused; estimated 5–10 hours of authoring + 1–2 hours of audits + commit chain. The [P] markers signal "no cross-section content conflict" but the single-file deliverable means parallel-authoring is best done by drafting each cluster in a scratch file then merging.
+
+---
+
+## Notes
+
+- The doc lives at `docs/reference/reading-a-mikebom-sbom.md`. Single file per spec Assumption 8.
+- Per the 2026-06-29 clarification (Q1 Option D), the doc does NOT name specific competing SBOM tools — framing is consumer-centric ("here's what mikebom emits and how to use it") rather than competitive.
+- Memory `feedback_prepr_gate_full_output.md` is directly relevant for T019: scan the FULL output rather than greping on `^test result: FAILED`.
+- The commit-message convention (T021) follows the milestone-134/144/145/146/147/148/149 precedent: `spec(150):` / `plan(150):` / `tasks(150):` / `docs(150):` (note the 4th uses `docs(150)` rather than `impl(150)` since this is a docs-only milestone).
+- Per spec FR-013 + Edge Case 6: every depth-covered signal MUST cite the milestone that introduced or stabilized it so consumers can map binary version → signal availability.
+- Per spec FR-011 + SC-004: jq recipes MUST be verified runnable at doc-authoring time (T018). The verify-recipes.sh script from T017 makes this re-runnable post-merge if doubt arises.
+- The appendix-coverage audit (T020 + SC-002) is mechanical — `diff /tmp/catalog-keys.txt /tmp/guide-keys.txt` per `quickstart.md` Scenario 2.
+- This milestone is ENTIRELY about consumer-facing documentation. Zero Rust source code change. Zero CLI flag change. Zero wire-format change. The mikebom binary is unchanged.

--- a/specs/150-sbom-consumer-guide/verify-recipes.sh
+++ b/specs/150-sbom-consumer-guide/verify-recipes.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Authoring artifact for milestone 150 — verifies jq recipes from
+# docs/reference/reading-a-mikebom-sbom.md against real mikebom-emitted SBOMs.
+#
+# Per spec FR-011 + SC-004: at least 5 jq recipes verified runnable at doc-
+# authoring time. This script makes the verification re-runnable post-merge.
+#
+# Usage:
+#   ./specs/150-sbom-consumer-guide/verify-recipes.sh
+#
+# Requires:
+#   - mikebom binary built (cargo build --release OR cargo run will trigger)
+#   - jq installed
+#   - the milestone-090 sibling-fixture repo cached at $MIKEBOM_FIXTURES_DIR
+#
+# Exit code 0 = all recipes produced expected output shape.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+FIXTURES_DIR="${MIKEBOM_FIXTURES_DIR:-$HOME/.cache/mikebom/fixtures/$(ls $HOME/.cache/mikebom/fixtures 2>/dev/null | head -1)}"
+if [[ ! -d "$FIXTURES_DIR" ]]; then
+    echo "ERROR: fixtures dir not found at $FIXTURES_DIR. Set MIKEBOM_FIXTURES_DIR." >&2
+    exit 2
+fi
+echo "Using fixtures from: $FIXTURES_DIR"
+
+TMP="$(mktemp -d)"
+trap "rm -rf $TMP" EXIT
+
+# Build mikebom once (release for speed).
+echo "Building mikebom (release) ..."
+cargo +stable build --release -p mikebom 2>&1 | tail -3
+MIKEBOM="$REPO_ROOT/target/release/mikebom"
+
+PASS=0
+FAIL=0
+
+run_recipe() {
+    local recipe_name="$1"
+    local format="$2"
+    local fixture="$3"
+    local extra_flags="$4"
+    local jq_recipe="$5"
+    local expectation="$6"  # 'nonempty' or 'present'
+
+    echo
+    echo "=== Recipe $recipe_name ($format on $fixture) ==="
+    local out="$TMP/$recipe_name.$format.json"
+    # shellcheck disable=SC2086
+    $MIKEBOM sbom scan --offline --path "$FIXTURES_DIR/$fixture" \
+        --format "$format" --output "$out" --no-deep-hash $extra_flags \
+        > /dev/null 2>&1
+
+    local result
+    result=$(jq "$jq_recipe" "$out" 2>/dev/null || echo "JQ_ERROR")
+
+    if [[ "$expectation" == "nonempty" && -n "$result" && "$result" != "null" && "$result" != "JQ_ERROR" ]]; then
+        echo "✓ PASS — recipe produced non-empty output:"
+        echo "$result" | head -5
+        PASS=$((PASS + 1))
+    elif [[ "$expectation" == "present" && "$result" != "JQ_ERROR" ]]; then
+        echo "✓ PASS — recipe ran without error (output may be empty if signal not in fixture):"
+        echo "$result" | head -3
+        PASS=$((PASS + 1))
+    else
+        echo "✗ FAIL — recipe error or unexpected output:"
+        echo "$result" | head -10
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Recipe 1: mikebom:lifecycle-scope (dev-scoped) in CDX
+# Requires --include-dev to see dev components
+run_recipe "lifecycle-scope-cdx" "cyclonedx-json" "transitive_parity/npm" \
+    "" \
+    '.components[]
+     | select(.properties[]?
+              | .name == "mikebom:lifecycle-scope" and .value == "development")
+     | .purl' \
+    "present"
+
+# Recipe 2: mikebom:lifecycle-scope (dev-scoped) in SPDX 2.3
+run_recipe "lifecycle-scope-spdx23" "spdx-2.3-json" "transitive_parity/npm" \
+    "" \
+    '.packages[]
+     | select(.annotations[]?
+              | .comment | fromjson?
+              | select(.field == "mikebom:lifecycle-scope" and .value == "development"))
+     | .name + " " + .versionInfo' \
+    "present"
+
+# Recipe 3: mikebom:lifecycle-scope (dev) in SPDX 3 — native LifecycleScopedRelationship.scope
+run_recipe "lifecycle-scope-spdx3" "spdx-3-json" "transitive_parity/npm" \
+    "" \
+    '.["@graph"][]
+     | select(.type == "Relationship"
+              and .relationshipType == "dependsOn"
+              and .scope == "development")
+     | .to[]?' \
+    "present"
+
+# Recipe 4: mikebom:source-type grouping
+run_recipe "source-type-cdx" "cyclonedx-json" "cargo/lockfile-v3" "" \
+    '[.components[]
+      | {purl, source_type: (.properties[]? | select(.name == "mikebom:source-type") | .value)}]
+     | group_by(.source_type)
+     | map({source_type: .[0].source_type, count: length})' \
+    "nonempty"
+
+# Recipe 5: mikebom:generation-context document-scope
+run_recipe "generation-context-cdx" "cyclonedx-json" "cargo/lockfile-v3" "" \
+    '.metadata.properties[]?
+     | select(.name == "mikebom:generation-context")
+     | .value' \
+    "present"
+
+# Recipe 6: mikebom:demoted-from-main-module — needs override flag
+run_recipe "demoted-from-main-module-cdx" "cyclonedx-json" "transitive_parity/cargo" \
+    "--root-name widget-svc --root-version 1.2.3 --preserve-manifest-main-module" \
+    '.components[]
+     | select(.properties[]?
+              | .name == "mikebom:demoted-from-main-module" and .value == "true")
+     | {purl, name, version}' \
+    "nonempty"
+
+echo
+echo "============================================================"
+echo "Verification summary: $PASS passed, $FAIL failed"
+echo "============================================================"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Publishes a new consumer-facing reference doc at `docs/reference/reading-a-mikebom-sbom.md` documenting the mikebom-emitted signals beyond the CDX/SPDX spec baseline. Closes a long-standing onboarding gap — until now, consumers reading a mikebom SBOM had to either reverse-engineer mikebom source or walk the 100+ row catalog (`sbom-format-mapping.md`) row-by-row to make sense of `mikebom:*` annotations.

This is a **docs-only milestone** — zero Rust source code change, zero CLI flag change, zero wire-format change. The mikebom binary is unchanged.

## Framing

Per the 2026-06-29 clarification (Q1 Option D), the doc is **consumer-centric, not competitive**. It focuses on "here's what mikebom makes available and how to use it" rather than "here's what mikebom does that other tools don't". The doc does NOT name specific competing SBOM tools — this sidesteps the verification burden of pinning external tool versions and keeps the doc evergreen against external-tool behavioral drift.

## What's in the doc

- **Opening positioning** — mikebom strictly conforms to CDX 1.6 / SPDX 2.3 / SPDX 3.0.1; `mikebom:*` annotations are parity-bridges per Constitution Principle V (only when no native field carries the signal across the target formats).
- **12 depth-covered signals** across 4 thematic clusters aligned with consumer use cases:
  - **Vulnerability scanning**: `mikebom:lifecycle-scope`, `mikebom:layer-digest`, `mikebom:duplicate-purl-divergent` + `mikebom:purl-collisions-detected`
  - **Compliance auditing**: `mikebom:license-concluded-source`, `mikebom:component-tier` (file value), `mikebom:demoted-from-main-module`
  - **Build provenance**: `mikebom:source-type`, `mikebom:generation-context`, `mikebom:source-document-binding`
  - **Transparency / completeness gaps**: `mikebom:file-inventory-mode`, `mikebom:graph-completeness` + `mikebom:graph-completeness-reason`, `mikebom:peer-edge-targets`
- Each signal renders with: plain-language description, per-format wire location, action-oriented consumer guidance, milestone-introduced citation, link to catalog C-row, and a verified-runnable `jq` recipe with expected output.
- **`mikebom-annotation/v1` envelope** documentation with canonical Rust source references (encoder at `mikebom-cli/src/generate/spdx/annotations.rs:31-67`, decoder at `mikebom-cli/src/parity/extractors/common.rs:185`).
- **Cross-format reading patterns** table showing where the same signal lives in each format, with SPDX 3 subject-routing quirk callout for `mikebom:demoted-from-main-module`.
- **Stability statement** listing every opt-in / experimental flag that affects emission.
- **For tool authors** integration guide with suggested patterns.
- **Cross-references** to 7 existing topical docs.
- **Appendix A**: 98-key alphabetical index covering every `mikebom:*` annotation in the catalog at milestone-150 ship time, each entry linking to its catalog C-row.
- **Appendix B**: 12-signal milestone-citation map mapping each depth-covered signal to the introducing/stabilizing milestone (for consumers correlating binary version → signal availability).

## Mechanical audit results

| SC | Audit | Result |
|---|---|---|
| SC-002 | Appendix coverage (every catalog key appears in appendix) | ✅ **0 diff** — perfect 98-key match |
| SC-003 | `docs/index.md` linkback | ✅ 1 match in Reference material section |
| SC-005 | Cluster count ≥4 | ✅ 4 clusters |
| SC-006 | Depth-covered signal count ≥8 | ✅ 12 signals (50% over floor) |
| SC-008 | Catalog reverse-link count ≥1 | ✅ 121 cross-references |
| SC-004 | ≥5 jq recipes verified runnable at doc-authoring time | ✅ 6/6 pass via `specs/150-sbom-consumer-guide/verify-recipes.sh` |
| SC-007 | Pre-PR gate green | ✅ except documented pre-existing `sbomqs_parity` env failure |
| SC-001 | Operator-cadence 5-question read-through audit | post-merge per spec Assumption 9 |

## Touched files

| File | Status | Lines |
|---|---|---|
| `docs/reference/reading-a-mikebom-sbom.md` | NEW | ~700 |
| `docs/index.md` | 1-line update | +6 |
| `specs/150-sbom-consumer-guide/verify-recipes.sh` | NEW authoring artifact (not shipped to public docs) | ~120 |

Zero changes to `mikebom-cli/`, `mikebom-common/`, `mikebom-ebpf/`, or any other crate source.

## Post-merge follow-up

- **SC-001 read-through audit**: per spec Assumption 9, the doc's quality is fundamentally an operator-cadence read-through assessment. After merge, an operator or external reviewer should sit down with a real mikebom-emitted SBOM + the new doc and answer the 5 SC-001 questions (`mikebom:lifecycle-scope` meaning / finding dev-only deps in SPDX 2.3 / OCI layer attribution / `mikebom:source-type` variants / `mikebom-annotation/v1` envelope shape) without consulting any other doc. Feedback drives future updates.
- **Future annotation additions**: post-150 milestones that add new `mikebom:*` annotations land in the catalog (`sbom-format-mapping.md`) only. The new guide's appendix index is a snapshot at milestone-150 ship time per spec Assumption 4. The catalog remains the canonical source-of-truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)