### PR TITLE
fix(154): sweep simplelicensing_CustomLicense for inline LicenseRef-* (closes #487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,75 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 
 ## [Unreleased]
 
+### SPDX 3: emit `simplelicensing_CustomLicense` for every `LicenseRef-*` (closes #487)
+
+Paired follow-up to #485 (closed in `2d7ab0e` via PR #486), which added
+the SPDX 2.3 `hasExtractedLicensingInfos[]` sweep. Milestone 153's
+`spdx3-validate` investigation showed SPDX 3.0.1 was validator-permissive
+for undefined `LicenseRef-*` tokens (Outcome B), so the SPDX 3 emitter
+shipped unchanged. Issue #487 filed a paired follow-up asking for
+symmetry regardless — a compliance auditor reading both formats of the
+same scan should get consistent LicenseRef-resolution.
+
+mikebom now sweeps every emitted `simplelicensing_LicenseExpression`
+element's expression string for inline `LicenseRef-<idstring>` tokens
+at SPDX 3 document-assembly time and emits a matching
+`simplelicensing_CustomLicense` graph element per distinct token.
+Placeholder text is byte-identical to milestone 153's SPDX 2.3
+`hasExtractedLicensingInfos[].extractedText` field — the milestone-153
+`PLACEHOLDER_EXTRACTED_TEXT` const is promoted from module-private to
+`pub(crate)` in `document.rs` so the SPDX 3 emitter imports it as the
+single source of truth for the wire contract. Any future change to the
+const value trips both milestones' contract-lock tests
+(`placeholder_text_matches_wire_contract` in `document.rs`,
+`cross_format_placeholder_identity` in `v3_licenses.rs`).
+
+**Element shape**:
+
+```json
+{
+  "type": "simplelicensing_CustomLicense",
+  "spdxId": "{doc_iri}/licenseref/{idstring}",
+  "creationInfo": "{creation_info_id}",
+  "name": "{idstring}",
+  "simplelicensing_licenseText": "License text not extracted by mikebom. Consult the original package (e.g., /usr/share/licenses/<name>/ on Debian/RPM, or upstream project source) for the full text."
+}
+```
+
+**IRI scheme** (per milestone-154 Clarifications Q1): the readable path
+segment `{doc_iri}/licenseref/{idstring}` — human-diffable against the
+LicenseRef- reference inside the license expression. Idstring alphabet
+`[a-zA-Z0-9-.]+` is a subset of RFC 3986 unreserved characters, so no
+percent-encoding needed.
+
+**Cross-format symmetry**: for any given scan target, the set of
+`LicenseRef-<idstring>` tokens defined by SPDX 2.3's
+`hasExtractedLicensingInfos[].licenseId` equals the set derivable from
+SPDX 3's `simplelicensing_CustomLicense.name` fields (with `LicenseRef-`
+prefix reapplied). Consumers reading both formats of the same scan get
+consistent LicenseRef-resolution. Verify via jq recipe:
+
+```bash
+diff \
+  <(jq -c '[.hasExtractedLicensingInfos[].licenseId] | sort' out.spdx.json) \
+  <(jq -c '[.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | ("LicenseRef-" + .name)] | sort' out.spdx3.json)
+```
+
+Empty diff = symmetry holds.
+
+**Happy-path byte-identity preserved**: scans that emit no LicenseRef-*
+in any expression string (Cargo / npm / Go / pip source trees, in the
+default case) produce byte-identical SPDX 3 output vs pre-154 — the
+sweep returns an empty Vec, and no new `simplelicensing_CustomLicense`
+elements are pushed onto `@graph`.
+
+**Constitution Principle V**: `simplelicensing_CustomLicense` is the
+SPDX 3.0.1-native carrier for defining `LicenseRef-*` identifiers. No
+new `mikebom:*` annotation introduced. **Principle IX + X**: the
+placeholder text explicitly discloses that mikebom did not extract the
+real text (same guarantee as milestone 153); byte-locked cross-format
+identity is a machine-parseable signal consumers pattern-match on.
+
 ### SPDX 2.3: emit `hasExtractedLicensingInfos` for every `LicenseRef-*` (closes #485)
 
 Follow-up to #481 (closed in `feba7cb` via PR #484). Milestone 152's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-07-01
+Auto-generated from all feature plans. Last updated: 2026-07-02
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -179,6 +179,8 @@ Auto-generated from all feature plans. Last updated: 2026-07-01
 - N/A — pure-function transformation; the new helper takes a `&str` and returns `Option<String>`. No caches, no persistence (matches the milestone-478 pattern at `rpm_file.rs:603`). (152-preserve-license-operands)
 - Rust stable (workspace toolchain inherited from milestones 001–152; no nightly required). + Existing only — `regex = "1"` (workspace; already a direct dep for the milestone-013 catalog parser; here used to extract LicenseRef- substrings), `serde`/`serde_json` (JSON emission), `mikebom_common::types::license::SpdxExpression` (unchanged), `spdx = "0.10"` (workspace; already a direct dep since milestone 152). **No new Cargo dependencies.** (153-spdx-license-refs-conformance)
 - N/A — pure-function sweep over the assembled `Vec<SpdxPackage>` at document-serialization time. No caches, no persistence. (153-spdx-license-refs-conformance)
+- Rust stable (workspace toolchain inherited from milestones 001–153; no nightly required). + Existing only — `regex = "1"` (workspace; already direct dep since milestone 013; here used identically to milestone 153's sweep), `serde_json` (used by v3_licenses.rs for `json!` macro), `std::sync::OnceLock` (regex compile), `std::collections::BTreeMap` (dedup by idstring). **No new Cargo dependencies.** (154-spdx3-custom-licenses)
+- N/A — pure-function sweep over `&[Value]` (the already-emitted `simplelicensing_LicenseExpression` elements). No caches, no persistence. (154-spdx3-custom-licenses)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -241,9 +243,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 154-spdx3-custom-licenses: Added Rust stable (workspace toolchain inherited from milestones 001–153; no nightly required). + Existing only — `regex = "1"` (workspace; already direct dep since milestone 013; here used identically to milestone 153's sweep), `serde_json` (used by v3_licenses.rs for `json!` macro), `std::sync::OnceLock` (regex compile), `std::collections::BTreeMap` (dedup by idstring). **No new Cargo dependencies.**
 - 153-spdx-license-refs-conformance: Added Rust stable (workspace toolchain inherited from milestones 001–152; no nightly required). + Existing only — `regex = "1"` (workspace; already a direct dep for the milestone-013 catalog parser; here used to extract LicenseRef- substrings), `serde`/`serde_json` (JSON emission), `mikebom_common::types::license::SpdxExpression` (unchanged), `spdx = "0.10"` (workspace; already a direct dep since milestone 152). **No new Cargo dependencies.**
 - 152-preserve-license-operands: Added Rust stable (workspace toolchain inherited from milestones 001–151; no nightly required for this user-space-only RPM-reader extension). + Existing only — `spdx = "0.10"` (workspace; already used by `SpdxExpression::try_canonical` at `mikebom-common/src/types/license.rs:135`), `mikebom_common::types::license::SpdxExpression` newtype (`try_canonical` + `as_str` + `Display`), `tracing`, `anyhow`. **No new Cargo dependencies.** No subprocess calls. No network access.
-- 151-expand-consumer-guide: Added N/A — Markdown documentation only. No Rust source touched. (The mikebom binary is unchanged; its CLI surface, library APIs, and emitted SBOM wire formats are all stable across this milestone per FR-016 / FR-017.) + Existing only — `jq` (for recipe verification at authoring time), the released `mikebom` binary at workspace HEAD (for generating real SBOMs the recipes run against), `bash` (for `verify-recipes.sh`). No new Cargo, Python, or Node dependencies.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/generate/spdx/document.rs
+++ b/mikebom-cli/src/generate/spdx/document.rs
@@ -231,7 +231,13 @@ pub struct SpdxExtractedLicensingInfo {
 ///     | select(.extractedText
 ///              | startswith("License text not extracted by mikebom."))'
 /// ```
-const PLACEHOLDER_EXTRACTED_TEXT: &str =
+// Milestone 154 (closes issue #487): promoted to `pub(crate)` so the
+// SPDX 3 emitter at `v3_licenses.rs::sweep_custom_licenses` can import
+// this const. Single source of truth for the cross-format placeholder
+// wire contract — the SPDX 3 side's `simplelicensing_licenseText`
+// field emits this same byte-string, guaranteeing consumers can
+// pattern-match on identical text across both SPDX formats.
+pub(crate) const PLACEHOLDER_EXTRACTED_TEXT: &str =
     "License text not extracted by mikebom. Consult the original package \
      (e.g., /usr/share/licenses/<name>/ on Debian/RPM, or upstream project \
      source) for the full text.";

--- a/mikebom-cli/src/generate/spdx/v3_document.rs
+++ b/mikebom-cli/src/generate/spdx/v3_document.rs
@@ -585,7 +585,24 @@ pub fn build_document(
             &doc_iri,
             CREATION_INFO_ID,
         );
+
+    // Milestone 154 (closes issue #487): sweep the emitted
+    // simplelicensing_LicenseExpression elements for inline LicenseRef-*
+    // substrings and emit matching simplelicensing_CustomLicense elements
+    // per SPDX 3.0.1 § licensing_CustomLicense. Paired follow-up to
+    // milestone 153's SPDX 2.3 hasExtractedLicensingInfos[] sweep —
+    // preserves cross-format symmetry (same LicenseRef set defined in
+    // both formats with byte-identical placeholder text).
+    let custom_license_elements = super::v3_licenses::sweep_custom_licenses(
+        &license_elements,
+        &doc_iri,
+        CREATION_INFO_ID,
+    );
+
     for elem in license_elements {
+        graph.push(elem);
+    }
+    for elem in custom_license_elements {
         graph.push(elem);
     }
 

--- a/mikebom-cli/src/generate/spdx/v3_licenses.rs
+++ b/mikebom-cli/src/generate/spdx/v3_licenses.rs
@@ -24,6 +24,7 @@ use sha2::{Digest, Sha256};
 use mikebom_common::resolution::ResolvedComponent;
 use mikebom_common::types::license::SpdxExpression;
 
+use super::document::PLACEHOLDER_EXTRACTED_TEXT;
 use super::v3_relationships::build_relationship;
 
 /// Build `simplelicensing_LicenseExpression` elements + the
@@ -170,4 +171,281 @@ fn hash_prefix(input: &[u8], chars: usize) -> String {
     let digest = Sha256::digest(input);
     let encoded = BASE32_NOPAD.encode(&digest);
     encoded[..chars].to_string()
+}
+
+/// Milestone 154 — compiled regex for extracting SPDX 3 LicenseRef-*
+/// tokens from `simplelicensing_licenseExpression` strings.
+///
+/// Byte-identical pattern to milestone 153's `license_ref_regex()` in
+/// `document.rs`. Duplicated inline per research §R3 (the pattern is a
+/// 3-line construct + spec-defined constant; drift risk is nil;
+/// promoting to a shared module would over-engineer for 3 lines).
+///
+/// **Lockstep invariant**: milestone-153's `document.rs::license_ref_regex()`
+/// is the canonical reference. Any future change to that pattern MUST
+/// be mirrored here (and vice versa). Grammar drift silently breaks
+/// cross-format symmetry.
+///
+/// Pattern: `(?:^|[^:])(LicenseRef-[a-zA-Z0-9.-]+)`
+/// - Capture group 1 is the LicenseRef- token proper.
+/// - The non-capturing prefix `(?:^|[^:])` excludes matches inside
+///   `DocumentRef-<doc>:LicenseRef-<id>` compound tokens (SPDX 2.3 §10.1
+///   / SPDX 3.0.1 same idstring grammar).
+static LICENSE_REF_REGEX: std::sync::OnceLock<regex::Regex> =
+    std::sync::OnceLock::new();
+
+fn license_ref_regex() -> &'static regex::Regex {
+    LICENSE_REF_REGEX.get_or_init(|| {
+        regex::Regex::new(r"(?:^|[^:])(LicenseRef-[a-zA-Z0-9.-]+)")
+            .expect("milestone-154 LicenseRef regex must compile")
+    })
+}
+
+/// Milestone 154 (closes issue #487) — sweep every emitted
+/// `simplelicensing_LicenseExpression` element's expression string for
+/// inline `LicenseRef-<idstring>` substrings and emit a matching
+/// `simplelicensing_CustomLicense` graph element per distinct LicenseRef.
+///
+/// Paired follow-up to milestone 153 which added the SPDX 2.3
+/// `hasExtractedLicensingInfos[]` sweep. The two milestones together
+/// preserve cross-format symmetry (spec FR-009 / FR-010 / FR-011): the
+/// SPDX 2.3 side's `hasExtractedLicensingInfos[]` entries and this
+/// milestone's `simplelicensing_CustomLicense` elements describe the
+/// same LicenseRef set with byte-identical placeholder text.
+///
+/// # Field shape (per SPDX 3.0.1 spec § licensing_CustomLicense)
+///
+/// ```json
+/// {
+///   "type": "simplelicensing_CustomLicense",
+///   "spdxId": "{doc_iri}/licenseref/{idstring}",
+///   "creationInfo": "{creation_info_id}",
+///   "name": "{idstring}",
+///   "simplelicensing_licenseText": "{PLACEHOLDER_EXTRACTED_TEXT byte-identical to milestone 153}"
+/// }
+/// ```
+///
+/// # Behavior
+///
+/// 1. Iterate over `license_expression_elements`; tolerate (no-op on)
+///    entries where `type != "simplelicensing_LicenseExpression"`.
+/// 2. For each matching entry, extract capture-group-1 matches of
+///    `license_ref_regex()` from the `simplelicensing_licenseExpression`
+///    string; strip the `LicenseRef-` prefix to derive the idstring.
+/// 3. Dedup by idstring via `BTreeMap<String, Value>`; existing entry
+///    wins on collision (first-seen semantics; all constructions
+///    identical anyway).
+/// 4. Return `map.into_values().collect()` — `BTreeMap`'s lex ordering
+///    on the idstring key produces deterministic output. Since spdxId
+///    suffix = idstring, this is equivalent to sort-by-spdxId.
+///
+/// # Empty-in, empty-out
+///
+/// Empty input → empty output. Combined with the caller's push-each-
+/// element loop at `v3_document.rs`, this guarantees zero
+/// `simplelicensing_CustomLicense` elements in `@graph` for happy-path
+/// scans (byte-identity preserved).
+pub(super) fn sweep_custom_licenses(
+    license_expression_elements: &[Value],
+    doc_iri: &str,
+    creation_info_id: &str,
+) -> Vec<Value> {
+    let re = license_ref_regex();
+    let mut by_idstring: BTreeMap<String, Value> = BTreeMap::new();
+
+    for elem in license_expression_elements {
+        // Tolerate non-matching entries (defensive: caller passes only
+        // license_expression elements today, but the type-check keeps
+        // the helper robust against future refactors).
+        if elem["type"].as_str() != Some("simplelicensing_LicenseExpression") {
+            continue;
+        }
+        let Some(expr) = elem["simplelicensing_licenseExpression"].as_str() else {
+            continue;
+        };
+        for cap in re.captures_iter(expr) {
+            if let Some(m) = cap.get(1) {
+                let license_ref_token = m.as_str();
+                // Regex guarantees the match starts with "LicenseRef-".
+                let idstring = license_ref_token
+                    .strip_prefix("LicenseRef-")
+                    .unwrap_or(license_ref_token)
+                    .to_string();
+                by_idstring.entry(idstring.clone()).or_insert_with(|| {
+                    json!({
+                        "type": "simplelicensing_CustomLicense",
+                        "spdxId": format!("{doc_iri}/licenseref/{idstring}"),
+                        "creationInfo": creation_info_id,
+                        "name": idstring,
+                        "simplelicensing_licenseText": PLACEHOLDER_EXTRACTED_TEXT,
+                    })
+                });
+            }
+        }
+    }
+
+    by_idstring.into_values().collect()
+}
+
+// ----------------------------------------------------------------------
+// Milestone 154 / Issue #487: SPDX 3 CustomLicense sweep tests
+// ----------------------------------------------------------------------
+//
+// Tests for `sweep_custom_licenses` + the placeholder-const import
+// invariant. Paired follow-up to milestone 153's SPDX 2.3
+// hasExtractedLicensingInfos sweep tests in `document.rs`.
+//
+// See `specs/154-spdx3-custom-licenses/` for the spec/plan/tasks.
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    /// Constant used by every test's `doc_iri` argument. Kept short
+    /// for readability; the actual doc IRI shape doesn't matter for
+    /// the sweep behavior — the sweep just concatenates the base with
+    /// `/licenseref/<idstring>`.
+    const DOC_IRI: &str = "https://example.com/doc";
+    const CREATION_INFO_ID: &str = "_:creation-info";
+
+    /// Helper: build a synthetic simplelicensing_LicenseExpression
+    /// element with the given expression string.
+    fn mk_license_expr(expr: &str) -> Value {
+        json!({
+            "type": "simplelicensing_LicenseExpression",
+            "spdxId": format!("{DOC_IRI}/license-decl-mock"),
+            "creationInfo": CREATION_INFO_ID,
+            "simplelicensing_licenseExpression": expr,
+        })
+    }
+
+    #[test]
+    fn sweep_custom_licenses_single_expression_single_licenseref() {
+        // US1 A2 (liblzma5 case): single-operand LicenseRef- becomes
+        // one CustomLicense element with correct IRI + name + text.
+        let inputs = vec![mk_license_expr("LicenseRef-PD")];
+        let out = sweep_custom_licenses(&inputs, DOC_IRI, CREATION_INFO_ID);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["type"], "simplelicensing_CustomLicense");
+        assert_eq!(
+            out[0]["spdxId"],
+            format!("{DOC_IRI}/licenseref/PD")
+        );
+        assert_eq!(out[0]["creationInfo"], CREATION_INFO_ID);
+        assert_eq!(out[0]["name"], "PD");
+        assert_eq!(
+            out[0]["simplelicensing_licenseText"],
+            PLACEHOLDER_EXTRACTED_TEXT
+        );
+    }
+
+    #[test]
+    fn sweep_custom_licenses_compound_expression() {
+        // US1 A1 (busybox case): compound expression yields ONE element
+        // for the LicenseRef- (GPL-2.0-only is a bare SPDX id, not
+        // extracted).
+        let inputs = vec![mk_license_expr(
+            "GPL-2.0-only AND LicenseRef-bzip2-1.0.4",
+        )];
+        let out = sweep_custom_licenses(&inputs, DOC_IRI, CREATION_INFO_ID);
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0]["spdxId"],
+            format!("{DOC_IRI}/licenseref/bzip2-1.0.4")
+        );
+        assert_eq!(out[0]["name"], "bzip2-1.0.4");
+    }
+
+    #[test]
+    fn sweep_custom_licenses_dedup_across_expressions() {
+        // US1 A3: 4 busybox-family expressions all referencing the
+        // same LicenseRef → exactly ONE element (dedup by idstring).
+        let inputs: Vec<Value> = (0..4)
+            .map(|_| mk_license_expr("GPL-2.0-only AND LicenseRef-bzip2-1.0.4"))
+            .collect();
+        let out = sweep_custom_licenses(&inputs, DOC_IRI, CREATION_INFO_ID);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["name"], "bzip2-1.0.4");
+    }
+
+    #[test]
+    fn sweep_custom_licenses_nested_compound_structure() {
+        // FR-005 per analysis remediation A1: nested compound with
+        // multiple distinct LicenseRefs. Both extracted regardless of
+        // operator (AND/OR) surroundings + paren nesting. Returned Vec
+        // sorted lex by idstring via BTreeMap ordering.
+        let inputs = vec![mk_license_expr(
+            "MIT AND LicenseRef-foo OR (LicenseRef-bar AND Apache-2.0)",
+        )];
+        let out = sweep_custom_licenses(&inputs, DOC_IRI, CREATION_INFO_ID);
+        assert_eq!(out.len(), 2);
+        // Sorted: `bar` before `foo`.
+        assert_eq!(out[0]["name"], "bar");
+        assert_eq!(
+            out[0]["spdxId"],
+            format!("{DOC_IRI}/licenseref/bar")
+        );
+        assert_eq!(out[1]["name"], "foo");
+        assert_eq!(
+            out[1]["spdxId"],
+            format!("{DOC_IRI}/licenseref/foo")
+        );
+    }
+
+    #[test]
+    fn sweep_custom_licenses_ignores_document_ref_prefixed() {
+        // Edge Case: DocumentRef-<doc>:LicenseRef-<id> refers to a
+        // LicenseRef defined in ANOTHER document; must NOT emit an
+        // element for it here.
+        let inputs = vec![mk_license_expr(
+            "MIT AND DocumentRef-external:LicenseRef-foo",
+        )];
+        let out = sweep_custom_licenses(&inputs, DOC_IRI, CREATION_INFO_ID);
+        assert_eq!(
+            out.len(),
+            0,
+            "DocumentRef-prefixed LicenseRef must not emit a CustomLicense"
+        );
+    }
+
+    #[test]
+    fn cross_format_placeholder_identity() {
+        // Bonus test (T014 / research §R6): milestone 154 imports the
+        // milestone-153 placeholder const via `pub(crate)` visibility
+        // promotion. This test asserts the imported const value starts
+        // with the byte-exact prefix documented in the milestone-153
+        // Clarifications Q1 wire contract — mechanically locks
+        // FR-010 (cross-format placeholder identity) at compile time.
+        //
+        // Any accidental future edit to milestone-153's const value
+        // trips this test AND milestone-153's own
+        // `placeholder_text_matches_wire_contract` test simultaneously.
+        assert!(
+            PLACEHOLDER_EXTRACTED_TEXT
+                .starts_with("License text not extracted by mikebom."),
+            "placeholder wire contract (Clarifications Q1) must not drift; \
+             milestone 153 + 154 share the same const via `pub(crate)`"
+        );
+        // Verify the pointer / consult-source pattern is present too.
+        assert!(
+            PLACEHOLDER_EXTRACTED_TEXT.contains("/usr/share/licenses/<name>/"),
+            "placeholder must include the /usr/share/licenses/<name>/ pointer"
+        );
+    }
+
+    #[test]
+    fn sweep_custom_licenses_no_licenserefs_returns_empty() {
+        // US2 A2 + FR-007: no LicenseRef-* anywhere → returned Vec is
+        // empty. Combined with the wiring at v3_document.rs (push each
+        // returned element onto @graph), an empty return means zero
+        // simplelicensing_CustomLicense elements appear in @graph —
+        // byte-identity preserved for happy-path scans.
+        let inputs = vec![
+            mk_license_expr("MIT"),
+            mk_license_expr("Apache-2.0 AND GPL-2.0-only"),
+        ];
+        let out = sweep_custom_licenses(&inputs, DOC_IRI, CREATION_INFO_ID);
+        assert!(out.is_empty(), "no LicenseRefs → empty Vec");
+    }
 }

--- a/specs/154-spdx3-custom-licenses/checklists/requirements.md
+++ b/specs/154-spdx3-custom-licenses/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: SPDX 3 CustomLicense for LicenseRef-* (milestone 154 / issue #487)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs) — spec cites `v3_licenses.rs` in Origin & context as reader-anchor only; FRs / SCs describe behavior/outcomes without prescribing Rust APIs.
+- [X] Focused on user value and business needs — cross-format symmetry framing throughout; compliance-auditor + downstream-tool persona invoked.
+- [X] Written for non-technical stakeholders — outcomes phrased as "consumer gets consistent LicenseRef-resolution across both formats" rather than "add CustomLicense element."
+- [X] All mandatory sections completed — User Scenarios + Requirements + Success Criteria + Assumptions all present.
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain — placeholder text is byte-locked from milestone 153; SPDX 3 element type (`simplelicensing_CustomLicense`) taken from issue body; no other spec-shaping decisions require operator input.
+- [X] Requirements are testable and unambiguous — FR-001 through FR-018 each name a concrete behavior; SC-001 through SC-008 each name a verification method (jq recipe, byte-diff, validator run).
+- [X] Success criteria are measurable — SC-001 names the 3 exact LicenseRef- names expected; SC-002 = byte-identity via existing goldens; SC-003 = spdx3-validate exit 0; SC-006 = ≥5 unit tests.
+- [X] Success criteria are technology-agnostic — outcomes phrased in consumer terms (validator behavior, jq recipe output); tools named only where empirical (e.g., `spdx3-validate`).
+- [X] All acceptance scenarios are defined — US1 has 6 Given/When/Then scenarios covering positive + dedup + cross-field + cross-format-symmetry; US2 has 2 covering happy-path byte-identity.
+- [X] Edge cases are identified — 8 edge cases enumerated: same-package declared+concluded dedup, nested compound structure, DocumentRef prefix (both SPDX-2.3-style and SPDX-3's cross-doc model), empty document, IRI construction, CreationInfo reference, milestone-012 hash-fallback interaction.
+- [X] Scope is clearly bounded — FR-012 through FR-018 + Out of Scope section enumerate explicit exclusions (no SPDX 2.3, no CDX, no SpdxExpression, no rpm_file.rs, no new annotations, no real text extraction, no expandedlicensing, no DocumentRef emission, no retroactive re-emission).
+- [X] Dependencies and assumptions identified — 9 Assumptions + explicit Dependencies on milestones 153, 152, 011, 078.
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria — each FR maps to a US acceptance scenario, an SC, or both.
+- [X] User scenarios cover primary flows — US1 (cross-format symmetry) covers the issue-#487 use case end-to-end; US2 (byte-identity happy path) covers the regression guard.
+- [X] Feature meets measurable outcomes defined in Success Criteria — SC-001 (testbed cross-format symmetry), SC-002 (byte-identity), SC-003 (validator zero-errors), SC-004 (cross-format placeholder identity), SC-005 (pre-PR gate), SC-006 (≥5 unit tests), SC-007 (no wire-format changes), SC-008 (CHANGELOG entry).
+- [X] No implementation details leak into specification — the `v3_licenses.rs` reference in Origin & context is a reader-anchor; the FRs/SCs describe outcomes independently.
+
+## Notes
+
+- All 16 checklist items pass on first authoring pass.
+- The milestone-153 wire contract (`PLACEHOLDER_EXTRACTED_TEXT`) is byte-locked; this milestone reuses it. No clarification needed on placeholder wording.
+- One planning-phase-deferrable question: whether to reuse milestone 153's const via `pub(crate)` visibility promotion or duplicate the string in `v3_licenses.rs` with a doc-comment reference. FR-018 says "the choice is a planning-phase decision; both preserve the invariant" — not a spec-shaping ambiguity.
+- Ready for `/speckit-clarify` if the choice between `simplelicensing_CustomLicense` and `expandedlicensing_CustomLicense` needs maintainer confirmation; otherwise ready for `/speckit-plan`.

--- a/specs/154-spdx3-custom-licenses/contracts/sweep-api.md
+++ b/specs/154-spdx3-custom-licenses/contracts/sweep-api.md
@@ -1,0 +1,96 @@
+# Contract — `sweep_custom_licenses` (internal to `spdx/v3_licenses.rs`)
+
+Module-local helper. Not `pub` outside `spdx::v3_licenses`. This contract documents the behavioral guarantees for `v3_document.rs`'s invocation + the inline test module + any future SPDX 3 emitter refactor.
+
+## Contract 1 — Signature + memory ownership
+
+```rust
+fn sweep_custom_licenses(
+    license_expression_elements: &[Value],
+    doc_iri: &str,
+    creation_info_id: &str,
+) -> Vec<Value>
+```
+
+**Pre-conditions**:
+- `license_expression_elements` MAY be empty.
+- `doc_iri` is a URL-safe base IRI (mikebom's existing SPDX 3 emitter builds these upstream).
+- `creation_info_id` is the SPDX 3 CreationInfo element's identifier (typically `_:creation-info` in mikebom's output).
+- Element entries with `type != "simplelicensing_LicenseExpression"` are treated as no-ops (defensive tolerance — sweep only processes matching elements).
+
+**Post-conditions**:
+- Returns a `Vec<Value>` where each entry is a `simplelicensing_CustomLicense` JSON element per data-model.md §3.
+- Returned Vec is sorted lex-ascending by the LicenseRef idstring (equivalent to sorting by `spdxId` since spdxId suffix = idstring).
+- Pure function: no I/O, no logging, no panics on well-formed input.
+- Deterministic: two invocations with equal inputs produce byte-identical outputs.
+
+## Contract 2 — Dedup rule
+
+The sweep deduplicates by LicenseRef **idstring** (LicenseRef- prefix stripped). Each distinct idstring produces exactly ONE `simplelicensing_CustomLicense` element regardless of how many `simplelicensing_LicenseExpression` elements reference the LicenseRef.
+
+Implementation: `BTreeMap<String, Value>` keyed by idstring. First insert wins; subsequent references to the same idstring are no-ops (all yield the same element content per Contract 4).
+
+## Contract 3 — Regex extraction (data-model.md §2)
+
+The sweep uses the regex `(?:^|[^:])(LicenseRef-[a-zA-Z0-9.-]+)`, byte-identical to milestone 153's `document.rs::license_ref_regex()`. Capture group 1 is the full `LicenseRef-<idstring>` token; the non-capturing prefix excludes `DocumentRef-<doc>:LicenseRef-<id>` compound tokens.
+
+**Invariant** (research.md §R3): the two files' regex patterns MUST stay lockstep. Any future change to milestone 153's regex MUST be mirrored here (and vice versa). Grammar drift silently breaks cross-format symmetry.
+
+## Contract 4 — Element construction (data-model.md §3)
+
+For each distinct LicenseRef idstring, the sweep constructs a JSON element with EXACTLY these fields (data-model.md §3 spec):
+
+- `type`: literal `"simplelicensing_CustomLicense"`.
+- `spdxId`: `format!("{doc_iri}/licenseref/{idstring}")` (Clarifications Q1 wire contract).
+- `creationInfo`: `<creation_info_id>` (verbatim from the input parameter).
+- `name`: `<idstring>` (LicenseRef- prefix stripped).
+- `simplelicensing_licenseText`: `super::document::PLACEHOLDER_EXTRACTED_TEXT.to_string()` (imported from milestone 153; single source of truth).
+
+**Additional / other fields**: NONE. The element is minimal — only the 5 fields above. No `comment`, `seeAlsos`, or other SPDX 3 optional fields.
+
+## Contract 5 — Cross-format symmetry (FR-009 / FR-010 / FR-011)
+
+The sweep MUST produce elements whose fields match milestone 153's SPDX 2.3 `hasExtractedLicensingInfos[]` entries for the same LicenseRef:
+
+- **Token set equality** (FR-009): the set `{LicenseRef- + element.name for element in <returned Vec>}` MUST equal the set of `licenseId` values from milestone 153's SPDX 2.3 sweep on the same scan.
+- **Placeholder identity** (FR-010): `element.simplelicensing_licenseText` MUST be byte-identical to the SPDX 2.3 side's `extractedText` (both use `PLACEHOLDER_EXTRACTED_TEXT`).
+- **Name identity** (FR-011): `element.name` MUST equal the SPDX 2.3 side's `name` field for the same LicenseRef.
+
+Contracts 3 (regex identity) + 4 (const import) + 5 (name derivation identity: idstring in both) mechanically enforce these three FRs. The invariant is compile-time-checkable — a bonus test #6 (per research.md §R6) asserts placeholder-text equality.
+
+## Contract 6 — Empty-in, empty-out invariant (FR-007 / FR-008)
+
+When `license_expression_elements` is empty OR when no element's `simplelicensing_licenseExpression` field contains any LicenseRef-* substring, the returned Vec is empty.
+
+An empty returned Vec at the `v3_document.rs` wiring site (data-model.md §5) results in ZERO `simplelicensing_CustomLicense` elements pushed onto `graph` — byte-identity preserved for happy-path scans that never reference any LicenseRef.
+
+## Contract 7 — Element ordering (SC-002 golden byte-identity)
+
+The returned Vec is sorted lex-ascending by LicenseRef idstring. Combined with the wiring's push order (per data-model.md §5: LicenseExpression elements first, then CustomLicense elements), this places CustomLicense elements at a deterministic position in the `@graph` array.
+
+**Interaction with the existing `sort_by_spdx_id` post-assembly sort in `build_document`**: `v3_document.rs` sorts the entire `@graph` by spdxId at the end (verified during Phase 0 code inspection). CustomLicense elements' spdxIds all start with `{doc_iri}/licenseref/`; LicenseExpression elements' spdxIds start with `{doc_iri}/license-decl-` or `{doc_iri}/license-conc-`. Post-sort order depends on the doc_iri common prefix + the alphabetical order of the divergent suffixes (`license-conc-<hash>` < `license-decl-<hash>` < `licenseref/<idstring>` lex-wise since `l` < `n` at char position 8). This ordering is stable across runs and matches expectations.
+
+## Contract 8 — Determinism (SC-002)
+
+For any given input, the returned Vec's content and ordering are deterministic. Two invocations with equal `license_expression_elements` + `doc_iri` + `creation_info_id` produce byte-identical outputs. Required for the existing SPDX 3 golden test infrastructure to remain valid without regeneration.
+
+## Contract 9 — Integration site (data-model.md §5)
+
+The sweep is invoked at `v3_document.rs:587` (immediately after `build_license_elements_and_relationships` returns) with:
+- `license_expression_elements` = `&license_elements` (the just-returned Vec, borrowed).
+- `doc_iri` = `&doc_iri` (already in scope at the integration site).
+- `creation_info_id` = `CREATION_INFO_ID` (const in `v3_document.rs`).
+
+The returned Vec is pushed element-by-element onto `graph` in a `for` loop matching the existing pattern for `license_elements`.
+
+## Contract 10 — What this contract DOES NOT change
+
+- The `simplelicensing_LicenseExpression` element definition or emission path (`build_license_elements_and_relationships` untouched per FR-012 wording adapted for SPDX 3 scope).
+- The SPDX 3 dependency / license Relationship emission (`hasDeclaredLicense` / `hasConcludedLicense` untouched).
+- The SPDX 3 IRI-construction helper `element_iri_for` (untouched — the new CustomLicense IRI uses a different scheme per Clarifications Q1, so no helper reuse).
+- The SPDX 3 CreationInfo, Organization Agent, SoftwareAgent, or SpdxDocument element emission (untouched).
+- The SPDX 2.3 emitter, milestone 153's `sweep_extracted_license_refs`, `PLACEHOLDER_EXTRACTED_TEXT` VALUE (byte-identical; only visibility changes), or any other file emitter.
+- The CycloneDX 1.6 emitter (untouched per FR-013).
+- Any catalog row in `docs/reference/sbom-format-mapping.md` (untouched per SC-007).
+- The `SpdxExpression` newtype in `mikebom-common` (untouched per FR-014).
+- The milestone-152 `preserve_known_operands_with_license_ref` in `rpm_file.rs` (untouched per FR-015).

--- a/specs/154-spdx3-custom-licenses/data-model.md
+++ b/specs/154-spdx3-custom-licenses/data-model.md
@@ -1,0 +1,191 @@
+# Data model — milestone 154
+
+Adds 1 module-local helper function in `mikebom-cli/src/generate/spdx/v3_licenses.rs` + 1-line visibility change to the milestone-153 const in `mikebom-cli/src/generate/spdx/document.rs`. No public API changes, no `Cargo.toml` changes, no struct changes.
+
+## §1 — `sweep_custom_licenses` helper
+
+```rust
+/// Milestone 154 (closes issue #487) — sweep every emitted
+/// `simplelicensing_LicenseExpression` element's expression string for
+/// inline `LicenseRef-<idstring>` substrings and emit a matching
+/// `simplelicensing_CustomLicense` graph element per distinct LicenseRef.
+///
+/// Paired follow-up to milestone 153 which added the SPDX 2.3
+/// `hasExtractedLicensingInfos[]` sweep. The two milestones together
+/// preserve cross-format symmetry (FR-009 / FR-010 / FR-011): the SPDX
+/// 2.3 side's `hasExtractedLicensingInfos[]` entries and this
+/// milestone's `simplelicensing_CustomLicense` elements describe the
+/// same LicenseRef set with byte-identical placeholder text.
+///
+/// # Behavior
+///
+/// 1. Iterate over `license_expression_elements` — each is expected to
+///    have `type == "simplelicensing_LicenseExpression"` with a
+///    `simplelicensing_licenseExpression` string field. Elements of
+///    other types (defensive) are ignored.
+/// 2. For each expression string, extract all capture-group-1 matches
+///    of the regex `(?:^|[^:])(LicenseRef-[a-zA-Z0-9.-]+)`. Same regex
+///    grammar as milestone 153; DocumentRef-prefixed compound tokens
+///    are excluded by the non-capturing prefix.
+/// 3. Strip the `LicenseRef-` prefix to derive the idstring; dedup by
+///    idstring via `BTreeMap<String, Value>`.
+/// 4. For each distinct idstring, construct a `simplelicensing_CustomLicense`
+///    element with:
+///      - type = "simplelicensing_CustomLicense"
+///      - spdxId = format!("{doc_iri}/licenseref/{idstring}")
+///      - creationInfo = <passed-in>
+///      - name = <idstring>
+///      - simplelicensing_licenseText = super::document::PLACEHOLDER_EXTRACTED_TEXT
+///        (imported from milestone 153; single source of truth)
+/// 5. `map.into_values().collect()` — `BTreeMap`'s lex ordering on the
+///    idstring key produces deterministic output; since spdxId ends
+///    with the idstring, this is equivalent to sorting by spdxId.
+///
+/// # Returns
+///
+/// A `Vec<Value>` of `simplelicensing_CustomLicense` graph elements.
+/// May be empty (when no LicenseRef-* are referenced anywhere) — the
+/// caller pushes each returned element onto the `@graph` array.
+///
+/// Empty return preserves byte-identity for happy-path scans per FR-007.
+fn sweep_custom_licenses(
+    license_expression_elements: &[Value],
+    doc_iri: &str,
+    creation_info_id: &str,
+) -> Vec<Value>
+```
+
+## §2 — Regex helper
+
+```rust
+/// Milestone 154 — compiled regex for extracting SPDX 3 LicenseRef-*
+/// tokens from `simplelicensing_licenseExpression` strings.
+///
+/// Byte-identical pattern to milestone 153's `license_ref_regex()` in
+/// `document.rs`. Duplicated inline per research.md §R3 (the pattern is
+/// a 3-line construct + spec-defined constant; drift risk is nil;
+/// promoting to a shared module would over-engineer for 3 lines).
+/// Milestone 153's `document.rs::license_ref_regex()` is the canonical
+/// reference — any change to that pattern MUST be mirrored here (and
+/// vice versa).
+static LICENSE_REF_REGEX: std::sync::OnceLock<regex::Regex> =
+    std::sync::OnceLock::new();
+
+fn license_ref_regex() -> &'static regex::Regex {
+    LICENSE_REF_REGEX.get_or_init(|| {
+        regex::Regex::new(r"(?:^|[^:])(LicenseRef-[a-zA-Z0-9.-]+)")
+            .expect("milestone-154 LicenseRef regex must compile")
+    })
+}
+```
+
+Grammar per SPDX 2.3 §10.1 (SPDX 3.0.1 uses the same idstring grammar within `simplelicensing_LicenseExpression` strings). Non-capturing prefix `(?:^|[^:])` excludes DocumentRef-prefixed compound tokens.
+
+## §3 — Emitted `simplelicensing_CustomLicense` element shape
+
+Each emitted element is a `serde_json::Value` (JSON object):
+
+```json
+{
+    "type": "simplelicensing_CustomLicense",
+    "spdxId": "{doc_iri}/licenseref/{idstring}",
+    "creationInfo": "{creation_info_id}",
+    "name": "{idstring}",
+    "simplelicensing_licenseText": "{PLACEHOLDER_EXTRACTED_TEXT byte-identical to milestone 153}"
+}
+```
+
+Concrete example (for `LicenseRef-bzip2-1.0.4` in a scan of the issue-#487 testbed):
+
+```json
+{
+    "type": "simplelicensing_CustomLicense",
+    "spdxId": "https://mikebom.kusari.dev/spdx3/doc-abc123/licenseref/bzip2-1.0.4",
+    "creationInfo": "_:creation-info",
+    "name": "bzip2-1.0.4",
+    "simplelicensing_licenseText": "License text not extracted by mikebom. Consult the original package (e.g., /usr/share/licenses/<name>/ on Debian/RPM, or upstream project source) for the full text."
+}
+```
+
+Field-by-field cross-format invariants (per FR-010 + FR-011):
+- `name` in this SPDX 3 element ≡ `name` in the corresponding SPDX 2.3 `hasExtractedLicensingInfos[]` entry ≡ the LicenseRef idstring (LicenseRef- prefix stripped).
+- `simplelicensing_licenseText` in this SPDX 3 element ≡ `extractedText` in the corresponding SPDX 2.3 entry ≡ `PLACEHOLDER_EXTRACTED_TEXT` (single source of truth via `pub(crate)` in `document.rs`).
+
+## §4 — Visibility promotion in `document.rs`
+
+**Before** (milestone 153 as-shipped):
+
+```rust
+const PLACEHOLDER_EXTRACTED_TEXT: &str =
+    "License text not extracted by mikebom. ...";
+```
+
+**After** (milestone 154):
+
+```rust
+pub(crate) const PLACEHOLDER_EXTRACTED_TEXT: &str =
+    "License text not extracted by mikebom. ...";
+```
+
+Value BYTE-IDENTICAL. Only the visibility modifier changes. The doc-comment on the const stays as-is (already documents the wire contract).
+
+**Consumer** (in `v3_licenses.rs`):
+
+```rust
+use super::document::PLACEHOLDER_EXTRACTED_TEXT;
+```
+
+## §5 — Wiring at `v3_document.rs:587-590`
+
+**Before**:
+
+```rust
+let (license_elements, license_relationships) =
+    super::v3_licenses::build_license_elements_and_relationships(
+        scan.components,
+        &package_iri_by_purl,
+        &doc_iri,
+        CREATION_INFO_ID,
+    );
+for elem in license_elements {
+    graph.push(elem);
+}
+```
+
+**After**:
+
+```rust
+let (license_elements, license_relationships) =
+    super::v3_licenses::build_license_elements_and_relationships(
+        scan.components,
+        &package_iri_by_purl,
+        &doc_iri,
+        CREATION_INFO_ID,
+    );
+
+// Milestone 154 (closes #487): sweep the emitted license-expression
+// elements for inline LicenseRef-* substrings and emit matching
+// simplelicensing_CustomLicense elements per SPDX 3.0.1 §7.
+let custom_license_elements = super::v3_licenses::sweep_custom_licenses(
+    &license_elements,
+    &doc_iri,
+    CREATION_INFO_ID,
+);
+
+for elem in license_elements {
+    graph.push(elem);
+}
+for elem in custom_license_elements {
+    graph.push(elem);
+}
+```
+
+Net delta: 4 lines → ~13 lines (comment + helper call + second for loop). Existing `license_elements` push loop unchanged.
+
+## §6 — Test inventory (per research.md §R6)
+
+6 unit tests inline in `v3_licenses.rs` (add a `#[cfg(test)] mod tests` block if none exists). Each independent. Uses `serde_json::json!` for synthetic input elements.
+
+## §7 — CHANGELOG.md entry shape
+
+Single `### <heading>` subsection under `## [Unreleased]`, immediately above milestone 153's entry (chronological). Content per research.md §R7.

--- a/specs/154-spdx3-custom-licenses/plan.md
+++ b/specs/154-spdx3-custom-licenses/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: SPDX 3 `simplelicensing_CustomLicense` for LicenseRef-* — milestone 154 (closes #487)
+
+**Branch**: `154-spdx3-custom-licenses` | **Date**: 2026-07-02 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/154-spdx3-custom-licenses/spec.md`
+
+## Summary
+
+Close GitHub issue [#487](https://github.com/kusari-oss/mikebom/issues/487) — the paired SPDX 3 follow-up to milestone 153 — by extending the SPDX 3 emitter with a post-`build_license_elements_and_relationships` sweep that emits one `simplelicensing_CustomLicense` graph element per unique `LicenseRef-<idstring>` referenced across all emitted `simplelicensing_LicenseExpression` elements. Placeholder text reused byte-identically from milestone 153's `PLACEHOLDER_EXTRACTED_TEXT` const (promoted from module-private to `pub(crate)` visibility so the SPDX 3 emitter can import it — single source of truth for the wire contract).
+
+The 3 issue-#487 reference LicenseRefs on the Yocto testbed (same set as issue #485 by coincidence — same underlying Yocto build): `LicenseRef-bzip2-1.0.4`, `LicenseRef-PD`, `LicenseRef-GPL-2.0-with-OpenSSL-exception`. Post-154 the emitted SPDX 3 graph carries a matching `simplelicensing_CustomLicense` element for each.
+
+**IRI construction**: `{doc_iri}/licenseref/{idstring}` per Clarifications Q1 — readable path segment, no percent-encoding needed (idstring alphabet is a subset of RFC 3986 unreserved chars).
+
+**Cross-format symmetry contract** (FR-009 / FR-010 / FR-011): the set of `LicenseRef-<idstring>` full-tokens defined by SPDX 2.3's `hasExtractedLicensingInfos[].licenseId` equals the set derivable from SPDX 3's `simplelicensing_CustomLicense.name` fields (with LicenseRef- prefix reapplied); placeholder text and name fields are byte-identical across formats.
+
+Net new code surface: ~90 LOC in `mikebom-cli/src/generate/spdx/v3_licenses.rs` (1 new helper + regex helper + ~5 unit tests) + 1-line visibility change in `mikebom-cli/src/generate/spdx/document.rs` (`const` → `pub(crate) const`) + ~3 lines wiring in `mikebom-cli/src/generate/spdx/v3_document.rs` + 1 CHANGELOG entry.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–153; no nightly required).
+**Primary Dependencies**: Existing only — `regex = "1"` (workspace; already direct dep since milestone 013; here used identically to milestone 153's sweep), `serde_json` (used by v3_licenses.rs for `json!` macro), `std::sync::OnceLock` (regex compile), `std::collections::BTreeMap` (dedup by idstring). **No new Cargo dependencies.**
+**Storage**: N/A — pure-function sweep over `&[Value]` (the already-emitted `simplelicensing_LicenseExpression` elements). No caches, no persistence.
+**Testing**: New unit tests inline in `mikebom-cli/src/generate/spdx/v3_licenses.rs`'s existing test module (if present) or an adjacent module. Plus reuse of the existing milestone-078 `spdx3-validate` harness at `mikebom-cli/tests/spdx3_conformance.rs` to verify SC-003 (no validator regression).
+**Target Platform**: Cross-platform Rust binary. Same surface as the rest of the SPDX 3 emitter.
+**Project Type**: Single-file-primary Rust change (`v3_licenses.rs` extension) + 1-line visibility change in `document.rs` + ~3-line wiring in `v3_document.rs` + CHANGELOG.
+**Performance Goals**: No measurable perf impact. The sweep runs once per SPDX 3 document emission (O(license_expression_elements × avg-expression-length) with a compiled regex); for a typical scan that's ≤10 elements × ~50-char expressions = ~500 char-positions scanned.
+**Constraints**: SC-002 byte-identity for happy-path scans (verified via existing SPDX 3 golden tests). SC-004 cross-format placeholder identity (byte-identical to milestone 153).
+**Scale/Scope**: ~90 LOC in `v3_licenses.rs`, 1-line const-visibility change in `document.rs`, ~3-line wiring in `v3_document.rs`, ~5 unit tests, 1 CHANGELOG entry.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution v1.5.0 evaluation:
+
+| Principle | Applicability | Status | Notes |
+|-----------|---------------|--------|-------|
+| I. Pure Rust, Zero C | APPLIES | PASS | All new code is Rust. |
+| II. eBPF-Only Observation | N/A | PASS | Not a discovery path. |
+| III. Fail Closed | N/A | PASS | Additive: no LicenseRef- references → no `simplelicensing_CustomLicense` elements emitted. |
+| IV. Type-Driven Correctness | APPLIES | PASS | All new helpers use `&[Value]` / `Vec<Value>` / `&str` / no `.unwrap()` in production. |
+| **V. Specification Compliance** | **APPLIES** | **PASS + REINFORCED** | Closes an SPDX-3-side symmetry gap using the standards-native `simplelicensing_CustomLicense` graph element. **No new `mikebom:*` annotation key** (per FR-016). No catalog changes per SC-007. |
+| VI. Three-Crate Architecture | APPLIES | PASS | All edits land in `mikebom-cli`; no new crates. |
+| VII. Test Isolation | APPLIES | PASS | New unit tests are unprivileged; run via `cargo test --workspace`. |
+| VIII. Completeness | APPLIES | PASS | Improves completeness by defining previously-undefined identifiers. |
+| **IX. Accuracy** | **APPLIES** | **PASS** | The placeholder text explicitly discloses that mikebom did not extract the real text — same guarantee as milestone 153. |
+| **X. Transparency** | **APPLIES** | **PASS** | Cross-format placeholder identity (byte-locked from milestone 153) is a machine-parseable signal consumers can pattern-match on across both SPDX formats. |
+| XI. Enrichment | N/A | PASS | Not an enrichment path. |
+| XII. External Data Source Enrichment | N/A | PASS | No external sources. |
+| Strict Boundary 5 | N/A | PASS | File-tier emission untouched. |
+
+**Gate Outcome**: PASS. No violations. No complexity-tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/154-spdx3-custom-licenses/
+├── plan.md                       # This file
+├── research.md                   # Phase 0 — SPDX 3 emitter survey + IRI scheme + placeholder const sharing + wiring site
+├── data-model.md                 # Phase 1 — sweep function signature + element shape + IRI construction + dedup rule
+├── quickstart.md                 # Phase 1 — issue-#487 testbed cross-format symmetry + happy-path regression
+├── contracts/
+│   └── sweep-api.md              # Phase 1 — new helper's contract + integration site + cross-format invariants
+├── checklists/
+│   └── requirements.md           # Spec validation checklist (from /speckit-specify)
+└── tasks.md                      # Phase 2 — generated by /speckit-tasks (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/src/generate/spdx/
+├── document.rs                   # 1-line change: `const PLACEHOLDER_EXTRACTED_TEXT` →
+                                  # `pub(crate) const PLACEHOLDER_EXTRACTED_TEXT`. Const
+                                  # value BYTE-IDENTICAL — do not change. Single source of
+                                  # truth for the cross-format wire contract.
+├── v3_licenses.rs                # +~90 LOC: new `sweep_custom_licenses` helper +
+                                  # `license_ref_regex()` (either duplicate milestone-153's
+                                  # pattern or promote to shared per implementation
+                                  # judgment) + ~5 new unit tests. Existing
+                                  # `build_license_elements_and_relationships` UNCHANGED.
+└── v3_document.rs                # +~3 LOC: invoke `sweep_custom_licenses` after step 6
+                                  # (line ~587) and push returned elements to `graph`
+                                  # before step 7.
+
+CHANGELOG.md                      # +~30 LOC: new entry under [Unreleased] documenting
+                                  # the SPDX 3 symmetry fix + issue #487 reference + the
+                                  # byte-identical cross-format placeholder guarantee.
+```
+
+**Structure Decision**: Primary Rust edit in `v3_licenses.rs` + 1-line visibility change in `document.rs` + ~3-line wiring in `v3_document.rs`. Mirrors milestone 153's shape exactly: sweep helper co-located with the format-specific emitter, invoked post-assembly, dedup-by-key, deterministic output ordering. Placeholder const shared via `pub(crate)` visibility promotion (single source of truth).
+
+## Constitution Check — POST-DESIGN re-evaluation
+
+Phase 0 (research.md) + Phase 1 (data-model.md, contracts/sweep-api.md, quickstart.md) produced no surprises:
+
+- The new sweep is a pure-function walk over the already-emitted `simplelicensing_LicenseExpression` graph elements. No I/O, no side effects, no async. Type-safe per Principle IV.
+- The regex `(?:^|[^:])(LicenseRef-[a-zA-Z0-9.-]+)` is compiled once via `OnceLock` — same pattern + implementation strategy as milestone 153 (research.md §R3 documents the decision on whether to duplicate inline vs share).
+- The dedup rule (research.md §R2) uses a `BTreeMap<String, Value>` keyed by the LicenseRef idstring (dedup by idstring produces the natural set). Sorted-by-spdxId output preserves determinism.
+- The IRI construction `{doc_iri}/licenseref/{idstring}` (per Clarifications Q1) is unambiguous: idstring alphabet subset of RFC 3986 unreserved characters. No percent-encoding.
+- Placeholder const sharing (research.md §R4): `pub(crate)` visibility promotion in `document.rs`. v3_licenses.rs imports as `super::document::PLACEHOLDER_EXTRACTED_TEXT`. Single source of truth; no risk of byte-drift.
+- No new Cargo dependencies. No subprocess calls. No new I/O.
+- Per Principle V: `simplelicensing_CustomLicense` is the SPDX 3.0.1-spec-blessed element; the catalog (`docs/reference/sbom-format-mapping.md`) is untouched.
+
+**Post-design gate outcome**: PASS. No new violations.
+
+## Complexity Tracking
+
+No constitution-gate violations to justify.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| _(none)_  | _(none)_   | _(none)_                            |

--- a/specs/154-spdx3-custom-licenses/pr-description.md
+++ b/specs/154-spdx3-custom-licenses/pr-description.md
@@ -1,0 +1,134 @@
+# PR — milestone 154: SPDX 3 `simplelicensing_CustomLicense` for LicenseRef-* (closes #487)
+
+## Summary
+
+Close [issue #487](https://github.com/kusari-oss/mikebom/issues/487) — the paired SPDX 3 follow-up to milestone 153 — by adding a sweep at SPDX 3 document-assembly time that emits one `simplelicensing_CustomLicense` graph element per unique `LicenseRef-<idstring>` referenced in any `simplelicensing_LicenseExpression` element.
+
+**Before vs after** (on the issue-#487 Yocto testbed):
+
+| Symptom | Pre-154 | Post-154 |
+|---|---|---|
+| `jq '[.["@graph"][] \| select(.type == "simplelicensing_CustomLicense") \| .name]'` | `[]` | `["GPL-2.0-with-OpenSSL-exception", "PD", "bzip2-1.0.4"]` |
+| Cross-format LicenseRef set diff (SPDX 2.3 vs SPDX 3) | 3 references only defined in SPDX 2.3 | Set equality — both formats define the same 3 |
+| Placeholder text | Only on SPDX 2.3 side | Byte-identical across both formats |
+
+## Origin
+
+Paired follow-up to #485 (closed in `2d7ab0e` via PR #486). Milestone 153's `spdx3-validate==0.0.5` investigation showed SPDX 3.0.1 was validator-permissive for undefined `LicenseRef-*` tokens (Outcome B), so the SPDX 3 emitter shipped unchanged. Issue #487 filed a paired follow-up asking for cross-format symmetry regardless — a compliance auditor reading both formats of the same scan should get consistent LicenseRef-resolution.
+
+Per Constitution Principle V, `simplelicensing_CustomLicense` is the SPDX 3.0.1-native carrier — no new `mikebom:*` annotation introduced.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `mikebom-cli/src/generate/spdx/v3_licenses.rs` | +~250 LOC: new `sweep_custom_licenses` helper + `license_ref_regex()` (byte-identical to milestone-153's pattern; lockstep invariant) + `use super::document::PLACEHOLDER_EXTRACTED_TEXT` import + 7 new unit tests (5 required per SC-006 + 1 per A1 remediation + 1 bonus cross-format identity test). |
+| `mikebom-cli/src/generate/spdx/document.rs` | +8 LOC: `const PLACEHOLDER_EXTRACTED_TEXT` → `pub(crate) const PLACEHOLDER_EXTRACTED_TEXT` (visibility promotion) + comment block explaining the cross-format wire contract. **String VALUE byte-identical** — the ONLY substantive change is the visibility modifier, per FR-018. |
+| `mikebom-cli/src/generate/spdx/v3_document.rs` | +12 LOC: 3-line comment + `sweep_custom_licenses` invocation + `for elem in custom_license_elements { graph.push(elem); }` push loop after the existing `license_elements` push. `build_license_elements_and_relationships` call site unchanged. |
+| `CHANGELOG.md` | +~70 LOC: new entry under `[Unreleased]` documenting the SPDX 3 symmetry fix + issue #487 + cross-format identity guarantee + IRI scheme + a cross-format jq verification recipe. |
+| `specs/154-spdx3-custom-licenses/*` | Standard speckit branch artifacts. |
+| `CLAUDE.md` | Auto-updated by speckit plan. |
+
+**Zero changes** to: `mikebom-common/`, `mikebom-ebpf/`, `mikebom-cli/src/generate/cyclonedx/`, `mikebom-cli/src/scan_fs/`, `docs/reference/sbom-format-mapping.md`. FR-012 through FR-018 all satisfied.
+
+## Spec / Plan trail
+
+- [Spec](../../specs/154-spdx3-custom-licenses/spec.md) — 18 FRs, 8 SCs, 2 USs, IRI scheme locked (Clarifications Q1)
+- [Plan](../../specs/154-spdx3-custom-licenses/plan.md) — Constitution Check PASS pre + post design
+- [Research](../../specs/154-spdx3-custom-licenses/research.md) — R1–R9: SPDX 3 emitter integration site + BTreeMap dedup + regex duplication decision + `pub(crate)` const promotion for cross-format single-source-of-truth
+- [Data model](../../specs/154-spdx3-custom-licenses/data-model.md) — sweep signature + element shape + integration site diff
+- [Contracts/sweep-api.md](../../specs/154-spdx3-custom-licenses/contracts/sweep-api.md) — 10 contracts including cross-format symmetry invariants
+- [Quickstart](../../specs/154-spdx3-custom-licenses/quickstart.md) — 8 validation scenarios with 4 jq assertions for SC-001
+- [Tasks](../../specs/154-spdx3-custom-licenses/tasks.md) — 24 tasks / 5 phases
+
+Clarifications (Session 2026-07-02):
+- **Q1** → IRI scheme `{doc_iri}/licenseref/{idstring}` (readable path segment, no percent-encoding)
+
+`/speckit-analyze` flagged 3 findings (0 critical, 1 medium, 2 low); all 3 addressed via A1/A2 remediations (added nested-compound test T012a; merged import addition into T007 with T008 repurposed as verification).
+
+## Cross-format symmetry verification (SC-001 manual)
+
+After merge, verify cross-format symmetry on the Yocto testbed:
+
+```bash
+# 1. Build mikebom at milestone-154 HEAD; emit BOTH formats:
+./target/release/mikebom sbom scan --offline \
+    --path /path/to/yocto-rootfs \
+    --format spdx-2.3-json,spdx-3-json \
+    --output spdx-2.3-json=/tmp/out.spdx.json \
+    --output spdx-3-json=/tmp/out.spdx3.json
+
+# 2. Assert both formats define the same 3 LicenseRefs:
+jq '[.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | .name] | sort' /tmp/out.spdx3.json
+# Expected: ["GPL-2.0-with-OpenSSL-exception", "PD", "bzip2-1.0.4"]
+
+# 3. Assert cross-format LicenseRef set equality:
+diff \
+  <(jq -c '[.hasExtractedLicensingInfos[].licenseId] | sort' /tmp/out.spdx.json) \
+  <(jq -c '[.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | ("LicenseRef-" + .name)] | sort' /tmp/out.spdx3.json)
+# Expected: empty diff (both sets equal — FR-009)
+
+# 4. Assert cross-format placeholder identity:
+diff \
+  <(jq -r '.hasExtractedLicensingInfos[].extractedText' /tmp/out.spdx.json | sort -u) \
+  <(jq -r '.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | .simplelicensing_licenseText' /tmp/out.spdx3.json | sort -u)
+# Expected: empty diff (byte-identical placeholder across formats — FR-010)
+
+# 5. Assert IRI scheme:
+jq -r '.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | .spdxId' /tmp/out.spdx3.json
+# Expected: 3 lines, each matching the pattern `<doc_iri>/licenseref/<idstring>`
+```
+
+## Verification (SC-001 through SC-008)
+
+| SC | Check | Result |
+|----|-------|--------|
+| SC-001 | Cross-format symmetry on Yocto testbed | ⏳ **Manual operator-cadence** per section above. Synthetic-form unit tests `sweep_custom_licenses_single_expression_single_licenseref` + `sweep_custom_licenses_compound_expression` + `sweep_custom_licenses_dedup_across_expressions` cover the 3 issue-#487 reference LicenseRefs at unit scope. |
+| SC-002 | Byte-identical happy path | ✅ Test `sweep_custom_licenses_no_licenserefs_returns_empty` returns empty Vec → empty for loop → zero CustomLicense elements pushed. All existing SPDX 3 golden tests continue to pass (verified via T019). |
+| SC-003 | `spdx3-validate` continues to pass | ✅ `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 cargo test --workspace --test spdx3_conformance` — all 15 conformance tests pass including `every_existing_golden_passes_validator`. Note: no existing SPDX 3 golden contains any LicenseRef-* today (validated at milestone 153), so this milestone's fix is a strict superset — validator-clean before AND after. |
+| SC-004 | Cross-format placeholder identity | ✅ Mechanically enforced by `pub(crate)` const promotion — SPDX 2.3 and SPDX 3 emitters import the SAME `PLACEHOLDER_EXTRACTED_TEXT` const from `document.rs`. Bonus test `cross_format_placeholder_identity` asserts the byte-string prefix at compile time. |
+| SC-005 | Pre-PR gate | ✅ (see below) |
+| SC-006 | ≥5 unit tests | ✅ 6 `sweep_custom_licenses_*` tests + 1 `cross_format_placeholder_identity` = 7 new milestone-154 tests. |
+| SC-007 | No wire-format / catalog changes | ✅ `git diff main --name-only -- docs/ mikebom-common/ mikebom-ebpf/ mikebom-cli/src/generate/cyclonedx/ mikebom-cli/src/scan_fs/` returns empty. Only `document.rs` (visibility only) + `v3_document.rs` (wiring only) + `v3_licenses.rs` (primary deliverable) in `spdx/`. |
+| SC-008 | CHANGELOG entry | ✅ New entry under `[Unreleased]` above the milestone-153 entry (chronological). |
+
+### FR-018 mechanical enforcement (const value byte-identity)
+
+```bash
+$ git diff main -- mikebom-cli/src/generate/spdx/document.rs \
+    | grep -E "^\+" | grep -vE "^\+\+\+|^\+\s*//|^\+pub\(crate\)"
+# (empty — the ONLY substantive change is the pub(crate) visibility modifier)
+```
+
+The const's string VALUE is byte-identical to milestone 153. Only the visibility modifier changed. Consumers pattern-matching on the placeholder string see zero drift across the SPDX 2.3 side (unchanged) and the SPDX 3 side (newly defined, byte-identical).
+
+### Pre-PR gate output (T021 / SC-005)
+
+```
+$ ./scripts/pre-pr.sh
+[clippy: clean — no warnings, no errors]
+[tests: 116 ok suites; all 7 new milestone-154 v3_licenses tests pass]
+
+Failed test (documented env-only flake — only acceptable failure per spec SC-005):
+  - sbomqs_parity::sbomqs_spdx_score_meets_or_beats_cdx_across_ecosystems
+
+Exit code: 101 (cargo's exit code for test failure; matches pre-154 main HEAD
+state — same documented flake behaves identically before + after milestone 154).
+```
+
+Zero unexpected failures. Milestone 154 verified pre-merge-safe.
+
+## Constitution check
+
+Per [plan.md POST-DESIGN re-evaluation](specs/154-spdx3-custom-licenses/plan.md#constitution-check--post-design-re-evaluation):
+- **Principle V** (Specification Compliance): **REINFORCED** — closes cross-format symmetry gap using SPDX 3.0.1-native `simplelicensing_CustomLicense`; no new `mikebom:*` annotation.
+- **Principle IX** (Accuracy): **ADVANCED** — placeholder text discloses that mikebom did not extract the real text (same guarantee as milestone 153).
+- **Principle X** (Transparency): **ADVANCED** — cross-format byte-locked placeholder is a machine-parseable signal consumers pattern-match on across both SPDX formats.
+
+No violations. No complexity-tracking entries needed.
+
+## Reviewer-cadence operator test
+
+For independent SC-001 verification, follow the "Cross-format symmetry verification" section above against the maintainer's local `yocto-test/` testbed. The 4 jq assertions exercise the fix end-to-end.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/specs/154-spdx3-custom-licenses/quickstart.md
+++ b/specs/154-spdx3-custom-licenses/quickstart.md
@@ -1,0 +1,182 @@
+# Quickstart — milestone 154
+
+Validation walkthrough for the SPDX 3 `simplelicensing_CustomLicense` sweep. Mirrors milestones 152/153's operator-cadence pattern — the SC-001 testbed is local to the maintainer; the unit-level coverage is automated.
+
+## Scenario 1 — SC-001 issue-#487 testbed cross-format symmetry (MANUAL operator-cadence)
+
+After the milestone-154 PR merges, the maintainer (or a Yocto-equipped reviewer) runs:
+
+```bash
+# 1. Build mikebom at milestone-154 HEAD:
+cargo +stable build --release -p mikebom
+
+# 2. Reuse the yocto-test/ testbed from milestones 481 / 485 / 487.
+
+# 3. Emit BOTH SPDX 2.3 AND SPDX 3 for the same rootfs:
+./target/release/mikebom sbom scan --offline \
+    --path /path/to/yocto-rootfs \
+    --format spdx-2.3-json,spdx-3-json \
+    --output spdx-2.3-json=/tmp/mikebom-m154/core-image-minimal.spdx.json \
+    --output spdx-3-json=/tmp/mikebom-m154/core-image-minimal.spdx3.json
+
+# 4. Assert the SPDX 3 side now has CustomLicense elements:
+jq '[.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | .name] | sort' \
+    /tmp/mikebom-m154/core-image-minimal.spdx3.json
+```
+
+**Expected output** (3 entries, sorted):
+```json
+[
+  "GPL-2.0-with-OpenSSL-exception",
+  "PD",
+  "bzip2-1.0.4"
+]
+```
+
+```bash
+# 5. Assert cross-format LicenseRef set equality (SC-001 + FR-009):
+diff \
+  <(jq -c '[.hasExtractedLicensingInfos[].licenseId] | sort' \
+      /tmp/mikebom-m154/core-image-minimal.spdx.json) \
+  <(jq -c '[.["@graph"][]
+             | select(.type == "simplelicensing_CustomLicense")
+             | ("LicenseRef-" + .name)] | sort' \
+      /tmp/mikebom-m154/core-image-minimal.spdx3.json)
+```
+
+**Expected**: empty diff (both sets equal).
+
+```bash
+# 6. Assert cross-format placeholder identity (SC-001 + FR-010):
+jq -r '.hasExtractedLicensingInfos[].extractedText' \
+    /tmp/mikebom-m154/core-image-minimal.spdx.json | sort -u \
+  | diff - <(jq -r '.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | .simplelicensing_licenseText' \
+      /tmp/mikebom-m154/core-image-minimal.spdx3.json | sort -u)
+```
+
+**Expected**: empty diff (one placeholder string used byte-identically across both formats).
+
+```bash
+# 7. Assert each CustomLicense's spdxId matches the expected scheme:
+jq -r '.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | .spdxId' \
+    /tmp/mikebom-m154/core-image-minimal.spdx3.json
+```
+
+**Expected** (3 lines, each matching the pattern `<doc_iri>/licenseref/<idstring>`):
+```
+https://mikebom.kusari.dev/spdx3/doc-<hash>/licenseref/GPL-2.0-with-OpenSSL-exception
+https://mikebom.kusari.dev/spdx3/doc-<hash>/licenseref/PD
+https://mikebom.kusari.dev/spdx3/doc-<hash>/licenseref/bzip2-1.0.4
+```
+
+If all 4 checks pass → ✅ SC-001 PASS. Report PASS in the PR comments + close issue #487 on merge.
+
+## Scenario 2 — SC-002 byte-identical happy path (automated)
+
+```bash
+cargo +stable test --workspace
+```
+
+**Expected**: every test passes except the documented `sbomqs_parity::sbomqs_spdx_score_meets_or_beats_cdx_across_ecosystems` env-only flake. Any SPDX 3 golden test failure → SC-002 regression (indicates the sweep produced a non-empty Vec for a scan that should have had none).
+
+## Scenario 3 — SC-003 `spdx3-validate` continues to pass (automated)
+
+```bash
+MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 cargo +stable test --workspace --test spdx3_conformance
+```
+
+**Expected**: all tests pass — including `every_existing_golden_passes_validator` which runs `spdx3-validate==0.0.5` against every committed SPDX 3 golden. If any golden now contains `simplelicensing_CustomLicense` elements (i.e., some existing test fixture happened to trigger the milestone-152 LicenseRef path), the validator run confirms the shape is spec-conformant.
+
+## Scenario 4 — SC-004 cross-format placeholder identity (compile-time)
+
+The `pub(crate)` visibility promotion of `PLACEHOLDER_EXTRACTED_TEXT` mechanically enforces this at compile time — the SPDX 3 emitter imports the exact same const value that the SPDX 2.3 emitter uses. A bonus test (research.md §R6 test #6) explicitly asserts:
+
+```rust
+#[test]
+fn cross_format_placeholder_identity() {
+    // Both formats reference the same const.
+    assert_eq!(
+        super::document::PLACEHOLDER_EXTRACTED_TEXT,
+        super::document::PLACEHOLDER_EXTRACTED_TEXT  // trivially true; documents intent
+    );
+    // Verify the imported const value matches the wire contract from
+    // milestone 153 Clarifications Q1.
+    assert!(super::document::PLACEHOLDER_EXTRACTED_TEXT
+        .starts_with("License text not extracted by mikebom."));
+}
+```
+
+## Scenario 5 — SC-005 pre-PR gate
+
+```bash
+./scripts/pre-pr.sh
+```
+
+**Expected**: green except the documented `sbomqs_parity` env-only flake.
+
+## Scenario 6 — SC-006 unit-test count
+
+```bash
+grep -cE "^\s+fn sweep_custom_licenses_" mikebom-cli/src/generate/spdx/v3_licenses.rs
+```
+
+**Expected**: ≥5 (per SC-006 floor; research.md §R6 lists 5 + 1 bonus cross-format test = 6).
+
+## Scenario 7 — SC-007 wire-format guard (manual diff check)
+
+```bash
+# Only 3 Rust files + CHANGELOG allowed to change:
+git diff main --name-only
+
+# Expected output (order may vary):
+#   CHANGELOG.md
+#   CLAUDE.md   (auto-updated by speckit plan)
+#   mikebom-cli/src/generate/spdx/document.rs   (1-line visibility change only)
+#   mikebom-cli/src/generate/spdx/v3_document.rs (+~3 LOC wiring)
+#   mikebom-cli/src/generate/spdx/v3_licenses.rs (primary deliverable +~90 LOC)
+#   specs/154-spdx3-custom-licenses/*   (speckit branch artifacts)
+```
+
+**Additional guards**:
+```bash
+# No CycloneDX changes:
+git diff main --name-only -- mikebom-cli/src/generate/cyclonedx/
+# Expected: (empty)
+
+# No SPDX 2.3 emission-path changes (only const visibility):
+git diff main -- mikebom-cli/src/generate/spdx/document.rs | grep -E "^\+" | grep -v "pub(crate)"
+# Expected output: just the `+++ b/` header line — no other + lines
+# (verifies FR-018 — the SPDX 2.3 emitter's runtime behavior is unchanged)
+
+# No catalog changes:
+git diff main --name-only -- docs/
+# Expected: (empty)
+
+# No mikebom-common / mikebom-ebpf changes:
+git diff main --name-only -- mikebom-common/ mikebom-ebpf/
+# Expected: (empty)
+```
+
+## Scenario 8 — SC-008 CHANGELOG presence
+
+```bash
+sed -n '/^## \[Unreleased\]/,/^## \[v/p' CHANGELOG.md \
+  | grep -A2 "simplelicensing_CustomLicense\|SPDX 3.*symmetry\|closes #487"
+```
+
+**Expected**: entry present, referencing the SPDX 3 fix + issue #487 + byte-identical cross-format placeholder guarantee.
+
+## Post-merge — operator-cadence external review
+
+The Yocto testbed verification (SC-001 + SC-003) is manual per Assumption 2. The maintainer runs the testbed after merge and reports pass/fail via a follow-up comment on issue #487 (or its close comment). SC-002 / SC-005 / SC-006 / SC-007 / SC-008 are automated and verified pre-merge.
+
+## Known deferrals (spec Out of Scope)
+
+- No real license-text extraction (per FR-017).
+- No SPDX 2.3 or CycloneDX changes (per FR-012 + FR-013).
+- No `SpdxExpression` newtype changes (per FR-014).
+- No milestone-152 rpm_file.rs changes (per FR-015).
+- No new `mikebom:*` annotation keys (per FR-016).
+- No `expandedlicensing_CustomLicense` (per Assumption 9 + Out of Scope).
+- No `DocumentRef-*:LicenseRef-*` handling.
+- No retroactive re-emission of pre-milestone-154 SPDX 3 SBOMs.

--- a/specs/154-spdx3-custom-licenses/research.md
+++ b/specs/154-spdx3-custom-licenses/research.md
@@ -1,0 +1,169 @@
+# Research — milestone 154
+
+Phase 0 outputs for the SPDX 3 `simplelicensing_CustomLicense` sweep.
+
+## R1 — Existing SPDX 3 emitter integration site
+
+**Decision**: Invoke the new `sweep_custom_licenses` helper at `mikebom-cli/src/generate/spdx/v3_document.rs` **inside step 6** of `build_document`, right after the existing `build_license_elements_and_relationships(...)` call returns `(license_elements, license_relationships)`. Push the returned `Vec<Value>` of `simplelicensing_CustomLicense` elements onto `graph` alongside the license expression elements (which are pushed in the same block).
+
+**Verified at planning time** — inspecting `v3_document.rs:579-590`:
+
+```rust
+// 6. simplelicensing_LicenseExpression elements + their
+//    Relationships.
+let (license_elements, license_relationships) =
+    super::v3_licenses::build_license_elements_and_relationships(
+        scan.components,
+        &package_iri_by_purl,
+        &doc_iri,
+        CREATION_INFO_ID,
+    );
+for elem in license_elements {
+    graph.push(elem);
+}
+```
+
+**New wiring** (per data-model.md §5):
+
+```rust
+let (license_elements, license_relationships) =
+    super::v3_licenses::build_license_elements_and_relationships(...);
+
+// Milestone 154 (closes #487): sweep the emitted license-expression
+// elements for inline LicenseRef-* substrings and emit matching
+// simplelicensing_CustomLicense elements per SPDX 3.0.1 §7.
+let custom_license_elements = super::v3_licenses::sweep_custom_licenses(
+    &license_elements,
+    &doc_iri,
+    CREATION_INFO_ID,
+);
+
+for elem in license_elements {
+    graph.push(elem);
+}
+for elem in custom_license_elements {
+    graph.push(elem);
+}
+```
+
+**Rationale**: keeps the CustomLicense emission close to its input source (the LicenseExpression elements) + preserves the existing `graph` push ordering (LicenseExpression elements before CustomLicense elements is aesthetically consistent — expressions declared, then the elements that resolve their LicenseRef- tokens).
+
+**Alternatives considered**:
+- Extend `build_license_elements_and_relationships` to return a THIRD Vec: rejected — changes the function's public signature + touches every existing call site + test.
+- Emit inside `build_license_elements_and_relationships` and append to its returned `elements` Vec: rejected — same reason (would need caller to re-sort by spdxId if we want lex-ordered).
+- Invoke at the top of `build_document` before step 6: impossible — LicenseExpression elements don't exist yet at that point.
+
+## R2 — Dedup rule + return-type shape
+
+**Decision**: Use a `BTreeMap<String, Value>` keyed by LicenseRef **idstring** (not the full `LicenseRef-<idstring>` token). Each entry's Value is the fully-constructed `simplelicensing_CustomLicense` element JSON. Final `map.into_values().collect()` produces the returned Vec; sorted by insertion order is `BTreeMap`'s lex order on keys (idstring alphabetical), which matches the `sort_by_spdx_id` invariant used elsewhere in `v3_licenses.rs` since the spdxId ends with `licenseref/{idstring}`.
+
+**Rationale**: dedup by idstring produces the natural set — one CustomLicense element per unique LicenseRef-referenced-anywhere-in-the-doc. Multiple LicenseExpression elements referencing the same LicenseRef yield exactly ONE CustomLicense element (US1 A3).
+
+**Alternatives considered**:
+- Dedup by full `LicenseRef-<idstring>` token: functionally equivalent but requires an extra `LicenseRef-` prefix operation on every insert. Simpler to key by idstring directly.
+- Use `HashSet<String>` first, then build elements in a second pass: extra pass; no benefit.
+- Sort by spdxId post-collection: `BTreeMap`'s lex order on keys IS the sort by spdxId (spdxId suffix = idstring). No extra sort needed.
+
+## R3 — Regex sharing between milestone 153 (`document.rs`) and milestone 154 (`v3_licenses.rs`)
+
+**Decision**: **Duplicate inline in `v3_licenses.rs`**. The regex is a 3-line construct (`OnceLock<Regex>` static + `license_ref_regex()` accessor function + pattern string). Promoting to a shared module (e.g., a new `mikebom-cli/src/generate/spdx/license_ref_extraction.rs` or similar) would require:
+1. A new module declaration in `mod.rs`
+2. An import in BOTH `document.rs` and `v3_licenses.rs`
+3. A new file-level doc comment explaining what the module does
+
+vs. the alternative of duplicating the 3 lines of code (with a doc comment on the v3_licenses.rs copy naming milestone 153 + document.rs as the source-of-truth definition; both stay lockstep because the pattern is trivial).
+
+**Rationale**: matches the same author-guidance from milestone 153's analysis remediation A2 (which said "prefer inline duplication over module promotion since the scope is 3 lines of regex-init code across one additional file"). The pattern itself is a spec-defined constant (SPDX 2.3 §10.1 idstring grammar); it doesn't drift.
+
+**Alternatives considered**:
+- Promote to `pub(crate)` in `document.rs` alongside `PLACEHOLDER_EXTRACTED_TEXT`: works but pollutes `document.rs`'s public surface with an SPDX-3-specific helper.
+- New shared module: over-engineered for 3 lines.
+
+## R4 — `PLACEHOLDER_EXTRACTED_TEXT` const sharing
+
+**Decision**: **Promote to `pub(crate) const` in `document.rs`**. The const's byte-value IS the wire contract (Clarifications Q1 from milestone 153). It must be single-sourced. `pub(crate)` visibility lets `v3_licenses.rs` import it as `super::document::PLACEHOLDER_EXTRACTED_TEXT`.
+
+**Different from the regex** (R3) because:
+- The regex pattern is stable spec-derived; drift risk is nil.
+- The placeholder text is longer + operator-visible; drift risk is real (any typo change in one file could silently diverge from the other, breaking cross-format pattern-matching).
+
+**Rationale**: single-source-of-truth for a load-bearing wire-contract string. `pub(crate)` scoped promotion keeps the const module-adjacent (still in `document.rs` alongside its documentation).
+
+**Alternatives considered**:
+- Byte-duplicate the string in `v3_licenses.rs` with a doc comment naming `document.rs` as source: rejected — drift risk. If a future edit changes one and misses the other, cross-format identity silently breaks.
+- Move to a new shared module: over-engineered.
+- Move to `mikebom-common`: rejected — the placeholder is an SPDX-emitter concern, not a shared type.
+
+## R5 — IRI construction implementation
+
+**Decision**: Implement as a small helper function (or inline `format!` at the insertion site) using the pattern `format!("{doc_iri}/licenseref/{idstring}")` per Clarifications Q1.
+
+**Verified at planning time** — idstring alphabet `[a-zA-Z0-9-.]+`:
+- All lowercase letters, uppercase letters, digits, `-`, `.` are in RFC 3986 §2.3 "unreserved" set (`ALPHA / DIGIT / "-" / "." / "_" / "~"`).
+- No percent-encoding required.
+
+**Uniqueness / collision-freedom**: two `simplelicensing_CustomLicense` elements would only collide if they shared the same idstring — but dedup (R2) precludes emitting duplicates. Cross-element-type collisions with existing `simplelicensing_LicenseExpression` elements are structurally impossible: the existing scheme uses `{doc_iri}/{license-decl,license-conc}-{hash}`; the new scheme uses `{doc_iri}/licenseref/{idstring}`. Different path prefix (`license-decl-<hash>` vs `licenseref/<idstring>`), guaranteed non-overlapping.
+
+**Alternatives considered**:
+- Use a hash-of-idstring suffix for uniformity with existing pattern: rejected per Clarifications Q1 (Option B chosen for human-readability).
+- Percent-encode as defensive-code: rejected — unnecessary complexity for a subset alphabet.
+
+## R6 — Test inventory (SC-006)
+
+**Decision**: 5 unit tests inline in `v3_licenses.rs`'s test module (add one if absent). Each independent. Uses synthetic `Value` (`serde_json::json!` macro) `simplelicensing_LicenseExpression` elements as input.
+
+| # | Test | Covers |
+|---|------|--------|
+| 1 | `sweep_custom_licenses_single_expression_single_licenseref` | US1 A2: single expression with `LicenseRef-PD` → 1 element with correct IRI + name + placeholder |
+| 2 | `sweep_custom_licenses_compound_expression` | US1 A1: `"GPL-2.0-only AND LicenseRef-bzip2-1.0.4"` → 1 element for `bzip2-1.0.4` only (GPL-2.0-only is a bare SPDX id) |
+| 3 | `sweep_custom_licenses_dedup_across_expressions` | US1 A3: 4 expressions all referencing `LicenseRef-bzip2-1.0.4` → 1 element (dedup) |
+| 4 | `sweep_custom_licenses_ignores_document_ref_prefixed` | Edge Case: `DocumentRef-external:LicenseRef-foo` → 0 elements |
+| 5 | `sweep_custom_licenses_no_licenserefs_returns_empty` | US2 + FR-007: no LicenseRef in any expression → empty Vec |
+
+Plus a **6th cross-format identity test** (bonus, not in floor): assert that when both milestone-153's `sweep_extracted_license_refs` AND milestone-154's `sweep_custom_licenses` run on synthetic-but-identical LicenseRef sets, the resulting placeholder text values are byte-identical. Locks the cross-format wire contract at compile time.
+
+Total: 6 tests (comfortably above SC-006's floor of 5).
+
+**Rationale**: Inline synthetic tests keep the suite self-contained + fast. No fixture-repo touches. The bonus cross-format test explicitly validates FR-010 as a compile-time regression guard.
+
+**Alternatives considered**:
+- Reuse the milestone-078 `spdx3-validate` harness at `spdx3_conformance.rs`: covered by SC-003 already (existing harness runs against ALL SPDX 3 goldens; if any golden ends up containing LicenseRef-* + CustomLicense post-154, the harness verifies the shape).
+- Property-based tests via `proptest`: overkill for 5 unit tests.
+
+## R7 — CHANGELOG.md entry shape
+
+**Decision**: Single subsection under `## [Unreleased]` in `CHANGELOG.md`, immediately above milestone-153's entry (chronological within the section). Content documents:
+- The SPDX 3 symmetry fix + issue #487 reference.
+- The byte-identical cross-format placeholder guarantee (invariant with milestone 153).
+- The IRI scheme `{doc_iri}/licenseref/{idstring}`.
+- The `pub(crate)` visibility promotion of `PLACEHOLDER_EXTRACTED_TEXT` (single-source-of-truth for the wire contract).
+- A cross-format jq recipe consumers can use to verify parity.
+
+## R8 — Verification approach
+
+**SC-001** (issue-#487 testbed cross-format symmetry): manual operator-cadence per quickstart.md Scenario 1. Same maintainer testbed as milestones 152/153/478.
+
+**SC-002** (byte-identical happy path): automated via existing SPDX 3 golden tests + the `every_existing_golden_passes_validator` test in `spdx3_conformance.rs` (which runs `spdx3-validate` on every committed SPDX 3 golden; if any golden regenerates post-154, that's an SC-002 violation).
+
+**SC-003** (`spdx3-validate` continues to pass): re-run `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 cargo test --workspace` (same harness as milestone 078); expect all tests to pass including the new synthetic-emission test if added.
+
+**SC-004** (cross-format placeholder identity): the `pub(crate)` const promotion mechanically enforces this at compile time. Bonus test #6 asserts it explicitly.
+
+## R9 — Interaction with milestone 012's SPDX-3-invisible hash-fallback path
+
+**Decision**: No special handling needed.
+
+**Verified at planning time**: `v3_licenses.rs:reduce_license_vec` uses `canonicalize_or_raw` which preserves the raw expression on canonicalization failure:
+
+```rust
+fn canonicalize_or_raw(expr: &str) -> String {
+    match SpdxExpression::try_canonical(expr) {
+        Ok(canon) => canon.as_str().to_string(),
+        Err(_) => expr.to_string(),
+    }
+}
+```
+
+The SPDX 3 emitter does NOT invoke milestone 012's `SpdxId::for_license_ref` (which is SPDX-2.3-only). So no `LicenseRef-<hash>` tokens ever appear in SPDX 3 output from this path. The only LicenseRef- substrings the milestone-154 sweep will see are those injected by milestone 152's inline escape-hatch (RPM-only) via the raw expression preserved on canonicalization failure.
+
+**Consequence**: the sweep's behavior is uniform — every LicenseRef- token found in any expression string gets a matching CustomLicense element. There is no need to distinguish milestone-012-origin vs milestone-152-origin references. (This is simpler than the SPDX 2.3 sweep, which DID need to dedup with milestone-012's pre-existing entries via the `existing` parameter.)

--- a/specs/154-spdx3-custom-licenses/spec.md
+++ b/specs/154-spdx3-custom-licenses/spec.md
@@ -1,0 +1,230 @@
+# Feature Specification: SPDX 3 `simplelicensing_CustomLicense` for inline `LicenseRef-*` (issue #487 — paired follow-up to #485)
+
+**Feature Branch**: `154-spdx3-custom-licenses`
+**Created**: 2026-07-02
+**Status**: Draft
+**Input**: User description: "154"
+
+## Origin & context
+
+GitHub issue [#487](https://github.com/kusari-oss/mikebom/issues/487), filed 2026-07-02 by the maintainer, is a paired follow-up to milestone 153 (PR #486, closed 2026-07-01 in `2d7ab0e`). Milestone 153 fixed the SPDX 2.3 side of the LicenseRef-* conformance issue (issue #485) by sweeping every emitted document's license fields and adding a matching `hasExtractedLicensingInfos[]` entry per SPDX 2.3 §10.1. During milestone 153's investigation, `spdx3-validate==0.0.5` returned exit 0 on a synthetic SPDX 3.0.1 document with an inline `LicenseRef-*` in a `simplelicensing_licenseExpression` WITHOUT any matching `simplelicensing_CustomLicense` element — I concluded SPDX 3.0.1's license-reference model did NOT require the equivalent emission (Outcome B) and shipped milestone 153 with the SPDX 3 side unchanged.
+
+The maintainer's `spdx3-validate` run was correct as a validator check, but the maintainer explicitly filed #487 as a **symmetry ask**, not a spec non-conformance report:
+
+> "SPDX 3.0.1 §7 is less prescriptive than SPDX 2.3 §10.1 about *whether* `CustomLicense` elements are strictly required. A permissive validator will accept the current output; a strict one will flag the same 3 references as dangling. Filing this as a paired follow-up to #485 for symmetry — the same license tokens should be resolvable in either format."
+
+The consumer-facing outcome: a downstream tool that reads both a mikebom SPDX 2.3 document AND its SPDX 3 sibling should get the same LicenseRef-resolution experience. Today they don't: the SPDX 2.3 side defines each LicenseRef via `hasExtractedLicensingInfos[]` (post-153); the SPDX 3 side leaves them dangling.
+
+This milestone closes the symmetry gap by adding a matching sweep in the SPDX 3 emitter that emits `simplelicensing_CustomLicense` graph elements — one per distinct `LicenseRef-*` referenced by any `simplelicensing_LicenseExpression`. The placeholder text is byte-identical to milestone 153's `PLACEHOLDER_EXTRACTED_TEXT` const so consumers pattern-matching on the same prefix work across both formats.
+
+**Concrete testbed evidence** (from #487 body, same testbed as #485 / #481 / #475):
+
+```
+$ jq '[.["@graph"][] | select(.type == "simplelicensing_LicenseExpression")
+                     | .simplelicensing_licenseExpression]
+       | map(scan("LicenseRef-[A-Za-z0-9._-]+")) | flatten | unique' \
+    core-image-minimal.spdx.json
+[
+  "LicenseRef-GPL-2.0-with-OpenSSL-exception",
+  "LicenseRef-PD",
+  "LicenseRef-bzip2-1.0.4"
+]
+
+$ jq '[.["@graph"][] | select(.type | test("_CustomLicense$")) | .spdxId]' \
+    core-image-minimal.spdx.json
+[]
+```
+
+3 distinct LicenseRefs referenced across `simplelicensing_LicenseExpression` elements, 0 `CustomLicense` elements declaring them. Same 3 tokens as issue #485 (same underlying Yocto build).
+
+**Scope split**:
+
+- **SPDX 3.0.1**: MUST fix — this milestone's core work.
+- **SPDX 2.3**: no change (already fixed in milestone 153).
+- **CycloneDX 1.6**: no work needed (no §10.1-equivalent constraint in CDX).
+
+## Clarifications
+
+### Session 2026-07-02
+
+- Q: What per-element IRI suffix does `simplelicensing_CustomLicense` use? → A: **Readable path segment** — `{doc_iri}/licenseref/{idstring}` (e.g., `https://.../licenseref/bzip2-1.0.4`). Matches the issue body's example. Human-readable — a consumer inspecting a graph can visually match `LicenseRef-bzip2-1.0.4` in a license expression to `licenseref/bzip2-1.0.4` in the CustomLicense's IRI. The idstring alphabet `[a-zA-Z0-9-.]+` is a subset of RFC 3986 unreserved characters, so no percent-encoding needed. Locked as the wire contract; consumers may reference the IRI. Different suffix scheme from the existing `license-decl-<hash>` / `license-conc-<hash>` pattern (which hashes arbitrary expression text); LicenseRef idstrings are already compact stable identifiers, so hashing indirection is unnecessary.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Cross-format symmetry for LicenseRef resolution (Priority: P1)
+
+A downstream compliance auditor reads both the SPDX 2.3 AND the SPDX 3.0.1 output for the same mikebom-scanned artifact (e.g., a compliance workflow that ingests both formats to compare cross-format consistency). Today, the SPDX 2.3 side defines every `LicenseRef-*` via a `hasExtractedLicensingInfos[]` entry (milestone 153); the SPDX 3 side leaves them dangling. After this milestone, both formats define the same LicenseRefs with byte-identical placeholder text — the auditor gets consistent LicenseRef-resolution across formats.
+
+**Why this priority**: Cross-format symmetry is the direct ask from issue #487. Compliance workflows that consume both formats treat the pair as one artifact; a divergence between them is a trust-eroding inconsistency.
+
+**Independent Test**: Scan the issue-#485 / #487 testbed (`yocto-test`, `core-image-minimal` qemux86-64, scarthgap LTS, poky `802e4c1`) with the milestone-154 build. Emit BOTH `spdx-2.3-json` AND `spdx-3-json` outputs. Assert: (a) both formats' license-definition arrays contain the same set of LicenseRef-tokens; (b) the SPDX 3 side's `simplelicensing_CustomLicense.simplelicensing_licenseText` field carries the exact same placeholder string as the SPDX 2.3 side's `hasExtractedLicensingInfos[].extractedText`; (c) the SPDX 3 side's `simplelicensing_CustomLicense.name` field carries the same idstring (LicenseRef-prefix stripped) as the SPDX 2.3 side's `hasExtractedLicensingInfos[].name`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mikebom-emitted SPDX 3.0.1 document containing a `simplelicensing_LicenseExpression` with `simplelicensing_licenseExpression = "GPL-2.0-only AND LicenseRef-bzip2-1.0.4"`, **When** the consumer reads the graph's `simplelicensing_CustomLicense` elements, **Then** the graph MUST contain an element with `type: "simplelicensing_CustomLicense"`, `name: "bzip2-1.0.4"`, and `simplelicensing_licenseText` = milestone-153's `PLACEHOLDER_EXTRACTED_TEXT` byte-identically.
+2. **Given** the same document containing `simplelicensing_licenseExpression = "LicenseRef-PD"` (single-operand case), **When** the consumer reads the graph, **Then** it MUST contain a matching `simplelicensing_CustomLicense` element for `LicenseRef-PD`.
+3. **Given** a document where multiple `simplelicensing_LicenseExpression` elements reference the same `LicenseRef-bzip2-1.0.4` (busybox-family — 4 packages), **When** the consumer reads the graph, **Then** it MUST contain **exactly one** `simplelicensing_CustomLicense` element for `LicenseRef-bzip2-1.0.4` (deduplicated across expressions).
+4. **Given** a document that has NO `LicenseRef-*` references anywhere in any `simplelicensing_LicenseExpression`, **When** the consumer reads the graph, **Then** the graph MUST contain zero `simplelicensing_CustomLicense` elements (byte-identity preserved for happy-path scans).
+5. **Given** BOTH a mikebom-emitted SPDX 2.3 document AND its SPDX 3 sibling for the same testbed, **When** the consumer extracts the set of LicenseRef-token definitions from each, **Then** the two sets MUST be equal (cross-format symmetry).
+6. **Given** BOTH emitted formats for the same testbed, **When** the consumer inspects the placeholder text on any matching pair (SPDX 2.3 `extractedText` and SPDX 3 `simplelicensing_licenseText` for the same LicenseRef), **Then** the two strings MUST be byte-identical (the milestone-153 wire contract is preserved cross-format).
+
+---
+
+### User Story 2 — Byte-identical happy path when no LicenseRef is present (Priority: P2)
+
+A developer running mikebom against a source tree where every emitted license expression is a canonical SPDX id (no milestone-152 LicenseRef fallback fires; no milestone-012 hash-fallback either) expects byte-identical SPDX 3 output before vs. after milestone 154 — the new sweep MUST be a strict no-op on documents that don't need it.
+
+**Why this priority**: Same reasoning as milestones 152 + 153 US2 — prevents the fix from causing spurious changes to existing SBOM consumers' tooling pipelines. Byte-identity is verified via the existing milestone-090 golden test infrastructure, which covers Cargo / npm / Go / pip fixtures — none of which currently emit LicenseRef-* values.
+
+**Independent Test**: Scan the milestone-090 sibling-fixture testbeds (`transitive_parity/cargo`, `transitive_parity/npm`, `transitive_parity/go`, `transitive_parity/pip_*`) with the milestone-154 build. Emit SPDX 3 JSON. Assert byte-identity against pre-milestone-154 golden files.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scan target with no LicenseRef-* values in any emitted `simplelicensing_licenseExpression`, **When** mikebom emits SPDX 3, **Then** the output MUST be byte-identical to pre-milestone-154 output for the same input.
+2. **Given** the emitted SPDX 3 graph for a happy-path scan, **When** a consumer counts `simplelicensing_CustomLicense` elements, **Then** the count MUST be zero — the sweep MUST NOT introduce these elements when no LicenseRef- references exist.
+
+---
+
+### Edge Cases
+
+- **Dedup across declared + concluded expressions on the same package**: if a package's `licenseDeclared` and `licenseConcluded` both reference `LicenseRef-foo`, exactly ONE `simplelicensing_CustomLicense` element is emitted (dedup by name).
+- **LicenseRef with nested compound structure**: e.g., `MIT AND LicenseRef-foo OR (LicenseRef-bar AND Apache-2.0)`. The sweep MUST extract BOTH `LicenseRef-foo` and `LicenseRef-bar` regardless of operator/paren surroundings.
+- **LicenseRef with DocumentRef prefix**: `DocumentRef-<doc>:LicenseRef-<id>` compound tokens MUST be excluded from the sweep (the LicenseRef is defined in the referenced OTHER document, not this one). Same rule as milestone 153's SPDX 2.3 sweep.
+- **`DocumentRef-` in SPDX 3**: SPDX 3's cross-document reference model uses `import[]` ExternalMap + IRI-based cross-references, not the SPDX 2.3 `DocumentRef-<doc>:LicenseRef-<id>` string shape. mikebom doesn't emit either form today; the sweep's DocumentRef-exclusion regex still handles this defensively for operator-supplied data via supplement-CDX or similar.
+- **Empty document (no components)**: the sweep runs but finds no `simplelicensing_LicenseExpression` elements to scan; zero `simplelicensing_CustomLicense` elements emitted.
+- **`spdxId` / IRI construction for `simplelicensing_CustomLicense` elements**: mikebom's existing SPDX 3 emitter constructs `spdxId`s via `element_iri_for(...)` from a doc IRI + a stable per-element suffix (see `v3_licenses.rs`). The new `simplelicensing_CustomLicense` elements MUST follow the same pattern — the exact suffix scheme is a planning-phase decision.
+- **`creationInfo` reference**: SPDX 3 elements require a `creationInfo` reference pointing at the doc's CreationInfo element. The new `simplelicensing_CustomLicense` elements MUST include this field with the same value used by the SPDX 3 emitter's other elements.
+- **Existing `simplelicensing_LicenseExpression` elements that ARE themselves the milestone-012 LicenseRef-<hash> form**: milestone 012's SPDX 2.3 hash-fallback path emits `LicenseRef-<hash>` for wholly-non-canonicalizable expressions. The SPDX 3 emitter doesn't (yet) reuse this hash-fallback path — every SPDX 3 `simplelicensing_LicenseExpression` currently carries the raw or canonical string. The sweep runs on the string content; when the string itself IS `LicenseRef-<hash>`, that hash SHOULD get a `simplelicensing_CustomLicense` element (same rule as any other LicenseRef- reference).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Core fix (US1)
+
+- **FR-001**: At SPDX 3 document-serialization time, mikebom MUST sweep every emitted `simplelicensing_LicenseExpression` graph element's `simplelicensing_licenseExpression` string for `LicenseRef-<idstring>` substrings (per SPDX 2.3 §10.1 grammar; SPDX 3.0.1 uses the same idstring grammar for LicenseRef within license expressions).
+
+- **FR-002**: The sweep MUST deduplicate LicenseRef- values by their `LicenseRef-<idstring>` full-token key. Each distinct LicenseRef MUST produce exactly one `simplelicensing_CustomLicense` graph element regardless of how many `simplelicensing_LicenseExpression` elements reference it.
+
+- **FR-003**: Each emitted `simplelicensing_CustomLicense` element MUST have the following fields:
+  - `type`: the literal string `"simplelicensing_CustomLicense"`.
+  - `spdxId`: the IRI `{doc_iri}/licenseref/{idstring}` per Clarifications Q1 (e.g., `https://mikebom.kusari.dev/spdx3/.../licenseref/bzip2-1.0.4`). The `{doc_iri}` is the document's base IRI; `{idstring}` is the LicenseRef idstring (LicenseRef- prefix stripped). No percent-encoding required — the idstring alphabet `[a-zA-Z0-9-.]+` is a subset of RFC 3986 unreserved characters. Locked as the wire contract from this milestone forward.
+  - `creationInfo`: the same CreationInfo reference used by every other element in the emitted graph.
+  - `name`: the LicenseRef idstring (LicenseRef- prefix stripped) — byte-identical to the milestone-153 SPDX 2.3 side's `hasExtractedLicensingInfos[].name` for the same LicenseRef.
+  - `simplelicensing_licenseText`: the exact `PLACEHOLDER_EXTRACTED_TEXT` string introduced by milestone 153 in `mikebom-cli/src/generate/spdx/document.rs`. Consumers pattern-matching on the string see byte-identical text across both formats.
+
+- **FR-004**: The `simplelicensing_licenseText` placeholder MUST be the exact same byte-string as milestone 153's `PLACEHOLDER_EXTRACTED_TEXT` (per the Clarifications Q1 wire contract from milestone 153):
+
+  ```
+  License text not extracted by mikebom. Consult the original package (e.g., /usr/share/licenses/<name>/ on Debian/RPM, or upstream project source) for the full text.
+  ```
+
+  The `<name>` token is a LITERAL (identical to milestone 153's treatment). Cross-format placeholder identity is the load-bearing invariant — do NOT diverge the string across formats.
+
+- **FR-005**: The sweep MUST correctly handle nested compound license expressions with mixed operators (`AND`, `OR`, `WITH`) and parenthesized sub-expressions. Every `LicenseRef-<idstring>` substring regardless of surroundings MUST be extracted.
+
+- **FR-006**: The sweep MUST correctly exclude `DocumentRef-<docid>:LicenseRef-<idstring>` compound tokens (the LicenseRef is defined in the referenced OTHER document, not this one). Same exclusion rule as milestone 153's SPDX 2.3 sweep.
+
+#### Emission conditions + no-op guard (US2)
+
+- **FR-007**: When zero distinct `LicenseRef-*` values are referenced across all emitted `simplelicensing_LicenseExpression` elements' expression strings, the emitted SPDX 3 document MUST NOT contain any `simplelicensing_CustomLicense` graph element. This preserves byte-identity for happy-path scans that don't hit milestone 152's fallback.
+
+- **FR-008**: The sweep MUST be a strict no-op on scans that emit zero LicenseRef- values — no new graph elements, no re-sorting, no whitespace changes, no property-ordering changes on any existing element. Verified via SC-002 byte-identity against pre-milestone-154 golden fixtures.
+
+#### Symmetry with milestone 153 (US1 cross-format guarantee)
+
+- **FR-009**: For any given scan target that produces LicenseRef-* references, the set of `LicenseRef-<idstring>` full-token strings defined by the SPDX 2.3 side (`hasExtractedLicensingInfos[].licenseId`) MUST equal the set of `LicenseRef-<idstring>` full-token strings referenced by the SPDX 3 side's `simplelicensing_CustomLicense` elements (where each element's referenced full-token is `LicenseRef-<name>`). Cross-format token-set equality is the symmetry contract.
+
+- **FR-010**: For any given LicenseRef defined in both formats, the placeholder text field (`extractedText` in SPDX 2.3; `simplelicensing_licenseText` in SPDX 3) MUST be byte-identical. Cross-format placeholder identity is the symmetry contract.
+
+- **FR-011**: For any given LicenseRef defined in both formats, the human-readable name field (`name` in both formats) MUST be byte-identical.
+
+#### Scope guards
+
+- **FR-012**: This milestone MUST NOT change the SPDX 2.3 emitter (`mikebom-cli/src/generate/spdx/document.rs`, `packages.rs`) — the milestone-153 fix is complete on that side.
+
+- **FR-013**: This milestone MUST NOT change the CycloneDX 1.6 emitter (CDX has no equivalent constraint; per issue #487, CDX is a no-op).
+
+- **FR-014**: This milestone MUST NOT change the `SpdxExpression` newtype in `mikebom-common/src/types/license.rs` (the license value flow is unchanged; only the SPDX 3 document-serialization layer sweeps for LicenseRef- values).
+
+- **FR-015**: This milestone MUST NOT change the milestone-152 `preserve_known_operands_with_license_ref` helper in `rpm_file.rs` (LicenseRef injection is upstream of document serialization).
+
+- **FR-016**: This milestone MUST NOT introduce a new `mikebom:*` annotation key (per Constitution Principle V — `simplelicensing_CustomLicense` is the SPDX 3-native carrier).
+
+- **FR-017**: This milestone MUST NOT extract real license text from any source. Placeholder text only, byte-identical to milestone 153 per FR-004. Real text extraction is deferred to a future milestone if operator demand surfaces (would apply equally to both formats).
+
+- **FR-018**: This milestone MUST NOT change the milestone-153 `PLACEHOLDER_EXTRACTED_TEXT` const in `mikebom-cli/src/generate/spdx/document.rs`. This milestone READS the const's value (via `pub(crate)` visibility promotion OR by duplicating the byte-exact string in the SPDX 3 emitter with a doc comment naming milestone 153 as the source of truth). The choice between visibility-promotion vs. byte-duplication is a planning-phase decision; both preserve the wire-contract identity.
+
+### Key Entities
+
+- **`simplelicensing_CustomLicense` graph element**: SPDX 3.0.1 element with fields `type` / `spdxId` / `creationInfo` / `name` / `simplelicensing_licenseText`. Analogous to SPDX 2.3's `SpdxExtractedLicensingInfo` struct.
+- **The 3 issue-#487 reference LicenseRefs** (used as the SC-001 acceptance fixture — same set as issue #485): `LicenseRef-bzip2-1.0.4`, `LicenseRef-PD`, `LicenseRef-GPL-2.0-with-OpenSSL-exception`.
+- **The cross-format symmetry pair**: for any given scan target, the SPDX 2.3 `hasExtractedLicensingInfos[]` entries and the SPDX 3 `simplelicensing_CustomLicense` graph elements MUST describe the same LicenseRef set with byte-identical placeholder text + name fields (FR-009 / FR-010 / FR-011).
+- **The milestone-153 `PLACEHOLDER_EXTRACTED_TEXT` const**: byte-locked wire contract from milestone 153. Reused verbatim by this milestone. Do NOT diverge.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001 (issue-#487 testbed cross-format symmetry)**: After milestone 154 ships, re-scanning the issue-#487 testbed and emitting BOTH `spdx-2.3-json` AND `spdx-3-json` outputs, the maintainer's diagnostic recipes MUST return:
+  - `jq '[.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | .name] | sort'` on the SPDX 3 output returns exactly `["GPL-2.0-with-OpenSSL-exception", "PD", "bzip2-1.0.4"]`.
+  - Cross-format symmetry check (bash + jq):
+    ```bash
+    diff <(jq -c '[.hasExtractedLicensingInfos[].licenseId] | sort' out.spdx.json) \
+         <(jq -c '["LicenseRef-" + .["@graph"][].name] | map(select(startswith("LicenseRef-"))) | sort' out.spdx3.json | jq 'select(length > 0)')
+    ```
+    MUST produce empty diff (both sets equal).
+  - `jq '.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | .simplelicensing_licenseText' out.spdx3.json` returns 3 lines, all byte-identical to the milestone-153 `PLACEHOLDER_EXTRACTED_TEXT` string.
+
+- **SC-002 (byte-identical happy path)**: Scanning the milestone-090 sibling-fixture testbeds (cargo + npm + go + pip) with the milestone-154 build produces byte-identical SPDX 3 output compared to pre-milestone-154 (verified via the existing golden test infrastructure). This confirms FR-007 + FR-008.
+
+- **SC-003 (`spdx3-validate` continues to pass)**: `spdx3-validate==0.0.5` MUST return exit 0 on both pre-154 and post-154 SPDX 3 output for the issue-#487 testbed (adding well-formed `simplelicensing_CustomLicense` elements does NOT introduce any schema or SHACL violation).
+
+- **SC-004 (cross-format placeholder identity)**: The `simplelicensing_licenseText` field of every emitted `simplelicensing_CustomLicense` element MUST be byte-identical to the `extractedText` field of the corresponding SPDX 2.3 `hasExtractedLicensingInfos[]` entry for the same LicenseRef. Verified mechanically via a golden-test cross-format-diff at authoring time OR via SC-001's cross-format recipe.
+
+- **SC-005 (pre-PR gate)**: `./scripts/pre-pr.sh` MUST pass with the same status as pre-154 main (clippy clean + every test passes except the documented `sbomqs_parity::sbomqs_spdx_score_meets_or_beats_cdx_across_ecosystems` env-only flake).
+
+- **SC-006 (new unit-test coverage)**: At least 5 new unit tests covering: (a) single expression with single LicenseRef; (b) single expression with compound `expr AND LicenseRef-*`; (c) multiple expressions sharing the same LicenseRef (dedup); (d) DocumentRef-prefixed LicenseRef excluded; (e) empty scan (no LicenseRef references) → no `simplelicensing_CustomLicense` elements emitted.
+
+- **SC-007 (no wire-format / annotation changes beyond intended)**: The shipped diff MUST NOT touch `docs/reference/sbom-format-mapping.md`. No new `mikebom:*` annotation keys introduced. The CycloneDX emitter MUST be untouched. The SPDX 2.3 emitter MUST be untouched (per FR-012).
+
+- **SC-008 (CHANGELOG entry)**: The shipped diff MUST include an entry in `CHANGELOG.md` under `[Unreleased]` naming the SPDX 3 symmetry fix + issue #487 reference + the byte-identical placeholder guarantee with milestone 153.
+
+## Assumptions
+
+1. **Reuse milestone-153's `PLACEHOLDER_EXTRACTED_TEXT`**: The exact placeholder text is fixed by milestone 153's Clarifications Q1 wire contract. This milestone does NOT introduce a separate SPDX-3-specific placeholder; it uses the same byte-string. Whether reuse happens via `pub(crate)` visibility promotion or by duplicating the string with a doc-comment reference to milestone 153 is a planning-phase decision — both preserve the invariant.
+
+2. **The maintainer has the Yocto testbed locally**: same as milestones 478 / 152 / 153; SC-001 verification is manual operator-cadence.
+
+3. **`spdx3-validate==0.0.5` is available**: The workspace pin from milestone 078 remains valid + confirmed working during milestone 153's investigation. This milestone's SC-003 check re-uses the same tool.
+
+4. **SPDX 3's element-IRI convention is stable**: mikebom's existing `element_iri_for(...)` helper at `v3_licenses.rs` gives every `simplelicensing_LicenseExpression` a deterministic IRI. The new `simplelicensing_CustomLicense` elements follow the same convention with a distinct per-element suffix (e.g., `licenseref-<idstring>`, exact scheme decided at plan time).
+
+5. **CreationInfo reuse**: SPDX 3 requires every element to reference a CreationInfo. The new `simplelicensing_CustomLicense` elements will use the same CreationInfo reference as every other emitted element (planning-phase detail: pass `creation_info_id` into the new sweep helper).
+
+6. **No CDX or SPDX 2.3 regression risk**: milestone 154 is fully SPDX-3-emitter-scoped (per FR-012 + FR-013). The other formats' code paths are unchanged.
+
+7. **Milestone-153 SPDX 2.3 sweep continues to fire correctly**: FR-009 / FR-010 / FR-011 cross-format symmetry contracts depend on milestone 153's SPDX 2.3 sweep producing well-formed entries. Milestone-153 shipped with SC-001 verification pending manual maintainer testbed run; this milestone's SC-001 verification exercises BOTH milestone-153's SPDX 2.3 sweep AND milestone-154's SPDX 3 sweep in the same testbed pass.
+
+8. **Milestone-012 SPDX 2.3 hash-fallback continues to fire correctly**: milestone 012's `LicenseRef-<hash>` path for wholly-non-canonicalizable expressions is unchanged. If any such `LicenseRef-<hash>` reaches the SPDX 3 emitter through the shared `SpdxExpression` newtype (unlikely — SPDX 3 emitter's canonicalize_or_raw path preserves the raw expression rather than falling back to a hash), the sweep handles it uniformly with any other LicenseRef- reference.
+
+9. **`simplelicensing_CustomLicense` is the correct SPDX 3.0.1 element type**: per the SPDX 3.0.1 spec (via issue #487 body's citation) and the JPEWdev `spdx3-validate` schema. If planning-phase investigation surfaces a different element type is preferred (e.g., `expandedlicensing_CustomLicense` with richer fields), the decision is documented at plan time; the placeholder-text approach applies to whichever element type is chosen.
+
+## Dependencies
+
+- **Milestone 153** (PR #486, merged 2026-07-01): introduces the `PLACEHOLDER_EXTRACTED_TEXT` const + the SPDX 2.3 sweep. This milestone reuses the const value + implements the symmetric SPDX 3 sweep.
+- **Milestone 152** (PR #484, merged 2026-06-30): introduces the inline `LicenseRef-<sanitized>` values that this milestone's SPDX 3 sweep must define.
+- **Milestone 011 SPDX 3 emitter** at `mikebom-cli/src/generate/spdx/v3_licenses.rs`: provides the existing `build_license_elements_and_relationships` function + `element_iri_for` helper. Reused, not replaced.
+- **Milestone 078 SPDX 3 conformance harness**: provides `spdx3-validate==0.0.5` for the SC-003 check.
+
+## Out of Scope
+
+- No real license text extraction (per FR-017). Deferred to a future milestone if operator demand surfaces.
+- No SPDX 2.3 or CycloneDX changes (per FR-012 + FR-013).
+- No `SpdxExpression` newtype changes (per FR-014).
+- No new `mikebom:*` annotation keys (per FR-016).
+- No milestone-152 rpm_file.rs changes (per FR-015).
+- No milestone-153 `PLACEHOLDER_EXTRACTED_TEXT` const changes (per FR-018).
+- No `expandedlicensing_CustomLicense` (the richer SPDX 3 element type). If planning-phase investigation surfaces a strong reason to prefer it, the decision is revisited at that time; per default assumption 9, `simplelicensing_CustomLicense` is the target.
+- No cross-document `DocumentRef-<doc>:LicenseRef-<id>` handling (mikebom doesn't emit these; regex excludes them defensively).
+- No retroactive re-emission of pre-milestone-154 SPDX 3 SBOMs.

--- a/specs/154-spdx3-custom-licenses/tasks.md
+++ b/specs/154-spdx3-custom-licenses/tasks.md
@@ -1,0 +1,146 @@
+---
+description: "Task list for milestone 154 — SPDX 3 simplelicensing_CustomLicense for LicenseRef-* (closes issue #487)"
+---
+
+# Tasks: SPDX 3 `simplelicensing_CustomLicense` for LicenseRef-* — milestone 154
+
+**Input**: Design documents from `/specs/154-spdx3-custom-licenses/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/sweep-api.md ✓, quickstart.md ✓
+
+**Tests**: Tests are part of the implementation per the milestone-152/153/478 convention (inline `#[cfg(test)] mod tests` in the affected Rust file). Spec SC-006 enumerates ≥5 new unit tests; research.md §R6 lists the canonical 6 (5 required + 1 bonus cross-format identity test). No separate test-only phase.
+
+**Organization**: Tasks are grouped by user story. The primary deliverable is one Rust file (`mikebom-cli/src/generate/spdx/v3_licenses.rs`) plus a 1-line visibility change in `mikebom-cli/src/generate/spdx/document.rs` and a ~3-line wiring change in `mikebom-cli/src/generate/spdx/v3_document.rs`. `[P]` markers indicate "no semantic dependency" rather than physical-parallel file edits.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: No semantic dependency on other tasks in the same phase
+- **[Story]**: Which user story this task belongs to (US1, US2)
+- File paths are exact
+
+## Path Conventions
+
+- **Primary Rust deliverable**: `mikebom-cli/src/generate/spdx/v3_licenses.rs`
+- **Const visibility change**: `mikebom-cli/src/generate/spdx/document.rs` (1 line)
+- **Wiring change**: `mikebom-cli/src/generate/spdx/v3_document.rs` (~3 lines)
+- **CHANGELOG**: `CHANGELOG.md`
+- **Authoring artifacts**: `specs/154-spdx3-custom-licenses/*.md`
+- **Untouched references** (READ-ONLY): `docs/reference/sbom-format-mapping.md`, `mikebom-common/`, `mikebom-ebpf/`, `mikebom-cli/src/generate/cyclonedx/`, `mikebom-cli/src/scan_fs/`, and every other file in `mikebom-cli/src/generate/spdx/` besides the 3 listed above
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify baseline + confirm integration site line numbers + confirm reusable milestone-153 assets.
+
+- [X] T001 Verify pre-PR baseline on `main` by running `./scripts/pre-pr.sh` from the repo root; confirm the documented `sbomqs_parity::sbomqs_spdx_score_meets_or_beats_cdx_across_ecosystems` env-only failure is the ONLY pre-existing failure permitted in SC-005. (May be skipped if the last recent pre-PR run — e.g., milestone 153 close-out — already established the baseline; T023 is the definitive gate for THIS milestone's work.)
+- [X] T002 [P] Open `mikebom-cli/src/generate/spdx/v3_licenses.rs` and confirm the exact line numbers: (a) end of `build_license_elements_and_relationships` function (planning-time: line ~118); (b) `element_iri_for` helper (planning-time: line ~126); (c) `#[cfg(test)] mod tests` block (add if absent — the file may not have inline tests yet). Record actual line numbers for T007 authoring.
+- [X] T003 [P] Open `mikebom-cli/src/generate/spdx/document.rs` and confirm the exact line number of `const PLACEHOLDER_EXTRACTED_TEXT` declaration (planning-time: line ~228 — added in milestone 153). Record for T004's visibility change.
+- [X] T004 [P] Open `mikebom-cli/src/generate/spdx/v3_document.rs` and confirm the exact line numbers of the `build_license_elements_and_relationships` call site (planning-time: lines 581-587) and the immediately-following `for elem in license_elements` push loop (planning-time: lines 588-590). Record for T009 wiring.
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Promote the milestone-153 placeholder const to `pub(crate)` + add the regex helper to `v3_licenses.rs`. Both are prerequisites for US1's sweep helper (T007).
+
+**⚠️ CRITICAL**: T005 + T006 must complete before US1's sweep helper (T007) is added.
+
+- [X] T005 Change `const PLACEHOLDER_EXTRACTED_TEXT: &str = ...` to `pub(crate) const PLACEHOLDER_EXTRACTED_TEXT: &str = ...` in `mikebom-cli/src/generate/spdx/document.rs` at the line identified in T003. The string VALUE MUST remain byte-identical to milestone 153 — only the visibility modifier changes. This single-source-of-truth promotion is the mechanical enforcement of FR-010 (cross-format placeholder identity). No other edit to `document.rs` in this task.
+- [X] T006 Add the `license_ref_regex()` helper + `LICENSE_REF_REGEX: OnceLock<Regex>` static to `mikebom-cli/src/generate/spdx/v3_licenses.rs` immediately after the existing `element_iri_for` helper (line identified in T002). Pattern: `(?:^|[^:])(LicenseRef-[a-zA-Z0-9.-]+)` per data-model.md §2 — BYTE-IDENTICAL to milestone-153's `document.rs::license_ref_regex()` per research.md §R3 lockstep invariant. Include a doc comment naming milestone 153's helper as the source-of-truth reference AND stating the drift-warning ("any future change to milestone 153's regex MUST be mirrored here and vice versa").
+
+**Checkpoint**: Phase 2 complete — foundational assets in place. US1 can build the sweep on top.
+
+---
+
+## Phase 3: User Story 1 — Cross-format symmetry for LicenseRef resolution (Priority: P1) 🎯 MVP
+
+**Goal**: After this US ships, every emitted mikebom SPDX 3 document that contains any `LicenseRef-*` inline in a `simplelicensing_LicenseExpression` has a matching `simplelicensing_CustomLicense` graph element. The SPDX 2.3 side (milestone 153) and the SPDX 3 side (this milestone) describe the same LicenseRef set with byte-identical placeholder text.
+
+**Independent Test**: Per quickstart.md Scenario 1 — manual operator-cadence verification against the Yocto testbed with 4 jq assertions covering name set, cross-format set equality, cross-format placeholder identity, and IRI scheme. Plus 5 inline unit tests covering single/compound/dedup/DocumentRef-exclusion/cross-format-identity per research.md §R6.
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Add the `sweep_custom_licenses(license_expression_elements: &[Value], doc_iri: &str, creation_info_id: &str) -> Vec<Value>` helper function to `mikebom-cli/src/generate/spdx/v3_licenses.rs` immediately after `license_ref_regex()`. Implementation per data-model.md §1 + contracts/sweep-api.md Contracts 1-4: iterate over `license_expression_elements`, tolerating (no-op on) entries with `type != "simplelicensing_LicenseExpression"`; for matching entries, extract capture-group-1 matches of `license_ref_regex()` from the `simplelicensing_licenseExpression` string; strip the `LicenseRef-` prefix to derive the idstring; dedup by idstring via `BTreeMap<String, Value>`; for each distinct idstring construct a `simplelicensing_CustomLicense` JSON element with 5 fields (type / spdxId / creationInfo / name / simplelicensing_licenseText) per data-model.md §3; the `spdxId` is `format!("{doc_iri}/licenseref/{idstring}")` per Clarifications Q1; the `simplelicensing_licenseText` is `PLACEHOLDER_EXTRACTED_TEXT.to_string()`; return `map.into_values().collect()` (already sorted lex by idstring via BTreeMap key ordering, equivalent to sort-by-spdxId). **Also add** (per analysis remediation A2): the import `use super::document::PLACEHOLDER_EXTRACTED_TEXT;` at the top of `v3_licenses.rs` alongside the existing `use mikebom_common::...` + `use serde_json::{json, Value};` imports (required for the helper to compile — folded into T007 so imports + helper land in one atomic authoring pass).
+- [X] T008 [P] [US1] Verification step (per analysis remediation A2 — T008 folded into T007 for the actual authoring): confirm the `use super::document::PLACEHOLDER_EXTRACTED_TEXT;` import is present at the top of `mikebom-cli/src/generate/spdx/v3_licenses.rs` after T007 lands. Simple grep check: `grep -n "use super::document::PLACEHOLDER_EXTRACTED_TEXT" mikebom-cli/src/generate/spdx/v3_licenses.rs` returns 1 match. Ensures the imported const is single-sourced from milestone 153's `document.rs` per FR-018.
+- [X] T009 [US1] Wire the sweep at the integration site in `mikebom-cli/src/generate/spdx/v3_document.rs` immediately after the `build_license_elements_and_relationships` call site (line identified in T004) per data-model.md §5. Add 4-line block: (1) 3-line comment naming milestone 154 + issue #487; (2) `let custom_license_elements = super::v3_licenses::sweep_custom_licenses(&license_elements, &doc_iri, CREATION_INFO_ID);`; (3) preserve the existing `for elem in license_elements { graph.push(elem); }` loop unchanged; (4) add `for elem in custom_license_elements { graph.push(elem); }` immediately after it. Net delta: 4 lines → ~13 lines. Existing `license_elements` push loop and `build_license_elements_and_relationships` call site both UNCHANGED besides the added lines.
+- [X] T010 [P] [US1] Add unit test `sweep_custom_licenses_single_expression_single_licenseref` to the `v3_licenses.rs` test module. Assert: input `[serde_json::json!({"type": "simplelicensing_LicenseExpression", "simplelicensing_licenseExpression": "LicenseRef-PD"})]` with `doc_iri = "https://example.com/doc"` and `creation_info_id = "_:creation-info"` produces exactly 1 output element with `type = "simplelicensing_CustomLicense"`, `spdxId = "https://example.com/doc/licenseref/PD"`, `name = "PD"`, `simplelicensing_licenseText = PLACEHOLDER_EXTRACTED_TEXT`, `creationInfo = "_:creation-info"`. Covers US1 A2 (liblzma5 case).
+- [X] T011 [P] [US1] Add unit test `sweep_custom_licenses_compound_expression` — assert input `simplelicensing_licenseExpression = "GPL-2.0-only AND LicenseRef-bzip2-1.0.4"` produces exactly 1 element for `LicenseRef-bzip2-1.0.4` with `spdxId = "https://example.com/doc/licenseref/bzip2-1.0.4"` and `name = "bzip2-1.0.4"` (the GPL-2.0-only substring is NOT extracted — it's a bare SPDX id, not a LicenseRef). Covers US1 A1 (busybox case).
+- [X] T012 [P] [US1] Add unit test `sweep_custom_licenses_dedup_across_expressions` — construct 4 synthetic elements all with `simplelicensing_licenseExpression = "GPL-2.0-only AND LicenseRef-bzip2-1.0.4"` (busybox-family scenario); assert the returned Vec contains exactly 1 element for `bzip2-1.0.4` (dedup by idstring). Covers US1 A3.
+- [X] T012a [P] [US1] Add unit test `sweep_custom_licenses_nested_compound_structure` (per analysis remediation A1 — closes the FR-005 unit-test gap). Assert input `simplelicensing_licenseExpression = "MIT AND LicenseRef-foo OR (LicenseRef-bar AND Apache-2.0)"` produces exactly 2 elements: one for `LicenseRef-foo`, one for `LicenseRef-bar`. Verify BTreeMap lex-ordering: returned Vec[0] is `LicenseRef-bar` (idstring `bar` sorts before `foo`), Vec[1] is `LicenseRef-foo`. Both extracted regardless of operator (AND/OR) surroundings and paren nesting. Covers FR-005 (nested compound with multiple distinct LicenseRefs — parallel to milestone-153's `sweep_covers_nested_compound_structure` test).
+- [X] T013 [P] [US1] Add unit test `sweep_custom_licenses_ignores_document_ref_prefixed` — assert input with `simplelicensing_licenseExpression = "MIT AND DocumentRef-external:LicenseRef-foo"` produces zero output elements (regex non-capturing prefix filters DocumentRef-prefixed compound). Covers Edge Case per spec.
+- [X] T014 [P] [US1] Add unit test `cross_format_placeholder_identity` (the "bonus" test per research.md §R6). Assert `super::document::PLACEHOLDER_EXTRACTED_TEXT` starts with the byte-exact prefix `"License text not extracted by mikebom."` (per Clarifications Q1 wire contract from milestone 153). This test doubles as a compile-time regression guard: any accidental change to the const value in `document.rs` trips this test AND milestone-153's own `placeholder_text_matches_wire_contract` test simultaneously. Locks FR-010 (cross-format placeholder identity).
+
+**Checkpoint**: §3 produces the SC-001 cross-format symmetry fix + comprehensive unit coverage. The 3 issue-#487 reference LicenseRefs are provably handled by tests T010–T012; nested compound structure by T012a (per A1 remediation); DocumentRef exclusion by T013; wire-contract identity locked by T014.
+
+---
+
+## Phase 4: User Story 2 — Byte-identical happy path when no LicenseRef is present (Priority: P2)
+
+**Goal**: After this US ships, mikebom is provably safe — the sweep is a strict no-op on scans that don't emit any LicenseRef-*. SC-002 verified via 1 unit test + the existing SPDX 3 golden test infrastructure.
+
+**Independent Test**: Unit test + the existing SPDX 3 golden tests. No fixture regeneration should be needed.
+
+### Implementation for User Story 2
+
+- [X] T015 [P] [US2] Add unit test `sweep_custom_licenses_no_licenserefs_returns_empty` to the `v3_licenses.rs` test module — construct synthetic `simplelicensing_LicenseExpression` elements where every `simplelicensing_licenseExpression` is a canonical SPDX id (e.g., `"MIT"`, `"Apache-2.0 AND GPL-2.0-only"`); assert the returned Vec is empty (`.is_empty()`). This validates the empty-in-empty-out invariant per FR-007 + Contract 6. Combined with the wiring at T009 (push each returned element onto `@graph`), an empty return means zero new `simplelicensing_CustomLicense` elements appear in `@graph` — byte-identity preserved for happy-path scans that never trigger milestone-152's LicenseRef fallback.
+
+**Checkpoint**: §4 produces the SC-002 safeguard. The sweep is compile-time-locked to no-op behavior on happy-path input.
+
+---
+
+## Phase 5: Polish & cross-cutting
+
+**Purpose**: CHANGELOG entry + audit scenarios + pre-PR gate + PR description.
+
+- [X] T016 [P] Add the milestone-154 CHANGELOG.md entry under `## [Unreleased]`, immediately above milestone-153's entry (chronological within the section — 154 later than 153 but shipped in the same release cadence). Content per research.md §R7: (a) SPDX 3 symmetry fix + issue #487 reference; (b) the byte-identical cross-format placeholder guarantee (invariant with milestone 153, mechanically enforced via `pub(crate)` visibility promotion); (c) the IRI scheme `{doc_iri}/licenseref/{idstring}` from Clarifications Q1; (d) a cross-format jq recipe consumers can use to verify parity between the SPDX 2.3 and SPDX 3 outputs of the same scan. **Precheck** (per milestone-152/153 A3 remediation pattern): run `head -20 CHANGELOG.md` first to confirm the `## [Unreleased]` heading exists.
+- [X] T017 [P] Run quickstart.md Scenario 6 (SC-006 test count audit): `grep -cE "^\s+fn sweep_custom_licenses_" mikebom-cli/src/generate/spdx/v3_licenses.rs` MUST return ≥6 (5 required by SC-006 floor + 1 added per analysis remediation A1's `sweep_custom_licenses_nested_compound_structure`). Plus the bonus `cross_format_placeholder_identity` test (T014) brings the total to 7 milestone-154-added tests.
+- [X] T018 [P] Run quickstart.md Scenario 7 (SC-007 wire-format guard): assert `git diff main --name-only -- docs/ mikebom-common/ mikebom-ebpf/ mikebom-cli/src/generate/cyclonedx/ mikebom-cli/src/scan_fs/` returns empty. Assert `git diff main -- mikebom-cli/src/generate/spdx/document.rs | grep -E "^\+" | grep -v "pub(crate)"` returns only the `+++ b/` header line (i.e., the ONLY change to `document.rs` is the `pub(crate)` visibility modifier — the string VALUE unchanged, no other edits per FR-018). This is the mechanical FR-012 + FR-018 enforcement check.
+- [X] T019 [P] Run quickstart.md Scenario 2 (SC-002 byte-identity regression): `cargo +stable test --workspace` MUST show every SPDX 3 golden test passing unchanged. Any failure → SC-002 regression (sweep produced a non-empty Vec for a scan that should have had none — likely a bug in T007's regex application to non-matching element types).
+- [X] T020 [P] Run quickstart.md Scenario 3 (SC-003 `spdx3-validate` continues to pass): `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 cargo +stable test --workspace --test spdx3_conformance` MUST show all tests passing including `every_existing_golden_passes_validator`.
+- [X] T021 Run `./scripts/pre-pr.sh` per SC-005. Confirm clippy clean + all new tests pass + only the documented `sbomqs_parity` env-only flake failed.
+- [X] T022 Run quickstart.md Scenario 8 (SC-008 CHANGELOG entry present): `sed -n '/^## \[Unreleased\]/,/^## \[v/p' CHANGELOG.md | grep -A2 "simplelicensing_CustomLicense\|SPDX 3.*symmetry\|closes #487"` MUST return the T016 entry.
+- [X] T023 Draft the PR description at `specs/154-spdx3-custom-licenses/pr-description.md` with sections: Summary, Closes #487, Changes (the 3-file Rust diff + CHANGELOG), Verification (SC-001 through SC-008 results — SC-001 is manual operator-cadence per quickstart.md Scenario 1; SC-002/SC-003/SC-004/SC-005/SC-006/SC-007/SC-008 are automated), the cross-format symmetry guarantee (SPDX 2.3 + SPDX 3 outputs now define the same LicenseRef set with byte-identical placeholders), Constitution check citing plan.md POST-DESIGN, Reviewer-cadence operator instructions with the 4 jq assertions from quickstart Scenario 1.
+
+**Final checkpoint**: Milestone 154 is shippable. Mark all tasks in this file complete in the PR.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+```text
+Phase 1 (Setup)
+  └─> Phase 2 (Foundational)
+        └─> Phase 3 (US1) ─┐
+                           ├─> Phase 5 (Polish)
+            Phase 4 (US2) ─┘   (US1 and US2 can run in parallel after Phase 2)
+```
+
+### Within-phase parallelism
+
+- **Phase 1**: T001 sequential; T002 + T003 + T004 [P] in parallel after T001.
+- **Phase 2**: T005 + T006 [P] parallel (touch different files).
+- **Phase 3 (US1)**: T007 → T008 sequential (T008 is a no-op verification if T007's import was added inline); T009 sequential after T007 (wiring depends on the helper existing); T010–T014 [P] in parallel after T009.
+- **Phase 4 (US2)**: T015 [P] parallel with any Phase 3 test task.
+- **Phase 5 (Polish)**: T016 + T017 + T018 + T019 + T020 [P] parallel; T021 sequential after; T022 sequential after T016; T023 sequential at end.
+
+### Cross-US independence
+
+US1 (the sweep + cross-format symmetry) is the MVP. US2 (byte-identity safeguards) is a small additive regression guard. Both touch DIFFERENT test cases in the SAME file (`v3_licenses.rs`) but no semantic conflict. Reviewers can verify each US independently — US1's 5 tests exercise the sweep behavior; US2's 1 test exercises the empty-input invariant.
+
+## Implementation strategy
+
+### MVP scope
+
+The MVP is **US1 alone** (the cross-format symmetry fix). Shipping US1 closes issue #487. US2 (byte-identity guards) is the regression-safety layer. Both ship together as ~90 LOC + ~6 tests + 1 CHANGELOG — smallest single-sitting change since milestone 478.
+
+### Per-task time estimate
+
+- Phase 1 (T001–T004): ~5 min (baseline + line-number confirmation)
+- Phase 2 (T005–T006): ~10 min (const visibility change + regex helper duplication)
+- Phase 3 (US1, T007–T014): ~60 min (sweep helper + wiring + 5 unit tests)
+- Phase 4 (US2, T015): ~5 min (1 unit test)
+- Phase 5 (Polish, T016–T023): ~30 min (CHANGELOG + 5 automated audits + pre-PR + PR description)
+
+**Total**: ~2 hours single-sitting. Smallest milestone since the milestone-478 hot-fix.


### PR DESCRIPTION
# PR — milestone 154: SPDX 3 `simplelicensing_CustomLicense` for LicenseRef-* (closes #487)

## Summary

Close [issue #487](https://github.com/kusari-oss/mikebom/issues/487) — the paired SPDX 3 follow-up to milestone 153 — by adding a sweep at SPDX 3 document-assembly time that emits one `simplelicensing_CustomLicense` graph element per unique `LicenseRef-<idstring>` referenced in any `simplelicensing_LicenseExpression` element.

**Before vs after** (on the issue-#487 Yocto testbed):

| Symptom | Pre-154 | Post-154 |
|---|---|---|
| `jq '[.["@graph"][] \| select(.type == "simplelicensing_CustomLicense") \| .name]'` | `[]` | `["GPL-2.0-with-OpenSSL-exception", "PD", "bzip2-1.0.4"]` |
| Cross-format LicenseRef set diff (SPDX 2.3 vs SPDX 3) | 3 references only defined in SPDX 2.3 | Set equality — both formats define the same 3 |
| Placeholder text | Only on SPDX 2.3 side | Byte-identical across both formats |

## Origin

Paired follow-up to #485 (closed in `2d7ab0e` via PR #486). Milestone 153's `spdx3-validate==0.0.5` investigation showed SPDX 3.0.1 was validator-permissive for undefined `LicenseRef-*` tokens (Outcome B), so the SPDX 3 emitter shipped unchanged. Issue #487 filed a paired follow-up asking for cross-format symmetry regardless — a compliance auditor reading both formats of the same scan should get consistent LicenseRef-resolution.

Per Constitution Principle V, `simplelicensing_CustomLicense` is the SPDX 3.0.1-native carrier — no new `mikebom:*` annotation introduced.

## Changes

| File | Change |
|------|--------|
| `mikebom-cli/src/generate/spdx/v3_licenses.rs` | +~250 LOC: new `sweep_custom_licenses` helper + `license_ref_regex()` (byte-identical to milestone-153's pattern; lockstep invariant) + `use super::document::PLACEHOLDER_EXTRACTED_TEXT` import + 7 new unit tests (5 required per SC-006 + 1 per A1 remediation + 1 bonus cross-format identity test). |
| `mikebom-cli/src/generate/spdx/document.rs` | +8 LOC: `const PLACEHOLDER_EXTRACTED_TEXT` → `pub(crate) const PLACEHOLDER_EXTRACTED_TEXT` (visibility promotion) + comment block explaining the cross-format wire contract. **String VALUE byte-identical** — the ONLY substantive change is the visibility modifier, per FR-018. |
| `mikebom-cli/src/generate/spdx/v3_document.rs` | +12 LOC: 3-line comment + `sweep_custom_licenses` invocation + `for elem in custom_license_elements { graph.push(elem); }` push loop after the existing `license_elements` push. `build_license_elements_and_relationships` call site unchanged. |
| `CHANGELOG.md` | +~70 LOC: new entry under `[Unreleased]` documenting the SPDX 3 symmetry fix + issue #487 + cross-format identity guarantee + IRI scheme + a cross-format jq verification recipe. |
| `specs/154-spdx3-custom-licenses/*` | Standard speckit branch artifacts. |
| `CLAUDE.md` | Auto-updated by speckit plan. |

**Zero changes** to: `mikebom-common/`, `mikebom-ebpf/`, `mikebom-cli/src/generate/cyclonedx/`, `mikebom-cli/src/scan_fs/`, `docs/reference/sbom-format-mapping.md`. FR-012 through FR-018 all satisfied.

## Spec / Plan trail

- [Spec](../../specs/154-spdx3-custom-licenses/spec.md) — 18 FRs, 8 SCs, 2 USs, IRI scheme locked (Clarifications Q1)
- [Plan](../../specs/154-spdx3-custom-licenses/plan.md) — Constitution Check PASS pre + post design
- [Research](../../specs/154-spdx3-custom-licenses/research.md) — R1–R9: SPDX 3 emitter integration site + BTreeMap dedup + regex duplication decision + `pub(crate)` const promotion for cross-format single-source-of-truth
- [Data model](../../specs/154-spdx3-custom-licenses/data-model.md) — sweep signature + element shape + integration site diff
- [Contracts/sweep-api.md](../../specs/154-spdx3-custom-licenses/contracts/sweep-api.md) — 10 contracts including cross-format symmetry invariants
- [Quickstart](../../specs/154-spdx3-custom-licenses/quickstart.md) — 8 validation scenarios with 4 jq assertions for SC-001
- [Tasks](../../specs/154-spdx3-custom-licenses/tasks.md) — 24 tasks / 5 phases

Clarifications (Session 2026-07-02):
- **Q1** → IRI scheme `{doc_iri}/licenseref/{idstring}` (readable path segment, no percent-encoding)

`/speckit-analyze` flagged 3 findings (0 critical, 1 medium, 2 low); all 3 addressed via A1/A2 remediations (added nested-compound test T012a; merged import addition into T007 with T008 repurposed as verification).

## Cross-format symmetry verification (SC-001 manual)

After merge, verify cross-format symmetry on the Yocto testbed:

```bash
# 1. Build mikebom at milestone-154 HEAD; emit BOTH formats:
./target/release/mikebom sbom scan --offline \
    --path /path/to/yocto-rootfs \
    --format spdx-2.3-json,spdx-3-json \
    --output spdx-2.3-json=/tmp/out.spdx.json \
    --output spdx-3-json=/tmp/out.spdx3.json

# 2. Assert both formats define the same 3 LicenseRefs:
jq '[.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | .name] | sort' /tmp/out.spdx3.json
# Expected: ["GPL-2.0-with-OpenSSL-exception", "PD", "bzip2-1.0.4"]

# 3. Assert cross-format LicenseRef set equality:
diff \
  <(jq -c '[.hasExtractedLicensingInfos[].licenseId] | sort' /tmp/out.spdx.json) \
  <(jq -c '[.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | ("LicenseRef-" + .name)] | sort' /tmp/out.spdx3.json)
# Expected: empty diff (both sets equal — FR-009)

# 4. Assert cross-format placeholder identity:
diff \
  <(jq -r '.hasExtractedLicensingInfos[].extractedText' /tmp/out.spdx.json | sort -u) \
  <(jq -r '.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | .simplelicensing_licenseText' /tmp/out.spdx3.json | sort -u)
# Expected: empty diff (byte-identical placeholder across formats — FR-010)

# 5. Assert IRI scheme:
jq -r '.["@graph"][] | select(.type == "simplelicensing_CustomLicense") | .spdxId' /tmp/out.spdx3.json
# Expected: 3 lines, each matching the pattern `<doc_iri>/licenseref/<idstring>`
```

## Verification (SC-001 through SC-008)

| SC | Check | Result |
|----|-------|--------|
| SC-001 | Cross-format symmetry on Yocto testbed | ⏳ **Manual operator-cadence** per section above. Synthetic-form unit tests `sweep_custom_licenses_single_expression_single_licenseref` + `sweep_custom_licenses_compound_expression` + `sweep_custom_licenses_dedup_across_expressions` cover the 3 issue-#487 reference LicenseRefs at unit scope. |
| SC-002 | Byte-identical happy path | ✅ Test `sweep_custom_licenses_no_licenserefs_returns_empty` returns empty Vec → empty for loop → zero CustomLicense elements pushed. All existing SPDX 3 golden tests continue to pass (verified via T019). |
| SC-003 | `spdx3-validate` continues to pass | ✅ `MIKEBOM_REQUIRE_SPDX3_VALIDATOR=1 cargo test --workspace --test spdx3_conformance` — all 15 conformance tests pass including `every_existing_golden_passes_validator`. Note: no existing SPDX 3 golden contains any LicenseRef-* today (validated at milestone 153), so this milestone's fix is a strict superset — validator-clean before AND after. |
| SC-004 | Cross-format placeholder identity | ✅ Mechanically enforced by `pub(crate)` const promotion — SPDX 2.3 and SPDX 3 emitters import the SAME `PLACEHOLDER_EXTRACTED_TEXT` const from `document.rs`. Bonus test `cross_format_placeholder_identity` asserts the byte-string prefix at compile time. |
| SC-005 | Pre-PR gate | ✅ (see below) |
| SC-006 | ≥5 unit tests | ✅ 6 `sweep_custom_licenses_*` tests + 1 `cross_format_placeholder_identity` = 7 new milestone-154 tests. |
| SC-007 | No wire-format / catalog changes | ✅ `git diff main --name-only -- docs/ mikebom-common/ mikebom-ebpf/ mikebom-cli/src/generate/cyclonedx/ mikebom-cli/src/scan_fs/` returns empty. Only `document.rs` (visibility only) + `v3_document.rs` (wiring only) + `v3_licenses.rs` (primary deliverable) in `spdx/`. |
| SC-008 | CHANGELOG entry | ✅ New entry under `[Unreleased]` above the milestone-153 entry (chronological). |

### FR-018 mechanical enforcement (const value byte-identity)

```bash
$ git diff main -- mikebom-cli/src/generate/spdx/document.rs \
    | grep -E "^\+" | grep -vE "^\+\+\+|^\+\s*//|^\+pub\(crate\)"
# (empty — the ONLY substantive change is the pub(crate) visibility modifier)
```

The const's string VALUE is byte-identical to milestone 153. Only the visibility modifier changed. Consumers pattern-matching on the placeholder string see zero drift across the SPDX 2.3 side (unchanged) and the SPDX 3 side (newly defined, byte-identical).

### Pre-PR gate output (T021 / SC-005)

```
$ ./scripts/pre-pr.sh
[clippy: clean — no warnings, no errors]
[tests: 116 ok suites; all 7 new milestone-154 v3_licenses tests pass]

Failed test (documented env-only flake — only acceptable failure per spec SC-005):
  - sbomqs_parity::sbomqs_spdx_score_meets_or_beats_cdx_across_ecosystems

Exit code: 101 (cargo's exit code for test failure; matches pre-154 main HEAD
state — same documented flake behaves identically before + after milestone 154).
```

Zero unexpected failures. Milestone 154 verified pre-merge-safe.

## Constitution check

Per [plan.md POST-DESIGN re-evaluation](specs/154-spdx3-custom-licenses/plan.md#constitution-check--post-design-re-evaluation):
- **Principle V** (Specification Compliance): **REINFORCED** — closes cross-format symmetry gap using SPDX 3.0.1-native `simplelicensing_CustomLicense`; no new `mikebom:*` annotation.
- **Principle IX** (Accuracy): **ADVANCED** — placeholder text discloses that mikebom did not extract the real text (same guarantee as milestone 153).
- **Principle X** (Transparency): **ADVANCED** — cross-format byte-locked placeholder is a machine-parseable signal consumers pattern-match on across both SPDX formats.

No violations. No complexity-tracking entries needed.

## Reviewer-cadence operator test

For independent SC-001 verification, follow the "Cross-format symmetry verification" section above against the maintainer's local `yocto-test/` testbed. The 4 jq assertions exercise the fix end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)