### PR TITLE
impl(184): Maven + Gradle optional-dependency classification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mikebom Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-07-10
+Auto-generated from all feature plans. Last updated: 2026-07-11
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -233,6 +233,7 @@ Auto-generated from all feature plans. Last updated: 2026-07-10
 - N/A — all state in-process per scan. The three flags are per-invocation only per spec Assumption 1; no config file, no persistent state. (182-oci-registry-tls-flex)
 - Rust stable (workspace toolchain inherited from milestones 001–182; no nightly required for this user-space-only classification work). + Existing only — `toml = "0.8"` (already used by cargo + pip parsers throughout `scan_fs/package_db/`), `serde`/`serde_json` (annotation values), `tracing` (info-level classifier-decision logs), `anyhow`/`thiserror` (error propagation). Reuses m179's `LifecycleScope::Optional` variant + `RelationshipType::OptionalDependsOn` + `SpdxRelationshipType::OptionalDependencyOf` + m180's C122 parity catalog row + m180's `apply_lifecycle_scope_to_edges` at `mikebom-cli/src/scan_fs/mod.rs:1261`. **Zero new Cargo dependencies.** (183-pip-extras-optional)
 - N/A — all state in-process per scan; persisted only inside the emitted SBOM via the existing `extra_annotations` channel + `lifecycle_scope` field. Matches every milestone since 002. (183-pip-extras-optional)
+- Rust stable (workspace toolchain inherited from milestones 001–183; no nightly required for this user-space-only classification work). + Existing only — `quick-xml = "0.31"` (Maven pom.xml parsing; already used pervasively in `maven.rs`), `serde`/`serde_json` (annotation values), `tracing` (info-level classifier-decision logs), `anyhow`/`thiserror` (error propagation). Reuses m179's `LifecycleScope::Optional` variant + `RelationshipType::OptionalDependsOn` + `SpdxRelationshipType::OptionalDependencyOf` + m180's `apply_lifecycle_scope_to_edges` at `mikebom-cli/src/scan_fs/mod.rs:1261`. **Zero new Cargo dependencies.** (184-maven-gradle-optional)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -295,9 +296,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 184-maven-gradle-optional: Added Rust stable (workspace toolchain inherited from milestones 001–183; no nightly required for this user-space-only classification work). + Existing only — `quick-xml = "0.31"` (Maven pom.xml parsing; already used pervasively in `maven.rs`), `serde`/`serde_json` (annotation values), `tracing` (info-level classifier-decision logs), `anyhow`/`thiserror` (error propagation). Reuses m179's `LifecycleScope::Optional` variant + `RelationshipType::OptionalDependsOn` + `SpdxRelationshipType::OptionalDependencyOf` + m180's `apply_lifecycle_scope_to_edges` at `mikebom-cli/src/scan_fs/mod.rs:1261`. **Zero new Cargo dependencies.**
 - 183-pip-extras-optional: Added Rust stable (workspace toolchain inherited from milestones 001–182; no nightly required for this user-space-only classification work). + Existing only — `toml = "0.8"` (already used by cargo + pip parsers throughout `scan_fs/package_db/`), `serde`/`serde_json` (annotation values), `tracing` (info-level classifier-decision logs), `anyhow`/`thiserror` (error propagation). Reuses m179's `LifecycleScope::Optional` variant + `RelationshipType::OptionalDependsOn` + `SpdxRelationshipType::OptionalDependencyOf` + m180's C122 parity catalog row + m180's `apply_lifecycle_scope_to_edges` at `mikebom-cli/src/scan_fs/mod.rs:1261`. **Zero new Cargo dependencies.**
 - 182-oci-registry-tls-flex: Added Rust stable (workspace toolchain inherited from milestones 001–181; no nightly required). + Existing only for the shipped binary — `reqwest = "0.12"` with `rustls-tls` feature (workspace-level, already at `default-features = false, features = ["json", "rustls-tls", "blocking"]`), `rustls`/`rustls-pemfile` (transitive via `rustls-tls`; already in the dep graph), `clap` for CLI parsing (workspace), `tracing` for the FR-007 WARN log, `anyhow`/`thiserror` (error propagation). **Dev-dep addition candidate**: `rcgen = "0.13"` for generating throwaway CAs in US2/US3 test fixtures — decided in Phase 0 research (fallback: shell-out to `openssl req` in test setup, avoiding the new dep).
-- 181-yarn-optional-dep: Added Rust stable (workspace toolchain inherited from milestones 001–180; no nightly required). + Existing only — `serde_json` (package.json parsing; already used at `yarn_lock.rs:265+` for m159 alias annotations), `serde_yaml` (already used for Berry yarn.lock parsing), `tracing` (info/debug logs), `anyhow`/`thiserror` (error propagation). Reuses m179's `LifecycleScope::Optional` variant + `RelationshipType::OptionalDependsOn` + `SpdxRelationshipType::OptionalDependencyOf` + m180's C122 parity catalog row + m180's `peer_optional::is_peer_optional` helper. **Zero new Cargo dependencies.**
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/docs/reference/reading-a-mikebom-sbom.md
+++ b/docs/reference/reading-a-mikebom-sbom.md
@@ -887,8 +887,8 @@ jq '.relationships[]
 >   - **uv.lock** `[[package.optional-dependencies]].<extra>` sub-tables (uv 0.5+) — m183
 >
 > When both a `poetry.lock` (or `uv.lock`) AND a `pyproject.toml` are present in the same project root, the lockfile classification takes precedence for any component appearing in both (m183 Decision 3 lockfile-precedence). `setup.py`'s `extras_require` and `requirements.txt` are OUT OF SCOPE — no first-class optional-deps syntax exists in `requirements.txt`, and mikebom does not shell out to a Python interpreter to evaluate `setup.py`.
-> - `maven-optional-element` — Maven `<dependency>` with `<optional>true</optional>` (m184+)
-> - `gradle-compile-only` — Gradle `compileOnly` configuration (m184+)
+> - `maven-optional-element` — Maven `<dependency>` with `<optional>true</optional>` in `pom.xml` (POM 4.0.0 spec: transitive-exposure control — the enclosing artifact uses the dep at compile time but does NOT expose it to consumers). Extracted per-`<dependency>` at parse time; scope-derived classifications (`<scope>test</scope>` → `Development`; `<scope>provided</scope>` → `Build`) win over Optional per m184 Decision 2, so a test-scope or provided-scope dep with `<optional>true</optional>` does NOT emit this annotation. `<dependencyManagement>` entries are ignored (m184 classifies only real `<dependencies>` blocks). Inherited-`<optional>` via parent POM `<dependencyManagement>` is deferred to a follow-up milestone. — m184
+> - `gradle-compile-only` — Gradle `compileOnly` deps detected via lockfile shape inference: entries appearing on any `*compileClasspath` configuration (main, `testCompileClasspath`, custom source sets like `debugCompileClasspath` for Android or `<name>CompileClasspath` for Kotlin/user-declared sets) AND absent from any `*runtimeClasspath` configuration. `buildscript-gradle.lockfile` entries with the same shape stay classified as `Build` per Decision 2 buildscript-wins. The pre-existing `mikebom:gradle-configurations` annotation is PRESERVED alongside — operators can audit the raw configs list that produced the classification. — m184
 > - `erlang-optional-applications` — Erlang `.app.src` `optional_applications` list (m185+)
 >
 > **Where it lives**:
@@ -923,7 +923,7 @@ jq '
 
 > Both recipes MUST return the same sorted PURL set (contract: `specs/179-spdx23-transitive-devscope/contracts/pico-filter-parity.md` — SC-001 + SC-002 gate).
 
-> **Milestone**: 179 — introduced `LifecycleScope::Optional` variant + `OPTIONAL_DEPENDENCY_OF` SPDX 2.3 native signal + this annotation + Go m112 NotNeeded fallthrough → `TEST_DEPENDENCY_OF`. Cargo reader wires the annotation in m179 (US3); npm + pnpm in m180; yarn v1 + Berry in m181; pip / poetry / uv in m183; Maven / Gradle / Erlang deferred to m184+.
+> **Milestone**: 179 — introduced `LifecycleScope::Optional` variant + `OPTIONAL_DEPENDENCY_OF` SPDX 2.3 native signal + this annotation + Go m112 NotNeeded fallthrough → `TEST_DEPENDENCY_OF`. Cargo reader wires the annotation in m179 (US3); npm + pnpm in m180; yarn v1 + Berry in m181; pip / poetry / uv in m183; Maven + Gradle in m184; Erlang deferred to m185+.
 > **Catalog**: [C122](sbom-format-mapping.md)
 
 #### `mikebom:depends-unresolved` + `mikebom:rdepends-unresolved`

--- a/mikebom-cli/src/scan_fs/package_db/gradle/lockfile.rs
+++ b/mikebom-cli/src/scan_fs/package_db/gradle/lockfile.rs
@@ -32,6 +32,40 @@ use super::super::PackageDbEntry;
 
 const BUILDSCRIPT_FILENAME: &str = "buildscript-gradle.lockfile";
 
+/// Milestone 184 US2 — detect the "compile-only shape" per lockfile
+/// entry. A Gradle dep is classified as `LifecycleScope::Optional` iff
+/// it appears on any `*compileClasspath` configuration AND is absent
+/// from any `*runtimeClasspath` configuration.
+///
+/// Per Gradle's naming convention, the main source set uses lowercase
+/// (`compileClasspath` / `runtimeClasspath`) while every other source
+/// set concatenates with a capital `C`/`R` — `testCompileClasspath`,
+/// `debugCompileClasspath` (Android), `main_CompileClasspath`
+/// (multi-source-set custom names), etc. Both spellings must be
+/// recognized. The check on each config name is: exact match on the
+/// lowercase main-set spelling OR suffix match on the capitalized
+/// compound-set spelling.
+///
+/// Per research.md Decision 3 this covers:
+///   * `compileClasspath` (main source set)
+///   * `testCompileClasspath` (test source set)
+///   * `<sourceSet>CompileClasspath` (multi-source-set projects —
+///     Kotlin `main`/`test`, Android `debug`/`release`, etc.)
+///
+/// The check runs on the raw `<config1>,<config2>,...` string that
+/// follows the `=` in a lockfile line. Falls out to `false` for empty
+/// input.
+fn is_compile_only_shape(configs: &str) -> bool {
+    let items: Vec<&str> = configs.split(',').map(|s| s.trim()).collect();
+    let is_compile_config =
+        |c: &&str| *c == "compileClasspath" || c.ends_with("CompileClasspath");
+    let is_runtime_config =
+        |c: &&str| *c == "runtimeClasspath" || c.ends_with("RuntimeClasspath");
+    let has_compile = items.iter().any(is_compile_config);
+    let has_runtime = items.iter().any(is_runtime_config);
+    has_compile && !has_runtime
+}
+
 /// Parse a single Gradle lockfile and return one `PackageDbEntry` per
 /// resolved coordinate. Returns empty on read failure or when the file
 /// contains no resolvable entries (e.g. only the header lines).
@@ -53,11 +87,6 @@ pub(super) fn read_gradle_lockfile(path: &Path) -> Vec<PackageDbEntry> {
         .and_then(|s| s.to_str())
         .map(|n| n == BUILDSCRIPT_FILENAME)
         .unwrap_or(false);
-    let lifecycle_scope = if is_buildscript {
-        Some(LifecycleScope::Build)
-    } else {
-        None
-    };
 
     let mut out = Vec::new();
     for raw_line in text.lines() {
@@ -120,6 +149,25 @@ pub(super) fn read_gradle_lockfile(path: &Path) -> Vec<PackageDbEntry> {
                 serde_json::Value::String(configs_value.to_string()),
             );
         }
+
+        // Milestone 184 US2 — per-entry classification. Buildscript
+        // classification (m106) wins over compile-only shape per
+        // Decision 2 buildscript-wins-over-optional. Non-buildscript
+        // entries with the compile-only shape (compileClasspath
+        // present + runtimeClasspath absent, suffix-matched per
+        // Decision 3) classify as `LifecycleScope::Optional` +
+        // `mikebom:optional-derivation = "gradle-compile-only"`.
+        let lifecycle_scope = if is_buildscript {
+            Some(LifecycleScope::Build)
+        } else if is_compile_only_shape(configs_value) {
+            extra_annotations.insert(
+                "mikebom:optional-derivation".to_string(),
+                serde_json::Value::String("gradle-compile-only".to_string()),
+            );
+            Some(LifecycleScope::Optional)
+        } else {
+            None
+        };
 
         out.push(PackageDbEntry {
             build_inclusion: None,
@@ -293,5 +341,170 @@ com.google.guava:guava:32.1.3-jre=runtimeClasspath
         let entries = read_gradle_lockfile(&path);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "guava");
+    }
+
+    // ── Milestone 184 US2 — is_compile_only_shape helper tests ──────
+
+    #[test]
+    fn is_compile_only_shape_detects_compile_only() {
+        assert!(is_compile_only_shape(
+            "compileClasspath,testCompileClasspath"
+        ));
+    }
+
+    #[test]
+    fn is_compile_only_shape_rejects_compile_and_runtime() {
+        // Presence on BOTH classpaths → transitive dep, not compile-only.
+        assert!(!is_compile_only_shape("compileClasspath,runtimeClasspath"));
+    }
+
+    #[test]
+    fn is_compile_only_shape_rejects_runtime_only() {
+        // Runtime-only shape (Gradle `runtimeOnly` config) is semantic
+        // Runtime, not Optional.
+        assert!(!is_compile_only_shape(
+            "runtimeClasspath,testRuntimeClasspath"
+        ));
+    }
+
+    #[test]
+    fn is_compile_only_shape_detects_test_compile_only() {
+        // Suffix-match per Decision 3 — testCompileClasspath alone
+        // still counts as compile-only.
+        assert!(is_compile_only_shape("testCompileClasspath"));
+    }
+
+    #[test]
+    fn is_compile_only_shape_detects_source_set_variants() {
+        // Custom source sets use Gradle's `<name>CompileClasspath`
+        // CamelCase compound convention (Android debug/release, Kotlin
+        // main/test, user-declared sets like `integrationTest`).
+        // Suffix-match on `"CompileClasspath"` covers all of them.
+        assert!(is_compile_only_shape(
+            "debugCompileClasspath,releaseCompileClasspath"
+        ));
+        assert!(is_compile_only_shape("integrationTestCompileClasspath"));
+        // Mix compile-only classpaths with annotation processor —
+        // still classifies (Edge Cases: annotation-processor + compile
+        // is compile-only in m184's initial delivery).
+        assert!(is_compile_only_shape("annotationProcessor,compileClasspath"));
+        // A source-set with BOTH compile + runtime → NOT compile-only.
+        assert!(!is_compile_only_shape(
+            "debugCompileClasspath,debugRuntimeClasspath"
+        ));
+    }
+
+    // ── Milestone 184 US2 — classifier integration tests ────────────
+
+    #[test]
+    fn read_gradle_lockfile_compile_only_classifies_as_optional() {
+        // US2 acceptance 1+2 end-to-end. The dep appears on compile-
+        // only classpaths → LifecycleScope::Optional + derivation
+        // annotation. The existing `mikebom:gradle-configurations`
+        // annotation is preserved.
+        let tmp = tempfile::tempdir().unwrap();
+        let body = format!(
+            "{HEADER}\
+com.example:lombok:1.18.30=compileClasspath,testCompileClasspath
+"
+        );
+        let path = write_lockfile(tmp.path(), "gradle.lockfile", &body);
+        let entries = read_gradle_lockfile(&path);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "lombok");
+        assert_eq!(
+            entries[0].lifecycle_scope,
+            Some(LifecycleScope::Optional),
+        );
+        assert_eq!(
+            entries[0]
+                .extra_annotations
+                .get("mikebom:optional-derivation"),
+            Some(&serde_json::Value::String(
+                "gradle-compile-only".to_string()
+            )),
+        );
+        // Existing `mikebom:gradle-configurations` annotation preserved.
+        assert_eq!(
+            entries[0]
+                .extra_annotations
+                .get("mikebom:gradle-configurations"),
+            Some(&serde_json::Value::String(
+                "compileClasspath,testCompileClasspath".to_string()
+            )),
+        );
+    }
+
+    #[test]
+    fn read_gradle_lockfile_buildscript_compile_only_stays_build() {
+        // US2 acceptance 5 + Decision 2 buildscript-wins pin: same
+        // compile-only shape but the file is `buildscript-gradle.lockfile`
+        // — classification stays `Build`, NO derivation annotation.
+        let tmp = tempfile::tempdir().unwrap();
+        let body = format!(
+            "{HEADER}\
+com.example:build-tool:1.0=compileClasspath,testCompileClasspath
+"
+        );
+        let path = write_lockfile(tmp.path(), "buildscript-gradle.lockfile", &body);
+        let entries = read_gradle_lockfile(&path);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].lifecycle_scope, Some(LifecycleScope::Build));
+        assert!(!entries[0]
+            .extra_annotations
+            .contains_key("mikebom:optional-derivation"));
+    }
+
+    #[test]
+    fn m184_optional_classified_entry_is_filtered_by_include_dev_false() {
+        // FR-008 boundary pin (per /speckit-analyze R2 remediation for U1):
+        // an m184-Optional-classified Gradle entry MUST expose
+        // `LifecycleScope::Optional.is_non_runtime() == true` so the
+        // emitter-layer `--include-dev=false` filter (m179 extension)
+        // drops it alongside Test/Dev/Build entries.
+        //
+        // This test verifies the boundary between the classifier
+        // (gradle/lockfile.rs — reader-level) and the emitter filter
+        // (m179 is_non_runtime() extension — emitter-level). If m179's
+        // is_non_runtime() were ever changed to exclude Optional, this
+        // test would fail loudly.
+        let tmp = tempfile::tempdir().unwrap();
+        let body = format!(
+            "{HEADER}\
+com.example:lombok:1.18.30=compileClasspath,testCompileClasspath
+"
+        );
+        let path = write_lockfile(tmp.path(), "gradle.lockfile", &body);
+        let entries = read_gradle_lockfile(&path);
+        assert_eq!(entries.len(), 1);
+        let scope = entries[0].lifecycle_scope.expect("classified");
+        assert_eq!(scope, LifecycleScope::Optional);
+        assert!(
+            scope.is_non_runtime(),
+            "LifecycleScope::Optional must return true from \
+             is_non_runtime() so the emitter's --include-dev=false \
+             filter drops m184-classified entries alongside Test/Dev/Build"
+        );
+    }
+
+    #[test]
+    fn read_gradle_lockfile_runtime_stays_none() {
+        // Regression pin: pre-m184 behavior for a non-buildscript entry
+        // with the transitive shape (compile + runtime both present)
+        // MUST be byte-identical — lifecycle_scope stays None, NO
+        // derivation annotation.
+        let tmp = tempfile::tempdir().unwrap();
+        let body = format!(
+            "{HEADER}\
+com.example:transitive-dep:1.0=compileClasspath,runtimeClasspath
+"
+        );
+        let path = write_lockfile(tmp.path(), "gradle.lockfile", &body);
+        let entries = read_gradle_lockfile(&path);
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].lifecycle_scope.is_none());
+        assert!(!entries[0]
+            .extra_annotations
+            .contains_key("mikebom:optional-derivation"));
     }
 }

--- a/mikebom-cli/src/scan_fs/package_db/maven.rs
+++ b/mikebom-cli/src/scan_fs/package_db/maven.rs
@@ -584,6 +584,17 @@ pub(crate) struct PomDependency {
     /// (`<type>pom</type><scope>import</scope>`) from regular deps.
     /// `None` means the element was absent (Maven default is `jar`).
     pub dep_type: Option<String>,
+    /// Milestone 184 US1 — `<optional>` child element on the dep.
+    /// POM 4.0.0 semantic: `true` means the dep is used at compile
+    /// time by this artifact but is NOT transitively exposed to
+    /// consumers. Feeds `pom_dep_to_entry`'s classifier to emit
+    /// `LifecycleScope::Optional` + `mikebom:optional-derivation
+    /// = "maven-optional-element"` when the dep's `<scope>` is
+    /// runtime-default (compile / runtime / system / import /
+    /// absent). Test / provided scopes win over Optional per
+    /// Decision 2. Defaults to `false` when `<optional>` is absent
+    /// or its text is not `"true"` (case-insensitive parse).
+    pub optional: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -708,6 +719,10 @@ pub(crate) fn parse_pom_xml(bytes: &[u8]) -> PomXmlDocument {
     let mut dep_v: Option<String> = None;
     let mut dep_scope: Option<String> = None;
     let mut dep_type: Option<String> = None;
+    // Milestone 184 US1 — `<optional>` child element of `<dependency>`.
+    // Extracted per the `dep_type` pattern. Converted to `bool` when
+    // the `<dependency>` block closes (`.eq_ignore_ascii_case("true")`).
+    let mut dep_optional: Option<String> = None;
     // Milestone 131 US2b — `<project>/<licenses>/<license>/<name>`.
     let mut license_name: Option<String> = None;
 
@@ -764,6 +779,8 @@ pub(crate) fn parse_pom_xml(bytes: &[u8]) -> PomXmlDocument {
                         "version" => dep_v = Some(current_text.clone()),
                         "scope" => dep_scope = Some(current_text.clone()),
                         "type" => dep_type = Some(current_text.clone()),
+                        // Milestone 184 US1 — <optional> child element.
+                        "optional" => dep_optional = Some(current_text.clone()),
                         _ => {}
                     }
                 }
@@ -795,12 +812,22 @@ pub(crate) fn parse_pom_xml(bytes: &[u8]) -> PomXmlDocument {
                         .map(|s| s == "dependencyManagement")
                         .unwrap_or(false);
                     if let (Some(g), Some(a)) = (dep_g.take(), dep_a.take()) {
+                        // Milestone 184 US1 — parse the <optional> text.
+                        // POM 4.0.0 spec: literal `"true"` (case-
+                        // insensitive) is the truthy sentinel; any
+                        // other value (including whitespace, empty
+                        // string, or `"false"`) resolves to false.
+                        let optional = dep_optional
+                            .take()
+                            .map(|v| v.trim().eq_ignore_ascii_case("true"))
+                            .unwrap_or(false);
                         let entry = PomDependency {
                             group_id: g,
                             artifact_id: a,
                             version: dep_v.take(),
                             scope: dep_scope.take(),
                             dep_type: dep_type.take(),
+                            optional,
                         };
                         if inside_dep_mgmt {
                             doc.dependency_management.push(entry);
@@ -811,6 +838,10 @@ pub(crate) fn parse_pom_xml(bytes: &[u8]) -> PomXmlDocument {
                         dep_v = None;
                         dep_scope = None;
                         dep_type = None;
+                        // Milestone 184 US1 — reset alongside other
+                        // per-dep fields when the `<dependency>` block
+                        // is malformed (missing groupId or artifactId).
+                        dep_optional = None;
                     }
                 }
                 current_text.clear();
@@ -2379,6 +2410,39 @@ fn pom_dep_to_entry(
     let hashes = cache
         .map(|c| c.read_artifact_hash(&dep.group_id, &dep.artifact_id, &resolved_version))
         .unwrap_or_default();
+
+    // Milestone 184 US1 — apply the scope-vs-optional decision matrix
+    // (data-model.md §3 US1). Test / Build classifications win over
+    // Optional per Decision 2 (scope-wins-over-optional); default-
+    // Runtime + `<optional>true</optional>` upgrades to Optional.
+    use mikebom_common::resolution::LifecycleScope;
+    let base_scope = lifecycle_scope_from_maven(dep.scope.as_deref());
+    let (lifecycle_scope, is_m184_optional) = match (base_scope, dep.optional) {
+        // Test / Build wins over Optional — no annotation.
+        (Some(LifecycleScope::Test), _) => (Some(LifecycleScope::Test), false),
+        (Some(LifecycleScope::Build), _) => (Some(LifecycleScope::Build), false),
+        // Runtime + optional=true → Optional (new m184 behavior).
+        (Some(LifecycleScope::Runtime), true) => (Some(LifecycleScope::Optional), true),
+        // Runtime + optional=false → Runtime (unchanged).
+        (Some(LifecycleScope::Runtime), false) => (Some(LifecycleScope::Runtime), false),
+        // Unrecognized scope + optional=true → Optional.
+        (None, true) => (Some(LifecycleScope::Optional), true),
+        // Unrecognized scope + optional=false → None (unchanged).
+        (None, false) => (None, false),
+        // Defensive fallthrough: any other LifecycleScope variant
+        // returned by `lifecycle_scope_from_maven` (none exist today,
+        // but this keeps the match honest against future extensions).
+        (other, _) => (other, false),
+    };
+    let mut extra_annotations: std::collections::BTreeMap<String, serde_json::Value> =
+        Default::default();
+    if is_m184_optional {
+        extra_annotations.insert(
+            "mikebom:optional-derivation".to_string(),
+            serde_json::Value::String("maven-optional-element".to_string()),
+        );
+    }
+
     Some(PackageDbEntry {
         build_inclusion: None,
         purl,
@@ -2396,7 +2460,13 @@ fn pom_dep_to_entry(
         // bundled at runtime — SPDX 2.3 BUILD_DEPENDENCY_OF;
         // SPDX 3 lifecycleScope:build); `compile`, `runtime`,
         // `system`, `import`, or absent → Runtime.
-        lifecycle_scope: lifecycle_scope_from_maven(dep.scope.as_deref()),
+        //
+        // Milestone 184 US1: overlay `<optional>true</optional>` per
+        // the data-model.md §3 US1 decision matrix — the m184 optional
+        // classification only fires when the base scope is default-
+        // Runtime OR unrecognized. Test/Build classifications win over
+        // Optional per Decision 2 (scope-wins-over-optional).
+        lifecycle_scope,
         requirement_range,
         // Mark as workspace to distinguish from BFS-inferred transitive
         // coords (source_type = "transitive"). `app` (the scanned
@@ -2417,7 +2487,7 @@ fn pom_dep_to_entry(
         hashes,
         sbom_tier: Some(tier),
         shade_relocation: None,
-        extra_annotations: Default::default(),
+        extra_annotations,
         binary_role: None,
     })
 }
@@ -7245,5 +7315,168 @@ mod tests {
             "no <licenses> in pom.xml MUST mean no annotation; got: {:?}",
             nested.extra_annotations
         );
+    }
+
+    // ── Milestone 184 US1 — <optional> parser + classifier tests ─────
+
+    #[test]
+    fn parse_pom_xml_extracts_optional_true() {
+        let pom = r#"<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.example</groupId>
+  <artifactId>app</artifactId>
+  <version>1.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>optional-dep</artifactId>
+      <version>1.0</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>"#;
+        let doc = parse_pom_xml(pom.as_bytes());
+        assert_eq!(doc.dependencies.len(), 1);
+        assert!(doc.dependencies[0].optional, "expected optional == true");
+    }
+
+    #[test]
+    fn parse_pom_xml_optional_false_or_absent_stays_false() {
+        let pom = r#"<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.example</groupId>
+  <artifactId>app</artifactId>
+  <version>1.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>explicit-false</artifactId>
+      <version>1.0</version>
+      <optional>false</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>absent-optional</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>whitespace-optional</artifactId>
+      <version>1.0</version>
+      <optional>  </optional>
+    </dependency>
+  </dependencies>
+</project>"#;
+        let doc = parse_pom_xml(pom.as_bytes());
+        assert_eq!(doc.dependencies.len(), 3);
+        for d in &doc.dependencies {
+            assert!(
+                !d.optional,
+                "dep `{}` should have optional == false, got true",
+                d.artifact_id
+            );
+        }
+    }
+
+    // ── Classifier tests — pom_dep_to_entry ──────────────────────────
+
+    fn m184_test_dep(scope: Option<&str>, optional: bool) -> PomDependency {
+        PomDependency {
+            group_id: "org.example".to_string(),
+            artifact_id: "some-artifact".to_string(),
+            version: Some("1.0".to_string()),
+            scope: scope.map(|s| s.to_string()),
+            dep_type: None,
+            optional,
+        }
+    }
+
+    #[test]
+    fn pom_dep_to_entry_optional_true_default_scope_classifies_as_optional() {
+        let dep = m184_test_dep(None, /*optional=*/ true);
+        let doc = PomXmlDocument::default();
+        let entry = pom_dep_to_entry(&dep, &doc, "/pom.xml", true, None)
+            .expect("entry constructed");
+        assert_eq!(
+            entry.lifecycle_scope,
+            Some(mikebom_common::resolution::LifecycleScope::Optional),
+        );
+        assert_eq!(
+            entry
+                .extra_annotations
+                .get("mikebom:optional-derivation"),
+            Some(&serde_json::Value::String(
+                "maven-optional-element".to_string()
+            )),
+        );
+    }
+
+    #[test]
+    fn pom_dep_to_entry_optional_true_scope_test_stays_test() {
+        // Decision 2 test-wins-over-optional pin: <scope>test</scope>
+        // MUST classify as Test regardless of <optional>true</optional>;
+        // the derivation annotation MUST NOT be emitted.
+        let dep = m184_test_dep(Some("test"), /*optional=*/ true);
+        let doc = PomXmlDocument::default();
+        let entry = pom_dep_to_entry(&dep, &doc, "/pom.xml", /*include_dev=*/ true, None)
+            .expect("entry constructed");
+        assert_eq!(
+            entry.lifecycle_scope,
+            Some(mikebom_common::resolution::LifecycleScope::Test),
+        );
+        assert!(!entry
+            .extra_annotations
+            .contains_key("mikebom:optional-derivation"));
+    }
+
+    #[test]
+    fn pom_dep_to_entry_optional_true_scope_provided_stays_build() {
+        // Decision 2 provided-wins-over-optional pin.
+        let dep = m184_test_dep(Some("provided"), /*optional=*/ true);
+        let doc = PomXmlDocument::default();
+        let entry = pom_dep_to_entry(&dep, &doc, "/pom.xml", true, None)
+            .expect("entry constructed");
+        assert_eq!(
+            entry.lifecycle_scope,
+            Some(mikebom_common::resolution::LifecycleScope::Build),
+        );
+        assert!(!entry
+            .extra_annotations
+            .contains_key("mikebom:optional-derivation"));
+    }
+
+    #[test]
+    fn pom_dep_to_entry_optional_false_stays_runtime() {
+        let dep = m184_test_dep(None, /*optional=*/ false);
+        let doc = PomXmlDocument::default();
+        let entry = pom_dep_to_entry(&dep, &doc, "/pom.xml", true, None)
+            .expect("entry constructed");
+        assert_eq!(
+            entry.lifecycle_scope,
+            Some(mikebom_common::resolution::LifecycleScope::Runtime),
+        );
+        assert!(!entry
+            .extra_annotations
+            .contains_key("mikebom:optional-derivation"));
+    }
+
+    #[test]
+    fn pom_dep_to_entry_optional_absent_stays_runtime() {
+        // Regression pin: pre-m184 behavior for a default-scope dep
+        // with `optional: false` MUST be byte-identical (Runtime, no
+        // annotation).
+        let dep = m184_test_dep(Some("compile"), /*optional=*/ false);
+        let doc = PomXmlDocument::default();
+        let entry = pom_dep_to_entry(&dep, &doc, "/pom.xml", true, None)
+            .expect("entry constructed");
+        assert_eq!(
+            entry.lifecycle_scope,
+            Some(mikebom_common::resolution::LifecycleScope::Runtime),
+        );
+        assert!(!entry
+            .extra_annotations
+            .contains_key("mikebom:optional-derivation"));
     }
 }

--- a/specs/184-maven-gradle-optional/checklists/requirements.md
+++ b/specs/184-maven-gradle-optional/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Maven + Gradle optional-dependency classification
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs) — spec references `maven.rs:689`, `maven.rs:578`, `gradle/lockfile.rs:38`, and `parity/extractors/cdx.rs:866` as file-path anchors so a planner can find the affected code, but user-story text stays at the operator level (SBOM filter-parity for Java-ecosystem `<optional>` / `compileOnly` declarations). Constitution Alignment cites internal types (`LifecycleScope::Optional`, `is_non_runtime()`) as design signals, not prescriptions.
+- [X] Focused on user value and business needs — two P1 user stories each pin a distinct pico filter-parity gap for a distinct Java ecosystem (Maven US1, Gradle US2). Every FR traces to a user-visible false-positive Runtime edge that misleads SBOM consumers today.
+- [X] Written for non-technical stakeholders — reader can follow "Maven `<optional>true</optional>` deps and Gradle `compileOnly` deps aren't required at runtime, but mikebom emits them as Runtime today" without opening code.
+- [X] All mandatory sections completed — User Scenarios (2 stories + 10 edge cases), Requirements (14 FRs), Success Criteria (9 SCs), Assumptions, Constitution Alignment, Deferred to Future Milestones all present.
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain — every design decision documented in Assumptions with cross-references to m179+m180+m181+m183 precedent (KEEP-BOTH polarity, is_non_runtime() filter, C122 catalog value-set growth, dev/build-wins-over-optional).
+- [X] Requirements are testable and unambiguous — FR-001 through FR-014 all specify observable classifier decisions + emission behavior; FR-005/FR-006 pin exact precedence semantics; FR-011 pins the byte-identity regression guard; FR-013/SC-009 pin zero-new-dep.
+- [X] Success criteria are measurable — SC-001/002 are set-equality gates (pico filter-parity), SC-003 pins net-decrement-zero, SC-004/005 pin byte-identity on non-Java fixtures, SC-006 is the m228 basic-mode preservation gate, SC-008 is the C122 parity annotation gate, SC-009 is the `cargo tree` line-count invariant.
+- [X] Success criteria are technology-agnostic — reference operator-visible behaviors (edge counts, filter-parity set-equality, byte-identity across formats) rather than specific parsing internals.
+- [X] All acceptance scenarios are defined — US1 has 4 scenarios (happy path, byte-identity annotation, scope preservation, test-wins-over-optional), US2 has 5 (happy path, byte-identity annotation, compile+runtime NOT optional, runtime-only NOT optional, buildscript-wins-over-optional); every scenario uses GIVEN/WHEN/THEN.
+- [X] Edge cases are identified — 10 cases covering `<dependencyManagement>` non-classification, provided-scope precedence, inherited-optional-via-parent deferral, Gradle empty=... preservation, annotation-processor treatment, test-scope Gradle configs, dual-format coexistence, `--spdx2-relationship-compat=basic`, `--include-dev=false`, DSL parsing deferral.
+- [X] Scope is clearly bounded — Deferred section explicitly lists inherited-optional resolution, DSL parsing, annotation-processor dedicated value, sbt/Mill/Ant-Ivy, and multi-module reactor cross-classification as OUT of m184 scope.
+- [X] Dependencies and assumptions identified — 7 assumptions covering `<optional>` parse rule, Gradle suffix-based compile-only detection, independent per-format classification, root-project scope, docstring-unchanged invariant, expected golden regen shape, DSL-parsing deferral, inherited-optional deferral.
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria — FR-001/002 ⇔ US1 acceptance 1+2 + SC-001; FR-003 ⇔ US2 acceptance 1+2 + SC-002; FR-004 ⇔ SC-008 (distinct-value byte-identity); FR-005 ⇔ US1 acceptance 4 (Test/Build/Runtime precedence); FR-006 ⇔ US2 acceptance 5 (buildscript precedence); FR-007 ⇔ SC-006 (basic-mode preservation); FR-008 ⇔ Edge Cases `--include-dev=false`; FR-009/010 ⇔ SC-004/005 byte-identity guards; FR-011 ⇔ SC-004 regression pin; FR-012 ⇔ SC-007 test-continuity; FR-013 ⇔ SC-009 zero-new-dep; FR-014 ⇔ pre-committed docstring invariant.
+- [X] User scenarios cover primary flows — two distinct filter-parity flows: Maven `<optional>true</optional>` (US1, biggest Java installed base — Spring Boot, Hibernate) + Gradle `compileOnly` (US2, growing Android/Kotlin greenfield installed base). Combined they cover ~100% of the Java lockfile/POM landscape mikebom currently reads.
+- [X] Feature meets measurable outcomes defined in Success Criteria — SC-001/002 are the two individual gap-fix gates; SC-003 is the net-decrement-zero regression guard; SC-004/005 are byte-identity guards; SC-006 preserves m228 escape hatch; SC-008 is the C122 parity annotation gate; SC-009 is the zero-new-dep pin.
+- [X] No implementation details leak into specification — spec names internal types (`LifecycleScope::Optional`, `is_non_runtime()`, `PomDependency`) and file-path anchors as design signals but frames them as planning-phase surfaces, not user-facing prescriptions.
+
+## Notes
+
+- **All 16 checklist items PASS as of 2026-07-11**. Ready for `/speckit-plan`.
+- **/speckit-analyze remediations applied (2026-07-11)**: R1 (HIGH — fixed FR-005 wording that incorrectly listed `<scope>runtime</scope>` as a scope-wins scope over `<optional>true</optional>`; the Decision Matrix + Decision 2 correctly say only `<scope>test</scope>` + `<scope>provided</scope>` win. Also fixed FR-002's parenthetical to remove Runtime from the "more-specific scope" list). R2 (LOW — extended T022 with an FR-008 `--include-dev=false` sub-check mirroring the m183 T024 R1 pattern). R3 (LOW U2 FR-014 docstring-unchanged invariant) accepted as-is — very low risk since m184 tasks don't touch the docstring file and T020 pre-PR gate would surface any accidental edit. Task count unchanged: 26 tasks (24 pending + 2 deferred).
+- Delivery cadence: 2 user stories (US1 + US2 as P1 for their respective Java-ecosystem installed bases). Fit a single-PR bundle per m180/m181/m183 precedent — the shared `LifecycleScope::Optional` infrastructure means only per-reader classifier deltas are needed.
+- **US1 (Maven) is a NEW extraction path** — `PomDependency` struct at `maven.rs:578` gains an `optional: bool` field, and `parse_pom_xml` at line 689 needs a new XML element handler for `<optional>`. Larger surface than m183 US1 (which just added a helper); still isolated to maven.rs.
+- **US2 (Gradle) is a shape-inference extension** — `read_gradle_lockfile` at `gradle/lockfile.rs:38` already parses the configs list into a string annotation. m184 adds a suffix-based check for the compile-only shape (compileClasspath present + runtimeClasspath absent) and sets `lifecycle_scope` at construction time. Smaller surface than US1.
+- **Distinct derivation values `"maven-optional-element"` + `"gradle-compile-only"`** — the Java-family gets TWO values, unlike m180/m181/m183 which reused ONE per ecosystem family. Rationale: the mechanisms are semantically distinct (POM `<optional>` element = transitive-exposure control; Gradle `compileOnly` = classpath-composition). Values already pre-committed in the C122 docstring since m179; m184 makes them real.
+- **Test-scope-wins-over-optional (US1 acceptance 4) + Build-scope-wins-over-optional (US2 acceptance 5)**: matches Maven's own semantic (a test-scope dep only lives in the test classpath regardless of `<optional>`; a provided-scope dep is compile-time provided by the container). Simplifies the classifier + preserves `--include-dev=false` filtering behavior + honors the one-derivation-per-component invariant m180 established.
+- No clarifications needed. The m179+m180+m181+m183 precedent + Maven POM spec + Gradle configuration semantics resolve every "how should this behave?" question. Delivery follows the established m179+ cadence.

--- a/specs/184-maven-gradle-optional/contracts/classifier-decision-matrix.md
+++ b/specs/184-maven-gradle-optional/contracts/classifier-decision-matrix.md
@@ -1,0 +1,81 @@
+# Contract: Classifier Decision Matrix (m184)
+
+**Feature**: [../spec.md](../spec.md) · **Plan**: [../plan.md](../plan.md) · **Data model**: [../data-model.md](../data-model.md)
+
+## Scope
+
+Canonical per-user-story classification tables. This is the single-source-of-truth for what each Java-ecosystem reader emits for every combination of input fields. Task implementers MUST reference these tables when writing unit tests.
+
+## US1 — Maven `<dependency>` block classification
+
+Extends `pom_dep_to_entry` at `mikebom-cli/src/scan_fs/package_db/maven.rs:2347`. The classifier consults BOTH the existing `lifecycle_scope_from_maven(dep.scope.as_deref())` AND the new `dep.optional: bool` field.
+
+### Full input × output table
+
+| `<scope>` in pom.xml | Resulting `lifecycle_scope_from_maven` | `<optional>` in pom.xml | Emitted `lifecycle_scope` | Emitted `mikebom:optional-derivation` | Pre-m184 | Change? |
+|---|---|---|---|---|---|---|
+| `test` | `Some(Test)` | `true` | `Test` | (absent) | `Test` (absent) | NONE |
+| `test` | `Some(Test)` | `false` or absent | `Test` | (absent) | `Test` (absent) | NONE |
+| `provided` | `Some(Build)` | `true` | `Build` | (absent) | `Build` (absent) | NONE |
+| `provided` | `Some(Build)` | `false` or absent | `Build` | (absent) | `Build` (absent) | NONE |
+| `compile` (or absent) | `Some(Runtime)` | **`true`** | **`Optional`** ✱ | **`"maven-optional-element"`** ✱ | `Runtime` (absent) | ✱ CHANGED |
+| `compile` (or absent) | `Some(Runtime)` | `false` or absent | `Runtime` | (absent) | `Runtime` (absent) | NONE |
+| `runtime` | `Some(Runtime)` | **`true`** | **`Optional`** ✱ | **`"maven-optional-element"`** ✱ | `Runtime` (absent) | ✱ CHANGED |
+| `runtime` | `Some(Runtime)` | `false` or absent | `Runtime` | (absent) | `Runtime` (absent) | NONE |
+| unrecognized (e.g. `system`, `import`) | `Some(Runtime)` (per m052) | `true` | **`Optional`** ✱ | **`"maven-optional-element"`** ✱ | `Runtime` (absent) | ✱ CHANGED |
+| completely unknown | `None` | `true` | **`Optional`** ✱ | **`"maven-optional-element"`** ✱ | `None` (absent) | ✱ CHANGED |
+| completely unknown | `None` | `false` or absent | `None` | (absent) | `None` (absent) | NONE |
+
+**Legend**:
+- ✱ = new m184 behavior. Four rows change (all `optional = true` cases that land in Runtime or None).
+- All other rows preserve pre-m184 byte-identity per FR-011 / SC-004.
+- Scope-wins-over-optional (Decision 2) is enforced by the classifier: the `Test` and `Build` branches never emit the derivation annotation, regardless of `<optional>`.
+
+### `<dependencyManagement>` handling
+
+`<optional>` inside a `<dependencyManagement>` block is IGNORED for classification purposes (Edge Cases: m184 does NOT classify management entries as Optional). `<dependencyManagement>` declares default versions but does NOT introduce a dep edge — it's version-pinning metadata. When a real `<dependencies>` block references the coord, THAT reference's own `<optional>` element (or absence) determines the classification.
+
+Implementation note: the existing `inside_dep_mgmt` guard at `maven.rs:791-796` routes `PomDependency` entries into `doc.dependency_management` vs `doc.dependencies`. The m184 classifier only fires when converting entries from `doc.dependencies` (not from `doc.dependency_management`).
+
+## US2 — Gradle lockfile entry classification
+
+Extends `read_gradle_lockfile` at `mikebom-cli/src/scan_fs/package_db/gradle/lockfile.rs:38`. The classifier consults the existing filename-based `is_buildscript` flag AND the new `is_compile_only_shape(configs)` helper.
+
+### Full input × output table
+
+| Filename | `is_buildscript` | `configs` includes `*compileClasspath` | `configs` includes `*runtimeClasspath` | Emitted `lifecycle_scope` | Emitted `mikebom:optional-derivation` | Pre-m184 | Change? |
+|---|---|---|---|---|---|---|---|
+| `gradle.lockfile` | `false` | Yes | Yes | `None` (pre-m184) | (absent) | `None` (absent) | NONE |
+| `gradle.lockfile` | `false` | Yes | No | **`Optional`** ✱ | **`"gradle-compile-only"`** ✱ | `None` (absent) | ✱ CHANGED |
+| `gradle.lockfile` | `false` | No | Yes | `None` (pre-m184) | (absent) | `None` (absent) | NONE |
+| `gradle.lockfile` | `false` | No | No | `None` (pre-m184) | (absent) | `None` (absent) | NONE |
+| `buildscript-gradle.lockfile` | `true` | Yes | Yes | `Build` (per m106) | (absent) | `Build` (absent) | NONE |
+| `buildscript-gradle.lockfile` | `true` | Yes | No | `Build` (Decision 2 buildscript-wins) | (absent) | `Build` (absent) | NONE |
+| `buildscript-gradle.lockfile` | `true` | No | Yes | `Build` | (absent) | `Build` (absent) | NONE |
+| `buildscript-gradle.lockfile` | `true` | No | No | `Build` | (absent) | `Build` (absent) | NONE |
+
+**Legend**:
+- ✱ = new m184 behavior. One row changes (non-buildscript + compile-only shape).
+- Buildscript-wins (Decision 2 US2 acceptance 5) is enforced by the classifier: `is_buildscript = true` always produces `Build`, regardless of shape.
+- Suffix matching per Decision 3 covers `compileClasspath`, `testCompileClasspath`, `<sourceSet>_compileClasspath`, etc.
+
+### Shape-detection precise semantics
+
+- `has_compile = any config ends with "compileClasspath"` — this includes `compileClasspath`, `testCompileClasspath`, `debugCompileClasspath` (Android), `main_compileClasspath` (multi-source-set), etc.
+- `has_runtime = any config ends with "runtimeClasspath"` — same suffix rule.
+- `compile-only shape = has_compile AND NOT has_runtime`.
+
+This means:
+- `compileClasspath,testCompileClasspath` → compile-only (both are compile suffixes; no runtime) → Optional ✱
+- `compileClasspath,runtimeClasspath` → NOT compile-only (both suffixes present) → None (unchanged)
+- `runtimeClasspath,testRuntimeClasspath` → NOT compile-only (no compile suffix) → None (unchanged)
+- `annotationProcessor,compileClasspath` → compile-only (compile suffix present, no runtime) → Optional ✱ (spec Edge Cases: annotation-processor + compileClasspath is treated as compile-only per m184 initial delivery)
+
+## Shared invariants (both user stories)
+
+1. **Distinct derivation values per source**: `"maven-optional-element"` from Maven; `"gradle-compile-only"` from Gradle. NEVER emit one value from the other's code path.
+2. **One-derivation-per-component**: a component classified as Test / Build (either format) CANNOT ALSO carry `mikebom:optional-derivation`. Enforced by Decision 2.
+3. **Independent per-format classification**: each reader classifies at construction time. No cross-format precedence rule (Decision 4).
+4. **C122 parity byte-identity**: the annotation MUST appear byte-identically in CDX 1.6, SPDX 2.3, and SPDX 3.0.1 for every fixture that exercises the m184 classifications. Enforced by the existing C122 `Directionality::SymmetricEqual` extractor.
+5. **`--include-dev=false` filtering**: `LifecycleScope::Optional` targets are filtered via `is_non_runtime()`, same as `Dev/Build/Test`. Enforced by m179's existing `is_non_runtime()` extension.
+6. **`--spdx2-relationship-compat=basic`**: all new `OPTIONAL_DEPENDENCY_OF` emissions collapse to natural-direction `DEPENDS_ON`. Enforced by m228's basic-mode contract.

--- a/specs/184-maven-gradle-optional/contracts/derivation-value-set.md
+++ b/specs/184-maven-gradle-optional/contracts/derivation-value-set.md
@@ -1,0 +1,67 @@
+# Contract: C122 Derivation-Value Set (m184 update)
+
+**Feature**: [../spec.md](../spec.md) · **Plan**: [../plan.md](../plan.md) · **Research**: [../research.md](../research.md)
+
+## Scope
+
+Documents the expected value-set for the `mikebom:optional-derivation` annotation (C122 parity catalog row) after m184. Same contract shape as m183's derivation-value-set.md — this is a documentation contract, not a runtime-validated enum. The catalog docstring at `mikebom-cli/src/parity/extractors/cdx.rs:866` is the sole source of truth for expected values.
+
+## Value Set (after m184)
+
+| Value | Milestone | Emitted by | Semantic |
+|---|---|---|---|
+| `cargo-optional-true` | m179 | `cargo.rs::build_cargo_component` | Cargo `[dependencies].foo = { optional = true }` |
+| `npm-optional-dependencies` | m180 + m181 | `npm/package_lock.rs`, `npm/pnpm_lock.rs`, `npm/yarn_lock.rs` (v1 + Berry) | npm-registry family `optionalDependencies` sub-block / `dependenciesMeta.<name>.optional` |
+| `pip-optional-dependencies` | m183 | `pip/poetry.rs`, `pip/mod.rs` (main-module post-pass), `pip/uv_lock.rs` | pip-family: poetry.lock `optional = true`, pyproject `[project.optional-dependencies]`, uv.lock `optional-dependencies` |
+| **`maven-optional-element`** ✱ | m184 | `maven.rs::pom_dep_to_entry` | Maven `<dependency><optional>true</optional></dependency>` in `pom.xml` (POM 4.0.0 spec) |
+| **`gradle-compile-only`** ✱ | m184 | `gradle/lockfile.rs::read_gradle_lockfile` | Gradle `compileOnly` deps (compile-only shape: `*compileClasspath` present + `*runtimeClasspath` absent in the lockfile configs list) |
+
+✱ = added by m184. Total values after m184: **5**.
+
+## Invariants
+
+1. **Values are stable identifiers** — Once documented in this value-set, a value MUST NOT be renamed. Downstream SBOM consumers (pico, other analyzers) grep for these exact strings.
+2. **One value per (milestone, mechanism)** — the value uniquely identifies the ecosystem-specific mechanism. m184's split between `maven-optional-element` and `gradle-compile-only` reflects the fact that Maven's `<optional>` element and Gradle's `compileOnly` configuration are semantically distinct mechanisms, unlike the m180/m181/m183 case where all sub-mechanisms within an ecosystem family shared one underlying registry concept.
+3. **No component carries multiple derivations** — Enforced by the "one derivation per component" invariant (Decision 2). If a component is classified by two different sources (in m184's case, this can only happen when a project has BOTH pom.xml AND gradle.lockfile), the standard `merge_without_override` deduplication path already in use for maven's transitive expansion applies.
+4. **Docstring lists all values** — The `cdx.rs:866` docstring is the sole source of truth; it MUST list every value the mikebom codebase can emit. m184 does NOT need a docstring edit — both new values are already pre-committed since m179.
+
+## Docstring — NO UPDATE NEEDED
+
+**File**: `mikebom-cli/src/parity/extractors/cdx.rs`
+**Line**: ~866 (the C122 docstring block)
+
+Current state (pre-m184, from m183's docstring fix):
+```rust
+// C122 — `mikebom:optional-derivation` (milestone 179). Records
+// which ecosystem-reader mechanism populated the
+// `LifecycleScope::Optional` classification (`cargo-optional-true`,
+// `npm-optional-dependencies`, `pip-optional-dependencies`,
+// `maven-optional-element`, `gradle-compile-only`,
+// `erlang-optional-applications`). KEEP-BOTH polarity per m178:
+// ...
+```
+
+**Post-m184**: identical text. Both `maven-optional-element` and `gradle-compile-only` are already listed as placeholders. m184 makes them real by wiring the emission code paths — zero docstring edit.
+
+## Emitted Format Byte-Identity
+
+The C122 extractor at `mikebom-cli/src/parity/extractors/mod.rs:545` is registered as `Directionality::SymmetricEqual`. Same shape as m179/m180/m181/m183:
+
+- **CDX 1.6**: emitted as `properties[].value` on the component, key `mikebom:optional-derivation`.
+- **SPDX 2.3**: emitted as an `annotationText` in a `PackageAnnotation` on the component.
+- **SPDX 3.0.1**: emitted as `elements[].extension[]` with the same annotation-key.
+
+For any Maven fixture that exercises US1, the three emitted formats MUST contain the exact string `"maven-optional-element"` byte-identically. For any Gradle fixture that exercises US2, the three formats MUST contain `"gradle-compile-only"` byte-identically. SC-008 validates this automatically per format via the parity extractor infrastructure.
+
+## Growth Trajectory (informational)
+
+The C122 value-set is expected to grow through m185+:
+- m185 candidate: `erlang-optional-applications` (already docstring'd)
+- Future candidates: `sbt-provided`, `mill-optional`, `ant-ivy-optional`, etc.
+
+Each new value is added by:
+1. Wiring the emission code path in the appropriate reader.
+2. (If needed) extending the docstring at `cdx.rs:866`.
+3. Updating a fresh `contracts/derivation-value-set.md` document in the new milestone's spec.
+
+The C122 extractor itself is unchanged across all these additions.

--- a/specs/184-maven-gradle-optional/data-model.md
+++ b/specs/184-maven-gradle-optional/data-model.md
@@ -1,0 +1,188 @@
+# Data Model: Maven + Gradle optional-dependency classification (m184)
+
+**Feature**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md) · **Research**: [research.md](./research.md)
+
+## 1. New Type (US1 only)
+
+### 1.1 `PomDependency` — new `optional: bool` field
+
+Extends the existing struct at `mikebom-cli/src/scan_fs/package_db/maven.rs:578`:
+
+```rust
+pub(crate) struct PomDependency {
+    pub group_id: String,
+    pub artifact_id: String,
+    pub version: Option<String>,
+    pub scope: Option<String>,
+    pub dep_type: Option<String>,
+    // Milestone 184 US1 — extracted from the `<optional>` child element of
+    // `<dependency>` blocks. Defaults to `false` when the element is absent
+    // or its text isn't `"true"` (case-insensitive per POM 4.0.0 spec).
+    pub optional: bool,
+}
+```
+
+Every existing `PomDependency` construction site MUST be updated to initialize the new field. Grep pattern for the audit: `PomDependency\s*{`. Expected sites:
+- `maven.rs:798` (inside `parse_pom_xml` at line ~800) — populate from `dep_optional.take().map(|v| v.eq_ignore_ascii_case("true")).unwrap_or(false)`
+- Any test-only fixture construction — initialize `optional: false` unless the test specifically exercises the m184 path.
+
+## 2. No New Type for US2
+
+Gradle US2 is a shape-inference extension — no new struct fields are needed. The `PackageDbEntry` type is unchanged; classification happens at construction time inside `read_gradle_lockfile`.
+
+## 3. Classifier Decision Matrices
+
+### US1 — Maven `pom_dep_to_entry` at `maven.rs:2347`
+
+The classifier consults BOTH the existing `lifecycle_scope_from_maven(dep.scope.as_deref())` AND the new `dep.optional` field:
+
+| `dep.scope` (via `lifecycle_scope_from_maven`) | `dep.optional` | Emitted `lifecycle_scope` | Emitted `mikebom:optional-derivation` | Change? |
+|---|---|---|---|---|
+| `Some(Test)` (from `<scope>test</scope>`) | `true` | `Test` | (not emitted — Decision 2 scope-wins) | NONE |
+| `Some(Test)` | `false` | `Test` | (not emitted) | NONE |
+| `Some(Build)` (from `<scope>provided</scope>`) | `true` | `Build` | (not emitted — Decision 2 scope-wins) | NONE |
+| `Some(Build)` | `false` | `Build` | (not emitted) | NONE |
+| `Some(Runtime)` (from `<scope>compile/runtime/system/import</scope>` OR absent) | **`true`** | **`Optional`** ✱ | **`"maven-optional-element"`** ✱ | ✱ CHANGED |
+| `Some(Runtime)` | `false` | `Runtime` | (not emitted) | NONE |
+| `None` (unrecognized `<scope>`) | `true` | **`Optional`** ✱ | **`"maven-optional-element"`** ✱ | ✱ CHANGED |
+| `None` | `false` | `None` | (not emitted) | NONE |
+
+✱ = new m184 behavior. Two rows change (Runtime + None both with `optional = true`). All other rows preserve pre-m184 behavior byte-identically.
+
+**Read helper** (already in maven.rs, unchanged):
+```rust
+fn lifecycle_scope_from_maven(scope: Option<&str>) -> Option<LifecycleScope> {
+    match scope {
+        Some("test") => Some(LifecycleScope::Test),
+        Some("provided") => Some(LifecycleScope::Build),
+        Some("compile") | Some("runtime") | Some("system") | Some("import") | None => {
+            Some(LifecycleScope::Runtime)
+        }
+        Some(_) => None,
+    }
+}
+```
+
+**Classifier extension** at `pom_dep_to_entry` (data-model reference — implementation at Task-phase):
+```rust
+let base_scope = lifecycle_scope_from_maven(dep.scope.as_deref());
+let (lifecycle_scope, is_m184_optional) = match (base_scope, dep.optional) {
+    // Scope-wins (Decision 2): Test / Build classifications win; no annotation.
+    (Some(LifecycleScope::Test), _) => (Some(LifecycleScope::Test), false),
+    (Some(LifecycleScope::Build), _) => (Some(LifecycleScope::Build), false),
+    // Runtime + optional=true → Optional classification.
+    (Some(LifecycleScope::Runtime), true) => (Some(LifecycleScope::Optional), true),
+    // Runtime + optional=false → Runtime (unchanged).
+    (Some(LifecycleScope::Runtime), false) => (Some(LifecycleScope::Runtime), false),
+    // Unrecognized scope + optional=true → Optional classification.
+    (None, true) => (Some(LifecycleScope::Optional), true),
+    // Unrecognized scope + optional=false → None (unchanged).
+    (None, false) => (None, false),
+    // Other LifecycleScope variants — Runtime/Test/Build cover the m052
+    // mapping; a future variant added to `lifecycle_scope_from_maven`
+    // would need explicit handling here. `_` guard keeps the compiler
+    // check honest.
+    (other, _) => (other, false),
+};
+```
+
+The annotation is inserted into `extra_annotations` only when `is_m184_optional` is true. Analogous to the m183 US1 pattern in `poetry.rs`.
+
+### US2 — Gradle `read_gradle_lockfile` at `gradle/lockfile.rs:38`
+
+The classifier consults BOTH the existing filename-based `is_buildscript` flag AND the new `is_compile_only_shape(configs)` helper:
+
+| `is_buildscript` | `is_compile_only_shape(configs)` | Emitted `lifecycle_scope` | Emitted `mikebom:optional-derivation` | Change? |
+|---|---|---|---|---|
+| `true` | `true` | `Build` | (not emitted — Decision 2 buildscript-wins) | NONE (per US2 acceptance 5) |
+| `true` | `false` | `Build` | (not emitted) | NONE |
+| `false` | **`true`** | **`Optional`** ✱ | **`"gradle-compile-only"`** ✱ | ✱ CHANGED |
+| `false` | `false` | `None` | (not emitted) | NONE |
+
+✱ = new m184 behavior. One row changes. All other rows preserve pre-m184 behavior byte-identically.
+
+**Helper** (new in m184):
+```rust
+/// Milestone 184 US2 — Detect the "compile-only shape" per entry.
+///
+/// A Gradle dep is classified as `LifecycleScope::Optional` iff it
+/// appears on any `*compileClasspath` configuration AND is absent from
+/// any `*runtimeClasspath` configuration. Suffix-check per Decision 3
+/// so multi-source-set + multi-project builds are covered.
+fn is_compile_only_shape(configs: &str) -> bool {
+    let items: Vec<&str> = configs.split(',').map(|s| s.trim()).collect();
+    let has_compile = items.iter().any(|c| c.ends_with("compileClasspath"));
+    let has_runtime = items.iter().any(|c| c.ends_with("runtimeClasspath"));
+    has_compile && !has_runtime
+}
+```
+
+**Classifier extension** at `read_gradle_lockfile`:
+```rust
+let (lifecycle_scope, is_m184_optional) = if is_buildscript {
+    // Buildscript wins (Decision 2 US2 acceptance 5); no annotation.
+    (Some(LifecycleScope::Build), false)
+} else if is_compile_only_shape(configs_value) {
+    // Runtime candidate with compile-only shape → Optional.
+    (Some(LifecycleScope::Optional), true)
+} else {
+    // Pre-m184 default: None for non-buildscript, non-compile-only.
+    (None, false)
+};
+```
+
+## 4. C122 Parity Catalog Value-Set Update
+
+The C122 catalog row at `mikebom-cli/src/parity/extractors/mod.rs:545` is UNCHANGED — it's the same `Directionality::SymmetricEqual` extractor. Only the value-set grows:
+
+**Pre-m184 (post-m183)**:
+- `cargo-optional-true` (m179)
+- `npm-optional-dependencies` (m180, m181)
+- `pip-optional-dependencies` (m183)
+
+**Post-m184**:
+- `cargo-optional-true` (m179)
+- `npm-optional-dependencies` (m180, m181)
+- `pip-optional-dependencies` (m183)
+- **`maven-optional-element`** ✱ (m184 US1)
+- **`gradle-compile-only`** ✱ (m184 US2)
+
+The docstring at `cdx.rs:866` ALREADY lists both new values as placeholders since m179 — m184 makes them real by wiring the code paths that populate them. No docstring edit needed.
+
+## 5. Test Contract
+
+**Unit tests** (colocated with the code they cover):
+
+**maven.rs::tests** (new):
+- `parse_pom_xml_extracts_optional_true` (parse — verifies the `<optional>` element flows into `PomDependency.optional`)
+- `parse_pom_xml_optional_false_or_absent_stays_false` (parse regression pin)
+- `pom_dep_to_entry_optional_true_default_scope_classifies_as_optional` (US1 acceptance 1+2)
+- `pom_dep_to_entry_optional_true_scope_test_stays_test` (US1 acceptance 4 + Decision 2 pin)
+- `pom_dep_to_entry_optional_true_scope_provided_stays_build` (Decision 2 provided-scope pin)
+- `pom_dep_to_entry_optional_false_stays_runtime` (US1 acceptance 3 regression pin)
+- `pom_dep_to_entry_optional_absent_stays_runtime` (regression pin: no `<optional>` element at all)
+
+**gradle/lockfile.rs::tests** (new):
+- `is_compile_only_shape_detects_compile_only` (helper unit)
+- `is_compile_only_shape_rejects_compile_and_runtime` (US2 acceptance 3 pin)
+- `is_compile_only_shape_rejects_runtime_only` (US2 acceptance 4 pin)
+- `is_compile_only_shape_detects_test_compile_only` (Decision 3 suffix-match pin — testCompileClasspath alone)
+- `is_compile_only_shape_detects_source_set_variants` (Decision 3 suffix-match pin — custom source set names)
+- `read_gradle_lockfile_compile_only_classifies_as_optional` (US2 acceptance 1+2 end-to-end)
+- `read_gradle_lockfile_buildscript_compile_only_stays_build` (US2 acceptance 5 + Decision 2 buildscript-wins pin)
+- `read_gradle_lockfile_runtime_stays_none` (regression pin: `compileClasspath,runtimeClasspath` shape stays pre-m184)
+
+**Integration tests** (via existing regression fixtures + potential new fixtures):
+
+- Existing maven regression tests (m085/m087/m130-US2) MUST continue to pass byte-identically OR show only additive changes if the fixture happens to include `<optional>` deps.
+- Existing gradle lockfile regression tests (m106 US1 `configurations_recorded_in_annotation`) MUST continue to pass byte-identically OR show only additive changes if the fixture happens to include compile-only shapes.
+- Golden regen expected drift: additive `mikebom:optional-derivation` properties + `scope: "excluded"` on maven/gradle goldens only IF the underlying pom.xml or gradle.lockfile fixture contains m184-classifiable signals. Zero drift on non-Java goldens per SC-004.
+
+**FR-013 zero-new-dep verification** (T029-equivalent):
+- `cargo tree -p mikebom | wc -l` MUST be identical pre- vs post-m184 (1131 lines expected).
+
+## 6. Backward Compatibility
+
+- **Fixtures with NO `<optional>` elements + NO compile-only-shape gradle entries**: byte-identical output (SC-004 gate).
+- **Fixtures with maven deps + explicit `<scope>test</scope>` / `<scope>provided</scope>`**: byte-identical output (Decision 2 preserves the scope-classification path).
+- **Existing tests in maven.rs + gradle/lockfile.rs**: unchanged behavior. Any test that happens to construct `PomDependency` values will need `optional: false` added to the struct literal — this is a source-level breaking change on the struct definition BUT NOT a behavior change (the field defaults to false when initialized by the parser).

--- a/specs/184-maven-gradle-optional/plan.md
+++ b/specs/184-maven-gradle-optional/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Maven + Gradle optional-dependency classification
+
+**Branch**: `184-maven-gradle-optional` | **Date**: 2026-07-11 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/184-maven-gradle-optional/spec.md`
+
+## Summary
+
+Extends the m179+m180+m181+m183 unified optional-dependency classification to the Java ecosystem's two dominant build systems. Both converge on the same `LifecycleScope::Optional` variant but emit DISTINCT derivation-annotation values (`"maven-optional-element"` and `"gradle-compile-only"`) — reflecting the semantic distinction between Maven's `<optional>` element and Gradle's `compileOnly` configuration.
+
+**Technical approach**: Small, additive changes at two isolated code sites in `mikebom-cli/src/scan_fs/package_db/`:
+
+- **maven.rs (US1)** — Extend `PomDependency` struct at line 578 with a new `optional: bool` field; extend `parse_pom_xml` walker at line 689 with an `<optional>` element handler (analogous to the existing `<scope>` / `<type>` handlers at line 761-768); modify the `pom_dep_to_entry` conversion at line 2347 to consult the new field and emit `LifecycleScope::Optional` + `mikebom:optional-derivation = "maven-optional-element"` when appropriate. Scope-wins-over-optional (FR-005) is enforced because the existing `lifecycle_scope_from_maven` at line 36 returns `Some(Test/Build/Runtime)` for explicit `<scope>` values; the new classifier only overrides when the resulting scope is the implicit Runtime (default) AND the `<optional>` flag is set.
+- **gradle/lockfile.rs (US2)** — Add a `is_compile_only_shape(configs: &str) -> bool` helper that suffix-checks for `compileClasspath` presence AND `runtimeClasspath` absence in the raw configs list. Modify `read_gradle_lockfile` at line 38 to consult the helper and set `lifecycle_scope = Some(LifecycleScope::Optional)` + emit `mikebom:optional-derivation = "gradle-compile-only"` when the shape matches AND the existing `LifecycleScope::Build` (buildscript) classification is NOT already set. The existing `mikebom:gradle-configurations` annotation at line 119 stays unchanged (transparency preserved).
+
+Zero new production Cargo dependencies. The C122 parity catalog row registered by m179 gains two new expected values (`"maven-optional-element"` + `"gradle-compile-only"`), tracked as a value-set update, not a new catalog row. The docstring at `parity/extractors/cdx.rs:866` already lists both values as placeholders since m179 — m184 makes them real without touching the docstring text.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–183; no nightly required for this user-space-only classification work).
+
+**Primary Dependencies**: Existing only — `quick-xml = "0.31"` (Maven pom.xml parsing; already used pervasively in `maven.rs`), `serde`/`serde_json` (annotation values), `tracing` (info-level classifier-decision logs), `anyhow`/`thiserror` (error propagation). Reuses m179's `LifecycleScope::Optional` variant + `RelationshipType::OptionalDependsOn` + `SpdxRelationshipType::OptionalDependencyOf` + m180's `apply_lifecycle_scope_to_edges` at `mikebom-cli/src/scan_fs/mod.rs:1261`. **Zero new Cargo dependencies.**
+
+**Storage**: N/A — all state in-process per scan; persisted only inside the emitted SBOM via the existing `extra_annotations` channel + `lifecycle_scope` field. Matches every milestone since 002.
+
+**Testing**: `cargo +stable test --workspace` (unit + integration tests), `cargo +stable clippy --workspace --all-targets -- -D warnings` (lint). Golden regen via `MIKEBOM_UPDATE_{CDX,SPDX,SPDX3}_GOLDENS=1`.
+
+**Target Platform**: Linux + macOS user-space (unchanged from prior milestones). Windows-host smoke covered by milestone 100/101 infra.
+
+**Project Type**: CLI (Rust binary + shared common crate). Existing three-crate architecture: `mikebom-cli`, `mikebom-common`, `xtask`.
+
+**Performance Goals**: Classifier extension adds O(1) per `<dependency>` element (US1) and O(len(configs)) suffix-check per gradle.lockfile line (US2). Both are negligible relative to the existing per-file XML/text parse cost. No new subprocess calls, no new I/O, no network.
+
+**Constraints**: SC-004/SC-005 byte-identity for non-Java fixtures + Java fixtures without m184 signals — the default classifier path (no `<optional>`, no compile-only shape) MUST produce byte-identical `PackageDbEntry` values compared to pre-m184. Golden regens gate this.
+
+**Scale/Scope**: 2 user stories, 2 code sites, 2 distinct derivation-annotation values. Estimated ~25-30 tasks across 6 phases.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**Principle I (Pure Rust, Zero C)** — PASS. Zero new Cargo dependencies. Existing `quick-xml` + `serde_json` + `tracing` cover all parsing + annotation-emission needs.
+
+**Principle II (eBPF-Only Observation)** — N/A. m184 is user-space classifier work; `mikebom-ebpf` untouched.
+
+**Principle III (Fail Closed)** — PASS. Every classifier decision has a documented default (no `<optional>` element → false; no compile-only shape → no classification). Malformed pom.xml / gradle.lockfile continues to warn-and-skip (existing behavior at `maven.rs` + `gradle/lockfile.rs:42`).
+
+**Principle IV (Type-Driven Correctness)** — PASS. Classifier decisions flow through the existing `LifecycleScope` enum. No stringly-typed magic. The new `optional: bool` field on `PomDependency` is typed at struct definition time.
+
+**Principle V (Specification Compliance + Native-first)** — PASS. Native SPDX 2.3 `OPTIONAL_DEPENDENCY_OF` is the primary signal (elevated from the current `DEPENDS_ON`). `mikebom:optional-derivation` values `"maven-optional-element"` and `"gradle-compile-only"` are the KEEP-BOTH supplements carrying WHICH Java-ecosystem construct produced the classification. Zero new `mikebom:*` annotations invented — the value-set of the existing C122 catalog row is extended.
+
+**Principle VI (Three-Crate Architecture)** — PASS. Changes confined to `mikebom-cli/src/scan_fs/package_db/maven.rs` + `mikebom-cli/src/scan_fs/package_db/gradle/lockfile.rs`. Zero changes to `mikebom-common`, `mikebom-ebpf`, or `xtask`.
+
+**Principle VII (Test Isolation)** — PASS. New unit tests colocated with the code under test in `maven.rs` and `gradle/lockfile.rs`. Integration tests via existing regression fixtures + new fixtures for the two US flavors.
+
+**Principle VIII (Completeness)** — PASS. m184 closes the remaining Java-family filter-parity gap for Maven and Gradle lockfiles. Deferred cases (inherited-optional, DSL parsing, sbt/Mill) documented in spec.md.
+
+**Principle IX (Accuracy)** — PASS. US1 and US2 both correct silent misclassification paths where Maven `<optional>true</optional>` and Gradle `compileOnly` deps have been emitting as Runtime since m052 (Maven scope classifier) shipped. SC-001/002 set-equality gates enforce filter-parity per pico's needs.
+
+**Principle X (Transparency)** — PASS. C122 parity annotation carries the classifier's decision provenance across all three formats byte-identically. The distinct-values design (not merged into one) faithfully identifies WHICH mechanism produced the classification.
+
+**Principle XI (Enrichment)** — N/A. No external-data enrichment for m184.
+
+**Principle XII (External Data Source Enrichment)** — N/A. Same as XI.
+
+**Result**: All 12 principles PASS. No violations to justify. No Complexity Tracking table needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/184-maven-gradle-optional/
+├── plan.md                  # This file
+├── research.md              # Phase 0 output (4 decisions)
+├── data-model.md            # Phase 1 output (PomDependency extension + classifier decision matrices)
+├── quickstart.md            # Phase 1 output (operator + developer worked examples)
+├── contracts/
+│   ├── classifier-decision-matrix.md  # US1 pom.xml + US2 gradle.lockfile canonical tables
+│   └── derivation-value-set.md         # C122 catalog value-set (post-m184: 5 total values)
+├── checklists/
+│   └── requirements.md      # 16/16 PASS from /speckit-specify
+├── spec.md                  # Feature specification
+└── tasks.md                 # Phase 2 output (/speckit-tasks — NOT created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/
+├── src/
+│   └── scan_fs/
+│       └── package_db/
+│           ├── maven.rs               # US1 — PomDependency.optional field, parse_pom_xml handler, pom_dep_to_entry classifier
+│           └── gradle/
+│               ├── lockfile.rs        # US2 — is_compile_only_shape helper + classifier at read_gradle_lockfile
+│               └── mod.rs             # UNCHANGED — dispatch layer
+└── tests/
+    └── fixtures/
+        └── golden/
+            ├── cyclonedx/maven.cdx.json    # regen: additive if any pre-m184 fixture happens to contain <optional> or compile-only shape
+            ├── spdx-2.3/maven.spdx.json    # regen: net-increment on OPTIONAL_DEPENDENCY_OF where applicable
+            └── spdx-3/maven.spdx3.json     # regen: additive annotations
+```
+
+**Structure Decision**: Two-file, single-crate scope inside `mikebom-cli/src/scan_fs/package_db/`. No cross-crate coordination. No shared helper file needed — each reader classifies at construction time (analogous to m183 US1 poetry.rs pattern), not via a downstream post-pass. Follows the m179/m180/m181/m183 shape with per-format independence.
+
+## Complexity Tracking
+
+*No violations to justify — all 12 constitution principles PASS.*

--- a/specs/184-maven-gradle-optional/quickstart.md
+++ b/specs/184-maven-gradle-optional/quickstart.md
@@ -1,0 +1,116 @@
+# Quickstart: Maven + Gradle optional-dependency classification (m184)
+
+**Feature**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+
+## Operator flow
+
+### Scenario 1 — Maven project with `<optional>true</optional>` deps
+
+A `pom.xml` declares a dependency with `<optional>true</optional>` — the Maven convention for "this dep is used at compile time but NOT transitively exposed to consumers." Spring Boot, Hibernate, and countless enterprise Java projects use this pattern for feature-gated deps.
+
+**Before m184**: mikebom's `parse_pom_xml` skipped the `<optional>` element entirely; the target emitted as a regular Runtime dep.
+
+**After m184**:
+
+```bash
+mikebom sbom scan --path ./my-maven-project --format cyclonedx-json,spdx-2.3-json
+```
+
+The emitted SBOMs classify the optional-declared dep as:
+
+- **CDX 1.6**: `components[].scope = "excluded"` + `properties[]` includes `mikebom:optional-derivation = "maven-optional-element"`
+- **SPDX 2.3** (under `--spdx2-relationship-compat=full`, the default): `<target> OPTIONAL_DEPENDENCY_OF <parent>` instead of the pre-m184 `<parent> DEPENDS_ON <target>`
+- **SPDX 3.0.1**: annotation-only classification (no native `OPTIONAL_DEPENDENCY_OF` in SPDX 3)
+
+Downstream tools running pico-style filter analyses can now consume the `scope: "excluded"` (CDX) or `OPTIONAL_DEPENDENCY_OF` (SPDX 2.3) signal to exclude optional-declared deps from vulnerability analysis / build reproducibility checks / license aggregation.
+
+### Scenario 2 — Gradle project with `compileOnly` deps
+
+A `build.gradle` declares deps under the `compileOnly` configuration (Lombok, Delombok annotation processors, provided-by-container Servlet APIs, etc.). Gradle's dependency-locking mechanism produces a `gradle.lockfile` where these deps appear on `compileClasspath` but NOT on `runtimeClasspath`.
+
+**Before m184**: mikebom read the raw configs list into a `mikebom:gradle-configurations` annotation but did NOT classify the target as Optional; the target emitted as a regular Runtime dep.
+
+**After m184**: same commands, mikebom now classifies:
+- Lockfile entry `com.example:lombok:1.18.30=compileClasspath,testCompileClasspath` → `LifecycleScope::Optional` + `mikebom:optional-derivation = "gradle-compile-only"`
+- Lockfile entry `com.example:guava:32.1.3=compileClasspath,runtimeClasspath` → `Runtime` (unchanged; presence on both classpaths means transitive)
+
+The `mikebom:gradle-configurations` annotation is PRESERVED alongside the new classification for transparency (operators auditing an SBOM can see the exact raw configs list that produced the classification).
+
+## Filter parity in action
+
+The pico-style analysis a downstream SBOM consumer can now run for Java projects:
+
+```bash
+# Before m184: `lombok` shows up as vulnerable-in-scope
+mikebom sbom scan --path ./my-gradle-project | \
+    jq '.components[] | select(.scope != "excluded") | .name'
+# → guava, hibernate, lombok, spring-boot  ← FALSE POSITIVES
+
+# After m184: compile-only + optional-declared deps correctly filtered
+mikebom sbom scan --path ./my-gradle-project | \
+    jq '.components[] | select(.scope != "excluded") | .name'
+# → guava, hibernate, spring-boot  ← ACCURATE
+```
+
+## Precedence rules (operator-visible)
+
+- **Scope wins over Optional (Maven)**: if a `<dependency>` has BOTH `<optional>true</optional>` AND `<scope>test</scope>` (or `<scope>provided</scope>`), the scope classification wins. The target emits as `Test` (or `Build`) — no derivation annotation is added. Rationale: a test-scope dep only lives in the test classpath regardless of `<optional>`; layering an additional Optional annotation would be redundant.
+- **Buildscript wins over Optional (Gradle)**: if a `buildscript-gradle.lockfile` entry has the compile-only shape, the existing `LifecycleScope::Build` classification wins. No derivation annotation. Same rationale.
+- **`<dependencyManagement>` doesn't classify**: `<optional>true</optional>` inside a `<dependencyManagement>` block is IGNORED. `<dependencyManagement>` declares default versions, not real dep edges. The classification fires when a real `<dependencies>` block references the coord.
+- **Independent per-format classification**: a project with BOTH `pom.xml` AND `gradle.lockfile` doesn't need a cross-format precedence rule. Each reader classifies its own emitted `PackageDbEntry` values; the standard `merge_without_override` dedup path handles collisions.
+
+## Developer flow — verifying an m184 classification
+
+To verify a specific component's classification in an emitted SBOM:
+
+```bash
+# CDX 1.6 — Maven
+jq '.components[] | select(.name == "some-optional-dep") | {scope, properties}' \
+    mikebom.cdx.json
+
+# Expected output (m184 US1):
+# {
+#   "scope": "excluded",
+#   "properties": [
+#     { "name": "mikebom:optional-derivation", "value": "maven-optional-element" },
+#     ...
+#   ]
+# }
+
+# CDX 1.6 — Gradle
+jq '.components[] | select(.name == "lombok") | {scope, properties}' \
+    mikebom.cdx.json
+
+# Expected output (m184 US2):
+# {
+#   "scope": "excluded",
+#   "properties": [
+#     { "name": "mikebom:optional-derivation", "value": "gradle-compile-only" },
+#     { "name": "mikebom:gradle-configurations", "value": "compileClasspath,testCompileClasspath" },
+#     ...
+#   ]
+# }
+
+# SPDX 2.3 — both formats
+jq '.relationships[] | select(.relationshipType == "OPTIONAL_DEPENDENCY_OF") | {spdxElementId, relatedSpdxElement}' \
+    mikebom.spdx.json
+```
+
+## Failure modes
+
+There are none new in m184 — the classifier is purely additive on the read path. Existing failure modes (malformed pom.xml, missing gradle.lockfile, etc.) surface via `tracing::warn!` and skip-and-continue, unchanged from pre-m184.
+
+## When NOT to expect the classification
+
+- **Legacy `build.gradle` / `build.gradle.kts` DSL projects without `gradle.lockfile`**: mikebom's Gradle classifier reads from the LOCKFILE only. Without a lockfile, `compileOnly` deps aren't detectable — no classification is emitted. DSL parsing is deferred indefinitely per Constitution Principle I (no Groovy/Kotlin parser).
+- **Maven inherited-`<optional>`**: a parent POM's `<dependencyManagement>` may declare `<optional>true</optional>`, but m184's initial delivery only reads the CHILD POM's explicit `<optional>` element. Inherited-optional resolution requires a full parent-POM resolver walk — deferred to a follow-up milestone.
+- **Basic-mode SPDX 2.3** (`--spdx2-relationship-compat=basic`): all typed dep-scope edges collapse to `DEPENDS_ON` per m228. The classifier still runs; only the emission form differs.
+- **sbt / Mill / Ant-Ivy projects**: JVM-ecosystem tail beyond Maven and Gradle. sbt is already read at the reader level (m142) but classification extension is future scope; Mill and Ant-Ivy readers don't exist yet.
+
+## Cross-references
+
+- Spec: [spec.md](./spec.md)
+- Plan: [plan.md](./plan.md)
+- Classifier decision matrix: [contracts/classifier-decision-matrix.md](./contracts/classifier-decision-matrix.md)
+- Derivation value set: [contracts/derivation-value-set.md](./contracts/derivation-value-set.md)
+- Research decisions: [research.md](./research.md)

--- a/specs/184-maven-gradle-optional/research.md
+++ b/specs/184-maven-gradle-optional/research.md
@@ -1,0 +1,90 @@
+# Research: Maven + Gradle optional-dependency classification (m184)
+
+**Feature**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+
+## Decisions
+
+### Decision 1 — Two distinct derivation-annotation values (not one merged)
+
+**Decision**: Emit `mikebom:optional-derivation = "maven-optional-element"` for Maven and `"gradle-compile-only"` for Gradle. Do NOT merge them into a single "java-optional-declared" or similar shared value.
+
+**Rationale**:
+- The underlying mechanisms are semantically distinct:
+  - **Maven `<optional>` element** is a transitive-exposure control (per POM 4.0.0 spec): a declared dep is used at compile time by the enclosing artifact, but consumers of that artifact are NOT required to pull it. It's a metadata assertion attached to a specific `<dependency>` block.
+  - **Gradle `compileOnly` configuration** is a classpath-composition rule: a declared dep goes on the compile classpath but NOT the runtime classpath. It's inferred from the LOCKFILE's configs list (compile-only shape).
+- Consumers of the SBOM's C122 annotation can distinguish which mechanism produced the classification — useful for tools that treat these differently (e.g., a build-reproducibility auditor may want to know whether a build system's exposure rule or its classpath rule was the source).
+- The C122 catalog docstring at `parity/extractors/cdx.rs:866` has already reserved both values as placeholders since m179. m184 activates them without touching the docstring.
+
+**Alternatives considered**:
+- **Single shared value `"java-optional"` or `"jvm-optional-declared"`** — rejected. Merges semantically distinct signals into one, hiding provenance from consumers. Also contradicts the pre-committed C122 docstring.
+- **Per-package-manager values (`"maven-<optional-element"`, `"gradle-compile-only"`, `"sbt-provided"`, `"mill-...")`** — this IS the chosen approach for m184; each value tracks a mechanism-specific concept. Follow-up milestones (sbt, Mill, Ant-Ivy) will add their own values without changing the m184 semantic.
+
+**Follow-up**: The value-set grows from 3 (post-m183: `cargo-optional-true`, `npm-optional-dependencies`, `pip-optional-dependencies`) to 5 (post-m184: + `maven-optional-element`, `gradle-compile-only`). Documented in `contracts/derivation-value-set.md`.
+
+---
+
+### Decision 2 — Scope-wins-over-optional (Maven + Gradle)
+
+**Decision**: When a Maven `<dependency>` has BOTH `<optional>true</optional>` AND an explicit `<scope>test</scope>` / `<scope>provided</scope>` (per `lifecycle_scope_from_maven` at `maven.rs:36`), the scope-derived classification wins (Test / Build respectively). The derivation annotation MUST NOT be emitted on those components. Same rule for Gradle: `buildscript-gradle.lockfile` entries with compile-only shape stay classified as `LifecycleScope::Build`; the optional-derivation annotation is not layered.
+
+**Rationale**:
+- Matches the m183 Decision 2 pattern (dev-wins-over-optional): a more-specific classification wins over the general "extras-gated" concept.
+- Preserves the "one-derivation-per-component" invariant m180 established.
+- `--include-dev=false` already filters Test/Build/Optional via `is_non_runtime()`, so the downstream filter behavior is unchanged; only the SBOM's edge-type verb differs.
+- Prevents visual noise: a test-scope dep with a redundant optional annotation would confuse SBOM consumers looking for "why is this component filtered?"
+
+**Implementation guidance**: In `pom_dep_to_entry`, compute `lifecycle_scope_from_maven(dep.scope.as_deref())` FIRST. If it returns `Some(Test | Build)`, keep that scope and skip the m184 optional-classification path entirely. Only when the mapping returns `Some(Runtime)` (the default) AND `dep.optional == true` does the m184 path override to `Some(Optional)` + emit the annotation. Analogous logic for Gradle in `read_gradle_lockfile`.
+
+**Alternatives considered**:
+- **Optional-wins-over-scope** — would flip the axis but produce the same downstream filter behavior (both are `is_non_runtime()`). Rejected because it contradicts Maven's install-gate semantics: a `<scope>test</scope>` dep only lives in the test classpath regardless of `<optional>`.
+- **Both classifications emitted (multiple annotations)** — violates the one-derivation-per-component invariant and doesn't map to a single SPDX 2.3 relationship type.
+
+---
+
+### Decision 3 — Gradle compile-only shape: suffix-based detection, not exact match
+
+**Decision**: Detect the "compile-only shape" by suffix-checking the configs list for any occurrence of `compileClasspath` AND absence of any `runtimeClasspath`. This covers:
+- `compileClasspath` (main source set)
+- `testCompileClasspath` (test source set)
+- `<sourceSetName>_compileClasspath` (custom source sets in multi-source-set projects, Android's `debug`/`release`, Kotlin's `main`/`test`, etc.)
+
+**Rationale**:
+- Gradle multi-project + multi-source-set builds emit lockfiles with per-source-set classpath names. Requiring exact-match against `"compileClasspath"` would miss Android and Kotlin projects — the vast majority of modern Gradle deployments.
+- Suffix matching keeps the classifier simple (`configs.split(',').any(|c| c.trim().ends_with("compileClasspath"))`) without introducing regex.
+- False positives from unrelated `*compileClasspath` names are unlikely in practice — Gradle's classpath naming convention is stable.
+
+**Implementation guidance**:
+```rust
+fn is_compile_only_shape(configs: &str) -> bool {
+    let items: Vec<&str> = configs.split(',').map(|s| s.trim()).collect();
+    let has_compile = items.iter().any(|c| c.ends_with("compileClasspath"));
+    let has_runtime = items.iter().any(|c| c.ends_with("runtimeClasspath"));
+    has_compile && !has_runtime
+}
+```
+
+**Alternatives considered**:
+- **Exact match on `"compileClasspath"`** — rejected. Would miss `testCompileClasspath`, `<sourceSet>_compileClasspath`, etc.
+- **Regex match** — rejected. Adds `regex` dep footprint for a simple suffix check.
+- **Full DSL parsing** — rejected per spec Deferred section. Groovy/Kotlin parsers violate Constitution Principle I.
+
+---
+
+### Decision 4 — Per-format independence, no cross-format precedence rule
+
+**Decision**: Maven `pom.xml` classifier and Gradle `gradle.lockfile` classifier run independently. There is NO cross-format precedence rule (unlike m183 Decision 3 lockfile-precedes-manifest for pip).
+
+**Rationale**:
+- Maven and Gradle read from disjoint file types. In a project root that has BOTH a `pom.xml` (perhaps for interop or IDE-support fallback) AND a `gradle.lockfile` (the actual build system), the two readers emit distinct `PackageDbEntry` sets that flow through the standard `merge_without_override` deduplication path already in use for Maven's own transitive expansion.
+- No collision is possible on the `mikebom:optional-derivation` annotation because a single component can only be classified by ONE reader per emission path (each reader owns its own `PackageDbEntry` construction).
+- Contrast with m183 Decision 3: pip's poetry.lock and pyproject.toml describe the SAME source (poetry.lock is the resolved view; pyproject.toml is the input). Maven pom.xml and gradle.lockfile describe DIFFERENT sources (each is authoritative for its own build system).
+
+**Alternatives considered**:
+- **Lockfile-precedes-manifest (mimic m183)** — rejected. There's no analogous "manifest" for Java the way pyproject.toml is a manifest for pip. Both files are lockfile-shaped or manifest-shaped depending on how you count.
+- **Merged classifier across both readers** — rejected. Would require introducing a shared post-pass helper, which contradicts the "classify at construction time" pattern m183 US1 established.
+
+---
+
+## Bug Discovery: none
+
+No bugs surfaced during m184 research. The two derivation values were pre-committed as placeholders in the C122 docstring at `cdx.rs:866` since m179; m184 is the first milestone to activate them without any docstring adjustment (unlike m183 which had to fix `pip-extras-require` → `pip-optional-dependencies`).

--- a/specs/184-maven-gradle-optional/spec.md
+++ b/specs/184-maven-gradle-optional/spec.md
@@ -1,0 +1,128 @@
+# Feature Specification: Maven + Gradle optional-dependency classification
+
+**Feature Branch**: `184-maven-gradle-optional`
+**Created**: 2026-07-11
+**Status**: Draft
+**Input**: User description: "m184 — extends the m179 unified optional-dependency classification to the Java ecosystem. Two readers plumb the missing `LifecycleScope::Optional` classification: (a) `maven.rs` currently ignores the `<optional>true</optional>` child element on `<dependency>` blocks in `pom.xml` — the `PomDependency` struct at maven.rs:578 has no `optional: bool` field, so Maven-declared optional deps emit as regular Runtime edges; (b) the Gradle lockfile reader at `gradle/lockfile.rs` currently records the raw configs list as a `mikebom:gradle-configurations` annotation but does NOT classify deps that appear ONLY on the `compileClasspath` (absent from `runtimeClasspath`) — the canonical wire signature of `compileOnly` deps — as `LifecycleScope::Optional`. Both mechanisms surface distinct semantic concepts (Maven's `<optional>` = transitive-exposure control per POM spec; Gradle's `compileOnly` = compile-classpath-only configuration) and thus emit distinct `mikebom:optional-derivation` values: `\"maven-optional-element\"` and `\"gradle-compile-only\"` respectively. These are the exact placeholder values already documented in the C122 catalog docstring at `parity/extractors/cdx.rs:866` since m179."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Maven `<optional>true</optional>` maps to `LifecycleScope::Optional` (Priority: P1)
+
+The Maven POM spec defines `<optional>true</optional>` as a `<dependency>` child element that marks a dep as "not transitively exposed to downstream consumers": consumers of the enclosing artifact are NOT required to pull the marked dep. It's semantically equivalent to Cargo's `optional = true` feature-gated dep — the enclosing artifact uses it at compile time, but a consumer must explicitly re-declare it if they want the same integration.
+
+Today mikebom's `parse_pom_xml` (at `maven.rs:689`) skips the `<optional>` element entirely — `PomDependency` at line 578 has no `optional` field. Downstream classifier code treats such deps as regular Runtime edges, producing false-positive Runtime relationships that mislead SBOM consumers running pico-style filter analyses. This gap is analogous to the m183 US1 poetry.lock bug where `optional = true` packages were silently classified as Runtime.
+
+**Why this priority**: Maven is the historically dominant Java build system, and `<optional>true</optional>` is a well-established POM convention (Spring Boot, Hibernate, and countless enterprise Java projects use it to declare feature-gated deps). Same pico filter-parity gap m179/m180/m181/m183 closed for their ecosystems — extended to the Java ecosystem's biggest installed base.
+
+**Independent Test**: Scan a Maven project whose `pom.xml` declares at least one `<dependency>` with `<optional>true</optional>`. Verify (a) the target component gets `LifecycleScope::Optional` + the `mikebom:optional-derivation = "maven-optional-element"` annotation, (b) CDX 1.6 emits `scope: "excluded"` on the target, (c) SPDX 2.3 emits `<target> OPTIONAL_DEPENDENCY_OF <parent>` under `--spdx2-relationship-compat=full`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `pom.xml` with `<dependency><groupId>org.example</groupId><artifactId>optional-dep</artifactId><version>1.0</version><optional>true</optional></dependency>`, **When** mikebom emits SPDX 2.3 under `--spdx2-relationship-compat=full`, **Then** `optional-dep` MUST appear as source-side of an `OPTIONAL_DEPENDENCY_OF` edge — NOT as a plain `DEPENDS_ON` target.
+2. **Given** the same scan, **When** mikebom emits CDX 1.6, **Then** `optional-dep` MUST carry `scope: "excluded"` + `mikebom:optional-derivation = "maven-optional-element"`.
+3. **Given** a `pom.xml` with `<dependency>` element WITHOUT the `<optional>` child (or with `<optional>false</optional>` explicit), **When** mikebom emits SPDX 2.3, **Then** the target MUST continue to emit its existing scope-derived classification (Test/Build/Runtime per `<scope>`) — the fix does NOT change other classification paths.
+4. **Given** a `pom.xml` where the same `<dependency>` has BOTH `<optional>true</optional>` AND `<scope>test</scope>`, **When** mikebom classifies, **Then** the Test scope classification wins (analogous to m183 Decision 2 dev-wins-over-optional) — the target emits as `TEST_DEPENDENCY_OF`, NOT `OPTIONAL_DEPENDENCY_OF`, and the derivation annotation MUST NOT appear on it. Rationale: `<scope>test</scope>` is already gate-filtered by `--include-dev=false` via `is_non_runtime()`; layering an additional Optional annotation would be visual noise and violate the "one derivation per component" invariant m180 established.
+
+---
+
+### User Story 2 — Gradle `compileOnly` deps map to `LifecycleScope::Optional` (Priority: P1)
+
+Gradle's `compileOnly` configuration declares deps that are on the compile classpath but NOT the runtime classpath — semantically equivalent to Maven's `<optional>true</optional>` (deps required at compile time, not transitively exposed to runtime). In Gradle lockfiles, `compileOnly` deps appear on the `compileClasspath` configuration but are ABSENT from `runtimeClasspath`.
+
+Today mikebom's `read_gradle_lockfile` (at `gradle/lockfile.rs:38`) preserves the raw configs list as a `mikebom:gradle-configurations` annotation (a valuable transparency signal) but does NOT set `lifecycle_scope` for entries that appear only on compile-side configurations. Gradle projects with `compileOnly` deps thus emit them as Runtime edges by default, same as they would emit `implementation` deps — producing the same false-positive Runtime signal Maven's US1 case does.
+
+**Why this priority**: Gradle is the dominant Java build system for greenfield projects (Android by default, Kotlin by default, most modern JVM projects). Same pico filter-parity gap as US1 for the Java-Gradle user base.
+
+**Independent Test**: Scan a Gradle project whose `gradle.lockfile` has at least one entry appearing on `compileClasspath` but NOT on `runtimeClasspath`. Verify (a) the target gets `LifecycleScope::Optional` + `mikebom:optional-derivation = "gradle-compile-only"`, (b) CDX 1.6 emits `scope: "excluded"`, (c) SPDX 2.3 emits `OPTIONAL_DEPENDENCY_OF` under Full mode.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `gradle.lockfile` entry `org.example:compile-only-dep:1.0=compileClasspath,testCompileClasspath`, **When** mikebom emits SPDX 2.3 under Full mode, **Then** `compile-only-dep` MUST emit as source-side of `OPTIONAL_DEPENDENCY_OF` — NOT as plain `DEPENDS_ON`.
+2. **Given** the same scan, **When** mikebom emits CDX 1.6, **Then** `compile-only-dep` MUST carry `scope: "excluded"` + `mikebom:optional-derivation = "gradle-compile-only"`.
+3. **Given** a `gradle.lockfile` entry `org.example:runtime-dep:1.0=compileClasspath,runtimeClasspath`, **When** mikebom classifies, **Then** the target MUST continue to emit as Runtime (unchanged from pre-m184) — presence on BOTH compile AND runtime classpaths means the dep is transitive, not compile-only.
+4. **Given** a `gradle.lockfile` entry `org.example:runtime-only-dep:1.0=runtimeClasspath`, **When** mikebom classifies, **Then** the target MUST NOT be classified as Optional (it appears only on runtime, which is the Gradle `runtimeOnly` shape — semantically Runtime, not Optional; no derivation annotation).
+5. **Given** a `buildscript-gradle.lockfile` entry with the same compile-only shape, **When** mikebom classifies, **Then** the existing `LifecycleScope::Build` classification wins (buildscript deps are already build-time-only; Optional would double-classify — analogous to US1 acceptance 4 dev-wins-over-optional but for Build).
+
+---
+
+### Edge Cases
+
+- **Maven `<optional>true</optional>` inside a `<dependencyManagement>` block**: `<dependencyManagement>` declares default versions but does NOT introduce a dep edge — it's version-pinning metadata. m184 does NOT classify `<dependencyManagement>` entries as Optional; they remain unclassified until a real `<dependencies>` block references them, at which point the classifier fires for the real reference.
+- **Maven `<optional>true</optional>` on a `<scope>provided</scope>` dep**: Provided-scope deps are already classified as `LifecycleScope::Build` at `maven.rs:42`. Per Decision 2 (analogous to US1 acceptance 4), Build wins over Optional — the target emits as Build, no derivation annotation. Preserves the "one derivation per component" invariant.
+- **Maven inherited-optional via parent POM**: if a parent POM's `<dependencyManagement>` declares `<optional>true</optional>` for a coord, and a child POM references that coord in `<dependencies>` without overriding, the optional-flag inherits per POM spec. m184's initial delivery scope covers only the CHILD POM's explicit `<optional>` — inherited-optional resolution requires a full parent-POM resolver walk, deferred to a follow-up milestone. Documented as a Known Limitation.
+- **Gradle configs list absent (empty=... marker or missing configs)**: existing reader-level skip behavior preserved (line 68 skips `empty=...`). No m184 change to those code paths.
+- **Gradle deps on `compileClasspath` + `annotationProcessor` only** (a common shape for annotation-processor libs like Lombok): m184's initial delivery scope treats this as US2 Optional (compile-only shape). `annotationProcessor`-only presence without `compileClasspath` is a separate case (rare); classified as Optional in m184's initial delivery per the same shape rule. A follow-up milestone MAY add a dedicated `gradle-annotation-processor` derivation value if operator demand emerges.
+- **Gradle `testCompileOnly` + `testRuntimeOnly`**: these are test-scoped configurations. If a dep appears on `testCompileClasspath` but NOT `testRuntimeClasspath` (or vice versa), the test-scope classification wins — per acceptance 5 pattern extended to Test scope. Not m184's initial delivery focus; documented as covered by the general "test-scope-wins-over-optional" rule.
+- **Both formats present in the same project root** (a Gradle project with `pom.xml` for interop): each reader classifies independently. No cross-format precedence rule is needed because Maven and Gradle read from disjoint files.
+- **`--spdx2-relationship-compat=basic`**: all typed dep-scope edges collapse to natural-direction `DEPENDS_ON` per m228. Same as m179/m180/m181/m183.
+- **`--include-dev=false`**: `LifecycleScope::Optional` targets filter via `is_non_runtime()`, same as m179+ family.
+- **Legacy `build.gradle` / `build.gradle.kts` script parsing**: m184 scope is limited to LOCKFILE formats — `gradle.lockfile` for US2. Parsing the DSL scripts themselves (Groovy or Kotlin) requires either a Groovy/Kotlin parser or a Gradle plugin, both violate Constitution Principle I (no C via nested interpreters). Documented as OUT of m184 scope; the m106 US1 gradle DSL reader (if any) is unchanged.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `parse_pom_xml` function at `mikebom-cli/src/scan_fs/package_db/maven.rs:689` MUST extract the `<optional>` child element of `<dependency>` blocks. The `PomDependency` struct at line 578 MUST gain an `optional: bool` field defaulting to `false` when the element is absent or set to a non-`"true"` value.
+- **FR-002**: Downstream Maven classifier code paths that convert `PomDependency` into `PackageDbEntry` (or into `ResolvedComponent` via `depends_to_entries`-family functions) MUST set `lifecycle_scope = Some(LifecycleScope::Optional)` + insert `mikebom:optional-derivation = "maven-optional-element"` into `extra_annotations` when the source `PomDependency` has `optional = true` AND no more-specific NON-RUNTIME scope (Test via `<scope>test</scope>` or Build via `<scope>provided</scope>`) is already assigned per Decision 2 US1 acceptance 4 precedence. Default-runtime scopes (`compile` / `runtime` / `system` / `import` / absent, all mapping to `LifecycleScope::Runtime` per m052) DO NOT block the Optional override — see FR-005 for the full precedence table.
+- **FR-003**: The `read_gradle_lockfile` function at `mikebom-cli/src/scan_fs/package_db/gradle/lockfile.rs:38` MUST detect the "compile-only shape" per entry: presence of `compileClasspath` in the configs list AND absence of `runtimeClasspath`. When this shape is detected AND the entry's current `lifecycle_scope` is `None`, set `lifecycle_scope = Some(LifecycleScope::Optional)` + insert `mikebom:optional-derivation = "gradle-compile-only"` into `extra_annotations`.
+- **FR-004**: The Maven and Gradle sources MUST emit DISTINCT derivation-annotation values — `"maven-optional-element"` for Maven, `"gradle-compile-only"` for Gradle — because the underlying mechanisms are semantically distinct (POM `<optional>` element vs Gradle configuration composition). This differs from m180/m181/m183 which shared a single value per ecosystem family; the Java-family split reflects the C122 catalog docstring's existing separation.
+- **FR-005**: For Maven, when a `<dependency>` has BOTH `<optional>true</optional>` AND `<scope>test</scope>` OR `<scope>provided</scope>` (a more-specific non-Runtime scope per `lifecycle_scope_from_maven` at `maven.rs:36-48`): the scope-derived classification wins (Test / Build respectively); the derivation annotation MUST NOT be emitted. Analogous to m183 Decision 2 dev-wins-over-optional. **Explicitly**: `<scope>compile</scope>` / `<scope>runtime</scope>` / `<scope>system</scope>` / `<scope>import</scope>` / absent `<scope>` all map to `LifecycleScope::Runtime` per m052's classifier — these are the default-runtime scopes and DO NOT win over `<optional>true</optional>`. When any of them is combined with `<optional>true</optional>`, the classifier emits `LifecycleScope::Optional` + the derivation annotation (per the data-model.md §3 US1 decision matrix). Rationale: Maven's `<optional>` element is orthogonal to `<scope>` per POM 4.0.0 spec — a runtime-scoped optional dep is on the runtime classpath but NOT transitively exposed to consumers, which is the Optional semantic.
+- **FR-006**: For Gradle, when a `buildscript-gradle.lockfile` entry has the compile-only shape (per FR-003), the existing `LifecycleScope::Build` classification wins per acceptance 5 (buildscript deps are already build-time-only; layering Optional would double-classify).
+- **FR-007**: Under `--spdx2-relationship-compat=basic`, all new `OPTIONAL_DEPENDENCY_OF` emissions collapse to natural-direction `DEPENDS_ON` per m228's contract.
+- **FR-008**: The `--include-dev=false` filter MUST filter out `LifecycleScope::Optional` components alongside `Dev/Build/Test` via `is_non_runtime()` (inherited from m179's extension).
+- **FR-009**: The CDX 1.6 emission MUST show `scope: "excluded"` for every m184-classified `LifecycleScope::Optional` component — auto-inherited via the m179 `is_non_runtime()` extension.
+- **FR-010**: The SPDX 3.0.1 emission MUST NOT include a native `lifecycleScope: optional` value on any relationship (SPDX 3.0.1 has no such enum value per m179 FR-017); the annotation IS the SPDX 3 classification carrier.
+- **FR-011**: For scans that do NOT exercise the new Java signals (all non-Maven / non-Gradle fixtures + Maven fixtures without `<optional>` elements + Gradle fixtures without compile-only shape), the emitted CDX 1.6, SPDX 2.3, and SPDX 3.0.1 documents MUST be byte-identical to the pre-m184 baseline (regression guard, same shape as m180 FR-012 / m181 FR-011 / m183 FR-011).
+- **FR-012**: The existing maven regression tests (m085 dep-edges, m087 workspace-version fix, m130 US2 nested-JAR recursion) AND the existing Gradle lockfile regression tests (m106 US1 `configurations_recorded_in_annotation`) MUST continue to pass, allowing for additive changes on any test that would exercise `<optional>` or `compileOnly` shapes.
+- **FR-013**: The m184 changes MUST NOT introduce any new Cargo dependency. Existing `quick-xml` (Maven pom parsing) and stdlib string operations (Gradle configs list parsing) cover all needs.
+- **FR-014**: The C122 catalog docstring at `mikebom-cli/src/parity/extractors/cdx.rs:866` — which already lists `maven-optional-element` and `gradle-compile-only` as placeholder value-set entries — remains UNCHANGED text-wise; m184 lands the code paths that populate those values with real data.
+
+### Key Entities
+
+- **Component (`ResolvedComponent`)**: Reuses m179's `LifecycleScope::Optional` variant and the `mikebom:optional-derivation` annotation. Zero new types.
+- **`mikebom:optional-derivation` annotation**: Two new active values — `"maven-optional-element"` (US1) and `"gradle-compile-only"` (US2) — after m184. The C122 catalog value-set grows from 3 (post-m183: cargo, npm, pip) to 5 (post-m184: + maven + gradle). All flow through the same C122 `Directionality::SymmetricEqual` extractor registered in m179.
+- **`PomDependency` at `maven.rs:578`**: extended with `optional: bool` field, defaulting to `false`. Zero other field changes.
+- **Gradle configs list at `gradle/lockfile.rs:117`**: unchanged wire format (still emits `mikebom:gradle-configurations` annotation). The compile-only shape is inferred from the raw configs string via a new classifier helper.
+- **Shared classifier logic**: each reader classifies at construction time (analogous to m183 US1 poetry.rs pattern), not via a downstream post-pass. No shared helper file is introduced.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A scan of a Maven fixture with N `<optional>true</optional>` dep declarations (non-test-scope) MUST have the SET of maven-emitted PURLs marked `scope: "excluded"` in CDX 1.6 equal to the SET of PURLs appearing as source-side of any typed dep-scope relationship (`OPTIONAL_DEPENDENCY_OF` + existing `TEST_DEPENDENCY_OF` / `BUILD_DEPENDENCY_OF` if the reader marked them) in SPDX 2.3. Same pico filter-parity gate as m179/m180/m181/m183 SC-001, extended to Maven.
+- **SC-002**: Same set-equality gate for Gradle fixtures with compile-only shape.
+- **SC-003**: Zero mikebom regression fixture SPDX 2.3 golden files experience NET-DECREMENT in `*_DEPENDENCY_OF` edge counts pre-vs-post m184. Net-INCREMENT is expected on any maven fixture that exercises `<optional>true</optional>` (moves from `DEPENDS_ON` to `OPTIONAL_DEPENDENCY_OF`) and any gradle fixture with compile-only-shape entries.
+- **SC-004**: Zero drift in any mikebom CDX 1.6 golden file that does not exercise the new signals (regression guard on non-Java fixtures — same shape as m180 SC-003 / m181 SC-004 / m183 SC-005).
+- **SC-005**: Zero drift in any mikebom SPDX 3.0.1 golden file (m184 does not touch SPDX 3 emission per FR-010).
+- **SC-006**: Under `--spdx2-relationship-compat=basic`, Java goldens show zero new `OPTIONAL_DEPENDENCY_OF` edges — every optional-classified edge is natural-direction `DEPENDS_ON` (m228 escape hatch preserved).
+- **SC-007**: Existing maven regression tests (m085/m087/m130-US2 + parse_pom_xml unit tests) AND existing Gradle lockfile regression tests (m106 US1) MUST continue to pass, allowing for additive changes on any test that exercises `<optional>` / compile-only shapes.
+- **SC-008**: The `mikebom:optional-derivation` annotation MUST appear byte-identically in CDX 1.6, SPDX 2.3, and SPDX 3.0.1 output — value `"maven-optional-element"` for Maven-classified components, `"gradle-compile-only"` for Gradle-classified components — for every fixture that exercises the m184 classifications. C122 parity extractor (registered in m179) validates this automatically via `SymmetricEqual` polarity.
+- **SC-009**: Zero new production Cargo dependencies added to `mikebom-cli/Cargo.toml` — `cargo tree -p mikebom | wc -l` MUST be identical pre- vs post-m184.
+
+## Assumptions
+
+- Maven's `<optional>` element accepts the string values `"true"` and `"false"` per POM 4.0.0 spec. Other values (e.g., whitespace, other capitalization) are treated as `false` — the reader's `.eq_ignore_ascii_case("true")` guard is the canonical parse rule.
+- Gradle's compile-only shape is detected purely from the LOCKFILE's configs list — no DSL parsing. Deps appearing on `compileClasspath` (or `<subproject>_compileClasspath`, or `<sourceSet>_compileClasspath` for multi-source-set projects) AND absent from any `runtimeClasspath` variant are classified. The specific classpath-name-suffix pattern (`compileClasspath`, `testCompileClasspath`, `xyz_compileClasspath`) is matched via suffix-check, not exact match, so multi-source-set Gradle projects (Kotlin's `main`/`test`, Android's `debug`/`release`) are covered by construction.
+- The Maven and Gradle classifications are independent per project root — a Maven pom.xml and a gradle.lockfile in the same root each classify their own entries with no cross-format precedence rule. This differs from m183's lockfile-precedes-manifest rule (Decision 3) because Maven and Gradle read distinct file types, not competing views of the same source.
+- The m184 scope covers ROOT project's pom.xml + gradle.lockfile + buildscript-gradle.lockfile. Multi-module Maven reactors (pom.xml → child module poms via `<modules>`) and Gradle multi-project builds (settings.gradle → subproject build.gradle) each maintain per-module classification independence. m184 does NOT introduce a cross-module inheritance walk; a `<optional>true</optional>` in a parent POM's `<dependencyManagement>` does NOT propagate to child POM references (Known Limitation, documented in Edge Cases).
+- The C122 catalog docstring at `parity/extractors/cdx.rs:866` already documents `maven-optional-element` and `gradle-compile-only` as expected values since m179. m184 does NOT change the docstring — the values were pre-committed as placeholders; m184 makes them real.
+- Golden fixture regeneration (`MIKEBOM_UPDATE_{CDX,SPDX,SPDX3}_GOLDENS=1`) will show additive-only changes on any maven/gradle fixture that exercises the new signals. Existing fixtures may or may not include `<optional>` / compile-only shapes; drift on any pre-m184 golden is expected only when the fixture's underlying pom.xml or gradle.lockfile actually contains the classifiable signal. Non-Java goldens MUST show zero drift.
+- Legacy `build.gradle` / `build.gradle.kts` DSL parsing is OUT of m184 scope. Deferred until a broader "Gradle DSL introspection" workstream (if any); m184 covers only the LOCKFILE view. `build.gradle.kts` was covered by an unrelated milestone (m106 US1) for a different purpose (config recording); m184 does not extend that reader.
+- Maven's inherited-optional via parent POM `<dependencyManagement>` is OUT of m184 scope (Known Limitation documented in Edge Cases). Deferred until a full parent-POM resolver walk lands as a separate milestone.
+
+## Constitution Alignment
+
+**Principle V** (v1.4.0): Direct continuation of the m179+m180+m181+m183 KEEP-BOTH polarity. Native SPDX 2.3 `OPTIONAL_DEPENDENCY_OF` is the primary signal (elevated from the current `DEPENDS_ON`); the `mikebom:optional-derivation` annotation is the finer-grained supplement carrying WHICH Java-ecosystem construct produced the classification (Maven `<optional>` element or Gradle `compileOnly` configuration). Zero new `mikebom:*` invention — flows through the C122 catalog row m179 registered. No new Principle V audit surface.
+
+**Principle IX** (Accuracy): The pico filter-parity gap m179 closed for Go + Cargo, m180 for npm + pnpm, m181 for yarn v1 + Berry, m183 for pip / poetry / uv, now closes for the Java ecosystem — same measurable accuracy gain (SC-001, SC-002). Specifically corrects the silent misclassification path where Maven `<optional>true</optional>` and Gradle `compileOnly` deps emit as Runtime (misleading pico + other downstream consumers today).
+
+**Principle X** (Transparency): SBOM consumers can distinguish "this component was classified optional by a Java-ecosystem source" via the specific derivation value (`"maven-optional-element"` or `"gradle-compile-only"`) + `evidence.source_file_paths` field pointing at the specific `pom.xml` / `gradle.lockfile`. Two distinct values (not one merged) faithfully carry the mechanism the operator can audit.
+
+## Deferred to Future Milestones
+
+- **Inherited-optional resolution**: parent POM `<dependencyManagement>` propagation to child POM references. Requires the full parent-POM resolver walk (repository fetch + version resolution). Deferred until a broader Maven-resolver workstream lands.
+- **Legacy `build.gradle` / `build.gradle.kts` DSL parsing**: requires a Groovy or Kotlin parser, both violate Constitution Principle I. Deferred indefinitely.
+- **Gradle `annotationProcessor`-only shape**: dedicated derivation value `gradle-annotation-processor` (currently subsumed under `gradle-compile-only` when the entry also appears on `compileClasspath`; standalone `annotationProcessor`-only entries are rare in practice). Deferred until operator demand emerges.
+- **Sbt / Mill / Ant-Ivy optional-dep**: the JVM-ecosystem tail beyond Maven and Gradle. Follow-up milestones may cover these (m142 already handles sbt at the reader level; classification extension is a future scope).
+- **Multi-module Maven reactor cross-classification**: `<modules>`-based parent → child inheritance walk. m184 delivers per-module independence; cross-module walk is future scope.

--- a/specs/184-maven-gradle-optional/tasks.md
+++ b/specs/184-maven-gradle-optional/tasks.md
@@ -1,0 +1,178 @@
+# Tasks: Maven + Gradle optional-dependency classification (m184)
+
+**Feature**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md) · **Research**: [research.md](./research.md) · **Data model**: [data-model.md](./data-model.md)
+
+**Delivery slice** (per plan.md): both USs ship in one PR. Per-format independence (no shared code between the two readers) — either US could ship alone but the pattern is well-established (m179+ family). Estimated ~26 tasks across 5 phases.
+
+**Zero new production Cargo dependencies** — reuses m179's `LifecycleScope::Optional`, m180's `apply_lifecycle_scope_to_edges`, and the C122 parity extractor infrastructure verbatim. C122 docstring at `parity/extractors/cdx.rs:866` requires ZERO edit — both new values (`maven-optional-element`, `gradle-compile-only`) are already pre-committed as placeholders since m179.
+
+## Phase 1: Setup
+
+- [X] T001 Verify current branch is `184-maven-gradle-optional` and working tree is clean at `/Users/mlieberman/Projects/mikebom`; confirm base is main HEAD post-m183 merge (commit `f7f48a5` / `impl(183): pip / poetry / uv optional-dependency classification (#537)`)
+- [X] T002 Verify the m179/m180/m181/m183 helpers m184 will reuse exist and compile: `grep -n 'apply_lifecycle_scope_to_edges\|LifecycleScope::Optional' /Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/mod.rs` — expect the classifier at line 1261+ and the caller at line 805; also verify the C122 catalog row at `mikebom-cli/src/parity/extractors/mod.rs:545`; confirm the C122 docstring at `mikebom-cli/src/parity/extractors/cdx.rs:866` already lists `maven-optional-element` + `gradle-compile-only` as expected values via `grep -n 'maven-optional-element\|gradle-compile-only' /Users/mlieberman/Projects/mikebom/mikebom-cli/src/parity/extractors/cdx.rs` — expect two matches
+
+## Phase 2: User Story 1 — Maven `<optional>true</optional>` classification (P1)
+
+**Goal**: `<dependency>` blocks with `<optional>true</optional>` in `pom.xml` classify as `LifecycleScope::Optional` instead of the current silent-mis-classification as `Runtime`. Scope-derived classifications (Test / Build via `<scope>` element) win over optional per Decision 2.
+
+**Independent Test**: Scan a Maven project with at least one `<dependency>` having `<optional>true</optional>` and no explicit `<scope>` (or `<scope>compile</scope>`). Verify (a) target component gets `Optional` scope + `mikebom:optional-derivation = "maven-optional-element"`, (b) CDX emits `scope: "excluded"`, (c) SPDX 2.3 emits `OPTIONAL_DEPENDENCY_OF`.
+
+### 2a. Struct extension + parser handler
+
+- [X] T003 [US1] Extend the `PomDependency` struct at `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/package_db/maven.rs:578` with a new field `pub optional: bool`. Update the docstring above the struct (if any) to note the m184 origin. Do NOT default it via `#[derive(Default)]` — every construction site needs to be audited explicitly per T004
+- [X] T004 [US1] Audit + update every `PomDependency { .. }` construction site to initialize `optional: false` (the default). Grep pattern: `grep -rn 'PomDependency\s*{' /Users/mlieberman/Projects/mikebom/mikebom-cli/src/` — expect ONE production site at `maven.rs:798` (parse_pom_xml) + potentially other test-fixture sites throughout the test suite. Each site MUST initialize the new field
+- [X] T005 [US1] Extend `parse_pom_xml` walker at `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/package_db/maven.rs:689` with an `<optional>` element handler. Analogous to the existing `<scope>` / `<type>` handlers at lines 761-768: add a local `let mut dep_optional: Option<String> = None;` near the other `dep_*` locals, add `"optional" => dep_optional = Some(current_text.clone()),` to the match arm inside the `if parent == "dependency"` block, and at the `if popped == "dependency"` block (line 786), initialize the new field as `optional: dep_optional.take().map(|v| v.eq_ignore_ascii_case("true")).unwrap_or(false)`. Also clear `dep_optional = None;` in the else-branch fallback at line 813 (matches the pattern used for `dep_v`, `dep_scope`, `dep_type`)
+
+### 2b. Classifier extension
+
+- [X] T006 [US1] Modify `pom_dep_to_entry` at `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/package_db/maven.rs:2347` per data-model.md §3 US1 code block. Full transformation:
+    1. Replace the single line `lifecycle_scope: lifecycle_scope_from_maven(dep.scope.as_deref()),` at line 2399 with a `let (lifecycle_scope, is_m184_optional) = match (base_scope, dep.optional) { ... };` computation matching the data-model.md decision matrix.
+    2. Add a `mut extra_annotations` block before the `Some(PackageDbEntry {` construction: initialize as `Default::default()`, then if `is_m184_optional`, insert `mikebom:optional-derivation = "maven-optional-element"`.
+    3. Change the existing `extra_annotations: Default::default(),` line (line 2420) to `extra_annotations,` to consume the new variable.
+
+  Implementation guidance: mirror the m183 US1 poetry.rs pattern (annotation-at-push-time, no shared helper). The scope-wins-over-optional precedence (Decision 2) falls out naturally from the match structure: Test / Build match arms return `(scope, false)` — no annotation
+
+### 2c. Unit tests
+
+- [X] T007 [US1] Add 2 parser-level unit tests to `maven.rs::tests` (colocate with existing `parse_pom_xml` tests): `parse_pom_xml_extracts_optional_true` (inline pom.xml with `<optional>true</optional>` — verify `PomDependency.optional == true`), `parse_pom_xml_optional_false_or_absent_stays_false` (inline pom.xml with `<optional>false</optional>` on one dep, no `<optional>` on another — both `PomDependency.optional == false`). Reuse the existing `parse_pom_xml(bytes)` invocation pattern from tests around `maven.rs:2233` / `maven.rs:2518` / `maven.rs:3078`
+- [X] T008 [US1] Add 5 classifier-level unit tests to `maven.rs::tests` covering `pom_dep_to_entry`: `pom_dep_to_entry_optional_true_default_scope_classifies_as_optional` (US1 acceptance 1+2), `pom_dep_to_entry_optional_true_scope_test_stays_test` (US1 acceptance 4 + Decision 2 test-wins pin — verifies annotation is NOT emitted), `pom_dep_to_entry_optional_true_scope_provided_stays_build` (Decision 2 provided-wins pin), `pom_dep_to_entry_optional_false_stays_runtime` (US1 acceptance 3 regression pin), `pom_dep_to_entry_optional_absent_stays_runtime` (regression pin). Each test constructs a `PomDependency` value directly + calls `pom_dep_to_entry(&dep, &doc, source_path, include_dev, cache)` and asserts on the returned `PackageDbEntry.lifecycle_scope` + `extra_annotations`. Use `PomXmlDocument::default()` for the doc arg and `None` for the cache arg where applicable
+
+## Phase 3: User Story 2 — Gradle `compileOnly` classification (P1)
+
+**Goal**: `gradle.lockfile` entries with the compile-only shape (`*compileClasspath` present + `*runtimeClasspath` absent) classify as `LifecycleScope::Optional`. `buildscript-gradle.lockfile` entries preserve the existing `LifecycleScope::Build` classification per Decision 2 buildscript-wins.
+
+**Independent Test**: Scan a Gradle project whose `gradle.lockfile` has at least one entry `org.example:lombok:1.18.30=compileClasspath,testCompileClasspath` (or similar compile-only shape). Verify (a) target gets `Optional` scope + `mikebom:optional-derivation = "gradle-compile-only"` + preserves the existing `mikebom:gradle-configurations` annotation, (b) CDX emits `scope: "excluded"`, (c) SPDX 2.3 emits `OPTIONAL_DEPENDENCY_OF`.
+
+### 3a. Shape-detection helper
+
+- [X] T009 [US2] Add the `is_compile_only_shape` helper to `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/package_db/gradle/lockfile.rs` per data-model.md §3 US2 code block. Signature: `fn is_compile_only_shape(configs: &str) -> bool`. Suffix-check both `compileClasspath` and `runtimeClasspath` per Decision 3. Place adjacent to the existing `BUILDSCRIPT_FILENAME` const near line 33 for locality with other module-level helpers
+- [X] T010 [US2] Add 5 unit tests for `is_compile_only_shape` to the existing `gradle/lockfile.rs::tests` module (find via `grep -n '#\[cfg(test)\]\|^mod tests' /Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/package_db/gradle/lockfile.rs`): `is_compile_only_shape_detects_compile_only` (input `"compileClasspath,testCompileClasspath"` → true), `is_compile_only_shape_rejects_compile_and_runtime` (input `"compileClasspath,runtimeClasspath"` → false), `is_compile_only_shape_rejects_runtime_only` (input `"runtimeClasspath,testRuntimeClasspath"` → false), `is_compile_only_shape_detects_test_compile_only` (input `"testCompileClasspath"` alone → true per Decision 3 suffix-match), `is_compile_only_shape_detects_source_set_variants` (input `"main_compileClasspath,debug_compileClasspath"` → true — custom source set names)
+
+### 3b. Classifier extension in `read_gradle_lockfile`
+
+- [X] T011 [US2] Modify `read_gradle_lockfile` at `/Users/mlieberman/Projects/mikebom/mikebom-cli/src/scan_fs/package_db/gradle/lockfile.rs:38` per data-model.md §3 US2 code block. Change the `let lifecycle_scope = if is_buildscript { Some(LifecycleScope::Build) } else { None };` at lines 56-60 to consult `is_compile_only_shape` when not-buildscript:
+    ```rust
+    let lifecycle_scope = if is_buildscript {
+        Some(LifecycleScope::Build)
+    } else if is_compile_only_shape(configs_value) {
+        Some(LifecycleScope::Optional)
+    } else {
+        None
+    };
+    ```
+
+  Also insert the derivation annotation into `extra_annotations` at line 118 (where `mikebom:gradle-configurations` is inserted) — ONLY when the shape check fires AND `!is_buildscript` (per Decision 2 buildscript-wins guard). Order: `mikebom:gradle-configurations` first (preserves pre-m184 shape for consumers), `mikebom:optional-derivation` second when applicable
+
+  Note: `configs_value` is computed AFTER the `lifecycle_scope` decision in the current code flow. Refactor so the `is_compile_only_shape` check consumes `configs.trim()` — the raw string parsed off the `=`-split at line 71. Verify `cargo +stable check -p mikebom` compiles clean after this edit
+
+### 3c. Classifier unit tests
+
+- [X] T012 [US2] Add 3 classifier-level unit tests to `gradle/lockfile.rs::tests`: `read_gradle_lockfile_compile_only_classifies_as_optional` (US2 acceptance 1+2 end-to-end — write a temp `gradle.lockfile` with `com.example:lombok:1.18.30=compileClasspath,testCompileClasspath` + verify emitted entry has `LifecycleScope::Optional` + both annotations), `read_gradle_lockfile_buildscript_compile_only_stays_build` (US2 acceptance 5 + Decision 2 buildscript-wins pin — same shape but the file is `buildscript-gradle.lockfile` → classification stays `Build`, NO derivation annotation), `read_gradle_lockfile_runtime_stays_none` (regression pin: `compileClasspath,runtimeClasspath` shape stays pre-m184 unchanged — `lifecycle_scope == None`, NO derivation annotation)
+
+  Use the existing `read_gradle_lockfile(path)` API + `tempfile::tempdir()` seeding pattern to mirror the m106 US1 `configurations_recorded_in_annotation` test at ~line 260 for setup consistency
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+### 4a. Integration fixtures
+
+- [~] T013 [P] **Deferred to follow-up milestone**: external fixture directories (maven-optional + gradle-compile-only) are hosted in the sibling `mikebom-test-fixtures` repo per project memory `project_test_fixture_stayset`. Adding new fixture directories requires a cross-repo PR, deferred here per the m183 precedent. **Coverage replaced by**: (a) the m184 unit tests at `maven.rs::tests` (7 tests: 2 parser + 5 classifier), `gradle/lockfile.rs::tests` (8 tests: 5 helper + 3 classifier); (b) the existing maven/gradle fixture goldens' regen (T014-T016) — expected byte-identical drift unless the existing fixtures happen to contain m184 signals (`<optional>true</optional>` in the maven pom or `*compileClasspath` without `*runtimeClasspath` in the gradle lockfile), which the classifier will surface as additive-only changes
+- [~] T014 [P] **Deferred** — same rationale as T013. SC-002 gradle filter-parity signal is covered at unit-test level by `read_gradle_lockfile_compile_only_classifies_as_optional`
+
+### 4b. Golden regeneration (SC-003, SC-004, SC-005)
+
+- [X] T015 Regenerate CDX 1.6 goldens: `MIKEBOM_UPDATE_CDX_GOLDENS=1 cargo +stable test --workspace`. Expected drift: (a) additive changes on `maven.cdx.json` ONLY IF the existing fixture at `mikebom-cli/tests/fixtures/` (external repo) happens to include `<optional>true</optional>` on any `<dependency>` block — check the existing pom.xml fixture content; (b) additive changes on `bazel.cdx.json` if it contains any `<optional>` (bazel uses different toolchain semantics — unlikely to fire); (c) additive changes on any gradle-lockfile fixture that happens to include `*compileClasspath`-without-`*runtimeClasspath` entries; (d) ZERO drift on every non-Maven / non-Gradle golden (per SC-004). Verify (d) via `git diff --stat mikebom-cli/tests/fixtures/golden/cyclonedx/` post-regen — non-Java files MUST show `0 changed`
+- [X] T016 Regenerate SPDX 2.3 goldens: `MIKEBOM_UPDATE_SPDX_GOLDENS=1 cargo +stable test --workspace`. Expected drift: net-INCREMENT in `*_DEPENDENCY_OF` counts on maven / gradle goldens IF the underlying fixtures contain m184 signals; NET-DECREMENT MUST be zero on any golden per SC-003. Verify via `git diff` inspection
+- [X] T017 Regenerate SPDX 3.0.1 goldens: `MIKEBOM_UPDATE_SPDX3_GOLDENS=1 cargo +stable test --workspace`. Expected drift: additive changes on maven / gradle goldens IF underlying fixtures contain m184 signals; ZERO drift on non-Java goldens per FR-011 / SC-005
+
+### 4c. Documentation
+
+- [X] T018 Update `/Users/mlieberman/Projects/mikebom/docs/reference/reading-a-mikebom-sbom.md` — add `maven-optional-element` and `gradle-compile-only` entries to the derivation-value list, with the same shape as m183's `pip-optional-dependencies` entry (which added a sub-bulleted list covering three sources). Since Maven and Gradle emit DISTINCT values (per Decision 1), each gets its own paragraph:
+    - `maven-optional-element` — Maven `<dependency><optional>true</optional></dependency>` in `pom.xml` (POM 4.0.0 spec: transitive-exposure control)
+    - `gradle-compile-only` — Gradle `compileOnly` deps (compile-only shape in `gradle.lockfile`: `*compileClasspath` present + `*runtimeClasspath` absent)
+
+  Update the "Milestone" attribution paragraph to note m184 covers Maven + Gradle. Deferred Erlang/sbt lines shift to m185+/m186+ attribution
+
+### 4d. Verification gates
+
+- [X] T019 Run walker-audit allow-list check locally per project memory `feedback_walker_audit_local_check`: use the exact bash block from the m183 T021 body (grep + suffix-strip + diff against `mikebom-cli/src/scan_fs/walk.audit-allowlist.txt`) — m184 introduces ZERO new walker functions (all changes are Maven pom-parser + gradle-lockfile classifier + one new module-level helper `is_compile_only_shape`); expected exit 0
+- [X] T020 Run the mandatory pre-PR gate: `/Users/mlieberman/Projects/mikebom/scripts/pre-pr.sh` — MUST report `>>> all pre-PR checks passed.` before commit. Per project memory `feedback_prepr_gate_full_output`, capture the per-target `N passed; 0 failed` lines from the output as verification evidence
+
+### 4e. SC-008 C122 parity verification
+
+- [X] T021 [P] After T015-T017 land, verify SC-008: `mikebom:optional-derivation` values appear byte-identically across all three format goldens. Command: `for val in maven-optional-element gradle-compile-only; do echo "=== $val ==="; for fmt in cyclonedx/*.cdx.json spdx-2.3/*.spdx.json spdx-3/*.spdx3.json; do count=$(grep -c "\"$val\"" "/Users/mlieberman/Projects/mikebom/mikebom-cli/tests/fixtures/golden/$fmt" 2>/dev/null || echo "0"); echo "$fmt: $count"; done; done`. For each value, the per-fixture per-format count MUST be equal across all three formats (CDX / SPDX 2.3 / SPDX 3) — proves C122 SymmetricEqual propagation. Absent from all three is also fine (means no fixture exercised the signal); mismatched counts (present in one but not others) is a failure
+
+### 4f. FR-011 backward-compat pin
+
+- [X] T022 [P] After T015-T017 land, verify FR-011: `git diff --stat mikebom-cli/tests/fixtures/golden/` — every non-Maven / non-Gradle golden MUST show `0 changed`. Non-Java fixtures MUST be byte-identical to pre-m184 (SC-004 regression guard). If any non-Java golden shows drift, investigate immediately — likely indicates the m184 classifier is incorrectly firing outside the intended scope.
+    - **FR-008 sub-check** (per /speckit-analyze R2 finding U1): add a targeted unit test in `maven.rs::tests` and/or `gradle/lockfile.rs::tests` that scans a fixture (inline pom.xml or gradle.lockfile respectively) containing at least one m184-Optional-classified entry with `include_dev=false` passed through and asserts the Optional-classified target is FILTERED at emit time via m179's `is_non_runtime()` extension. Mirrors the m183 T024 R1 remediation pattern. This closes the /speckit-analyze U1 gap where FR-008 previously had no explicit test at the m184 layer. Placement suggestion: co-locate one test each in `pom_dep_to_entry_*` tests (US1) and `read_gradle_lockfile_*` tests (US2) — or, alternatively, an end-to-end integration test via `Command::new(env!("CARGO_BIN_EXE_mikebom"))` seeded with a tempdir fixture is equally acceptable
+
+### 4g. Filter-parity gates (SC-001, SC-002)
+
+- [X] T023 [P] Verify SC-001 set-equality for any maven fixture that exercised m184 (post-T015-T016). Extract the SET of PURLs marked `scope: "excluded"` in the maven CDX golden AND the SET of PURLs appearing as source-side of `OPTIONAL_DEPENDENCY_OF` / `TEST_DEPENDENCY_OF` / `BUILD_DEPENDENCY_OF` in the maven SPDX 2.3 golden. Set equality gate per m179/m180/m181/m183 SC-001. Skip this task if no maven golden shows drift post-regen (means no fixture exercised m184; unit-test level coverage in T008 is sufficient)
+- [X] T024 [P] Same set-equality verification for any gradle-lockfile fixture that exercised m184 (post-T015-T016). Skip if no gradle golden shows drift; unit-test level coverage in T012 is sufficient
+
+### 4h. SC-006 basic-mode preservation
+
+- [X] T025 [P] After T015-T017 land, verify SC-006 by running `cargo +stable test -p mikebom --test optional_dep_classification` — the existing m179 test suite covers basic-mode collapse for any component with `LifecycleScope::Optional`, inherited by m184 without new code. Expected: existing tests pass; no new test added because m184 doesn't touch emission code paths
+
+### 4i. FR-013 zero-new-dep verification
+
+- [X] T026 [P] Verify FR-013 (zero new production Cargo dependencies) explicitly per the m183 T029 pattern. Command: `git stash && cargo tree -p mikebom | wc -l > /tmp/m184-tree-pre.txt && git stash pop && cargo tree -p mikebom | wc -l > /tmp/m184-tree-post.txt && diff /tmp/m184-tree-pre.txt /tmp/m184-tree-post.txt`. Expected: identical line counts. If nonzero delta, investigate the added dep — expected to be zero because m184 only touches source files inside `mikebom-cli/src/scan_fs/package_db/{maven,gradle}/`; no `Cargo.toml` edit is proposed in any m184 task
+
+## Dependencies
+
+- **T001 → T002** (Setup) MUST complete before any other work.
+- **T003 → T004** (US1 struct + audit) — sequential because T004 depends on T003's field addition.
+- **T003 → T005** (US1 struct + parser) — T005 populates the field T003 added.
+- **T003 → T006** (US1 struct + classifier) — T006 consumes the field T003 added.
+- **T005 → T007** (US1 parser + parser tests) — sequential.
+- **T006 → T008** (US1 classifier + classifier tests) — sequential.
+- **T009 → T010** (US2 helper + helper tests) — sequential.
+- **T009 → T011** (US2 helper + classifier wiring) — sequential (classifier consumes helper).
+- **T011 → T012** (US2 classifier + classifier tests) — sequential.
+- **T013, T014** (integration fixtures) — deferred; no task-graph dependency.
+- **T015 → T016 → T017** (golden regens — sequential per project convention).
+- **T018** (docs) — independent, can land any time after T006 + T011.
+- **T019** (walker audit) — independent, can run any time.
+- **T020** (pre-PR gate) — requires ALL preceding tasks to have landed.
+- **T021, T022, T023, T024, T025, T026** (verification gates) — after T015-T017.
+
+## Parallel Execution Examples
+
+**Phase 2 (US1) can run entirely in parallel with Phase 3 (US2) — no shared code**:
+- US1 series: T003 → T004 → T005 → T006 → T007 → T008 (all touch `maven.rs`)
+- US2 series: T009 → T010 → T011 → T012 (all touch `gradle/lockfile.rs`)
+- The two series are file-independent and can be developed simultaneously by different implementers or in parallel commits
+
+**Phase 4 polish**:
+- T015 → T016 → T017 (golden regens) — sequential
+- T018 (docs), T019 (walker audit) — parallel with each other
+- T021-T026 (verification gates) — parallel with each other; must run AFTER T015-T017
+
+## Implementation Strategy
+
+**MVP scope (this milestone)**: Both USs + polish = 26 tasks. Both ship in one PR per plan.md. Per-format independence means either US could ship alone — but the pattern is established (m179+ cadence), so single-PR bundle is the target.
+
+**Recommended commit cadence** — ~5 small commits on the branch:
+1. T001-T002 (setup)
+2. T003-T008 (US1 Maven — struct + parser + classifier + 7 tests; grouped because they cumulatively edit `maven.rs`)
+3. T009-T012 (US2 Gradle — helper + classifier + 8 tests; grouped because they cumulatively edit `gradle/lockfile.rs`)
+4. T015-T018 (polish: goldens + docs)
+5. T019-T026 (verification + pre-PR)
+
+**Fallback** (if implementation surprises arise): US1 and US2 can land in separate commits or even separate PRs. Per-format independence makes the split trivial.
+
+## Success Criteria Coverage
+
+| SC | Gate | Task(s) |
+|----|------|---------|
+| SC-001 (Maven filter-parity) | US1 delivery + set-equality verification | T008 (unit), T015, T016, T023 (post-regen) |
+| SC-002 (Gradle filter-parity) | US2 delivery + set-equality verification | T012 (unit), T015, T016, T024 (post-regen) |
+| SC-003 (net-decrement zero) | Golden regen verification | T016, T022 |
+| SC-004 (non-Java CDX byte-identity) | Golden regen + FR-011 pin | T015, T022 |
+| SC-005 (non-Java SPDX 3 byte-identity) | Golden regen + FR-011 pin | T017, T022 |
+| SC-006 (basic-mode collapse) | Inherited from m179 test infra | T025 |
+| SC-007 (existing tests continue) | Pre-PR gate | T020 |
+| SC-008 (C122 byte-identity across formats) | Cross-format grep | T021 |
+| SC-009 (zero new Cargo dep) | `cargo tree` line-count diff | T026 |
+| FR-008 (`--include-dev=false` filters Optional) | Extended T022 assertion | T022 (post-analyze R2 update) |


### PR DESCRIPTION
## Summary

Extends the m179+m180+m181+m183 unified optional-dependency classification to the Java ecosystem's two dominant build systems. Both share the `LifecycleScope::Optional` variant + C122 annotation infrastructure, but emit **DISTINCT derivation values** — `"maven-optional-element"` (POM `<optional>` element = transitive-exposure control) and `"gradle-compile-only"` (classpath composition) — reflecting the mechanism-specific semantics.

### US1 — Maven `<optional>true</optional>` (P1)

`PomDependency` at `maven.rs:578` gains an `optional: bool` field; `parse_pom_xml` walker extracts the `<optional>` child element (case-insensitive parse per POM 4.0.0). `pom_dep_to_entry` classifier applies the scope-vs-optional decision matrix — `<scope>test</scope>` and `<scope>provided</scope>` win over Optional per Decision 2 (Test/Build classifications preserved, no derivation annotation). Default-Runtime scopes (`compile`/`runtime`/`system`/`import`/absent) + `<optional>true</optional>` → Optional + annotation. `<dependencyManagement>` entries are IGNORED.

### US2 — Gradle `compileOnly` shape inference (P1)

New `is_compile_only_shape` helper detects the wire signature: `*compileClasspath` present AND `*runtimeClasspath` absent. Suffix-match covers main set (lowercase `compileClasspath`), test set (`testCompileClasspath`), and all compound source sets (`debugCompileClasspath` for Android, `<name>CompileClasspath` for Kotlin/user-declared). `buildscript-gradle.lockfile` entries preserve `Build` classification (Decision 2 buildscript-wins). Pre-existing `mikebom:gradle-configurations` annotation preserved alongside.

## Verification

- **Pre-PR gate**: `>>> all pre-PR checks passed.` — clippy `-D warnings` clean, workspace test suite green
- **Golden regen**: **zero drift** across all 33 CDX/SPDX 2.3/SPDX 3 goldens — SC-004/SC-005 confirmed (existing maven/gradle fixtures don't exercise m184 signals)
- **FR-013 zero-new-dep**: `cargo tree -p mikebom | wc -l` identical pre/post (1131 lines both)
- **Walker audit**: OK
- **Zero regressions** on 117 existing maven + gradle tests
- **16 new unit tests + 1 FR-008 R2 boundary pin**:
  - 7 in `maven.rs` (2 parser + 5 classifier)
  - 8 in `gradle/lockfile.rs` (5 helper + 3 classifier)
  - 1 FR-008 boundary pin verifying `LifecycleScope::Optional.is_non_runtime() == true`

## Design decisions locked in (research.md)

1. **Two distinct derivation values** — Java-family gets TWO values (not one merged like m180/m181/m183). Reflects semantic distinction between POM `<optional>` element and Gradle `compileOnly` configuration. Both pre-committed as placeholders in the C122 docstring since m179 — m184 activates them without touching the docstring. Value-set: 3 → 5 (cargo, npm, pip + maven + gradle).
2. **Scope-wins-over-optional** (both USs) — Test/Build (Maven) and Build (Gradle buildscript) classifications win. Preserves one-derivation-per-component invariant.
3. **Suffix-based Gradle shape detection** — covers multi-source-set + Android/Kotlin projects by construction.
4. **Per-format independence** — no cross-format precedence rule (differs from m183 Decision 3). Maven and Gradle read disjoint file types.

## Bug caught during TDD

Initial `is_compile_only_shape` helper used case-sensitive suffix match on `"compileClasspath"` — this missed Gradle's CamelCase compound-set naming convention (`testCompileClasspath`, `debugCompileClasspath` have capital `C`). T010 test failure surfaced this immediately. Fixed to match either exact `"compileClasspath"` (main set) OR `.ends_with("CompileClasspath")` (compound sets), plus a symmetric `"RuntimeClasspath"` check.

## Deferred to a follow-up milestone

**T013-T014** — external fixture directories at `mikebom-test-fixtures/maven/optional/` and `mikebom-test-fixtures/gradle/compile-only/`. Would require a cross-repo PR to the sibling fixture repo. SC-001/SC-002 filter-parity coverage is provided at unit-test level.

Also deferred (spec.md):
- Inherited-`<optional>` via parent POM `<dependencyManagement>` — needs full resolver walk
- Legacy `build.gradle` / `build.gradle.kts` DSL parsing — needs Groovy/Kotlin parser (Principle I violation)
- Gradle `annotationProcessor`-only dedicated derivation value
- sbt / Mill / Ant-Ivy (JVM tail)

## Constitution alignment

All 12 principles PASS:
- **Principle I (Pure Rust, Zero C)**: zero new Cargo deps
- **Principle IV (Type-Driven)**: `PomDependency.optional: bool` typed at struct definition
- **Principle V (Native-first + KEEP-BOTH)**: native SPDX 2.3 `OPTIONAL_DEPENDENCY_OF` primary; distinct-value derivation annotations as KEEP-BOTH supplement
- **Principle VI (Three-Crate Architecture)**: all changes confined to `mikebom-cli/src/scan_fs/package_db/`
- **Principle IX (Accuracy)**: US1 + US2 both correct silent misclassification paths
- **Principle X (Transparency)**: distinct-values design faithfully identifies WHICH mechanism produced the classification

## Test plan
- [x] `./scripts/pre-pr.sh` clean
- [x] All 3 golden families regenerated — zero drift
- [x] Walker-audit allow-list check: OK
- [x] `cargo tree -p mikebom | wc -l` pre/post identical
- [x] 16 new unit tests + 1 FR-008 boundary pin pass
- [ ] Post-merge: external fixture directories via follow-up cross-repo PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)