### PR TITLE
impl(164): pnpm v9 multi-version edge disambiguation (implements milestone 164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,89 @@ adheres to [Semantic Versioning](https://semver.org/) once it exits
 
 ## [Unreleased]
 
+### pnpm v9 multi-version edge disambiguation (milestone 164)
+
+Empirical follow-up to milestone 163's podman-desktop re-measurement
+(2026-07-05, live upstream `github.com/podman-desktop/podman-desktop`).
+Post-163 BFS reachability jumped 24.6% → 77.4% (+52.8pp) as designed,
+but a 22-point residual gap remained. Root-cause investigation traced
+435 of 568 remaining orphans (76.6% of the gap) to a single bug class:
+pnpm-lock v9 emitted multi-version co-existence (e.g.
+`pkg:npm/@algolia/autocomplete-core@1.17.9` AND
+`pkg:npm/@algolia/autocomplete-core@1.19.8`), but parent edges targeted
+the WRONG version.
+
+Concrete root cause verified 2026-07-05: `@docsearch/react@3.9.0`'s
+pnpm-lock declaration was `@algolia/autocomplete-core: 1.17.9(...)`
+(with peer-dep suffix), but the emitted SBOM edge pointed at
+`@algolia/autocomplete-core@1.19.8`. `parse_pnpm_key` at
+`pnpm_lock.rs:479-492` correctly extracted `(name, "1.17.9")` from the
+peer-dep-suffixed value, but the caller at line 80 discarded the
+version via `_canon_ver` and pushed the bare name into `depends`.
+Downstream `name_to_purl` resolution at `scan_fs/mod.rs:471` then
+last-write-wins on the name-only key, picking whichever version was
+inserted last. **Constitution Principle IX (Accuracy) failure**:
+emitted edges pointed at the wrong version of a real component.
+
+**Fix**: thread the version through `collect_pnpm_dep_names` via a new
+`emit_versioned: bool` parameter. When true (called from the v9
+`snapshots:` path only), the function pushes
+`format!("{canon_name} {canon_ver}")` — the disambiguation-key form
+already indexed at `scan_fs/mod.rs:519-525` (extended for npm per issue
+#262 + milestone-087 cargo precedent). When false (v6/v7 inline path,
+per User Story 2 byte-identity guard), pre-164 bare-name emission is
+preserved. Milestone-159's `rewrite_dep_names` was updated to split
+each input on the first space and preserve the version segment through
+alias substitution (FR-003 alias-composition contract).
+
+**No new annotations, no new parity-catalog rows, no new CLI flags.**
+Reuses existing `name_to_purl` disambiguation mechanism — the receiver
+was already in place, milestone 164 just activates it on the pnpm v9
+code path.
+
+**Empirical impact on live podman-desktop** (measured 2026-07-05):
+
+| Metric | Pre-163 | Post-163 | Post-164 |
+|---|---|---|---|
+| BFS reachability | 24.6% | 77.4% | **99.6%** |
+| Multi-version orphans | 902 | 435 | **12** |
+| Truly-isolated orphans | 1235 | 133 | **0** (were all multi-version) |
+| Empty-version PURLs | 159 | 0 | 0 |
+| Phantom edges | 902 | 0 | 0 |
+
+Milestone 164 blew past its SC-002 ≥93% target — reached **99.6%** BFS
+reachability, essentially achieving milestone-158's aspirational
+≥99% target for the npm ecosystem. The FR-008 malformed-key WARN
+counter fired 0 times on podman-desktop (2668 snapshots processed),
+confirming research R3's option (a): `parse_pnpm_key` returns `None`
+for empty-version keys, making the WARN branch defensive-only.
+
+**New tracing observability** (FR-009): the existing `pnpm-lock parsed`
+info-log gains two fields:
+- `multi_version_disambiguated_count` — deps emitted through the new
+  versioned-form path.
+- `malformed_key_warn_count` — FR-008 fallback fires (defensive-only
+  in practice per research R3).
+
+**Consumer jq recipes**:
+
+```bash
+# Verify no wrong-version edges (multi-version orphans) on any scan
+jq '[
+  .components[] | select(.purl | startswith("pkg:npm/")) | .purl
+] | group_by(sub("@[^@]+$"; "")) | map(select(length > 1))
+  | .[] | .[]' sbom.cdx.json  # shows multi-version co-existence
+
+# Grep the FR-009 log summary
+mikebom sbom scan --path <monorepo> 2>&1 | grep 'pnpm-lock parsed'
+# Look for: multi_version_disambiguated_count=<N> malformed_key_warn_count=<W>
+```
+
+Delivers essentially all remaining reachability toward milestone-158's
+≥99% aspirational target for the npm ecosystem. Future milestone 165
+would address the small residual (12 remaining multi-version orphans
+on podman-desktop — likely edge cases involving deep peer-dep chains).
+
 ### npm workspace-peer phantom empty-version edges eliminated (milestone 163)
 
 Closes issue #498 (surfaced during the milestone-158 T035 measurement

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,7 @@ Auto-generated from all feature plans. Last updated: 2026-07-05
 - N/A — all state in-process per scan; matches every milestone since 002. The allowlist lives in the compiled binary; the synthetic components live in the `Vec<PackageDbEntry>` returned by `gem::read`. (162-ruby-built-in-gems)
 - Rust stable (workspace toolchain inherited from milestones 001–162; no nightly required). + Existing only — `mikebom_common::types::purl::{Purl, encode_purl_segment}` (already used by `npm/mod.rs::build_npm_purl`), `serde`/`serde_json` (annotation values), `tracing` (FR-009 log), `anyhow`/`thiserror` (error propagation). **Zero new Cargo dependencies.** No semver crate needed — Q2 disposition sidesteps range-comparison logic (the lockfile is authoritative). (163-npm-phantom-edges)
 - N/A — cross-workspace resolution index lives in `Vec<PackageDbEntry>` scan-locally, rebuilt from Tier-A output per scan. Matches every milestone since 002. (163-npm-phantom-edges)
+- Rust stable (workspace toolchain inherited from milestones 001–163; no nightly required for this user-space-only work). + Existing only — `serde_yaml` (already used pervasively in the pnpm-lock parser), `tracing`, `anyhow`. **Zero new Cargo dependencies.** (164-pnpm-multi-version-edges)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -261,9 +262,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 164-pnpm-multi-version-edges: Added Rust stable (workspace toolchain inherited from milestones 001–163; no nightly required for this user-space-only work). + Existing only — `serde_yaml` (already used pervasively in the pnpm-lock parser), `tracing`, `anyhow`. **Zero new Cargo dependencies.**
 - 163-npm-phantom-edges: Added Rust stable (workspace toolchain inherited from milestones 001–162; no nightly required). + Existing only — `mikebom_common::types::purl::{Purl, encode_purl_segment}` (already used by `npm/mod.rs::build_npm_purl`), `serde`/`serde_json` (annotation values), `tracing` (FR-009 log), `anyhow`/`thiserror` (error propagation). **Zero new Cargo dependencies.** No semver crate needed — Q2 disposition sidesteps range-comparison logic (the lockfile is authoritative).
 - 162-ruby-built-in-gems: Added Rust stable (workspace toolchain inherited from milestones 001–161; no nightly required for this user-space-only work). + Existing only — `mikebom_common::types::purl::{Purl, encode_purl_segment}` (already used by `gem.rs::build_gem_purl`), `serde`/`serde_json` (annotation values), `tracing` (FR-011 log), `anyhow`/`thiserror` (error propagation). **Zero new Cargo dependencies.** The allowlist is a `const &[&str]` array literal.
-- 161-go-workspace-edges: Added Rust stable (workspace toolchain inherited from milestones 001–160; no nightly required for this user-space-only work). + Existing only — `std::process::Command` for the `GOWORK=off go mod graph` subprocess invocations (same pattern as milestone-055 `run_go_mod_graph` at `go_mod_graph.rs:81`), `std::fs::exists` for `go.work` detection, `serde`/`serde_json` (annotation values), `tracing` (FR-011 log), `anyhow`/`thiserror` (error propagation). **Zero new Cargo dependencies.** The go.work parser is stdlib-only (line-based, mirrors the existing `parse_go_mod` structure at `legacy.rs:200`).
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/scan_fs/package_db/npm/alias_mapping.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/alias_mapping.rs
@@ -313,19 +313,34 @@ pub(crate) fn detect_yarn_v1_alias(
 /// Rewrite a dep-name list to use aliased canonical names per FR-005.
 ///
 /// For each dep-name in `dep_names`:
-///   - Look up in `alias_map`. If present, replace with
-///     `aliased_name`.
-///   - Otherwise preserve byte-identically.
+///   - Split on the FIRST space to separate `<name>` from an optional
+///     `<version>` suffix (per milestone 164's version-qualified
+///     disambiguation form emitted by `collect_pnpm_dep_names` when
+///     `emit_versioned=true`).
+///   - Look up `<name>` in `alias_map`. If present:
+///       * With version → emit `format!("{aliased_name} {version}")`
+///         (version preserved through alias substitution — m164 FR-003
+///         alias-composition contract).
+///       * Without version → emit bare `aliased_name` (pre-164
+///         behavior preserved for the no-version case).
+///   - Otherwise preserve byte-identically (both name and any version).
 ///
 /// Preserves the input ordering.
 pub(crate) fn rewrite_dep_names(dep_names: &[String], alias_map: &AliasMap) -> Vec<String> {
     dep_names
         .iter()
-        .map(|name| {
-            alias_map
-                .get(name)
-                .map(|ident| ident.aliased_name.clone())
-                .unwrap_or_else(|| name.clone())
+        .map(|dep| {
+            let (name, version_opt) = match dep.find(' ') {
+                Some(idx) => (&dep[..idx], Some(&dep[idx + 1..])),
+                None => (dep.as_str(), None),
+            };
+            match alias_map.get(name) {
+                Some(ident) => match version_opt {
+                    Some(v) => format!("{} {}", ident.aliased_name, v),
+                    None => ident.aliased_name.clone(),
+                },
+                None => dep.clone(),
+            }
         })
         .collect()
 }
@@ -544,6 +559,30 @@ mod tests {
                 "@slorber/react-helmet-async".to_string(),
             ]
         );
+    }
+
+    // ─── Milestone 164 (T007a): rewrite_dep_names must preserve the
+    // version segment through alias substitution when milestone-164's
+    // `emit_versioned=true` path puts `"<name> <version>"` into
+    // `depends`. Closes the FR-003 alias-composition test gap.
+    #[test]
+    fn t007a_rewrite_dep_names_preserves_version() {
+        let alias_map = make_alias_map(&[("foo", "@real/foo", "1.2.3")]);
+
+        // Case (a): bare name + alias hit → aliased bare (no version to
+        // preserve — pre-164 behavior).
+        let out_bare = rewrite_dep_names(&["foo".to_string()], &alias_map);
+        assert_eq!(out_bare, vec!["@real/foo".to_string()]);
+
+        // Case (b): versioned form + alias hit → version preserved
+        // through substitution (m164 FR-003).
+        let out_versioned = rewrite_dep_names(&["foo 1.2.3".to_string()], &alias_map);
+        assert_eq!(out_versioned, vec!["@real/foo 1.2.3".to_string()]);
+
+        // Case (c): versioned form + no alias hit → passthrough
+        // unchanged (byte-identical).
+        let out_passthrough = rewrite_dep_names(&["baz 4.5.6".to_string()], &alias_map);
+        assert_eq!(out_passthrough, vec!["baz 4.5.6".to_string()]);
     }
 
     // ─── AliasEcosystem helper tests ───

--- a/mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs
@@ -47,8 +47,21 @@ fn collect_pnpm_dep_names(
     entry_tbl: &serde_yaml::Mapping,
     aliases: &mut Vec<super::alias_mapping::AliasResolution>,
     source_path: &str,
+    // Milestone 164 (T003, implements m164 FR-001): when true, push
+    // `"<name> <version>"` disambiguation form into `deps` so the
+    // downstream `name_to_purl` lookup at `scan_fs/mod.rs:519-525`
+    // (extended for npm per issue #262 + m087 cargo precedent) can
+    // pick the correct version when multiple emitted `pkg:npm/<name>@*`
+    // components exist. When false, preserve pre-164 bare-name
+    // emission — used at the v6/v7 inline call site to satisfy m164
+    // User Story 2 byte-identity guard.
+    emit_versioned: bool,
+    versioned_counter: Option<&mut usize>,
+    warn_counter: Option<&mut usize>,
 ) -> Vec<String> {
     let mut deps: Vec<String> = Vec::new();
+    let mut versioned_local: usize = 0;
+    let mut warn_local: usize = 0;
     for section in PNPM_DEP_SECTIONS {
         let Some(sub) = entry_tbl
             .get(serde_yaml::Value::String((*section).to_string()))
@@ -66,7 +79,15 @@ fn collect_pnpm_dep_names(
             if let Some(alias) =
                 super::alias_mapping::detect_pnpm_alias(dep_name, dep_ver_raw, source_path)
             {
-                deps.push(alias.aliased_name.clone());
+                // Milestone 164: when emit_versioned, carry the aliased
+                // version through for the downstream `rewrite_dep_names`
+                // pass to preserve on substitution (m164 FR-003 + R7).
+                if emit_versioned && !alias.aliased_version.is_empty() {
+                    deps.push(format!("{} {}", alias.aliased_name, alias.aliased_version));
+                    versioned_local += 1;
+                } else {
+                    deps.push(alias.aliased_name.clone());
+                }
                 aliases.push(alias);
                 continue;
             }
@@ -77,15 +98,37 @@ fn collect_pnpm_dep_names(
             let stripped = dep_pair_raw
                 .strip_prefix('/')
                 .unwrap_or(&dep_pair_raw);
-            let Some((canon_name, _canon_ver)) = parse_pnpm_key(stripped) else {
+            let Some((canon_name, canon_ver)) = parse_pnpm_key(stripped) else {
                 tracing::debug!(dep = %dep_pair_raw, "pnpm-lock: skipping non-registry dep value");
                 continue;
             };
-            deps.push(canon_name);
+            // Milestone 164 (T003, FR-001 + FR-008): thread the version
+            // through when the caller wants disambiguation.
+            if emit_versioned {
+                if canon_ver.is_empty() {
+                    tracing::warn!(
+                        key = %stripped,
+                        "pnpm-lock v9: peer-dep-suffixed key parsed to empty version; falling back to bare-name form"
+                    );
+                    warn_local += 1;
+                    deps.push(canon_name);
+                } else {
+                    versioned_local += 1;
+                    deps.push(format!("{canon_name} {canon_ver}"));
+                }
+            } else {
+                deps.push(canon_name);
+            }
         }
     }
     deps.sort();
     deps.dedup();
+    if let Some(c) = versioned_counter {
+        *c += versioned_local;
+    }
+    if let Some(c) = warn_counter {
+        *c += warn_local;
+    }
     deps
 }
 
@@ -102,6 +145,10 @@ fn build_snapshots_lookup(
     root: &serde_yaml::Value,
     aliases: &mut Vec<super::alias_mapping::AliasResolution>,
     source_path: &str,
+    // Milestone 164 (T004): threaded from `parse_pnpm_lock` for
+    // the FR-009 info-log summary.
+    versioned_counter: &mut usize,
+    warn_counter: &mut usize,
 ) -> std::collections::HashMap<String, Vec<String>> {
     let mut out = std::collections::HashMap::new();
     let Some(snapshots) = root
@@ -119,7 +166,16 @@ fn build_snapshots_lookup(
         };
         let canonical = format!("{name}@{version}");
         let Some(tbl) = entry.as_mapping() else { continue };
-        let deps = collect_pnpm_dep_names(tbl, aliases, source_path);
+        // Milestone 164 (T004, FR-001): v9 snapshots are the load-bearing
+        // multi-version site — emit disambiguation form.
+        let deps = collect_pnpm_dep_names(
+            tbl,
+            aliases,
+            source_path,
+            /* emit_versioned = */ true,
+            Some(versioned_counter),
+            Some(warn_counter),
+        );
         out.insert(canonical, deps);
     }
     out
@@ -148,6 +204,11 @@ pub(crate) fn parse_pnpm_lock(
 ) -> Vec<PackageDbEntry> {
     let mut out = Vec::new();
     let mut fell_back_count: usize = 0;
+    // Milestone 164 (T006, FR-009): tally counters threaded through
+    // `build_snapshots_lookup` and surfaced in the `pnpm-lock parsed`
+    // info-log summary at the end of this function.
+    let mut multi_version_disambiguated_count: usize = 0;
+    let mut malformed_key_warn_count: usize = 0;
 
     // Milestone 157: lockfileVersion detection for FR-007 / FR-008
     // diagnostic gating. Field may be quoted string ('9.0') or
@@ -176,7 +237,13 @@ pub(crate) fn parse_pnpm_lock(
     // lookup keyed by canonical name@version. Empty HashMap on
     // v6/v7 (no snapshots section) — the inline packages path
     // takes precedence via collect_pnpm_dep_names.
-    let snapshots_lookup = build_snapshots_lookup(root, &mut aliases, source_path);
+    let snapshots_lookup = build_snapshots_lookup(
+        root,
+        &mut aliases,
+        source_path,
+        &mut multi_version_disambiguated_count,
+        &mut malformed_key_warn_count,
+    );
 
     // v6/v7 put per-package info under `packages:` keyed by
     // "/<name>@<version>" (or "/@scope/name@version"). v9 removes
@@ -259,7 +326,16 @@ pub(crate) fn parse_pnpm_lock(
                 Vec::new()
             }
         } else {
-            collect_pnpm_dep_names(tbl, &mut aliases, source_path)
+            // Milestone 164 (T005): v6/v7 inline path preserves pre-164
+            // bare-name emission (User Story 2 byte-identity guard).
+            collect_pnpm_dep_names(
+                tbl,
+                &mut aliases,
+                source_path,
+                /* emit_versioned = */ false,
+                None,
+                None,
+            )
         };
 
         out.push(PackageDbEntry {
@@ -374,6 +450,10 @@ pub(crate) fn parse_pnpm_lock(
         packages_count = packages.len(),
         snapshots_count = snapshots_lookup.len(),
         fell_back_to_snapshots = fell_back_count,
+        // Milestone 164 (T006, FR-009): two new fields extending the
+        // existing summary line. Backward-compat for regex consumers.
+        multi_version_disambiguated_count = multi_version_disambiguated_count,
+        malformed_key_warn_count = malformed_key_warn_count,
         "pnpm-lock parsed"
     );
 
@@ -497,7 +577,10 @@ snapshots:
         let parsed: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
         let out = parse_pnpm_lock(&parsed, "/pnpm-lock.yaml", false);
         let foo = entry_by_name(&out, "foo").expect("foo emitted");
-        assert_eq!(foo.depends, vec!["bar"]);
+        // Milestone 164 (T003): v9 depends now carry version-qualified
+        // disambiguation form so the downstream `name_to_purl` lookup
+        // picks the correct version when multi-version cases arise.
+        assert_eq!(foo.depends, vec!["bar 2.0.0"]);
     }
 
     #[test]
@@ -543,8 +626,9 @@ snapshots:
         let foo = entry_by_name(&out, "foo").expect("foo emitted");
         // Identity peer-suffix stripped from PURL.
         assert_eq!(foo.purl.as_str(), "pkg:npm/foo@1.0.0");
-        // Value peer-suffix stripped from edge target.
-        assert_eq!(foo.depends, vec!["baz"]);
+        // Value peer-suffix stripped from edge target. Milestone 164
+        // (T003): v9 depends carry version-qualified disambiguation form.
+        assert_eq!(foo.depends, vec!["baz 3.0.0"]);
     }
 
     #[test]
@@ -598,10 +682,11 @@ snapshots:
         let parsed: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
         let out = parse_pnpm_lock(&parsed, "/pnpm-lock.yaml", false);
         let foo = entry_by_name(&out, "foo").expect("foo emitted");
-        // Sorted + deduped union (shared@5.0.0 appears once).
+        // Sorted + deduped union (shared@5.0.0 appears once). Milestone
+        // 164 (T003): v9 depends carry version-qualified form.
         assert_eq!(
             foo.depends,
-            vec!["a", "b", "c", "shared"]
+            vec!["a 1.0.0", "b 2.0.0", "c 3.0.0", "shared 5.0.0"]
         );
     }
 
@@ -659,9 +744,10 @@ snapshots:
         let foo = entry_by_name(&out, "foo").expect("foo emitted");
         assert_eq!(
             foo.depends,
-            vec!["only-snapshots"],
+            vec!["only-snapshots 2.0.0"],
             "v9 MUST read edges from snapshots and MUST NOT emit \
-             the specifier-only edge from packages:.peerDependencies"
+             the specifier-only edge from packages:.peerDependencies. \
+             Milestone 164 (T003): depends carry version-qualified form."
         );
     }
 
@@ -791,14 +877,18 @@ snapshots:
         );
 
         // The depender's depends list references the aliased identity.
+        // Milestone 164 (T003 + T007): v9 depends now carry the
+        // version-qualified disambiguation form; milestone-159 alias
+        // substitution preserves the version segment through the rename
+        // (per T007 `rewrite_dep_names` update).
         let docusaurus = by_name["docusaurus-core"];
-        assert!(docusaurus.depends.contains(&"@slorber/react-helmet-async".to_string()));
-        assert!(docusaurus.depends.contains(&"@docusaurus/react-loadable".to_string()));
+        assert!(docusaurus.depends.contains(&"@slorber/react-helmet-async 1.3.0".to_string()));
+        assert!(docusaurus.depends.contains(&"@docusaurus/react-loadable 6.0.0".to_string()));
         assert!(!docusaurus.depends.contains(&"react-helmet-async".to_string()));
 
         let cliui = by_name["cliui"];
-        assert!(cliui.depends.contains(&"string-width".to_string()));
-        assert!(cliui.depends.contains(&"strip-ansi".to_string()));
+        assert!(cliui.depends.contains(&"string-width 4.2.3".to_string()));
+        assert!(cliui.depends.contains(&"strip-ansi 6.0.1".to_string()));
         assert!(!cliui.depends.contains(&"string-width-cjs".to_string()));
     }
 
@@ -866,6 +956,243 @@ snapshots:
                 !entry.extra_annotations.contains_key("mikebom:pnpm-alias"),
                 "no-alias lockfile MUST NOT add mikebom:pnpm-alias; {} did",
                 entry.name
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Milestone 164 (T008-T014, implements m164 FR-001 through FR-010)
+    // Cross-workspace multi-version disambiguation unit tests.
+    // -----------------------------------------------------------------
+
+    fn make_yaml_mapping(yaml: &str) -> serde_yaml::Mapping {
+        let v: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        v.as_mapping().unwrap().clone()
+    }
+
+    /// T008: `emit_versioned=true` produces `"<name> <version>"` form
+    /// per SC-007 (a) + (b).
+    #[test]
+    fn t008_collect_pnpm_dep_names_emit_versioned_true_produces_versioned() {
+        let tbl = make_yaml_mapping(
+            r#"
+dependencies:
+  foo: 1.2.3(peer@4.5.6)
+"#,
+        );
+        let mut aliases = Vec::new();
+        let deps = collect_pnpm_dep_names(&tbl, &mut aliases, "/test", true, None, None);
+        assert_eq!(deps, vec!["foo 1.2.3".to_string()]);
+    }
+
+    /// T009: `emit_versioned=false` preserves pre-164 bare-name form
+    /// per SC-007 (b) + US2 regression guard.
+    #[test]
+    fn t009_collect_pnpm_dep_names_emit_versioned_false_preserves_bare_name() {
+        let tbl = make_yaml_mapping(
+            r#"
+dependencies:
+  foo: 1.2.3(peer@4.5.6)
+"#,
+        );
+        let mut aliases = Vec::new();
+        let deps = collect_pnpm_dep_names(&tbl, &mut aliases, "/test", false, None, None);
+        assert_eq!(deps, vec!["foo".to_string()]);
+    }
+
+    /// T010: FR-008 malformed-key fallback. Per research R3 option (a),
+    /// verified empirically 2026-07-05 (`malformed_key_warn_count=0`
+    /// on live podman-desktop): `parse_pnpm_key` returns `None` (never
+    /// `Some((name, ""))`) for empty-version keys, so the WARN branch
+    /// is defensive-only. This test asserts THAT parser property —
+    /// the FR-008 branch fires only if `parse_pnpm_key` ever regresses
+    /// to returning `Some(_, "")`. Any future change to `parse_pnpm_key`
+    /// that violates this invariant will surface here.
+    #[test]
+    fn t010_parse_pnpm_key_never_returns_empty_version() {
+        // Cases that should return None (either malformed or unparseable):
+        let none_cases = &[
+            "foo@",         // empty version
+            "@scope/foo@",  // scoped empty version
+            "@scope/foo",   // no @version separator (scope-only)
+            "foo",          // no @version separator
+            "",             // empty
+        ];
+        for case in none_cases {
+            let result = parse_pnpm_key(case);
+            assert!(
+                result.is_none() || result.as_ref().map(|(_, v)| !v.is_empty()).unwrap_or(true),
+                "parse_pnpm_key({case:?}) returned Some with empty version — \
+                 milestone-164 FR-008 WARN branch would fire on this input. \
+                 Fix `parse_pnpm_key` to return None on empty-version keys."
+            );
+        }
+    }
+
+    /// T011: v9 `build_snapshots_lookup` emits versioned form + threads
+    /// counters per SC-007 (b).
+    #[test]
+    fn t011_build_snapshots_lookup_emits_versioned_for_v9() {
+        let yaml = r#"
+lockfileVersion: '9.0'
+packages:
+  foo@1.0.0:
+    resolution: {integrity: sha512-aaaa}
+  bar@2.0.0:
+    resolution: {integrity: sha512-bbbb}
+snapshots:
+  foo@1.0.0:
+    dependencies:
+      bar: 2.0.0
+  bar@2.0.0: {}
+"#;
+        let root: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        let mut aliases = Vec::new();
+        let mut versioned = 0usize;
+        let mut warned = 0usize;
+        let lookup =
+            build_snapshots_lookup(&root, &mut aliases, "/test.yaml", &mut versioned, &mut warned);
+        assert_eq!(lookup.get("foo@1.0.0"), Some(&vec!["bar 2.0.0".to_string()]));
+        assert!(versioned >= 1, "versioned_counter must increment on v9");
+        assert_eq!(warned, 0, "no malformed keys expected on well-formed fixture");
+    }
+
+    /// T012: multi-version edges resolve correctly — parents pointing
+    /// at different versions of the same package. Per SC-007 (f).
+    #[test]
+    fn t012_parse_pnpm_lock_multi_version_edges_resolve_correctly() {
+        let yaml = r#"
+lockfileVersion: '9.0'
+packages:
+  foo@1.0.0:
+    resolution: {integrity: sha512-aaaa}
+  foo@2.0.0:
+    resolution: {integrity: sha512-bbbb}
+  parent-a@1.0.0:
+    resolution: {integrity: sha512-cccc}
+  parent-b@1.0.0:
+    resolution: {integrity: sha512-dddd}
+snapshots:
+  foo@1.0.0: {}
+  foo@2.0.0: {}
+  parent-a@1.0.0:
+    dependencies:
+      foo: 1.0.0
+  parent-b@1.0.0:
+    dependencies:
+      foo: 2.0.0
+"#;
+        let root: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        let out = parse_pnpm_lock(&root, "/test.yaml", false);
+        // (a) both foo@1.0.0 AND foo@2.0.0 emitted
+        let foo_versions: Vec<&str> = out
+            .iter()
+            .filter(|e| e.name == "foo")
+            .map(|e| e.version.as_str())
+            .collect();
+        assert!(foo_versions.contains(&"1.0.0"), "foo@1.0.0 missing: {foo_versions:?}");
+        assert!(foo_versions.contains(&"2.0.0"), "foo@2.0.0 missing: {foo_versions:?}");
+        // (b) parent-a → foo 1.0.0 (versioned form for downstream disambiguation)
+        let parent_a = entry_by_name(&out, "parent-a").expect("parent-a emitted");
+        assert_eq!(parent_a.depends, vec!["foo 1.0.0"]);
+        // (c) parent-b → foo 2.0.0
+        let parent_b = entry_by_name(&out, "parent-b").expect("parent-b emitted");
+        assert_eq!(parent_b.depends, vec!["foo 2.0.0"]);
+    }
+
+    /// T013: FR-005 — emitted PURL NEVER contains peer-dep suffix `(`.
+    #[test]
+    fn t013_parse_pnpm_lock_purl_never_includes_peer_dep_suffix() {
+        let yaml = r#"
+lockfileVersion: '9.0'
+packages:
+  foo@1.0.0:
+    resolution: {integrity: sha512-aaaa}
+  bar@2.0.0:
+    resolution: {integrity: sha512-bbbb}
+snapshots:
+  foo@1.0.0(bar@2.0.0):
+    dependencies:
+      bar: 2.0.0
+  bar@2.0.0: {}
+"#;
+        let root: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        let out = parse_pnpm_lock(&root, "/test.yaml", false);
+        for entry in &out {
+            assert!(
+                !entry.purl.as_str().contains('('),
+                "FR-005 violated: emitted PURL contains `(`: {}",
+                entry.purl.as_str()
+            );
+        }
+    }
+
+    /// T014: FR-010 — `peerDependencies` inclusion behavior unchanged
+    /// by milestone 164 (still part of the SC-004 3-section union per
+    /// milestone 157 Q1). Milestone 164 does NOT touch peer-dep
+    /// semantics; verifies pre-164 handling persists.
+    #[test]
+    fn t014_peer_dependencies_handling_unchanged_after_164() {
+        let yaml = r#"
+lockfileVersion: '9.0'
+packages:
+  foo@1.0.0:
+    resolution: {integrity: sha512-aaaa}
+  peer-dep@2.0.0:
+    resolution: {integrity: sha512-bbbb}
+snapshots:
+  foo@1.0.0:
+    peerDependencies:
+      peer-dep: 2.0.0
+  peer-dep@2.0.0: {}
+"#;
+        let root: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        let out = parse_pnpm_lock(&root, "/test.yaml", false);
+        let foo = entry_by_name(&out, "foo").expect("foo emitted");
+        // Per milestone 157 Q1, peerDependencies is part of the union;
+        // milestone 164 preserves that behavior AND applies the new
+        // disambiguation-key form to peer-dep edges (uniform treatment
+        // across all 3 sub-sections).
+        assert_eq!(foo.depends, vec!["peer-dep 2.0.0"]);
+    }
+
+    /// T016 (US2): pnpm v6/v7 inline path emits bare-name form (NO
+    /// version-qualified disambiguation). Confirms FR-002 byte-identity
+    /// guard for pre-v9 lockfiles — even though `collect_pnpm_dep_names`
+    /// now has an `emit_versioned` parameter, the v6/v7 code path calls
+    /// it with `emit_versioned=false` so pre-164 output shape is
+    /// preserved. Milestone 164 (T005 + T016 US2).
+    #[test]
+    fn t016_v6_v7_inline_path_emits_bare_names() {
+        let yaml = r#"
+lockfileVersion: '6.0'
+packages:
+  /foo@1.0.0:
+    resolution: {integrity: sha512-aaaa}
+    dependencies:
+      bar: 2.0.0
+      baz: 3.0.0
+    peerDependencies:
+      qux: 4.0.0
+    optionalDependencies:
+      opt: 5.0.0
+"#;
+        let root: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        let out = parse_pnpm_lock(&root, "/test.yaml", false);
+        let foo = entry_by_name(&out, "foo").expect("foo emitted");
+        // Pre-164 bare-name form preserved for v6/v7 lockfiles.
+        assert_eq!(
+            foo.depends,
+            vec!["bar", "baz", "opt", "qux"],
+            "v6/v7 inline path MUST emit bare-name form (US2 byte-identity guard); \
+             got {:?}",
+            foo.depends
+        );
+        // Guard: no versioned form leaked through.
+        for dep in &foo.depends {
+            assert!(
+                !dep.contains(' '),
+                "v6/v7 dep `{dep}` MUST NOT contain space — versioned form leaked from m164 path"
             );
         }
     }

--- a/mikebom-cli/tests/pnpm_multi_version.rs
+++ b/mikebom-cli/tests/pnpm_multi_version.rs
@@ -1,0 +1,300 @@
+//! Milestone 164 US1 P1 MVP integration test — verifies the pnpm-lock
+//! v9 multi-version edge disambiguation on a synthesized workspace
+//! monorepo with two versions of the same package + two parents each
+//! declaring a different version.
+//!
+//! Assertions (per SC-008):
+//!  1. Both `pkg:npm/foo@1.0.0` and `pkg:npm/foo@2.0.0` present in
+//!     `components[]`.
+//!  2. `pkg:npm/parent-a@1.0.0`'s `dependsOn` contains
+//!     `pkg:npm/foo@1.0.0` (NOT `2.0.0`) — correct version-specific
+//!     resolution.
+//!  3. `pkg:npm/parent-b@1.0.0`'s `dependsOn` contains
+//!     `pkg:npm/foo@2.0.0` (NOT `1.0.0`).
+//!  4. BFS from `metadata.component` reaches BOTH `foo@1.0.0` AND
+//!     `foo@2.0.0` — zero multi-version orphans.
+//!  5. Milestone-163 SC-002 + SC-004 invariants preserved:
+//!     zero empty-version PURLs AND zero phantom edges.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Build a synthesized pnpm-workspace monorepo with:
+/// - workspace root package.json + pnpm-workspace.yaml
+/// - pnpm-lock.yaml v9 with two versions of `foo` + two parents (each
+///   consumes a different version) + two workspace peers that consume
+///   the parents
+/// - two `packages/consumer-*` peer directories
+fn build_fixture(tmp: &std::path::Path) {
+    // Workspace root package.json.
+    std::fs::write(
+        tmp.join("package.json"),
+        r#"{
+  "name": "monorepo-root",
+  "version": "0.0.0",
+  "private": true
+}
+"#,
+    )
+    .unwrap();
+
+    // pnpm-workspace.yaml declares peer directories.
+    std::fs::write(
+        tmp.join("pnpm-workspace.yaml"),
+        "packages:\n  - 'packages/*'\n",
+    )
+    .unwrap();
+
+    // pnpm-lock.yaml v9 — the load-bearing multi-version scenario.
+    // `foo` exists at both 1.0.0 and 2.0.0; `parent-a` depends on
+    // foo@1.0.0, `parent-b` depends on foo@2.0.0. Consumer-a/b import
+    // parent-a/b at the workspace-peer level.
+    std::fs::write(
+        tmp.join("pnpm-lock.yaml"),
+        r#"lockfileVersion: '9.0'
+
+importers:
+  packages/consumer-a:
+    dependencies:
+      parent-a:
+        specifier: ^1.0.0
+        version: 1.0.0
+  packages/consumer-b:
+    dependencies:
+      parent-b:
+        specifier: ^1.0.0
+        version: 1.0.0
+
+packages:
+  foo@1.0.0:
+    resolution: {integrity: sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
+  foo@2.0.0:
+    resolution: {integrity: sha512-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb}
+  parent-a@1.0.0:
+    resolution: {integrity: sha512-ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc}
+  parent-b@1.0.0:
+    resolution: {integrity: sha512-ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd}
+
+snapshots:
+  foo@1.0.0: {}
+  foo@2.0.0: {}
+  parent-a@1.0.0:
+    dependencies:
+      foo: 1.0.0
+  parent-b@1.0.0:
+    dependencies:
+      foo: 2.0.0
+"#,
+    )
+    .unwrap();
+
+    // Consumer peer directories.
+    let consumer_a = tmp.join("packages").join("consumer-a");
+    std::fs::create_dir_all(&consumer_a).unwrap();
+    std::fs::write(
+        consumer_a.join("package.json"),
+        r#"{
+  "name": "consumer-a",
+  "version": "0.0.0",
+  "dependencies": {
+    "parent-a": "^1.0.0"
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let consumer_b = tmp.join("packages").join("consumer-b");
+    std::fs::create_dir_all(&consumer_b).unwrap();
+    std::fs::write(
+        consumer_b.join("package.json"),
+        r#"{
+  "name": "consumer-b",
+  "version": "0.0.0",
+  "dependencies": {
+    "parent-b": "^1.0.0"
+  }
+}
+"#,
+    )
+    .unwrap();
+}
+
+fn scan_fixture(tmp: &std::path::Path) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let out_path = tempfile::NamedTempFile::new()
+        .expect("tempfile")
+        .path()
+        .to_path_buf();
+    let output = Command::new(bin)
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(tmp)
+        .arg("--output")
+        .arg(&out_path)
+        .arg("--no-deep-hash")
+        .output()
+        .expect("mikebom should run");
+    assert!(
+        output.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let raw = std::fs::read_to_string(&out_path).expect("read sbom");
+    serde_json::from_str(&raw).expect("valid JSON")
+}
+
+fn dependencies_of<'a>(sbom: &'a serde_json::Value, purl: &str) -> Vec<&'a str> {
+    let Some(arr) = sbom.get("dependencies").and_then(|d| d.as_array()) else {
+        return Vec::new();
+    };
+    arr.iter()
+        .find(|d| d.get("ref").and_then(|r| r.as_str()) == Some(purl))
+        .and_then(|d| d.get("dependsOn"))
+        .and_then(|d| d.as_array())
+        .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default()
+}
+
+#[test]
+fn t015_synthesized_multi_version_zero_orphans_and_correct_edges() {
+    let tmp_holder = tempfile::tempdir().expect("tempdir");
+    let tmp = tmp_holder.path();
+    build_fixture(tmp);
+
+    let sbom = scan_fixture(tmp);
+    let components = sbom
+        .get("components")
+        .and_then(|c| c.as_array())
+        .expect("components array");
+
+    let npm_purls: HashSet<String> = components
+        .iter()
+        .filter_map(|c| c.get("purl").and_then(|p| p.as_str()).map(String::from))
+        .filter(|p| p.starts_with("pkg:npm/"))
+        .collect();
+
+    // ---------------------------------------------------------------
+    // Assertion 1: both `foo@1.0.0` AND `foo@2.0.0` emitted.
+    // ---------------------------------------------------------------
+    assert!(
+        npm_purls.contains("pkg:npm/foo@1.0.0"),
+        "foo@1.0.0 missing from components[]. Present npm PURLs: {npm_purls:#?}"
+    );
+    assert!(
+        npm_purls.contains("pkg:npm/foo@2.0.0"),
+        "foo@2.0.0 missing from components[]. Present npm PURLs: {npm_purls:#?}"
+    );
+
+    // ---------------------------------------------------------------
+    // Assertion 2: parent-a → foo@1.0.0 (correct version).
+    // ---------------------------------------------------------------
+    let parent_a_edges = dependencies_of(&sbom, "pkg:npm/parent-a@1.0.0");
+    assert!(
+        parent_a_edges.contains(&"pkg:npm/foo@1.0.0"),
+        "parent-a@1.0.0 → foo@1.0.0 edge missing. Actual edges: {parent_a_edges:?}"
+    );
+    assert!(
+        !parent_a_edges.contains(&"pkg:npm/foo@2.0.0"),
+        "parent-a@1.0.0 must NOT point at foo@2.0.0 (wrong version). Actual: {parent_a_edges:?}"
+    );
+
+    // ---------------------------------------------------------------
+    // Assertion 3: parent-b → foo@2.0.0 (correct version).
+    // ---------------------------------------------------------------
+    let parent_b_edges = dependencies_of(&sbom, "pkg:npm/parent-b@1.0.0");
+    assert!(
+        parent_b_edges.contains(&"pkg:npm/foo@2.0.0"),
+        "parent-b@1.0.0 → foo@2.0.0 edge missing. Actual edges: {parent_b_edges:?}"
+    );
+    assert!(
+        !parent_b_edges.contains(&"pkg:npm/foo@1.0.0"),
+        "parent-b@1.0.0 must NOT point at foo@1.0.0 (wrong version). Actual: {parent_b_edges:?}"
+    );
+
+    // ---------------------------------------------------------------
+    // Assertion 4: BFS reaches BOTH foo versions (zero multi-version orphans).
+    // ---------------------------------------------------------------
+    let root_purl = sbom
+        .get("metadata")
+        .and_then(|m| m.get("component"))
+        .and_then(|c| c.get("purl"))
+        .and_then(|p| p.as_str())
+        .expect("metadata.component.purl must exist");
+
+    let mut adj: HashMap<String, Vec<String>> = HashMap::new();
+    if let Some(arr) = sbom.get("dependencies").and_then(|d| d.as_array()) {
+        for node in arr {
+            let from = node
+                .get("ref")
+                .and_then(|r| r.as_str())
+                .unwrap_or("")
+                .to_string();
+            let targets: Vec<String> = node
+                .get("dependsOn")
+                .and_then(|d| d.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+            adj.insert(from, targets);
+        }
+    }
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue = vec![root_purl.to_string()];
+    while let Some(cur) = queue.pop() {
+        if !visited.insert(cur.clone()) {
+            continue;
+        }
+        if let Some(targets) = adj.get(&cur) {
+            for t in targets {
+                if !visited.contains(t) {
+                    queue.push(t.clone());
+                }
+            }
+        }
+    }
+    assert!(
+        visited.contains("pkg:npm/foo@1.0.0"),
+        "foo@1.0.0 not BFS-reachable from root {root_purl}"
+    );
+    assert!(
+        visited.contains("pkg:npm/foo@2.0.0"),
+        "foo@2.0.0 not BFS-reachable from root {root_purl}"
+    );
+
+    // ---------------------------------------------------------------
+    // Assertion 5 (SC-004 milestone-163 invariants preserved):
+    // zero empty-version PURLs AND zero phantom edges.
+    // ---------------------------------------------------------------
+    let empty_version_purls: Vec<&String> =
+        npm_purls.iter().filter(|p| p.ends_with('@')).collect();
+    assert!(
+        empty_version_purls.is_empty(),
+        "SC-004 violated: empty-version PURLs found: {empty_version_purls:?}"
+    );
+    if let Some(arr) = sbom.get("dependencies").and_then(|d| d.as_array()) {
+        for node in arr {
+            if let Some(targets) = node.get("dependsOn").and_then(|d| d.as_array()) {
+                for tgt in targets {
+                    if let Some(s) = tgt.as_str() {
+                        assert!(
+                            !(s.starts_with("pkg:npm/") && s.ends_with('@')),
+                            "SC-004 violated: phantom edge target `{s}`"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn _keep_pathbuf() -> PathBuf {
+    PathBuf::new()
+}

--- a/mikebom-cli/tests/pnpm_multi_version_audit.rs
+++ b/mikebom-cli/tests/pnpm_multi_version_audit.rs
@@ -1,0 +1,159 @@
+//! Milestone 164 SC-010 optional real-testbed audit — gated behind
+//! `MIKEBOM_PNPM_MULTIVER_AUDIT=1`. If a cached copy of
+//! `podman-desktop` is available (via `MIKEBOM_FIXTURES_DIR`), assert
+//! multi-version orphan count ≤ 30 and BFS reachability ≥ 93%. NOT
+//! blocking for the PR — matches milestone-160 T033 + milestone-161
+//! T040 + milestone-162 T034 + milestone-163 T037 pattern.
+//!
+//! Empirical baseline (2026-07-05, live podman-desktop):
+//!   Pre-164: multi-version orphans = 435, BFS reachability = 77.4%
+//!   Post-164: multi-version orphans = 12, BFS reachability = 99.6%
+//! Assertion thresholds intentionally loose (≤30 and ≥93%) to survive
+//! reasonable upstream drift.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::process::Command;
+
+fn should_run() -> Option<PathBuf> {
+    if std::env::var("MIKEBOM_PNPM_MULTIVER_AUDIT").is_err() {
+        return None;
+    }
+    let fixtures_dir = std::env::var("MIKEBOM_FIXTURES_DIR").ok()?;
+    let candidate = PathBuf::from(fixtures_dir).join("podman-desktop");
+    if !candidate.join("pnpm-lock.yaml").is_file() {
+        return None;
+    }
+    Some(candidate)
+}
+
+fn scan(path: &std::path::Path) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_mikebom");
+    let out = tempfile::NamedTempFile::new()
+        .expect("tempfile")
+        .path()
+        .to_path_buf();
+    let status = Command::new(bin)
+        .arg("--offline")
+        .arg("sbom")
+        .arg("scan")
+        .arg("--path")
+        .arg(path)
+        .arg("--output")
+        .arg(&out)
+        .arg("--no-deep-hash")
+        .output()
+        .expect("run mikebom");
+    assert!(
+        status.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+    let raw = std::fs::read_to_string(&out).expect("read sbom");
+    serde_json::from_str(&raw).expect("parse sbom")
+}
+
+#[test]
+fn t020_podman_desktop_multi_version_orphans_and_bfs_within_thresholds() {
+    let Some(path) = should_run() else {
+        eprintln!(
+            "t020 SKIP: set MIKEBOM_PNPM_MULTIVER_AUDIT=1 + MIKEBOM_FIXTURES_DIR to a \
+             directory containing a `podman-desktop/` subdir with pnpm-lock.yaml"
+        );
+        return;
+    };
+    let sbom = scan(&path);
+    let components = sbom
+        .get("components")
+        .and_then(|c| c.as_array())
+        .expect("components array");
+    let deps = sbom
+        .get("dependencies")
+        .and_then(|d| d.as_array())
+        .expect("dependencies array");
+    let root = sbom
+        .get("metadata")
+        .and_then(|m| m.get("component"))
+        .and_then(|c| c.get("purl"))
+        .and_then(|p| p.as_str())
+        .expect("metadata.component.purl");
+
+    // BFS.
+    let mut adj: HashMap<String, Vec<String>> = HashMap::new();
+    for node in deps {
+        let from = node
+            .get("ref")
+            .and_then(|r| r.as_str())
+            .unwrap_or("")
+            .to_string();
+        let tgts: Vec<String> = node
+            .get("dependsOn")
+            .and_then(|d| d.as_array())
+            .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+            .unwrap_or_default();
+        adj.insert(from, tgts);
+    }
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut q = vec![root.to_string()];
+    while let Some(cur) = q.pop() {
+        if !visited.insert(cur.clone()) {
+            continue;
+        }
+        if let Some(tgts) = adj.get(&cur) {
+            for t in tgts {
+                if !visited.contains(t) {
+                    q.push(t.clone());
+                }
+            }
+        }
+    }
+
+    let npm_purls: Vec<String> = components
+        .iter()
+        .filter_map(|c| c.get("purl").and_then(|p| p.as_str()).map(String::from))
+        .filter(|p| p.starts_with("pkg:npm/"))
+        .collect();
+
+    // Multi-version orphan classification.
+    let mut by_name: HashMap<String, Vec<String>> = HashMap::new();
+    for p in &npm_purls {
+        let base = p[8..].rsplit_once('@').map(|(n, _)| n.to_string()).unwrap_or_default();
+        by_name.entry(base).or_default().push(p.clone());
+    }
+    let orphans: Vec<&String> = npm_purls.iter().filter(|p| !visited.contains(*p)).collect();
+    let multi_version_orphans: usize = orphans
+        .iter()
+        .filter(|o| {
+            let base = o[8..].rsplit_once('@').map(|(n, _)| n).unwrap_or("");
+            by_name
+                .get(base)
+                .map(|siblings| siblings.iter().any(|s| visited.contains(s)))
+                .unwrap_or(false)
+        })
+        .count();
+
+    let bfs_pct = visited
+        .iter()
+        .filter(|p| p.starts_with("pkg:npm/"))
+        .count() as f64
+        / npm_purls.len() as f64
+        * 100.0;
+
+    // SC-001: multi-version orphans ≤ 30 (94% reduction from 435).
+    assert!(
+        multi_version_orphans <= 30,
+        "SC-001 violated: multi-version orphans = {multi_version_orphans} (expected ≤ 30). \
+         Pre-164 baseline: 435. Post-164 target: ≤ 30."
+    );
+    // SC-002: BFS reachability ≥ 93% (+15pp from 77.4%).
+    assert!(
+        bfs_pct >= 93.0,
+        "SC-002 violated: BFS reachability = {bfs_pct:.1}% (expected ≥ 93%). \
+         Pre-164 baseline: 77.4%. Post-164 target: ≥ 93%."
+    );
+
+    eprintln!(
+        "t020 PASS: multi-version orphans = {multi_version_orphans} (target ≤ 30), \
+         BFS reachability = {bfs_pct:.1}% (target ≥ 93%)"
+    );
+}

--- a/specs/164-pnpm-multi-version-edges/checklists/requirements.md
+++ b/specs/164-pnpm-multi-version-edges/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: pnpm v9 multi-version edge disambiguation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- Milestone 164 is an empirical follow-up to milestone 163's podman-desktop measurement (2026-07-05); no upstream GitHub issue number is assigned at spec time. Commit uses `implements milestone 164` rather than `closes #NNN`.
+- Concrete root cause verified 2026-07-05: `@docsearch/react@3.9.0` lockfile-declared dep on `@algolia/autocomplete-core: 1.17.9(...)` but SBOM edge points at `1.19.8` — pnpm-lock parser doesn't emit disambiguation-key form into parent's `depends`.
+- Existing infrastructure to reuse: `scan_fs/mod.rs:519-525` `<name> <version>` disambiguation key mechanism (extended for npm per issue #262 + milestone 087 cargo precedent). No new infrastructure required.

--- a/specs/164-pnpm-multi-version-edges/contracts/README.md
+++ b/specs/164-pnpm-multi-version-edges/contracts/README.md
@@ -1,0 +1,39 @@
+# Contracts: milestone 164 — pnpm v9 multi-version edge disambiguation
+
+**No new external contracts.**
+
+Milestone 164 is a pure implementation fix at the pnpm-lock parser (`mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs`). The emitted SBOM's wire format (CDX 1.6 / SPDX 2.3 / SPDX 3.0.1) is byte-identical in SHAPE — only edge target PURLs change to reflect correct lockfile-declared versions.
+
+Existing contracts unchanged:
+
+- **CLI**: no new flags. `mikebom sbom scan` behaves identically from a CLI-argument perspective.
+- **Emitted SBOM shape**: no new component types, no new annotation vocabularies, no new parity-catalog rows. Consumers reading milestone-163-era SBOMs read milestone-164-era SBOMs identically.
+- **Parity catalog**: no new rows. Existing rows C1–C115 all applicable unchanged.
+- **`mikebom:*` annotations**: no new annotations. FR-007 explicitly documents standards-native precedence — the fix reuses existing `name_to_purl` disambiguation infrastructure.
+- **Tracing log convention**: extends the existing `pnpm-lock parsed` info-level log with 2 new fields (`multi_version_disambiguated_count`, `malformed_key_warn_count`) per FR-009. Backward-compat for regex consumers.
+
+## SBOM consumer-observable delta
+
+The only user-observable change is the CORRECTNESS of emitted `dependsOn` edge targets. Concrete example on `github.com/podman-desktop/podman-desktop`:
+
+**Pre-164** (bug):
+```json
+{
+  "ref": "pkg:npm/%40docsearch/react@3.9.0",
+  "dependsOn": [
+    "pkg:npm/%40algolia/autocomplete-core@1.19.8"   // ← WRONG
+  ]
+}
+```
+
+**Post-164** (correct):
+```json
+{
+  "ref": "pkg:npm/%40docsearch/react@3.9.0",
+  "dependsOn": [
+    "pkg:npm/%40algolia/autocomplete-core@1.17.9"   // ← CORRECT
+  ]
+}
+```
+
+Consumer contract: none. Every consumer already reads `dependsOn` targets as opaque strings; milestone 164 just makes those strings correct. Existing vulnerability scanners, graph walkers, and license aggregators require zero code changes — they'll simply start returning correct results for pnpm-monorepo SBOMs.

--- a/specs/164-pnpm-multi-version-edges/data-model.md
+++ b/specs/164-pnpm-multi-version-edges/data-model.md
@@ -1,0 +1,258 @@
+# Data Model: milestone 164 — pnpm v9 multi-version edge disambiguation
+
+**Date**: 2026-07-05
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Research**: [research.md](./research.md)
+
+Phase 1 data model. Milestone 164 is a pure implementation fix — no new component types, no new annotations, no new parity-catalog rows, no wire-format changes. This document catalogs the single Rust-type change + the small function-signature change that constitute the entire data-model surface.
+
+## Rust types
+
+### E1 — `collect_pnpm_dep_names` signature extension (EDITED)
+
+**Location**: `mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs:46-90`
+
+**Pre-164 signature**:
+```rust
+fn collect_pnpm_dep_names(
+    entry_tbl: &serde_yaml::Mapping,
+    aliases: &mut Vec<super::alias_mapping::AliasResolution>,
+    source_path: &str,
+) -> Vec<String>
+```
+
+**Post-164 signature**:
+```rust
+fn collect_pnpm_dep_names(
+    entry_tbl: &serde_yaml::Mapping,
+    aliases: &mut Vec<super::alias_mapping::AliasResolution>,
+    source_path: &str,
+    emit_versioned: bool,   // NEW: milestone 164 (T003)
+) -> Vec<String>
+```
+
+**Fields**: adds 1 parameter — `emit_versioned: bool`. Return type unchanged (`Vec<String>`, but the semantic content of each string changes based on the new parameter — bare name when `false`, `"<name> <version>"` disambiguation form when `true`).
+
+**Relationships**: consumed by (a) `build_snapshots_lookup` (line 122) — pass `true`; (b) v6/v7 inline path in `parse_pnpm_lock` (line 262) — pass `false`.
+
+**Validation rules**:
+- When `emit_versioned=true` AND `canon_ver.is_empty()` (parser degeneracy): emit `tracing::warn!` per FR-008 and fall back to bare-name emission.
+- Otherwise: emit `format!("{canon_name} {canon_ver}")` when `emit_versioned=true`, bare `canon_name` when `emit_versioned=false`.
+- `canon_name` is never empty (guarded by `parse_pnpm_key`'s existing `Option<(name, version)>` return).
+
+### E2 — `build_snapshots_lookup` call-site update (EDITED)
+
+**Location**: `mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs:122`
+
+**Pre-164**:
+```rust
+let deps = collect_pnpm_dep_names(tbl, aliases, source_path);
+```
+
+**Post-164**:
+```rust
+let deps = collect_pnpm_dep_names(tbl, aliases, source_path, /* emit_versioned = */ true);
+```
+
+**Rationale**: v9 snapshots are the load-bearing multi-version site. Every value in the returned `HashMap<String, Vec<String>>` now contains disambiguation-form strings.
+
+### E3 — v6/v7 inline call-site update (EDITED)
+
+**Location**: `mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs:262`
+
+**Pre-164**:
+```rust
+} else {
+    collect_pnpm_dep_names(tbl, &mut aliases, source_path)
+};
+```
+
+**Post-164**:
+```rust
+} else {
+    collect_pnpm_dep_names(tbl, &mut aliases, source_path, /* emit_versioned = */ false)
+};
+```
+
+**Rationale**: v6/v7 inline dep-value shape doesn't include peer-dep suffixes; the bare-name form works correctly today for both single-version AND multi-version pnpm v6/v7 lockfiles (verified via existing v6/v7 goldens continuing to pass). Preserving bare-name emission here honors User Story 2 byte-identity guard.
+
+### E4 — Malformed-key WARN counter (NEW local)
+
+**Location**: `mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs`'s `parse_pnpm_lock` function.
+
+Add two local `usize` accumulators to `parse_pnpm_lock`:
+```rust
+let mut multi_version_disambiguated_count: usize = 0;
+let mut malformed_key_warn_count: usize = 0;
+```
+
+The `collect_pnpm_dep_names` function's WARN path needs to increment `malformed_key_warn_count` — done via passing a `&mut usize` (or via returning a small `CollectPnpmStats` struct). We prefer the STRUCT return form for future-proofing:
+
+```rust
+struct CollectPnpmStats {
+    versioned_count: usize,
+    warn_count: usize,
+}
+
+fn collect_pnpm_dep_names(
+    entry_tbl: &serde_yaml::Mapping,
+    aliases: &mut Vec<super::alias_mapping::AliasResolution>,
+    source_path: &str,
+    emit_versioned: bool,
+) -> (Vec<String>, CollectPnpmStats)
+```
+
+Actually — for minimum diff, we use the `&mut usize` counter pattern (simpler, and this is the ONLY caller that cares about the counts):
+
+```rust
+fn collect_pnpm_dep_names(
+    entry_tbl: &serde_yaml::Mapping,
+    aliases: &mut Vec<super::alias_mapping::AliasResolution>,
+    source_path: &str,
+    emit_versioned: bool,
+    stats: Option<&mut CollectPnpmStats>,   // Option<&mut _> so v6/v7 caller can pass None
+) -> Vec<String>
+```
+
+**Decision**: minimize churn by using two `Option<&mut usize>` counters:
+
+```rust
+fn collect_pnpm_dep_names(
+    entry_tbl: &serde_yaml::Mapping,
+    aliases: &mut Vec<super::alias_mapping::AliasResolution>,
+    source_path: &str,
+    emit_versioned: bool,
+    versioned_counter: Option<&mut usize>,
+    warn_counter: Option<&mut usize>,
+) -> Vec<String>
+```
+
+The v6/v7 caller passes `None` for both. The v9 (`build_snapshots_lookup`) caller passes `Some(&mut multi_version_disambiguated_count)` + `Some(&mut malformed_key_warn_count)`. Signature widens from 3 → 6 params — acceptable for a hot internal helper. If reviewers push back, we can refactor to a `CollectPnpmStats` struct.
+
+### E5 — Extended `pnpm-lock parsed` info log (EDITED)
+
+**Location**: `mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs:373-377` (existing info log).
+
+**Pre-164**:
+```rust
+tracing::info!(
+    lockfile = %source_path,
+    lockfile_version = %lock_version,
+    packages_count = out.len(),
+    snapshots_count = snapshots_lookup.len(),
+    fell_back_to_snapshots = fell_back_count,
+    "pnpm-lock parsed"
+);
+```
+
+**Post-164**:
+```rust
+tracing::info!(
+    lockfile = %source_path,
+    lockfile_version = %lock_version,
+    packages_count = out.len(),
+    snapshots_count = snapshots_lookup.len(),
+    fell_back_to_snapshots = fell_back_count,
+    multi_version_disambiguated_count = multi_version_disambiguated_count,   // NEW
+    malformed_key_warn_count = malformed_key_warn_count,                     // NEW
+    "pnpm-lock parsed"
+);
+```
+
+**Rationale**: FR-009. Two new fields extend the existing summary line. Backward-compat for consumers doing regex parsing (new fields append, don't reorder).
+
+### E6 — `rewrite_dep_names` post-164 update (EDITED)
+
+**Location**: `mikebom-cli/src/scan_fs/package_db/npm/alias_mapping.rs` (existing milestone-159 utility).
+
+Currently `rewrite_dep_names` takes `&[String]` (bare local names) and returns rewritten `Vec<String>`. Post-164, some inputs will be in `"<name> <version>"` form. The rewrite MUST:
+1. Split each input on the FIRST space to separate `name` from `version` (if any).
+2. Look up `name` in `alias_map`.
+3. If match: emit `format!("{aliased_name} {version}")` (preserving version if present) or bare `aliased_name` (if no version).
+4. If no match: pass through unchanged.
+
+**Signature unchanged**: still `fn rewrite_dep_names(deps: &[String], alias_map: &AliasMap) -> Vec<String>`. Internal logic gains split-on-space + rejoin.
+
+**Validation**: after rewrite, each output string is either bare `<name>` (input was bare or aliased to non-versioned) or `<name> <version>` (input carried version and pass-through or alias preserved it).
+
+## Wire types
+
+**None.** Milestone 164 changes intermediate parser state (`PackageDbEntry.depends`) but does NOT change emitted SBOM wire format. Every emitted PURL, edge, annotation, and metadata field is identical in SHAPE — only the target PURL of edges changes to the CORRECT version (per FR-005 the emitted PURL never includes the peer-dep suffix, unchanged from pre-164).
+
+## Relationships
+
+```text
+build_snapshots_lookup (v9 path)
+    ↓ calls with emit_versioned=true
+collect_pnpm_dep_names
+    ↓ pushes into deps
+    ├── "@foo/bar 1.2.3"     ← versioned form (multi-version safe)
+    ├── "@baz 4.5.6"
+    └── ...
+    ↓ returned to snapshots_lookup[canonical] = deps
+parse_pnpm_lock main loop
+    ↓ resolves canonical = "<name>@<version>" per package
+    ↓ if snapshots_lookup.get(&canonical).is_some() → depends = snap_deps.clone()
+    ↓ PackageDbEntry.depends = ["@foo/bar 1.2.3", "@baz 4.5.6", ...]
+milestone-159 alias post-processing
+    ↓ rewrite_dep_names(depends, alias_map)
+    ↓ preserves version segment across alias substitution
+    ↓ depends now = ["@real/foo 1.2.3", "@baz 4.5.6", ...] (if @foo/bar was aliased)
+scan_fs/mod.rs:471-525 index build
+    ↓ name_to_purl keys inserted for both bare AND disambiguation form
+scan_fs/mod.rs:729-731 edge emit
+    ↓ for dep_name in entry.depends
+    ↓ normalize_dep_name(ecosystem, dep_name) → e.g., "@foo/bar 1.2.3"
+    ↓ name_to_purl.get(&key) → hits disambiguation-form entry → correct-version PURL
+    ↓ Relationship.to = "pkg:npm/@foo/bar@1.2.3"   ← CORRECT
+```
+
+## State transitions
+
+**Pre-164 → Post-164 for a single snapshot dep** (`@algolia/autocomplete-core: 1.17.9(...)` as declared by `@docsearch/react@3.9.0`):
+
+```text
+parse_pnpm_key(stripped) → Some(("@algolia/autocomplete-core", "1.17.9"))
+
+Pre-164:
+    let Some((canon_name, _canon_ver)) = ...;
+    deps.push(canon_name);
+    → deps contains "@algolia/autocomplete-core"
+
+    Later, at edge emit:
+    key = ("npm", normalize_dep_name("npm", "@algolia/autocomplete-core"))
+    name_to_purl.get(&key) → returns LAST-INSERTED PURL for that name
+    → often "pkg:npm/@algolia/autocomplete-core@1.19.8" (WRONG)
+
+Post-164:
+    let Some((canon_name, canon_ver)) = ...;
+    if emit_versioned && !canon_ver.is_empty() {
+        deps.push(format!("{canon_name} {canon_ver}"));
+    } else {
+        deps.push(canon_name);
+    }
+    → deps contains "@algolia/autocomplete-core 1.17.9"
+
+    Later, at edge emit:
+    key = ("npm", normalize_dep_name("npm", "@algolia/autocomplete-core 1.17.9"))
+    name_to_purl.get(&key) → hits the "<name> <version>" disambiguation entry
+    → "pkg:npm/@algolia/autocomplete-core@1.17.9" (CORRECT)
+```
+
+## Data volume assumptions
+
+- **Per-lockfile impact**: podman-desktop's pnpm-lock has 2668 snapshots × ~5 deps per snapshot avg = ~13,340 disambiguation-form strings emitted per scan. Each is ~40-80 bytes of allocation (canon_name + space + version). Delta memory: ~1 MB temporary per pnpm-lock parse. Negligible.
+- **Per-lockfile compute**: `format!("{} {}", ...)` per dep = one small heap allocation. 13k allocations × pnpm-lock parse ≈ ~10 ms extra on the hot path. Empirically verified during T003 to have no measurable perf regression.
+- **Per-scan compute**: only pnpm-lock v9 files trigger the new path. Repos without pnpm-lock v9 have zero delta.
+
+## Validation rules (aggregated)
+
+| Rule | Enforcement |
+|------|-------------|
+| Zero empty-version PURLs post-164 (SC-004 inherit) | Enforced by construction — no PURL emission path is touched (FR-005). Preserved by milestone-163 mechanism. |
+| Zero phantom edges post-164 (SC-002 inherit) | Enforced by construction — resolver behavior unchanged. Preserved by milestone-163 mechanism. |
+| Multi-version orphans ≤ 30 (SC-001) | Enforced by test T012 + audit T017. Every parent's `depends` entry resolves to a lockfile-declared PURL via disambiguation lookup. |
+| BFS reachability ≥ 93% (SC-002) | Consequence of SC-001 fix. Enforced by audit T017 (opt-in) + T012 integration test on synthesized fixture. |
+| Component count preserved (SC-005) | Enforced by construction — no components added or removed. Only edge targets change. Verified via T012 integration test. |
+| FR-005 emitted PURL never contains `(` | Enforced by construction — `parse_pnpm_key` strips peer-dep suffix; emitted PURLs use base version only. Verified by unit test T013. |
+| FR-010 peerDependencies unchanged | Enforced by scope — milestone 164 doesn't touch peerDependencies handling. Verified by unit test T014. |
+| Malformed-key fallback logs WARN + preserves bare-name (FR-008) | Enforced by explicit branch in `collect_pnpm_dep_names`. Verified by unit test T009. |

--- a/specs/164-pnpm-multi-version-edges/plan.md
+++ b/specs/164-pnpm-multi-version-edges/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: pnpm v9 multi-version edge disambiguation
+
+**Branch**: `164-pnpm-multi-version-edges` | **Date**: 2026-07-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/164-pnpm-multi-version-edges/spec.md`
+
+## Summary
+
+Fix pnpm-lock v9's `collect_pnpm_dep_names` helper at `mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs:80` where `parse_pnpm_key` returns `(canon_name, canon_ver)` but the version is immediately discarded with `_canon_ver`. The consequence: `snapshots_lookup` values are `Vec<String>` of bare names, which flow into each `PackageDbEntry.depends`, which the downstream edge resolver at `scan_fs/mod.rs:729-731` looks up name-only in `name_to_purl` — last-write-wins between multiple emitted versions of the same package. Result: 435 of 568 orphan components on live podman-desktop (2026-07-05 measurement), 15pp of the 22-point BFS reachability gap.
+
+**Fix approach**: thread the version through `collect_pnpm_dep_names` via a new boolean parameter `emit_versioned: bool`. When `emit_versioned=true` (called from the v9 `snapshots:` path only), push `format!("{canon_name} {canon_ver}")` — the disambiguation-key form already indexed at `scan_fs/mod.rs:519-525` (extended for npm per issue #262 + milestone-087 cargo precedent). When `emit_versioned=false` (v6/v7 inline path), preserve pre-164 bare-name emission (User Story 2 byte-identity guard).
+
+**Empirical target** (podman-desktop, live upstream): multi-version orphans 435 → ≤30; BFS reachability 77.4% → ≥93%. All milestone-163 invariants (SC-002/SC-004) preserved.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–163; no nightly required for this user-space-only work).
+**Primary Dependencies**: Existing only — `serde_yaml` (already used pervasively in the pnpm-lock parser), `tracing`, `anyhow`. **Zero new Cargo dependencies.**
+**Storage**: N/A — all state in-process per scan (matches every milestone since 002).
+**Testing**: `cargo +stable test --workspace --no-fail-fast`. 8+ new unit tests (SC-007) + 1 new integration test (SC-008) + 1 optional audit test (SC-010).
+**Target Platform**: All mikebom-supported hosts (Linux, macOS, Windows). No platform-specific behavior.
+**Project Type**: Rust CLI (mikebom-cli) — single-crate scope; only `pnpm_lock.rs` and existing test helpers touched.
+**Performance Goals**: Zero degradation. The change is a single-line push-form change inside an existing hot loop — no new allocations, no new syscalls.
+**Constraints**: Constitution Principle IX (Accuracy — wrong-version edges are unacceptable), Principle V (standards-native precedence — no new `mikebom:*` annotations; reuse existing `name_to_purl` infrastructure), Principle VIII (Completeness — no silent drops on malformed keys per FR-008).
+**Scale/Scope**: Live podman-desktop = 27058-line pnpm-lock.yaml with ~2668 packages and 2668 snapshot entries. Post-fix expected to correctly resolve ~435 previously-mis-targeted multi-version edges on this fixture.
+
+## Constitution Check
+
+**GATE**: Pass before Phase 0 research. Re-check after Phase 1 design.
+
+Constitution v1.5.0 principles evaluated against milestone 164 scope:
+
+- **I. Pure Rust, Zero C**: PASS — Rust stable only, no new crates, no FFI.
+- **II. Deterministic Scan Output**: PASS — same input produces same output. The fix is deterministic single-pass parse.
+- **III. Attestation-First**: N/A — no attestation code touched.
+- **IV. No `.unwrap()` in Production**: PASS — the two-line diff at `pnpm_lock.rs:80-84` uses existing `let Some(...) = ... else { continue }` pattern; no new unwrap.
+- **V. Specification Compliance (standards-native precedence)**: PASS — reuses existing `name_to_purl` disambiguation-key mechanism at `scan_fs/mod.rs:519-525`. No new `mikebom:*` annotations. FR-007 explicitly documents the reuse.
+- **VI. Three-Crate Architecture (workspace layout)**: PASS — only `mikebom-cli` touched.
+- **VII. eBPF-Only Observation**: N/A — user-space code path.
+- **VIII. Completeness — Never Silently Drop**: PASS — FR-008 mandates a `tracing::warn!` fallback for malformed peer-dep-suffixed keys. Fall-back to bare-name form matches pre-164 behavior — no data loss.
+- **IX. Accuracy — No Fake Versions**: PASS — the whole point of this milestone. Post-fix, edge targets match lockfile-declared versions exactly.
+- **X. Transparency — Explicit Signals**: PASS — FR-009 mandates the info-level summary log (`multi_version_disambiguated_count`, `malformed_key_warn_count`). Grep-friendly per convention.
+- **XI. Every Scan Produces an SBOM**: PASS — no scan-termination paths added.
+- **XII. Ecosystem Coverage**: PASS — extends pnpm v9 support; doesn't remove coverage of any ecosystem.
+
+**Strict Boundaries** (v1.5.0):
+
+- §1 (deterministic PURL): PASS — emitted PURLs unchanged (FR-005: base version only, peer-dep suffix stripped).
+- §2 (workspace layout): PASS.
+- §3 (constitution amendment process): N/A.
+- §4 (single source of truth): PASS — reuses `name_to_purl` as the single truth for edge resolution.
+- §5 (no duplicate file-tier components): N/A — no file-tier code path touched.
+
+**Verdict**: All principles + boundaries clear. No violations, no Complexity Tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/164-pnpm-multi-version-edges/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (empty stub — no new external contracts)
+├── checklists/
+│   └── requirements.md  # /speckit.specify output
+└── tasks.md             # /speckit.tasks output (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/
+├── src/
+│   └── scan_fs/
+│       └── package_db/
+│           └── npm/
+│               └── pnpm_lock.rs    # ← EDITED (T003, T005): thread version through
+│                                   #   `collect_pnpm_dep_names` via `emit_versioned` param.
+│                                   #   FR-009 log emission.
+└── tests/
+    ├── pnpm_multi_version.rs        # ← NEW (T012): SC-008 integration test — synthesized
+    │                                #   pnpm-lock v9 fixture with 2 versions of same pkg.
+    └── pnpm_multi_version_audit.rs  # ← NEW (T017 optional): SC-010 opt-in real-testbed audit
+                                     #   gated behind MIKEBOM_PNPM_MULTIVER_AUDIT=1.
+```
+
+**Structure Decision**: Single-crate scope. Only `mikebom-cli` touched. Two files edited (`pnpm_lock.rs` implementation + tests), two integration test files added. No new modules, no restructuring. This is the smallest possible surface for a bug fix of this scope — matches milestone-087's cargo-fix footprint precedent.
+
+## Complexity Tracking
+
+No entries required. All Constitution gates pass without justification. This is a straightforward disambiguation-key emission fix using infrastructure already validated by milestone 087.

--- a/specs/164-pnpm-multi-version-edges/quickstart.md
+++ b/specs/164-pnpm-multi-version-edges/quickstart.md
@@ -1,0 +1,279 @@
+# Quickstart: milestone 164 — pnpm v9 multi-version edge disambiguation
+
+**Date**: 2026-07-05
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+Contributor onboarding for milestone 164. Assumes a working mikebom dev environment (per top-level `CLAUDE.md`).
+
+## 1. Prerequisites
+
+- Rust stable toolchain (workspace-managed).
+- No external tooling required (integration test synthesizes fixture in tempdir).
+
+Verify:
+```bash
+cargo +stable --version   # cargo 1.75+
+```
+
+## 2. Implementation overview
+
+Milestone 164 is scoped to a SINGLE FILE:
+
+- `mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs` — the parser change.
+
+Plus:
+- `mikebom-cli/src/scan_fs/package_db/npm/alias_mapping.rs` — one small update to `rewrite_dep_names` per research §R7 (preserve version segment through alias substitution).
+- `mikebom-cli/tests/pnpm_multi_version.rs` — NEW SC-008 integration test.
+- `mikebom-cli/tests/pnpm_multi_version_audit.rs` — NEW opt-in SC-010 audit test.
+
+**Total surface**: 4 files (2 edited, 2 new). Matches milestone-087 cargo-fix footprint precedent.
+
+## 3. Step-by-step implementation
+
+### 3a. Extend `collect_pnpm_dep_names` signature (T003)
+
+At `mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs:46-90`:
+
+```rust
+fn collect_pnpm_dep_names(
+    entry_tbl: &serde_yaml::Mapping,
+    aliases: &mut Vec<super::alias_mapping::AliasResolution>,
+    source_path: &str,
+    emit_versioned: bool,                     // ← NEW
+    versioned_counter: Option<&mut usize>,    // ← NEW (FR-009 tally)
+    warn_counter: Option<&mut usize>,         // ← NEW (FR-009 tally)
+) -> Vec<String> {
+    let mut deps: Vec<String> = Vec::new();
+    // ...existing section loop...
+    for (dep_key, dep_value) in sub {
+        // ...existing alias detection unchanged...
+        let dep_pair_raw = format!("{dep_name}@{dep_ver_raw}");
+        let stripped = dep_pair_raw.strip_prefix('/').unwrap_or(&dep_pair_raw);
+        let Some((canon_name, canon_ver)) = parse_pnpm_key(stripped) else {
+            tracing::debug!(dep = %dep_pair_raw, "pnpm-lock: skipping non-registry dep value");
+            continue;
+        };
+        // Milestone 164 (T003): thread version through when caller requests.
+        if emit_versioned {
+            if canon_ver.is_empty() {
+                tracing::warn!(
+                    key = %stripped,
+                    "pnpm-lock v9: peer-dep-suffixed key parsed to empty version; falling back to bare-name form"
+                );
+                if let Some(c) = warn_counter.as_deref_mut() { *c += 1; }
+                deps.push(canon_name);
+            } else {
+                if let Some(c) = versioned_counter.as_deref_mut() { *c += 1; }
+                deps.push(format!("{canon_name} {canon_ver}"));
+            }
+        } else {
+            deps.push(canon_name);
+        }
+    }
+    deps.sort();
+    deps.dedup();
+    deps
+}
+```
+
+**Note**: `versioned_counter` and `warn_counter` use `Option<&mut usize>` so the v6/v7 caller can pass `None` without allocating a dummy counter.
+
+### 3b. Update `build_snapshots_lookup` call-site (T004)
+
+At `mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs:101-126`:
+
+```rust
+fn build_snapshots_lookup(
+    root: &serde_yaml::Value,
+    aliases: &mut Vec<super::alias_mapping::AliasResolution>,
+    source_path: &str,
+    versioned_counter: &mut usize,   // ← NEW (thread through from caller)
+    warn_counter: &mut usize,        // ← NEW
+) -> std::collections::HashMap<String, Vec<String>> {
+    let mut out = std::collections::HashMap::new();
+    // ...existing preamble...
+    for (key, entry) in snapshots {
+        // ...existing key parsing...
+        let deps = collect_pnpm_dep_names(
+            tbl,
+            aliases,
+            source_path,
+            /* emit_versioned = */ true,
+            Some(versioned_counter),
+            Some(warn_counter),
+        );
+        out.insert(canonical, deps);
+    }
+    out
+}
+```
+
+### 3c. Update `parse_pnpm_lock` v6/v7 inline call-site (T005)
+
+At `pnpm_lock.rs:262`:
+
+```rust
+} else {
+    collect_pnpm_dep_names(
+        tbl,
+        &mut aliases,
+        source_path,
+        /* emit_versioned = */ false,
+        None,
+        None,
+    )
+};
+```
+
+### 3d. Add tally locals + extend info log (T006)
+
+Near the top of `parse_pnpm_lock`:
+
+```rust
+let mut multi_version_disambiguated_count: usize = 0;
+let mut malformed_key_warn_count: usize = 0;
+```
+
+And thread these into `build_snapshots_lookup`:
+
+```rust
+let snapshots_lookup = build_snapshots_lookup(
+    root,
+    &mut aliases,
+    source_path,
+    &mut multi_version_disambiguated_count,
+    &mut malformed_key_warn_count,
+);
+```
+
+Extend the existing info log at `pnpm_lock.rs:373-377`:
+
+```rust
+tracing::info!(
+    lockfile = %source_path,
+    lockfile_version = %lock_version,
+    packages_count = out.len(),
+    snapshots_count = snapshots_lookup.len(),
+    fell_back_to_snapshots = fell_back_count,
+    multi_version_disambiguated_count = multi_version_disambiguated_count,
+    malformed_key_warn_count = malformed_key_warn_count,
+    "pnpm-lock parsed"
+);
+```
+
+### 3e. Update `rewrite_dep_names` for alias composition (T007)
+
+At `mikebom-cli/src/scan_fs/package_db/npm/alias_mapping.rs`:
+
+Split each dep on the first space to separate `name` from `version`. Look up `name` in `alias_map`. If found, emit `format!("{aliased_name} {version}")` (with version preserved) or bare `aliased_name` (if no version).
+
+Pseudocode:
+```rust
+pub fn rewrite_dep_names(deps: &[String], alias_map: &AliasMap) -> Vec<String> {
+    deps.iter().map(|dep| {
+        let (name, version_opt) = split_first_space(dep);
+        match alias_map.get(name) {
+            Some(aliased) => match version_opt {
+                Some(ver) => format!("{} {}", aliased.aliased_name, ver),
+                None => aliased.aliased_name.clone(),
+            },
+            None => dep.clone(),
+        }
+    }).collect()
+}
+
+fn split_first_space(s: &str) -> (&str, Option<&str>) {
+    match s.find(' ') {
+        Some(idx) => (&s[..idx], Some(&s[idx + 1..])),
+        None => (s, None),
+    }
+}
+```
+
+### 3f. Write unit tests (T008-T014)
+
+Inside the existing `#[cfg(test)] mod tests` block at end of `pnpm_lock.rs`. Follow the milestone-163 T024/T024a naming convention (`t008_*` through `t014_*`). Each test synthesizes a minimal `serde_yaml::Mapping` and asserts the expected output shape. See research §R5 for the enumerated test list.
+
+### 3g. Write integration test (T015)
+
+Create `mikebom-cli/tests/pnpm_multi_version.rs`. Synthesize a tempdir with:
+- `pnpm-lock.yaml` v9 containing two versions of `@shared/lib` (`1.0.0` and `2.0.0`) with two workspace peers each declaring a different version.
+- `pnpm-workspace.yaml` listing the workspace peers.
+- Two peer `package.json` files.
+
+Invoke the release binary via `env!("CARGO_BIN_EXE_mikebom")`. Parse emitted CDX. Assert per SC-008.
+
+### 3h. Optional real-testbed audit (T017)
+
+Create `mikebom-cli/tests/pnpm_multi_version_audit.rs`. Gated behind `MIKEBOM_PNPM_MULTIVER_AUDIT=1`. If a cached `podman-desktop` is available (via `MIKEBOM_FIXTURES_DIR`), scan it and assert multi-version orphans ≤ 30 AND BFS reachability ≥ 93%.
+
+## 4. Testing
+
+```bash
+# Full pre-PR gate
+./scripts/pre-pr.sh
+
+# Unit tests only (pnpm-lock module)
+cargo +stable test --bin mikebom scan_fs::package_db::npm::pnpm_lock
+
+# Integration test
+cargo +stable test --test pnpm_multi_version
+
+# Optional real-testbed audit (only if you have a podman-desktop cache)
+MIKEBOM_PNPM_MULTIVER_AUDIT=1 \
+    MIKEBOM_FIXTURES_DIR=/tmp/podman-desktop-cache \
+    cargo +stable test --test pnpm_multi_version_audit
+```
+
+## 5. Debugging: tracing recipes
+
+```bash
+# See per-lockfile summary with the two new milestone-164 fields
+RUST_LOG=mikebom_cli::scan_fs::package_db::npm::pnpm_lock=info \
+    mikebom sbom scan --path <podman-desktop-clone> 2>&1 \
+    | grep 'pnpm-lock parsed'
+
+# Expected fields include:
+#   multi_version_disambiguated_count=<N>
+#   malformed_key_warn_count=<W>
+```
+
+## 6. Empirical verification against live podman-desktop
+
+Post-implementation, verify SC-001 + SC-002 on a fresh clone:
+
+```bash
+TMPDIR=$(mktemp -d)
+git clone --depth 1 https://github.com/podman-desktop/podman-desktop.git "$TMPDIR/podman-desktop"
+
+./target/release/mikebom --offline sbom scan \
+    --path "$TMPDIR/podman-desktop" \
+    --output "$TMPDIR/out.cdx.json" \
+    --no-deep-hash
+
+# BFS reachability check
+python3 <<'PY'
+import json, collections
+sbom = json.load(open('/tmp/xxx/out.cdx.json'))  # replace path
+root = sbom['metadata']['component']['purl']
+deps = sbom['dependencies']
+adj = {d['ref']: d.get('dependsOn', []) for d in deps}
+visited, q = set(), collections.deque([root])
+while q:
+    c = q.popleft()
+    if c in visited: continue
+    visited.add(c)
+    for t in adj.get(c, []): q.append(t)
+npm = [c['purl'] for c in sbom['components'] if c.get('purl','').startswith('pkg:npm/')]
+reach = sum(1 for p in npm if p in visited)
+print(f"BFS reachability: {reach}/{len(npm)} = {reach/len(npm)*100:.1f}%")
+# Expected: ≥93% (up from 77.4% pre-164 baseline)
+PY
+```
+
+## 7. Common pitfalls
+
+- **Forgetting to update `rewrite_dep_names`**: milestone-159's alias post-processing will silently break for versioned inputs. Symptom: aliased deps become bare after rewrite even though the version was present in the input.
+- **Off-by-one in `split_first_space`**: use `s.find(' ')` (first space), NOT `s.rfind(' ')` (last space). Scoped package names never contain spaces, so first-space split is safe.
+- **Failing to update the info log**: milestone-164's FR-009 requires the two new counter fields. Missing them fails the FR-009 unit test.
+- **Passing `emit_versioned=true` in the v6/v7 path**: User Story 2 byte-identity guard violated. Existing v6/v7 golden tests catch this.

--- a/specs/164-pnpm-multi-version-edges/research.md
+++ b/specs/164-pnpm-multi-version-edges/research.md
@@ -1,0 +1,171 @@
+# Research: milestone 164 — pnpm v9 multi-version edge disambiguation
+
+**Date**: 2026-07-05
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+Phase 0 research. Milestone 164 was empirically-grounded before spec time (root cause verified 2026-07-05 on live podman-desktop), so this research documents the design decisions rather than exploring unknowns.
+
+## R1 — Exact line-number pinpoint of the bug
+
+**Decision**: The bug lives at `mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs:80-84`.
+
+```rust
+let Some((canon_name, _canon_ver)) = parse_pnpm_key(stripped) else {
+    tracing::debug!(dep = %dep_pair_raw, "pnpm-lock: skipping non-registry dep value");
+    continue;
+};
+deps.push(canon_name);   // ← BARE NAME — version discarded via `_canon_ver`
+```
+
+`parse_pnpm_key` correctly extracts both `(canon_name, canon_ver)` from peer-dep-suffixed values like `"@algolia/autocomplete-core@1.17.9(algoliasearch@5.42.0)(search-insights@2.17.3)"` — the version `"1.17.9"` is available in-scope but immediately discarded with the `_canon_ver` underscore. The bare `canon_name` propagates into `snapshots_lookup` values, then into per-package `PackageDbEntry.depends`, then into edge-resolution at `scan_fs/mod.rs:729-731` where the name-only key hits last-write-wins between multiple emitted versions.
+
+**Rationale**: The version discard is the load-bearing single line. Everything else is in place: `parse_pnpm_key` extracts it, `scan_fs/mod.rs:519-525` indexes emitted entries by both bare-name AND `"<name> <version>"` disambiguation-key form, and the edge-resolution loop already tolerates both key shapes. Only the parser's emit-side needs to change.
+
+**Alternatives considered**:
+- **A. Change the emit-side lookup at `scan_fs/mod.rs:729-731`**: rejected — the resolver code is ecosystem-neutral and shared with cargo/maven. Adding pnpm-specific logic there would violate the ecosystem-neutral abstraction.
+- **B. Add a post-parse disambiguation pass**: rejected — the parser has the version info in-scope; discarding it and re-computing later is silly.
+- **C. Fix at the discard site (chosen)**: minimal diff, no cross-cutting changes.
+
+## R2 — Threading the version through `collect_pnpm_dep_names`
+
+**Decision**: Add a boolean parameter `emit_versioned: bool` to `collect_pnpm_dep_names`. When `true`, push `format!("{canon_name} {canon_ver}")` (disambiguation form). When `false`, push bare `canon_name` (pre-164 behavior).
+
+**Function signature change**:
+```rust
+fn collect_pnpm_dep_names(
+    entry_tbl: &serde_yaml::Mapping,
+    aliases: &mut Vec<super::alias_mapping::AliasResolution>,
+    source_path: &str,
+    emit_versioned: bool,    // ← NEW
+) -> Vec<String>
+```
+
+**Call sites**:
+1. `build_snapshots_lookup` (line 122) — pass `emit_versioned = true` (v9 snapshot values carry peer-dep-suffixed keys with versions; disambiguation form is safe).
+2. v6/v7 inline path (line 262) — pass `emit_versioned = false` (User Story 2 byte-identity guard; v6/v7 fixtures don't need the disambiguation form because the existing bare-name path already works for the pre-v9 lockfile shape).
+
+**Rationale**: Parameter is more explicit than an implicit callsite-inspection pattern. `bool` is minimal state — no enum needed because the two states are truly binary. Both callers are static/deterministic (no runtime branching on lockfile content beyond version detection which already exists).
+
+**Alternatives considered**:
+- **A. Add `emit_versioned: bool` parameter (chosen)**: minimal API change, explicit at every call site, easy to unit-test.
+- **B. Duplicate `collect_pnpm_dep_names` into `collect_pnpm_dep_names_versioned`**: rejected — introduces divergence risk (the two functions could drift). Parameterization keeps one code path.
+- **C. Always emit versioned form**: rejected — violates User Story 2 (v6/v7 byte-identity guard). Even though `depends` isn't directly serialized, changing it changes intermediate state that some tests inspect.
+- **D. Global mutable flag or thread-local**: rejected — invisible dependency, harder to test.
+
+## R3 — Malformed peer-dep-suffixed key handling (FR-008)
+
+**Decision**: If `parse_pnpm_key` returns `None` (malformed key), the existing `continue` at line 82 already handles this — the whole dep is dropped from `deps` and a debug-level log fires (line 81). This is the pre-164 behavior. Milestone 164 does NOT change error handling.
+
+However, FR-008 mandates that when the version is empty/malformed (e.g., `parse_pnpm_key` returns `("foo", "")` — unlikely but possible if the key form drifts), the parser MUST fall back to bare-name emission WITH a `tracing::warn!` (not just debug). We add:
+
+```rust
+if emit_versioned {
+    if canon_ver.is_empty() {
+        tracing::warn!(
+            key = %stripped,
+            "pnpm-lock v9: peer-dep-suffixed key parsed to empty version; falling back to bare-name form"
+        );
+        deps.push(canon_name);
+    } else {
+        deps.push(format!("{canon_name} {canon_ver}"));
+    }
+} else {
+    deps.push(canon_name);
+}
+```
+
+**Rationale**: Constitution Principle VIII (Completeness) — never silently drop. Constitution Principle X (Transparency) — the warn log makes the fallback observable. If the malformed-key case fires in the wild, CI logs surface it.
+
+**Alternatives considered**:
+- **A. Fall back silently to bare-name**: rejected — violates Principle X (Transparency).
+- **B. Fail hard (return error)**: rejected — violates Principle VIII (Completeness); a single malformed dep shouldn't fail the whole scan.
+- **C. Warn + fall back to bare-name (chosen)**: matches milestone-055/091/160 pattern for degraded-mode recovery.
+
+## R4 — FR-009 tracing log fields
+
+**Decision**: The existing `pnpm-lock parsed` info-level log at `pnpm_lock.rs:373-377` already carries `packages_count`, `snapshots_count`, `fell_back_to_snapshots`. Milestone 164 EXTENDS this line with two new fields:
+- `multi_version_disambiguated_count` — count of snapshot deps where `emit_versioned=true` produced a versioned form (i.e., every non-empty-version snapshot dep emitted through the new path).
+- `malformed_key_warn_count` — count of `tracing::warn!` fallbacks per R3.
+
+These are cheap accumulators (two `usize` locals). The log line becomes:
+```
+pnpm-lock parsed lockfile=<path> lockfile_version=9.0 packages_count=N snapshots_count=M fell_back_to_snapshots=M multi_version_disambiguated_count=K malformed_key_warn_count=W
+```
+
+**Rationale**: Extending the existing log line preserves the milestone-157/158/159/160/161/162/163 observability convention (single grep-friendly summary per lockfile). Adding two fields is trivially backward-compat for consumers doing regex parsing.
+
+**Alternatives considered**:
+- **A. Extend existing log (chosen)**: minimal footprint, preserves convention.
+- **B. Emit a separate `milestone-164 summary` log**: rejected — noisy, doesn't compose with the existing per-lockfile log.
+
+## R5 — Test strategy (SC-007 + SC-008 + SC-010)
+
+**Decision**: Three test tiers, mirroring milestone-160/161/162/163 pattern.
+
+**Tier 1: Unit tests** (SC-007, ≥8 tests inside `pnpm_lock.rs`'s existing `#[cfg(test)] mod tests` block):
+- **T007** `collect_pnpm_dep_names_emit_versioned_true_produces_versioned`: minimal snapshot mapping with peer-dep-suffixed value; assert `deps` contains `"foo 1.2.3"`.
+- **T008** `collect_pnpm_dep_names_emit_versioned_false_preserves_bare_name`: same input, `emit_versioned=false`; assert `deps` contains `"foo"` (pre-164 behavior).
+- **T009** `collect_pnpm_dep_names_empty_version_falls_back_with_warn`: synthesize a malformed key where `parse_pnpm_key` returns empty version; assert `deps` contains bare `"foo"` (fallback). WARN log verification via `tracing_subscriber::fmt::TestWriter` or capture stub.
+- **T010** `collect_pnpm_dep_names_v6_v7_bare_name_unchanged`: pnpm v6/v7 inline path uses `emit_versioned=false`; assert byte-identical to pre-164 output.
+- **T011** `build_snapshots_lookup_emits_versioned_for_v9`: end-to-end via `build_snapshots_lookup`; assert the lookup values contain versioned forms.
+- **T012** `parse_pnpm_lock_multi_version_edges_resolve_correctly`: minimal fixture with 2 versions of same package + 2 parents (each declaring a different version); assert each parent's `depends` array carries the correct `"<name> <version>"` form.
+- **T013** `parse_pnpm_lock_purl_never_includes_peer_dep_suffix` (FR-005): assert emitted PURLs never contain `(`.
+- **T014** `peer_dependencies_handling_unchanged_after_164` (FR-010): assert the pnpm parser's `peerDependencies:` handling is unchanged.
+
+**Tier 2: Integration test** (SC-008, `tests/pnpm_multi_version.rs`):
+- **T015** `t015_synthesized_multi_version_zero_orphans`: tempdir-based fixture with two workspace packages, each declaring a different version of `@shared/lib`. Invoke the release binary via `env!("CARGO_BIN_EXE_mikebom")`. Assert (a) both `@shared/lib@1.0.0` and `@shared/lib@2.0.0` emitted; (b) parent A's `dependsOn` targets `1.0.0`; (c) parent B's `dependsOn` targets `2.0.0`; (d) both versions BFS-reachable; (e) zero multi-version orphans.
+
+**Tier 3: Optional real-testbed audit** (SC-010, `tests/pnpm_multi_version_audit.rs`):
+- **T017** `t017_podman_desktop_multi_version_gap_below_30`: gated behind `MIKEBOM_PNPM_MULTIVER_AUDIT=1` + `MIKEBOM_FIXTURES_DIR` (or a cached podman-desktop clone). If not gated, skip silently. Assert multi-version orphans ≤ 30 AND BFS reachability ≥ 93%.
+
+**Rationale**: Matches milestone-160 T033 + milestone-161 T040 + milestone-162 T034 + milestone-163 T037 fixture-gated audit precedent. Real-testbed audits are OPPORTUNISTIC per the pattern — not blocking for the PR.
+
+## R6 — Empirical baseline (2026-07-05, live podman-desktop)
+
+**Decision**: Pin the empirical baseline to the measurement performed 2026-07-05 with mikebom `bfd0f6d` on a fresh clone of `github.com/podman-desktop/podman-desktop`.
+
+**Baseline numbers**:
+- Total components: **2748** (2694 npm + 54 file-tier)
+- Reachable via BFS: **2126** = **77.4%**
+- Orphans: **568**
+- Multi-version orphans: **435** (76.6% of orphans)
+- Truly-isolated orphans: **133** (broken down into ~50-100 platform-optional bindings + ~30-50 other; both out of scope for m164)
+
+**Target numbers** (post-164):
+- Multi-version orphans: **≤30** (94% reduction)
+- BFS reachability: **≥93%** (+15pp)
+- Zero SC-002 regression (phantom edges = 0)
+- Zero SC-004 regression (empty-version PURLs = 0)
+
+**Rationale**: The multi-version-orphan class accounts for exactly the 15pp gap milestone-164 targets. Achieving ≤30 remaining multi-version orphans (from 435) leaves a small buffer for edge cases (e.g., aliased multi-version composition, malformed lockfile entries) without overpromising.
+
+**Empirical-revision escape hatch**: if implementation reveals additional edge cases that cap improvement below 93%, SC-002 target may be revised inline per the milestone-156/157/158/159/160/161/162/163 empirical-revision pattern.
+
+## R7 — Interaction with milestone-159 alias handling
+
+**Decision**: Milestone-159's alias handling (line 105-125 of pnpm_lock.rs, the `alias_map` + `reverse_map` post-processing) runs AFTER the parse loop. By the time alias rewriting fires, `depends` arrays already carry the disambiguation form. `rewrite_dep_names` (milestone 159's utility) MUST be updated to handle both bare names AND `"<name> <version>"` forms — check the local-name of the input, match against `alias_map`, and if found, replace the name portion while preserving the version portion.
+
+**Concrete example**:
+- Pre-164 alias rewrite: `"my-local"` → `"@real/pkg"` (bare name substitution).
+- Post-164 alias rewrite: `"my-local 1.0.0"` → `"@real/pkg 1.0.0"` (name substituted, version preserved).
+
+**Rationale**: Alias handling and version disambiguation are orthogonal transformations. Composition = "substitute the name, preserve the version". This preserves the FR-003 composability guarantee (alias syntax at any version).
+
+**Implementation impact**: `rewrite_dep_names` in `alias_mapping.rs` needs a small update. The rest of milestone-159's alias flow is unchanged.
+
+## R8 — SC-003 dual-side byte-identity verification
+
+**Decision**: Non-pnpm-v9 goldens verified via existing test suite (`cargo test --workspace`). Every non-pnpm-v9 milestone-090 golden fixture runs through its existing integration test; if the golden diffed, the test fails and blocks the PR.
+
+**Coverage**:
+- 10 non-pnpm ecosystems (apk, bazel, cargo, cmake, deb, gem, golang, maven, pip, rpm) × 3 formats = 30 goldens.
+- 1 `npm` fixture (uses `package-lock.json`, not `pnpm-lock.yaml v9`) × 3 formats = 3 goldens.
+- Total: **33 goldens must remain byte-identical**.
+
+Pnpm-lock v9 fixtures (if any exist in milestone-090) MAY change. Verified at authoring time: `find mikebom-cli/tests/fixtures/pnpm* -name 'pnpm-lock.yaml' -exec head -3 {} \;` reveals whether they're v6/v7 or v9. If v9 AND multi-version, goldens legitimately drift — regenerate via `MIKEBOM_UPDATE_CDX_GOLDENS=1 cargo test`.
+
+**Rationale**: Matches milestone-160/161/162/163 SC-003 verification pattern. Zero-diff on non-pnpm-v9 is enforced by the existing golden test infrastructure; no new test code needed for SC-003.
+
+## Open items (none blocking)
+
+All research questions resolved. Ready for Phase 1 (data-model.md + contracts + quickstart).

--- a/specs/164-pnpm-multi-version-edges/spec.md
+++ b/specs/164-pnpm-multi-version-edges/spec.md
@@ -1,0 +1,208 @@
+# Feature Specification: pnpm v9 multi-version edge disambiguation
+
+**Feature Branch**: `164-pnpm-multi-version-edges`
+**Created**: 2026-07-05
+**Status**: Draft
+**Input**: Empirical follow-up to milestone 163. 2026-07-05 re-measurement of `github.com/podman-desktop/podman-desktop` with milestone-163 mikebom (`bfd0f6d`) confirmed BFS reachability jumped 24.6% → 77.4% (+52.8pp) as designed. 22-point residual gap remains. Root-cause investigation traced 435 of 568 remaining orphans (76.6% of the gap) to a single bug class: pnpm-lock v9 multi-version edge misresolution — same-name package emitted at multiple versions, parent edges point at the wrong version because the pnpm-lock parser doesn't preserve the version qualifier through to the edge resolver.
+
+## Motivation
+
+Post-163 measurement (2026-07-05, live upstream podman-desktop, fresh clone):
+
+- Empty-version PURLs: **0** ✅ (milestone-163 SC-004 pass)
+- Phantom edges: **0** ✅ (milestone-163 SC-002 pass)
+- BFS reachability: **24.6% → 77.4%** (+52.8pp)
+- 568 orphans remain (out of 2748 npm components)
+
+Orphan classification:
+
+- **435 (76.6%) — multi-version orphans**: same package name emitted at multiple versions (e.g. `pkg:npm/@algolia/autocomplete-core@1.17.9` AND `pkg:npm/@algolia/autocomplete-core@1.19.8`). Only one version is reachable per name; the other is orphaned.
+- **~50-100 — platform-specific optional bindings** (`@oxc-parser/binding-*`, `@esbuild/*-*`): out of scope, separate follow-on.
+- **~30-50 — truly isolated**: out of scope, separate investigation.
+
+Concrete root cause verified 2026-07-05:
+
+- **Lockfile ground truth** (podman-desktop pnpm-lock.yaml, `@docsearch/react@3.9.0`'s deps):
+  ```yaml
+  dependencies:
+    '@algolia/autocomplete-core': 1.17.9(@algolia/client-search@5.42.0)(algoliasearch@5.42.0)(search-insights@2.17.3)
+  ```
+
+- **Mikebom's emitted SBOM** (`pkg:npm/@docsearch/react@3.9.0.dependsOn`):
+  ```
+  → pkg:npm/@algolia/autocomplete-core@1.19.8   ← WRONG (lockfile says 1.17.9)
+  ```
+
+Both versions are legitimately present in the lockfile (different peer-dep constraint scopes install different `@algolia/autocomplete-core` versions). Mikebom's `name_to_purl` disambiguation at `scan_fs/mod.rs:471-525` handles multi-version resolution via a `"<name> <version>"` disambiguation key form (per issue #262, extended for npm alongside cargo per milestone 087). But the pnpm-lock parser doesn't emit into the parent's `depends` array in that disambiguation form — it emits bare names — so the name-only fallback path last-write-wins between `1.17.9` and `1.19.8`.
+
+**This is a Constitution Principle IX (Accuracy) failure**: emitted edges point at the wrong version of a real component. Milestone 087 solved the same class for cargo. Milestone 164 applies the analogous fix to pnpm v9.
+
+## Distinction from milestones 147, 159, 163
+
+- **Milestone 147** (npm peer-deps C1/C2): peer-dep envelope annotation on the CONSUMER. Different mechanism.
+- **Milestone 159** (pnpm/yarn alias): alias name-remapping. Different failure class.
+- **Milestone 163** (npm workspace-peer phantom empty-version edges): eliminated 159 phantom empty-version PURLs. Different bug — phantom targets, not wrong-version targets.
+
+All four are complementary. Milestone 164 is the natural next step: with phantoms gone (163) and aliases resolved (159), the remaining gap is dominated by wrong-version edges among real components.
+
+## User Scenarios & Testing
+
+### User Story 1 - SBOM consumer's edges resolve to the correct concrete version (Priority: P1)
+
+An SBOM consumer (Kusari Inspector, a vulnerability scanner) loads mikebom's npm SBOM for a pnpm-monorepo with multi-version co-existence. Pre-164, half the multi-version edges point at the wrong version — a downstream CVE lookup gets false negatives (the vulnerable version is orphaned; the "wrong-target" edge points at a safe version). Post-164, every parent's `dependsOn` edge targets the SAME concrete version pnpm-lock actually resolved.
+
+**Why this priority**: Constitution Principle IX (Accuracy). Directly delivers ~15pp of BFS reachability on podman-desktop (435 of 568 orphans). Load-bearing for closing the milestone-158 aspirational ≥99% target.
+
+**Independent Test**: Scan `github.com/podman-desktop/podman-desktop` (freshly cloned). BFS-walk the emitted `dependencies[]` graph. Assert:
+
+- Multi-version orphan count MUST drop from 435 to ≤ 30 (94% reduction).
+- Total BFS reachability MUST increase from 77.4% to ≥ 93%.
+- Zero regressions in SC-002/SC-004 from milestone 163 (phantom edge + empty-version PURL invariants preserved).
+
+**Acceptance Scenarios**:
+
+1. **Given** a pnpm-lock v9 fixture where `@docsearch/react@3.9.0` depends on `@algolia/autocomplete-core: 1.17.9(...)` per the lockfile, **When** mikebom emits the SBOM, **Then** `pkg:npm/%40docsearch/react@3.9.0`'s `dependsOn` MUST include `pkg:npm/%40algolia/autocomplete-core@1.17.9` — NOT `pkg:npm/%40algolia/autocomplete-core@1.19.8`.
+
+2. **Given** the same fixture where BOTH `1.17.9` AND `1.19.8` are emitted, **When** BFS-walking from the workspace root, **Then** BOTH versions MUST be reachable (each via a distinct parent).
+
+3. **Given** any pnpm-lock v9 lockfile with N distinct versions of the same package, **When** mikebom emits the SBOM, **Then** the fraction of correctly-wired edges (edge target version == lockfile-declared version) MUST equal 100%.
+
+---
+
+### User Story 2 - pnpm v6/v7 legacy lockfile format unchanged (Priority: P2)
+
+Users on pnpm v6/v7 (which pre-dates the peer-dep-suffixed key form) see byte-identical output vs pre-164.
+
+**Why this priority**: Regression guard. Pnpm v6/v7 doesn't use peer-dep-suffixed keys and isn't affected by the milestone-164 fix. Confirming zero drift on the pnpm v6/v7 path prevents accidental over-scoping.
+
+**Independent Test**: Regenerate any milestone-090 pnpm v6/v7 fixture. Diff against pre-164. Zero diff bytes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pnpm-lock v6 fixture, **When** mikebom scans, **Then** emitted SBOM MUST be byte-identical to pre-164.
+
+---
+
+### User Story 3 - Non-pnpm-v9 scans byte-identical to pre-164 (Priority: P3)
+
+Users scanning repos without pnpm-lock v9 files (yarn.lock, package-lock.json, bun.lock, non-npm ecosystems entirely) see byte-identical SBOM output vs pre-164.
+
+**Why this priority**: Regression guard. Mirrors milestones 158/159/160/161/162/163 dual-side byte-identity precedent.
+
+**Independent Test**: Regenerate all non-pnpm-v9 milestone-090 goldens. Diff against pre-164. Zero diff bytes on 10 non-pnpm × 3 = 30 goldens PLUS the `npm` fixture (which uses package-lock.json, not pnpm-lock.yaml v9).
+
+**Acceptance Scenarios**:
+
+1. **Given** the milestone-090 cargo fixture (no pnpm components), **When** mikebom scans, **Then** the emitted CDX diff vs pre-164 is exactly ZERO bytes.
+
+### Edge Cases
+
+- **Two versions of the same package, both with parents in the lockfile**: happy path. Each parent's `dependsOn` targets its lockfile-declared version.
+
+- **Two versions where one is only in `snapshots:` (peer-dep-suffixed key form)**: mikebom emits the base `<name>@<version>` component (stripping the peer-dep suffix per FR-005). Parent edges MUST target the correct version via the disambiguation key form.
+
+- **Three-plus versions of the same package** (rare but valid): all N versions correctly wire.
+
+- **Package declared with a peer-dep-suffixed key but no matching parent** (dangling target): the component is emitted but has no incoming edge. Legitimate orphan — mikebom's existing `mikebom:orphan-reason` (milestone 158) covers this.
+
+- **Aliased dep at a specific version**: milestone-159's alias handling remains authoritative. If a peer declares `"my-name": "npm:@real@^1.0.0"` AND the lockfile pins `@real` at TWO versions, the alias + version disambiguation compose (each is orthogonal).
+
+- **Same-version-different-source** (GitHub URL vs registry install of the same package at the same version): mikebom emits a single component (PURL is version-only). Milestone 164 doesn't address source-provenance; orthogonal.
+
+- **pnpm v9 `overrides:` field**: overrides pin specific versions across the tree. Milestone 164 respects the lockfile's authoritative version (whatever pnpm resolved with overrides applied), not the pre-override manifest declaration.
+
+- **Malformed peer-dep-suffixed key**: unbalanced parentheses, missing version. Per FR-008, mikebom logs a warning and falls back to bare-name form (pre-164 behavior). Never crash, never silently drop.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: mikebom's pnpm-lock parser MUST emit each parent's `depends` array in a version-qualified form (`"<name> <version>"` — the disambiguation key form used at `scan_fs/mod.rs:519-525`) whenever the parent's lockfile-declared dep specifier resolves to a specific, unambiguous version. When the lockfile declares `'@docsearch/react@3.9.0' → depends: '@algolia/autocomplete-core': 1.17.9(...)`, the parent's `depends` entry MUST let the downstream `name_to_purl` lookup disambiguate between multiple emitted versions.
+
+- **FR-002**: The disambiguation MUST work for pnpm-lock v9 (the format that introduced peer-dep-suffixed keys). Pnpm v6/v7 lockfiles are unchanged (byte-identity per User Story 2).
+
+- **FR-003**: The disambiguation MUST hold for ALL npm scoped-name shapes: `@scope/name`, plain `name`, and aliased-name variants from milestone 159's alias handling.
+
+- **FR-004**: When the lockfile declares a peer-dep-suffixed dep-value like `1.17.9(@algolia/client-search@5.42.0)(algoliasearch@5.42.0)(search-insights@2.17.3)`, mikebom MUST parse out the base version (`1.17.9`) and use it for edge disambiguation. The peer-dep suffix itself is discarded for PURL purposes (matches milestone 147 posture — peer relationships are their own signal, not part of the target's PURL).
+
+- **FR-005**: The emitted PURL for the target component MUST NOT include the peer-dep suffix. `pkg:npm/@algolia/autocomplete-core@1.17.9` is the correct emitted PURL; NEVER `pkg:npm/@algolia/autocomplete-core@1.17.9(algoliasearch@5.42.0)`.
+
+- **FR-006**: Multi-version co-existence in the emitted SBOM MUST remain observable. When the lockfile pins both `1.17.9` AND `1.19.8`, BOTH components MUST appear in `components[]`. Milestone 164 fixes edge resolution; it does NOT collapse or dedup emitted components.
+
+- **FR-007**: Standards-native precedence per Constitution Principle V. This milestone reuses the existing `name_to_purl` disambiguation mechanism at `scan_fs/mod.rs:519-525`. No new annotations, no new parity-catalog rows.
+
+- **FR-008**: When a peer-dep-suffixed key form CANNOT be parsed (malformed lockfile, unexpected format drift), mikebom MUST log a `tracing::warn!` naming the malformed key and fall back to the bare-name form (pre-164 behavior). Constitution Principle VIII (Completeness) — never silently drop; never crash.
+
+- **FR-009**: An info-level tracing log line MUST fire per pnpm-lock v9 file processed, summarizing: (a) `packages_count`, (b) `snapshots_count`, (c) `multi_version_disambiguated_count`, (d) `malformed_key_warn_count`. Grep-friendly per the milestone-157/158/159/160/161/162/163 observability convention.
+
+- **FR-010**: Milestone-147 peer-dep handling (peerDependencies C1/C2 annotations) MUST remain unchanged. Milestone 164's scope is `dependencies:` + inline `snapshots:` resolution ONLY.
+
+### Key Entities
+
+- **Peer-dep-suffixed key**: pnpm-lock v9 dep-value form like `1.17.9(@algolia/client-search@5.42.0)(algoliasearch@5.42.0)(search-insights@2.17.3)`. The base version (`1.17.9`) is the concrete resolved version; parenthesized suffixes are peer-dep discriminators used by pnpm's resolver internally.
+
+- **Version-qualified disambiguation form**: `"<name> <version>"` string used as the `name_to_purl` lookup key (per issue #262 npm precedent + milestone 087 cargo precedent). Mikebom's edge resolver already indexes by both bare name AND this disambiguation form; milestone 164 ensures the pnpm-lock parser emits into `depends` in the disambiguation form for edges that need it.
+
+- **Multi-version orphan**: an emitted component whose PURL is `pkg:npm/<name>@<version-A>` where another `pkg:npm/<name>@<version-B>` is ALSO emitted, AND `<version-A>` has zero incoming `dependsOn` edges. Pre-164 podman-desktop baseline: 435 such orphans / 2748 total components.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001 (multi-version orphan reduction)**: On live `github.com/podman-desktop/podman-desktop` (freshly cloned), multi-version orphan count MUST drop from 435 to ≤ 30 (94% reduction).
+
+- **SC-002 (BFS reachability improvement)**: Post-164, BFS-walking `dependencies[]` from `metadata.component` on podman-desktop MUST achieve ≥ 93% npm-component reachability. Pre-164 baseline (measured 2026-07-05): 77.4% (2126 of 2748). Target: ≥ 93% (+15pp from milestone-164 alone). Full ≥99% aspiration requires follow-on milestones addressing platform-optional-binding + truly-isolated classes.
+
+- **SC-003 (dual-side byte-identity, mirrors milestones 158–163)**: For every milestone-090 non-pnpm-v9 golden fixture (10 non-pnpm ecosystems + the `npm` fixture which uses package-lock.json), emitted CDX / SPDX 2.3 / SPDX 3 SBOMs MUST be byte-identical to pre-164. Zero diff bytes on 11 × 3 = 33 goldens. Pnpm-lock v9 fixture goldens MAY change (deliberate — edge targets change to correct versions).
+
+- **SC-004 (milestone-163 invariants preserved)**: Zero empty-version PURLs and zero phantom edges in ANY scan post-164. Milestone 163's SC-002 + SC-004 MUST continue to hold.
+
+- **SC-005 (component count preserved)**: Post-164 emitted SBOM component count MUST equal pre-164 count for any given fixture. Milestone 164 fixes edge targets, not components emitted.
+
+- **SC-006 (pre-PR gate)**: `cargo +stable clippy --workspace --all-targets -- -D warnings` and `cargo +stable test --workspace --no-fail-fast` MUST both pass with zero errors.
+
+- **SC-007 (unit test coverage)**: The new pnpm-lock parser changes MUST have at least 8 unit tests covering: (a) peer-dep-suffixed key parses to base version; (b) parent `depends` array carries version-qualified disambiguation form; (c) `name_to_purl` disambiguation lookup returns the correct version-specific PURL; (d) pnpm v6/v7 key form unchanged (regression guard); (e) malformed peer-dep-suffixed key falls back to bare-name form with WARN log (FR-008); (f) multi-version co-existence: both versions emitted, both reachable via their respective parents; (g) FR-010 peerDependencies handling unchanged; (h) FR-005 emitted PURL never includes peer-dep suffix.
+
+- **SC-008 (integration test)**: A new integration test at `mikebom-cli/tests/pnpm_multi_version.rs` MUST synthesize a pnpm-lock v9 fixture with two versions of the same package (both with parent entries) and assert (a) both parent edges resolve to their correct version-specific PURLs; (b) both versions are BFS-reachable from the workspace root; (c) zero multi-version orphans.
+
+- **SC-009 (CHANGELOG entry)**: `CHANGELOG.md` MUST document the fix + the empirical pre/post numbers on podman-desktop (77.4% → ≥93%; 435 → ≤30) + a consumer jq recipe.
+
+- **SC-010 (opportunistic real audit)**: A gated integration test at `mikebom-cli/tests/pnpm_multi_version_audit.rs` (behind `MIKEBOM_PNPM_MULTIVER_AUDIT=1`, matching milestone-160/161/162/163 pattern) MUST assert on a cached `podman-desktop` (via `MIKEBOM_FIXTURES_DIR`) that (a) multi-version orphans ≤ 30; (b) BFS reachability ≥ 93%. NOT blocking for the PR.
+
+- **SC-011 (empirical closure)**: The impl commit MUST reference this milestone and demonstrably resolve the observed symptom (multi-version orphan count 435 → ≤ 30 on podman-desktop). Since this milestone is not tied to a specific GitHub issue number (empirical follow-up to milestone 163's podman-desktop re-measurement), the commit body MUST include the empirical measurement table and reference the 2026-07-05 baseline.
+
+## Assumptions
+
+- **Podman-desktop is the empirical benchmark**: SC-001/SC-002 numbers are pinned to a live clone of `github.com/podman-desktop/podman-desktop`. Numbers may drift with upstream commits; the milestone MUST re-measure at implementation time and adjust SC-001/SC-002 targets if the pre-164 baseline shifted materially (matches milestone-156/157/158 empirical-revision precedent).
+
+- **Pnpm-lock v9 is the peer-dep-suffixed key format**: Introduced transitionally in pnpm 8.0, finalized in pnpm 9.x. Milestone 164 targets v9 specifically; pnpm 8.0 transitional format is implicitly covered iff its shape matches v9 (verified at authoring time).
+
+- **Milestone-087 cargo pattern is directly applicable**: The `<name> <version>` disambiguation-key mechanism at `scan_fs/mod.rs:519-525` was extended for npm per issue #262 (see the inline comment block referencing the nested-`node_modules/<parent>/node_modules/<dep>` case). Milestone 164 activates that mechanism on the pnpm v9 code path — the receiver is already there.
+
+- **Peer-dep-suffix stripping is at the pnpm-lock parser**: The existing parser at `mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs:400` already strips parenthesized peer-dep suffixes (per inline comment "Strip any parenthesised peer-dep suffix"). Milestone 164 preserves the stripped base-version + threads it into the `depends` array in disambiguation form.
+
+- **No new Cargo dependencies**: Following the milestone-158/159/160/161/162/163 precedent.
+
+- **milestone-090 pnpm fixture MAY change**: If existing pnpm-lock fixtures include multi-version cases, their goldens drift deliberately. Verified at authoring time.
+
+- **SC-001/SC-002 targets are empirically-adjustable**: If investigation reveals corner cases that cap improvement below 93%, SC-002 may be revised inline per the milestone-156/157/158/159/160/161/162/163 empirical-revision pattern.
+
+- **No GitHub issue number pending**: Milestone 164 is an empirical follow-up to milestone 163's podman-desktop measurement — surfaced during the 2026-07-05 audit, not filed as a separate issue at spec time. The `implements milestone 164` commit reference (rather than `closes #NNN`) matches this posture.
+
+## Out of Scope
+
+- **Platform-specific optional-binding orphans** (`@oxc-parser/binding-*`, `@esbuild/*-*`) — separate future milestone. `optionalDependencies:` entries where the lockfile lists ALL platform binaries but only one is loaded per host. ~50-100 orphans on podman-desktop.
+
+- **Truly-isolated orphans not covered by the multi-version pattern** — separate follow-on. ~30-50 residual orphans need their own root-cause analysis.
+
+- **Pnpm-lock v6/v7 key form** — unchanged (User Story 2 byte-identity guard). Pre-v8 lockfiles don't use peer-dep-suffixed keys; edges already resolve correctly via the bare-name path.
+
+- **Yarn v1 / Yarn Berry / bun.lock** — different formats, different resolution semantics. Yarn multi-version handling is milestone 106's territory.
+
+- **Non-npm ecosystems** — cargo multi-version disambiguation was solved by milestone 087. Other ecosystems' multi-version handling is out of scope.
+
+- **Aliased-dep multi-version composition** — milestone 159 remains authoritative for alias name-remapping; milestone 164 handles version disambiguation on the already-resolved target name. The two compose; neither subsumes the other.
+
+- **Peer-dep suffix as first-class SBOM data** — milestone 147 already handles peer-dep relationships via C1/C2. Milestone 164 does NOT introduce a "the peer-dep constraint context that pinned this version" annotation.
+
+- **Retroactive rewrite of pre-164 SBOMs** — scan-time fix only; no consumer-side migration tooling.

--- a/specs/164-pnpm-multi-version-edges/tasks.md
+++ b/specs/164-pnpm-multi-version-edges/tasks.md
@@ -1,0 +1,213 @@
+---
+description: "Task list for milestone 164 — pnpm v9 multi-version edge disambiguation"
+---
+
+# Tasks: pnpm v9 multi-version edge disambiguation
+
+**Input**: Design documents from `/specs/164-pnpm-multi-version-edges/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/README.md, quickstart.md
+
+**Tests**: INCLUDED. SC-007 requires ≥8 unit tests; SC-008 requires a new integration test. All test surfaces are load-bearing SC evidence and MUST land alongside the implementation.
+
+**Organization**: Tasks grouped by 3 user stories from spec.md (US1 P1 MVP correct-version edge resolution, US2 P2 pnpm v6/v7 byte-identity, US3 P3 non-pnpm-v9 byte-identity). US1 is the load-bearing MVP. Total: 23 tasks (2 setup + 6 foundational + 8 US1 + 1 US2 + 2 US3 + 4 polish).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Different files, no dependencies on incomplete tasks — parallelizable.
+- **[Story]**: US1 / US2 / US3 for user-story tasks. Setup, Foundational, Polish have NO story label.
+
+## Path Conventions
+
+Single-project workspace layout per plan.md §Project Structure. All paths absolute-relative to repo root `/Users/mlieberman/Projects/mikebom/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Verify prerequisites + baseline current state before making changes.
+
+- [X] T001 Verify the current pnpm-lock parser matches the research.md R1 pinpoint: `grep -n '_canon_ver' mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs` — MUST show line 80 discarding the version. If not present (upstream drift), abort and re-baseline research.md R1.
+- [X] T002 Verify existing pnpm-lock tests baseline: `cargo +stable test --bin mikebom scan_fs::package_db::npm::pnpm_lock` — MUST pass clean before starting. Records the pre-164 test-count baseline for the T021 pre-PR gate diff.
+
+**Checkpoint**: Codebase state confirmed. Ready for foundational implementation.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Implement the parser fix + supporting infrastructure. All user stories depend on this phase.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 Extend `collect_pnpm_dep_names` signature at `mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs:46-90` per data-model.md E1. Add 3 parameters: `emit_versioned: bool`, `versioned_counter: Option<&mut usize>`, `warn_counter: Option<&mut usize>`. Preserve return type `Vec<String>`. In the body: replace the `_canon_ver` discard with `canon_ver`; branch on `emit_versioned` — if true AND non-empty version: push `format!("{canon_name} {canon_ver}")` and increment `versioned_counter`; if true AND empty version: `tracing::warn!` per FR-008 + increment `warn_counter` + push bare `canon_name`; if false: push bare `canon_name`. Keep the existing dedup + sort at function end.
+- [X] T004 Extend `build_snapshots_lookup` signature at `pnpm_lock.rs:101-126` per data-model.md E2. Add `&mut usize` counters for `versioned_counter` + `warn_counter`. Update the single `collect_pnpm_dep_names` call at line 122 to pass `emit_versioned=true, Some(versioned_counter), Some(warn_counter)`.
+- [X] T005 Update the v6/v7 inline call to `collect_pnpm_dep_names` at `pnpm_lock.rs:262` per data-model.md E3 to pass `emit_versioned=false, None, None`. This preserves User Story 2 byte-identity guard for pnpm v6/v7 lockfiles.
+- [X] T006 Add tally locals + extend info log at `pnpm_lock.rs` per data-model.md E4 + E5. Near the top of `parse_pnpm_lock`: `let mut multi_version_disambiguated_count: usize = 0; let mut malformed_key_warn_count: usize = 0;`. Thread these into the `build_snapshots_lookup` call. Extend the existing `tracing::info!("pnpm-lock parsed")` at `pnpm_lock.rs:373-377` with two new fields: `multi_version_disambiguated_count`, `malformed_key_warn_count`. Grep-friendly per FR-009 + milestone-157/158/159/160/161/162/163 observability convention.
+- [X] T007 Update `rewrite_dep_names` in `mikebom-cli/src/scan_fs/package_db/npm/alias_mapping.rs` per data-model.md E6 + research.md R7. Split each input on FIRST space to separate `name` from optional `version`; look up `name` in `alias_map`; if match: emit `format!("{aliased_name} {version}")` (preserving version) or bare `aliased_name` (if no version); if no match: pass through unchanged. This preserves milestone-159 alias composition when milestone-164 puts versions into `depends`.
+- [X] T007a Unit test `t007a_rewrite_dep_names_preserves_version` in `mikebom-cli/src/scan_fs/package_db/npm/alias_mapping.rs` mod tests block. Verify three cases per FR-003 alias-composition contract: (a) bare `"foo"` + alias-map hit `foo → @real/foo` → output `"@real/foo"` (pre-164 behavior preserved when no version); (b) versioned `"foo 1.2.3"` + same alias-map hit → output `"@real/foo 1.2.3"` (version preserved through alias substitution); (c) versioned `"baz 4.5.6"` + no alias-map hit → output `"baz 4.5.6"` unchanged (passthrough). Closes the FR-003 test gap surfaced during analyze — without this, a subtle milestone-159 regression when milestone-164 lands would only surface at podman-desktop-audit time, not at unit-test time.
+
+**Checkpoint**: `cargo +stable check -p mikebom` succeeds. `cargo +stable clippy --workspace --all-targets -- -D warnings` clean. All existing tests continue to pass EXCEPT the pnpm v9 tests that expected pre-164 bare-name emission (Phase 3 tests will cover those).
+
+---
+
+## Phase 3: User Story 1 - Correct-version edge resolution on pnpm v9 (Priority: P1) 🎯 MVP
+
+**Goal**: Verify the milestone-087-style disambiguation-key emission produces correct edge targets on pnpm v9 lockfiles with multi-version cases.
+
+**Independent Test**: Synthesize a minimal pnpm-lock v9 fixture with two versions of the same package and two parents each declaring a different version. Assert both parent edges resolve to their correct version-specific PURLs, both versions are BFS-reachable, and zero multi-version orphans emerge.
+
+### Tests for User Story 1
+
+- [X] T008 [P] [US1] Unit test `t008_collect_pnpm_dep_names_emit_versioned_true_produces_versioned` in `mikebom-cli/src/scan_fs/package_db/npm/pnpm_lock.rs` mod tests block. Synthesize a minimal `serde_yaml::Mapping` with a `dependencies:` sub-mapping containing `foo: 1.2.3(peer@4.5.6)`. Call `collect_pnpm_dep_names(&tbl, &mut aliases, "/test", true, None, None)`. Assert `deps == ["foo 1.2.3"]` per SC-007 (a).
+- [X] T009 [P] [US1] Unit test `t009_collect_pnpm_dep_names_emit_versioned_false_preserves_bare_name` in `pnpm_lock.rs` mod tests. Same input as T008 but `emit_versioned=false`. Assert `deps == ["foo"]` (pre-164 bare-name form) per SC-007 (b) + US2 regression guard.
+- [X] T010 [P] [US1] Unit test `t010_collect_pnpm_dep_names_empty_version_falls_back_with_warn` in `pnpm_lock.rs` mod tests. **Pre-condition**: first verify `parse_pnpm_key`'s return semantics for edge inputs (`"foo@"`, `"foo"`, `"@scope/foo@"`). Two possible outcomes: **(a) `parse_pnpm_key` returns `None` on empty-version keys**: then FR-008's WARN branch fires only on parser bugs. Mark T010 as defensive-only: verify the WARN branch via direct fault injection (temporarily pass a wrapper closure that returns `Some(("foo", ""))` to the branch under test, OR extract the WARN branch logic into a helper `fn emit_dep_with_disambiguation(deps: &mut Vec<String>, name: &str, ver: &str, versioned_counter: &mut usize, warn_counter: &mut usize)` and unit-test that helper directly with `ver = ""`). Assert `deps == ["foo"]` AND `warn_counter == 1`. **(b) `parse_pnpm_key` returns `Some(("foo", ""))`**: then construct a lockfile-shaped input that triggers this and assert the full `collect_pnpm_dep_names` code path. Either way, T010 verifies the FR-008 fallback contract; the fragility framing goes away once the parse_pnpm_key behavior is nailed down.
+- [X] T011 [P] [US1] Unit test `t011_build_snapshots_lookup_emits_versioned_for_v9` in `pnpm_lock.rs` mod tests. Synthesize a v9 `snapshots:` YAML section with one entry containing a dep. Call `build_snapshots_lookup` with fresh counters. Assert the returned `HashMap` values contain versioned-form strings per SC-007 (b).
+- [X] T012 [P] [US1] Unit test `t012_parse_pnpm_lock_multi_version_edges_resolve_correctly` in `pnpm_lock.rs` mod tests. Synthesize a v9 pnpm-lock YAML with two versions of `foo` (`1.0.0` and `2.0.0`) + two parent packages each declaring one version via `snapshots:`. Call `parse_pnpm_lock`. Assert (a) both `PackageDbEntry` for `foo@1.0.0` and `foo@2.0.0` emitted; (b) parent 1's `depends` contains `"foo 1.0.0"`; (c) parent 2's `depends` contains `"foo 2.0.0"` per SC-007 (f).
+- [X] T013 [P] [US1] Unit test `t013_parse_pnpm_lock_purl_never_includes_peer_dep_suffix` in `pnpm_lock.rs` mod tests. Synthesize a v9 pnpm-lock with a peer-dep-suffixed key like `foo@1.0.0(bar@2.0.0)`. Parse. Assert emitted `PackageDbEntry.purl.as_str()` == `"pkg:npm/foo@1.0.0"` — NEVER contains `(` per FR-005 + SC-007 (h).
+- [X] T014 [P] [US1] Unit test `t014_peer_dependencies_handling_unchanged_after_164` in `pnpm_lock.rs` mod tests. Synthesize a v9 snapshot with a `peerDependencies:` block. Parse. Assert that peer-dep handling matches pre-164 behavior (existing milestone-147 semantic) per FR-010 + SC-007 (g).
+- [X] T015 [US1] Integration test at `mikebom-cli/tests/pnpm_multi_version.rs` per SC-008 — synthesize a tempdir with:
+  - `<tempdir>/pnpm-workspace.yaml` — declaring `packages: ['packages/*']`.
+  - `<tempdir>/package.json` — root workspace declaring `name: monorepo-root`.
+  - `<tempdir>/pnpm-lock.yaml` v9 — packages: `foo@1.0.0` + `foo@2.0.0` (both real registry entries); snapshots: `parent-a@1.0.0` depending on `foo: 1.0.0`, `parent-b@1.0.0` depending on `foo: 2.0.0`; importers section declaring both parents at workspace roots.
+  - `<tempdir>/packages/consumer-a/package.json` — declaring `dependencies: {parent-a: "^1.0.0"}`.
+  - `<tempdir>/packages/consumer-b/package.json` — declaring `dependencies: {parent-b: "^1.0.0"}`.
+
+  Invoke the release binary via `env!("CARGO_BIN_EXE_mikebom")`, parse emitted CDX, assert per SC-008:
+  1. Both `pkg:npm/foo@1.0.0` and `pkg:npm/foo@2.0.0` present in `components[]`.
+  2. `pkg:npm/parent-a@1.0.0`'s `dependsOn` contains `pkg:npm/foo@1.0.0` (NOT `2.0.0`).
+  3. `pkg:npm/parent-b@1.0.0`'s `dependsOn` contains `pkg:npm/foo@2.0.0` (NOT `1.0.0`).
+  4. BFS from `metadata.component` reaches BOTH `foo@1.0.0` AND `foo@2.0.0` — zero multi-version orphans.
+  5. **Milestone-163 invariants preserved** (SC-004): `[.components[].purl | select(test("^pkg:npm/[^@]+@$"))] | length == 0` (zero empty-version PURLs) AND `[.dependencies[].dependsOn[] | select(test("^pkg:npm/[^@]+@$"))] | length == 0` (zero phantom edges). Catches accidental milestone-163 drift at MVP-test time; without this assertion, an m164 regression breaking m163 invariants would only surface if an unrelated m163 golden test happens to fail — not guaranteed for the synthesized fixture territory.
+
+**Checkpoint**: US1 is fully functional. Running `cargo +stable test --test pnpm_multi_version` verifies the end-to-end fix on a synthesized fixture. All 7 unit tests + 1 integration test pass.
+
+---
+
+## Phase 4: User Story 2 - pnpm v6/v7 lockfile format byte-identity (Priority: P2)
+
+**Goal**: Verify pnpm v6/v7 lockfile emission is byte-identical to pre-164.
+
+**Independent Test**: Regenerate any existing pnpm v6/v7 fixture. Diff against pre-164. Zero diff bytes.
+
+### Tests for User Story 2
+
+- [X] T016 [P] [US2] Unit test `t016_v6_v7_inline_path_emits_bare_names` in `pnpm_lock.rs` mod tests. Synthesize a v6/v7 pnpm-lock YAML (has `packages:` but no `snapshots:`) with a dep. Parse. Assert emitted `PackageDbEntry.depends` contains bare `["foo"]` (NOT `["foo 1.2.3"]`). Confirms FR-002 v6/v7 byte-identity path.
+
+**Checkpoint**: US2 is fully functional. Existing pnpm v6/v7 golden tests continue passing (verified by full workspace test run in T018).
+
+---
+
+## Phase 5: User Story 3 - Non-pnpm-v9 scans byte-identical to pre-164 (Priority: P3)
+
+**Goal**: Regression guard. Verify the milestone-090 non-pnpm-v9 goldens (10 non-pnpm ecosystems + the npm-with-package-lock fixture × 3 formats = 33 files) are byte-identical to pre-164.
+
+**Independent Test**: `cargo +stable test --workspace --no-fail-fast` — every existing golden test that operates on non-pnpm-v9 fixtures MUST pass unchanged.
+
+### Golden verification for User Story 3
+
+- [X] T017 [US3] Run `cargo +stable test --workspace --no-fail-fast` after Phase 2+3+4 land. Every existing golden test on non-pnpm-v9 fixtures (10 non-pnpm ecosystems + `npm` fixture using `package-lock.json`) MUST pass unchanged. Any golden diff on those 33 files indicates an emission-leak bug that needs fixing before proceeding.
+- [X] T018 [US3] If existing pnpm-v9 fixtures exist AND contain multi-version cases, their goldens will drift deliberately. Regenerate via `MIKEBOM_UPDATE_CDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX_GOLDENS=1 MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo test` and manually inspect the diff. Verify the change is limited to: edge targets in `dependencies[].dependsOn[]` shifting from wrong-version to correct-version PURLs. NO new components, NO new annotations. If no pnpm-v9 multi-version fixture exists, this task is a no-op.
+
+**Checkpoint**: SC-003 byte-identity verified. 33 non-pnpm-v9 goldens unchanged.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, CHANGELOG, optional real-testbed audit, pre-PR gate, empirical closure.
+
+- [X] T019 [P] Add `CHANGELOG.md` entry per SC-009 documenting: (a) motivation (2026-07-05 podman-desktop re-measurement + root-cause pinpoint at `pnpm_lock.rs:80`), (b) fix summary (thread version through `collect_pnpm_dep_names` via `emit_versioned` param), (c) empirical impact — pre/post SC-001/SC-002 numbers on podman-desktop (77.4% → target ≥93% BFS; 435 → ≤30 multi-version orphans; measured via T015 synthesized fixture; T020 opportunistic real audit), (d) consumer jq recipe from contracts/README.md, (e) note that no new annotations, parity rows, or CLI flags were added — reuses existing `name_to_purl` mechanism per FR-007 + Constitution Principle V.
+- [X] T020 Optional SC-010 real-testbed audit test at `mikebom-cli/tests/pnpm_multi_version_audit.rs` per research.md R5 — gated behind `MIKEBOM_PNPM_MULTIVER_AUDIT=1` env var. If a cached copy of `podman-desktop` is available (via `MIKEBOM_FIXTURES_DIR`), invoke the release binary + assert (a) multi-version orphans ≤ 30; (b) BFS reachability ≥ 93%. NOT blocking for the PR. Matches milestone-160 T033 + milestone-161 T040 + milestone-162 T034 + milestone-163 T037 fixture-gated audit pattern.
+- [X] T021 Run `./scripts/pre-pr.sh` — both `cargo +stable clippy --workspace --all-targets -- -D warnings` and `cargo +stable test --workspace --no-fail-fast` MUST pass clean (SC-006). Any failure blocks PR opening.
+- [X] T022 Include `implements milestone 164` in the impl PR body per SC-011 (milestone 164 has no upstream GitHub issue — it's an empirical follow-up to milestone 163's podman-desktop measurement). PR body should also document: (a) empirical measurement table (pre/post podman-desktop numbers), (b) SC-001+SC-002 verified via T015 synthesized fixture, (c) real podman-desktop verification is T020 opt-in (parallels milestone-160 T033 + milestone-161 T040 + milestone-162 T034 + milestone-163 T037 pattern), (d) delivers +15pp of milestone-158's ≥99% aspirational target for the npm ecosystem; remaining ~7pp gap belongs to future milestone 165 (platform-optional bindings + truly-isolated orphans).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No prerequisites. Baseline verification.
+- **Phase 2 (Foundational)**: Depends on Phase 1. Parser signature + call-site updates + alias-rewrite update + alias-rewrite unit test + FR-009 log emission. Blocks US1/US2/US3.
+- **Phase 3 (US1)**: Depends on Phase 2. 7 unit tests + SC-008 integration test.
+- **Phase 4 (US2)**: Depends on Phase 2 (needs T005's `emit_versioned=false` at the v6/v7 site). 1 test.
+- **Phase 5 (US3)**: Depends on Phases 2+3+4. Byte-identity verification via full workspace test.
+- **Phase 6 (Polish)**: Depends on Phases 1–5.
+
+### Within Each User Story
+
+- **US1**: T008-T014 (7 unit tests, all in `pnpm_lock.rs`, non-conflicting append-only) → T015 (integration test).
+- **US2**: T016 (1 unit test).
+- **US3**: T017 (test-run + inspect) → T018 (regenerate + inspect diff if applicable).
+
+### Parallel Opportunities
+
+Genuine `[P]` (different files, no dependencies):
+
+- **Phase 3 T008-T014** — 7 unit tests all in the same file (`pnpm_lock.rs`) BUT non-conflicting append-only fn additions; can be authored in parallel.
+- **Phase 4 T016** — 1 unit test in the same file, non-conflicting with Phase 3 tests.
+- **Phase 6 T019** — CHANGELOG update in a different file from everything else.
+
+**Foundational tasks T003-T007 are strictly sequential** — each touches `pnpm_lock.rs` or `alias_mapping.rs` and depends on the prior task's compilation state. **T007a** is parallelizable with US1 tests (different file: `alias_mapping.rs`) once T007 lands.
+
+---
+
+## Parallel Example: Phase 3 unit tests
+
+```bash
+# T008-T014 all append tests to the same #[cfg(test)] mod tests block in pnpm_lock.rs
+# but are non-conflicting fn definitions — safe to author in parallel.
+Task: "Add unit test t008_collect_pnpm_dep_names_emit_versioned_true_produces_versioned in pnpm_lock.rs"
+Task: "Add unit test t009_collect_pnpm_dep_names_emit_versioned_false_preserves_bare_name in pnpm_lock.rs"
+Task: "Add unit test t010_collect_pnpm_dep_names_empty_version_falls_back_with_warn in pnpm_lock.rs"
+Task: "Add unit test t011_build_snapshots_lookup_emits_versioned_for_v9 in pnpm_lock.rs"
+Task: "Add unit test t012_parse_pnpm_lock_multi_version_edges_resolve_correctly in pnpm_lock.rs"
+Task: "Add unit test t013_parse_pnpm_lock_purl_never_includes_peer_dep_suffix in pnpm_lock.rs"
+Task: "Add unit test t014_peer_dependencies_handling_unchanged_after_164 in pnpm_lock.rs"
+
+# T015 depends on T003-T007 completing (integration test invokes the release binary).
+```
+
+---
+
+## Implementation Strategy
+
+### MVP scope
+
+**US1 alone is the MVP.** Delivers the observable-bug fix (correct-version edge resolution + zero multi-version orphans) via the T015 fully-controlled synthesized fixture. US2 + US3 are regression guards.
+
+Ship order:
+
+1. Phase 1 (Setup) — 5 min. Baseline verification.
+2. Phase 2 (Foundational) — 1 sitting. Parser + call-sites + alias rewrite + info log. Small diff (~40 lines).
+3. Phase 3 (US1) — 1 sitting. 7 unit tests + integration test.
+4. **STOP + VALIDATE**: Run T015 integration test. Iterate if failures.
+5. Phase 4 (US2) — 15 min. 1 unit test.
+6. Phase 5 (US3) — 30 min. Full workspace test + golden diff inspection.
+7. Phase 6 (Polish) — 30 min. CHANGELOG + optional audit + pre-PR gate + PR body.
+
+### Total effort
+
+~23 tasks. Estimated 1-2 focused sessions total. Smaller than milestone 162 (34 tasks) and much smaller than milestone 163 (40 tasks).
+
+### Empirical revision escape hatch
+
+Per spec.md Assumption bullet, if T015/T020 investigation reveals corner cases that cap the improvement below 93%, SC-002 target may be revised inline per the milestone-156/157/158/159/160/161/162/163 empirical-revision pattern. The T015 fully-controlled synthesized fixture provides 100% BFS reachability as the achievable floor.
+
+### Parallel team strategy
+
+Single-contributor scope. If needed:
+
+- Contributor A: Phase 1 → Phase 2 → Phase 3 US1 core (T015) — the load-bearing path.
+- Contributor B: Phase 3 unit tests (T008-T014, in parallel with A after T003 lands) + Phase 4 US2 test + Phase 6 CHANGELOG.
+
+---
+
+## Notes
+
+- All test tasks are load-bearing SC evidence (SC-007 requires ≥8 unit tests; SC-008 requires the integration test). Skipping tests fails milestone acceptance.
+- No new Cargo dependencies. No new annotations. No new parity-catalog rows. No new CLI flags.
+- Constitution Principle IV (`no .unwrap()` in production): all new code follows the milestone-055/091/160/161/162/163 pattern with `Option<&mut _>` counters + `Some(...)/None` matching.
+- Constitution Principle V (standards-native precedence): reuses existing `name_to_purl` disambiguation mechanism at `scan_fs/mod.rs:519-525` per FR-007 + research.md R1.
+- Delivers +15pp toward milestone-158's ≥99% BFS-reachability aspirational target for the npm ecosystem. Remaining ~7pp gap (platform-optional bindings + truly-isolated orphans) is out of scope; future milestone 165.
+- Empirical baseline (2026-07-05) is pinned to live `github.com/podman-desktop/podman-desktop`. Numbers may drift with upstream commits; re-measure at implementation time and adjust SC-001/SC-002 targets if the pre-164 baseline shifted materially.


### PR DESCRIPTION
## Summary

Empirical follow-up to milestone 163's podman-desktop re-measurement (2026-07-05, live upstream). Post-163 BFS reachability jumped **24.6% → 77.4%** (+52.8pp) as designed, but a 22-point residual gap remained. Root-cause investigation traced **435 of 568 remaining orphans (76.6%)** to a single bug class: pnpm-lock v9 multi-version co-existence where parent edges pointed at the wrong version.

Post-164 on live podman-desktop: **99.6% BFS reachability** — blew past SC-002's ≥93% target, essentially achieving milestone-158's ≥99% aspirational target for the npm ecosystem.

Milestone 164 has **no upstream GitHub issue** — it's a direct empirical follow-up to milestone 163's podman-desktop measurement (matches milestone-160/161 empirical-continuation posture).

## Root cause (verified 2026-07-05)

At `pnpm_lock.rs:80`:

```rust
let Some((canon_name, _canon_ver)) = parse_pnpm_key(stripped) else { ... };
                     ^^^^^^^^^^^ ← version discarded via underscore
deps.push(canon_name);   // bare name only
```

`parse_pnpm_key` correctly extracted both `(name, version)` from peer-dep-suffixed values like `\"1.17.9(algoliasearch@5.42.0)(search-insights@2.17.3)\"`, but the caller immediately discarded the version. Downstream ` name_to_purl` lookup at `scan_fs/mod.rs:471` then last-write-wins on the name-only key. Concrete example: `@docsearch/react@3.9.0` lockfile-declared \`@algolia/autocomplete-core: 1.17.9(...)\` but the SBOM edge pointed at `@algolia/autocomplete-core@1.19.8`. **Constitution Principle IX (Accuracy) failure**.

## Fix

Thread the version through `collect_pnpm_dep_names` via a new `emit_versioned: bool` parameter. When true (v9 `snapshots:` path only), push `format!(\"{canon_name} {canon_ver}\")` — the disambiguation-key form already indexed at `scan_fs/mod.rs:519-525` (extended for npm per issue #262 + milestone-087 cargo precedent). When false (v6/v7 inline path, User Story 2 byte-identity guard), preserve pre-164 bare-name emission. Milestone 159's `rewrite_dep_names` updated to preserve the version segment through alias substitution (FR-003 alias-composition contract, T007).

**The receiver was already in place.** Milestone 164 just activates the existing `name_to_purl` disambiguation mechanism on the pnpm v9 code path.

## Zero new dependencies

- Zero new Cargo dependencies
- Zero new `mikebom:*` annotations
- Zero new parity-catalog rows
- Zero new CLI flags
- Zero new tracing conventions (extends existing `pnpm-lock parsed` info-log with 2 new fields per FR-009)

Reuses existing infrastructure end-to-end per FR-007 + Constitution Principle V (standards-native precedence).

## Empirical impact (live podman-desktop, measured 2026-07-05)

| Metric | Pre-163 | Post-163 | **Post-164** |
|---|---|---|---|
| BFS reachability | 24.6% | 77.4% | **99.6%** |
| Multi-version orphans | 902 | 435 | **12** |
| Truly-isolated orphans | 1235 | 133 | **0** |
| Empty-version PURLs | 159 | 0 | 0 |
| Phantom edges | 902 | 0 | 0 |

The 133 \"truly-isolated\" orphans identified in the milestone-164 spec turned out to ALL be multi-version cases that this fix resolves. FR-008 malformed-key WARN counter fired **0 times** on 2668 snapshots — confirms research R3 option (a): `parse_pnpm_key` returns `None` for empty-version keys, making the WARN branch defensive-only.

## Tests

- **8 new unit tests** in `pnpm_lock.rs` (T008–T014) covering emit-versioned/bare-name paths, `parse_pnpm_key` invariant (defensive T010), `build_snapshots_lookup` versioned emission, multi-version resolution, FR-005 PURL suffix stripping, FR-010 peer-dep handling.
- **1 alias-composition unit test** in `alias_mapping.rs` (T007a) — 3 cases: bare passthrough, versioned preservation, no-match passthrough. Closes FR-003 test gap surfaced by `/speckit-analyze`.
- **1 US2 regression guard** (T016) — v6/v7 inline path emits bare-name form.
- **1 US1 integration test** at `tests/pnpm_multi_version.rs` (T015) — synthesized multi-version monorepo, 5 assertions including milestone-163 SC-004 invariants preserved.
- **1 opt-in audit test** at `tests/pnpm_multi_version_audit.rs` (T020) — gated behind `MIKEBOM_PNPM_MULTIVER_AUDIT=1` + `MIKEBOM_FIXTURES_DIR`. Verified locally: `multi-version orphans = 12 (target ≤ 30), BFS reachability = 99.6% (target ≥ 93%)`.
- **5 pre-existing v9 tests updated inline** to reflect the milestone-164 disambiguation-key form (`pnpm_v9_minimal_dependencies_only_emits_edge`, `pnpm_v9_peer_dep_suffix_normalized_in_key_and_value`, `pnpm_v9_all_three_sub_mappings_union_with_dedup`, `pnpm_v9_snapshots_authoritative_ignoring_packages_specifiers`, `m159_pnpm_alias_test_podman_desktop_shape`).

## Test plan

- [x] `cargo +stable clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo +stable test --workspace --no-fail-fast` — **4001 passed / 0 failed**
- [x] SC-001 verified via T015 synthesized fixture (zero multi-version orphans)
- [x] SC-002 verified via T020 opt-in against live podman-desktop (99.6% BFS)
- [x] SC-003 dual-side byte-identity: 33 non-pnpm-v9 goldens unchanged (T017)
- [x] SC-004 milestone-163 invariants preserved (T015 assertion 5)
- [x] SC-007 ≥ 8 unit tests covering sub-items a-h + T007a alias-composition

Delivers essentially all remaining reachability toward milestone-158's ≥99% aspirational target for the npm ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)