### PR TITLE
fix(189): bun.lock JSONC parser must strip trailing commas (#555)

### DIFF
--- a/mikebom-cli/src/scan_fs/package_db/npm/jsonc.rs
+++ b/mikebom-cli/src/scan_fs/package_db/npm/jsonc.rs
@@ -1,33 +1,52 @@
-//! JSONC (JSON with Comments) stripper — milestone 106 phase 2A.
+//! JSONC (JSON with Comments) stripper — milestone 106 phase 2A;
+//! extended in milestone 189 (#555) to also strip trailing commas.
 //!
 //! Used by the Bun lockfile reader (`bun.lock`) which is JSONC-formatted
 //! per Bun 1.2+. Every real-world `bun.lock` carries at least the
 //! top-of-file `// bun: lockfileVersion: 1` marker comment that
-//! `serde_json::from_str` rejects.
+//! `serde_json::from_str` rejects AND (per Fable5's 2026-07-13 audit
+//! finding) trailing commas inside `packages` map objects that trigger
+//! silent parser rejection + entire-resolved-tree truncation. Pre-m189
+//! bug: 282 components emitted instead of 1584 for the same repo.
 //!
 //! Behavior:
 //! - Strips `// ... \n` line comments and `/* ... */` block comments.
+//! - Strips trailing commas: `,` immediately preceding (post-whitespace)
+//!   `]` or `}`, both at top level and nested. Only outside string
+//!   literals.
 //! - Preserves newlines from stripped comments as `\n` so
 //!   `serde_json`'s line/column error positions stay accurate.
 //! - String literal contents are PRESERVED verbatim — comment markers
-//!   inside `"..."` strings are NOT stripped.
+//!   and commas inside `"..."` strings are NOT stripped.
 //!
 //! Pattern mirrors `gem::strip_ruby_comment` and
 //! `golang::legacy::strip_line_comment` (single-line strippers already
-//! in mikebom). This helper extends those with block-comment + string-
-//! boundary awareness.
+//! in mikebom). This helper extends those with block-comment +
+//! string-boundary awareness + trailing-comma stripping.
 
-/// Strip C-style line comments (`//`) and block comments (`/* */`) from
-/// a JSONC source string, returning a String suitable for passing to
-/// `serde_json::from_str`.
+/// Strip C-style line comments (`//`), block comments (`/* */`), AND
+/// trailing commas from a JSONC source string, returning a String
+/// suitable for passing to `serde_json::from_str`.
 ///
-/// String-literal contents are preserved verbatim — comments inside
-/// `"..."` strings are NOT stripped.
+/// String-literal contents are preserved verbatim — comments and
+/// commas inside `"..."` strings are NOT stripped.
 ///
 /// Newlines from `//` and `/* */` are preserved as `\n` so line/column
 /// info in serde_json error messages still points at correct positions.
+///
+/// Trailing-comma pass added in milestone 189 (#555) — every real-world
+/// `bun.lock` produced by Bun 1.2+ has trailing commas inside its
+/// `packages` map, causing pre-m189 silent parser rejection + resolved-
+/// tree truncation.
 #[allow(dead_code)] // wired by US2 (T024); see milestone 106 plan
 pub(super) fn strip_comments(input: &str) -> String {
+    let after_comments = strip_comments_only(input);
+    strip_trailing_commas(&after_comments)
+}
+
+/// Pre-m189 behavior — comment stripping only. Kept as a private helper
+/// so the two passes remain independently testable.
+fn strip_comments_only(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let bytes = input.as_bytes();
     let mut state = State::Normal;
@@ -96,6 +115,78 @@ enum State {
     InString,
     LineComment,
     BlockComment,
+}
+
+/// Strip trailing commas from JSONC input — `,` immediately followed
+/// (past whitespace) by `]` or `}` is removed. String-literal contents
+/// are preserved verbatim.
+///
+/// Milestone 189 (#555) — fix for Fable5's audit finding that mikebom
+/// silently truncated bun.lock parses to manifest-tier only (282
+/// components vs 1584 for the full transitive graph).
+fn strip_trailing_commas(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = String::with_capacity(bytes.len());
+    let mut state = TrailingState::Normal;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match state {
+            TrailingState::Normal => {
+                if b == b'"' {
+                    out.push('"');
+                    state = TrailingState::InString;
+                    i += 1;
+                } else if b == b',' {
+                    // Peek forward past whitespace to see if the next
+                    // non-whitespace byte is `]` or `}`. If so, drop
+                    // the comma.
+                    let mut j = i + 1;
+                    while j < bytes.len() && is_json_whitespace(bytes[j]) {
+                        j += 1;
+                    }
+                    if j < bytes.len() && (bytes[j] == b']' || bytes[j] == b'}') {
+                        // Drop the comma — preserve the whitespace
+                        // between it and the closer so error line/column
+                        // info stays accurate.
+                        i += 1;
+                    } else {
+                        out.push(',');
+                        i += 1;
+                    }
+                } else {
+                    out.push(b as char);
+                    i += 1;
+                }
+            }
+            TrailingState::InString => {
+                if b == b'\\' && i + 1 < bytes.len() {
+                    out.push(b as char);
+                    out.push(bytes[i + 1] as char);
+                    i += 2;
+                } else if b == b'"' {
+                    out.push('"');
+                    state = TrailingState::Normal;
+                    i += 1;
+                } else {
+                    out.push(b as char);
+                    i += 1;
+                }
+            }
+        }
+    }
+    out
+}
+
+#[derive(Copy, Clone, Debug)]
+enum TrailingState {
+    Normal,
+    InString,
+}
+
+/// JSON whitespace per RFC 8259 §2 — space, tab, LF, CR.
+fn is_json_whitespace(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\n' | b'\r')
 }
 
 #[cfg(test)]
@@ -169,5 +260,83 @@ mod tests {
     #[test]
     fn empty_input() {
         assert_eq!(strip_comments(""), "");
+    }
+
+    // ── Milestone 189 (#555) — trailing-comma stripping ──
+
+    #[test]
+    fn strips_trailing_comma_before_close_brace() {
+        let input = r#"{"a": 1, "b": 2,}"#;
+        let out = strip_comments(input);
+        // Trailing comma before `}` removed.
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["a"], serde_json::json!(1));
+        assert_eq!(parsed["b"], serde_json::json!(2));
+    }
+
+    #[test]
+    fn strips_trailing_comma_before_close_bracket() {
+        let input = r#"[1, 2, 3,]"#;
+        let out = strip_comments(input);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed, serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn strips_trailing_commas_with_whitespace_between() {
+        let input = "{\n  \"a\": 1,\n  \"b\": 2  ,\n\n}";
+        let out = strip_comments(input);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["a"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn does_not_strip_comma_inside_string() {
+        let input = r#"{"key": "a,b,c,","other": 1}"#;
+        let out = strip_comments(input);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["key"], serde_json::json!("a,b,c,"));
+    }
+
+    #[test]
+    fn does_not_strip_non_trailing_commas() {
+        // Comma between elements MUST be preserved.
+        let input = r#"[1, 2, 3]"#;
+        assert_eq!(strip_comments(input), "[1, 2, 3]");
+    }
+
+    #[test]
+    fn bun_lock_realistic_snippet_parses() {
+        // Real-world bun.lock shape — comment + trailing commas at
+        // multiple nesting levels.
+        let input = r#"// bun: lockfileVersion: 1
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "myapp",
+      "dependencies": {
+        "lodash": "4.17.21",
+      },
+    },
+  },
+  "packages": {
+    "lodash": ["lodash@4.17.21", "sha512-abc"],
+  },
+}
+"#;
+        let out = strip_comments(input);
+        let parsed: serde_json::Value = serde_json::from_str(&out)
+            .expect("bun.lock realistic snippet should parse after strip");
+        assert_eq!(parsed["lockfileVersion"], serde_json::json!(1));
+        assert!(parsed["packages"]["lodash"].is_array());
+    }
+
+    #[test]
+    fn nested_trailing_commas_all_stripped() {
+        let input = r#"{"outer":{"inner":[1,2,],},}"#;
+        let out = strip_comments(input);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["outer"]["inner"], serde_json::json!([1, 2]));
     }
 }

--- a/mikebom-cli/tests/scan_bun_lock.rs
+++ b/mikebom-cli/tests/scan_bun_lock.rs
@@ -86,3 +86,98 @@ fn bun_lock_basic_fixture_emits_npm_components() {
         "expected URL-encoded @mikebom-fixture/types-pkg in output; got: {npm_purls:?}",
     );
 }
+
+/// Milestone 189 (#555) — regression test for Fable5's 2026-07-13 audit
+/// finding: bun.lock with trailing commas (which every real Bun 1.2+
+/// output has) MUST parse cleanly rather than silently truncating to
+/// manifest-tier only. Pre-m189 bug produced 282 components instead of
+/// 1584 on a typical bun project.
+#[test]
+fn bun_lock_with_trailing_commas_parses_and_emits_components() {
+    // Fabricate a bun.lock with trailing commas at multiple nesting
+    // levels — matches the shape Fable5 observed in real-world files.
+    let bun_lock_content = r#"// bun: lockfileVersion: 1
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "m189-trailing-comma-fixture",
+      "dependencies": {
+        "mikebom-fixture-lib": "1.2.3",
+        "@mikebom-fixture/types-pkg": "4.5.6",
+      },
+    },
+  },
+  "packages": {
+    "mikebom-fixture-lib": ["mikebom-fixture-lib@1.2.3", "sha512-abc"],
+    "@mikebom-fixture/types-pkg": ["@mikebom-fixture/types-pkg@4.5.6", "sha512-def"],
+  },
+}
+"#;
+
+    let workdir = tempfile::tempdir().expect("workdir tempdir");
+    let fake_home = tempfile::tempdir().expect("fake-home tempdir");
+    let scan_root = workdir.path().join("project");
+    std::fs::create_dir_all(&scan_root).expect("mkdir project");
+    std::fs::write(scan_root.join("bun.lock"), bun_lock_content).expect("write bun.lock");
+    // Sibling package.json so the manifest-tier reader also sees the deps.
+    let pkg_json = r#"{
+  "name": "m189-trailing-comma-fixture",
+  "version": "0.1.0",
+  "dependencies": {
+    "mikebom-fixture-lib": "1.2.3",
+    "@mikebom-fixture/types-pkg": "4.5.6"
+  }
+}
+"#;
+    std::fs::write(scan_root.join("package.json"), pkg_json).expect("write package.json");
+    let out_path = workdir.path().join("sbom.cdx.json");
+
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    cmd.env("MIKEBOM_FIXED_TIMESTAMP", "2026-01-01T00:00:00Z");
+    cmd.args([
+        "--offline",
+        "sbom",
+        "scan",
+        "--path",
+        scan_root.to_str().unwrap(),
+        "--format",
+        "cyclonedx-json",
+        "--output",
+        out_path.to_str().unwrap(),
+    ]);
+    let output = cmd.output().expect("spawn mikebom");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "bun.lock scan with trailing commas failed: stderr={stderr}"
+    );
+
+    // Critical: verify mikebom did NOT emit a bun.lock parse-failure
+    // WARN (that'd mean we're still silently falling back to
+    // manifest-tier).
+    assert!(
+        !stderr.contains("bun.lock JSONC parse failed"),
+        "trailing-comma bun.lock triggered the m189-fixed parse-failure WARN: stderr={stderr}"
+    );
+
+    let bytes = std::fs::read(&out_path).expect("read emitted SBOM");
+    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("parse JSON");
+    let components = json["components"]
+        .as_array()
+        .expect("components array present");
+    let npm_purls: Vec<&str> = components
+        .iter()
+        .filter_map(|c| c["purl"].as_str())
+        .filter(|p| p.starts_with("pkg:npm/"))
+        .collect();
+    assert!(
+        npm_purls.contains(&"pkg:npm/mikebom-fixture-lib@1.2.3"),
+        "expected mikebom-fixture-lib from bun.lock in output; got: {npm_purls:?}"
+    );
+    assert!(
+        npm_purls.contains(&"pkg:npm/%40mikebom-fixture/types-pkg@4.5.6"),
+        "expected scoped fixture package from bun.lock in output; got: {npm_purls:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes Fable5's 2026-07-13 audit finding: mikebom's bun.lock parser silently rejected the file on the first trailing comma, causing the entire resolved dependency tree to be dropped and the manifest-tier reader to take over. On a real bun repo the pre-fix SBOM contained **282 components** from manifests only; post-fix (with trailing commas manually stripped) regeneration produced **1584 components** with the complete transitive graph — a ~5.6x truncation that was going unreported.

Root cause: `strip_comments` in `mikebom-cli/src/scan_fs/package_db/npm/jsonc.rs` handled `//` and `/* */` comments but not trailing commas. `serde_json::from_str` is strict; the bun.lock parser fell through to `None` on any trailing comma, logged a WARN, and moved on. Since bun 1.2+ ALWAYS produces trailing commas in its `packages` map, every bun shop scanning with mikebom was getting direct-deps-only coverage.

## Fix

Composed a new `strip_trailing_commas` pass after the existing comment stripping. State machine tracks `Normal` vs `InString` so commas inside `\"...\"` are never touched. Only removes `,` immediately preceding `]` or `}` past whitespace.

## Test plan
- [x] 7 new unit tests in `jsonc::tests` + 10 pre-existing pass — trailing-comma cases at every nesting level, string preservation, realistic bun.lock snippet
- [x] New integration test `bun_lock_with_trailing_commas_parses_and_emits_components` fabricates a bun.lock with trailing commas at multiple levels; asserts (a) scan succeeds, (b) pre-m189 `bun.lock JSONC parse failed` WARN log is absent, (c) both fixture packages emit as `pkg:npm/` components
- [x] Existing `bun_lock_basic_fixture_emits_npm_components` still passes (no drift)
- [x] `cargo +stable clippy --workspace --all-targets -- -D warnings` — clean
- [x] `./scripts/pre-pr.sh` — green
- [x] SC-007 zero-new-deps: `cargo tree --workspace | wc -l` = 1136 pre/post

## Constitution alignment

- **Principle III (Fail Closed)**: pre-m189 was a silent fall-through — parser rejects, reader returns `None`, no operator-visible signal. Post-m189, well-formed JSONC bun.lock files parse cleanly; malformed content still triggers the existing WARN + fall-through.
- **Principle IX (Accuracy)**: closes a ~5.6x accuracy gap on typical bun repos.

Closes #555. Reported by Fable5 audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)