### PR TITLE
fix(192): pre-rewrite dropped-mainmod edges BEFORE graph-completeness runs

### DIFF
--- a/mikebom-cli/src/generate/cyclonedx/builder.rs
+++ b/mikebom-cli/src/generate/cyclonedx/builder.rs
@@ -478,13 +478,58 @@ impl CycloneDxBuilder {
                 effective_components,
             );
 
-        let metadata_relationships_augmented: Vec<Relationship> = relationships
+        // Milestone 192 — pre-rewrite dropped-main-module relationships
+        // BEFORE the classifier runs. When operator-override drops a
+        // native main-module (e.g., `--root-name X` on a Go source scan
+        // that had `pkg:golang/github.com/example/foo` as its detected
+        // mainmod), the mainmod's outgoing DependsOn edges are still in
+        // `relationships` with `.from = <dropped-purl>`. The m086 rewrite
+        // block below re-anchors those edges onto `target_ref`; without
+        // running that rewrite here, `compute_graph_completeness` sees
+        // stale edges pointing FROM components that no longer exist in
+        // `effective_components`, and BFS from the operator's synthetic
+        // target_ref can't reach the transitive Go/npm/etc. deps that
+        // used to hang off the dropped mainmod. Pre-m192 this manifested
+        // as `partial: multi-ecosystem-partial-root: <eco>`; post-m192
+        // (post-bfs.rs fix) it manifested as `partial: orphaned-
+        // components-detected: N` because the m192 synthesis empties
+        // ecosystems_without_root but doesn't rebuild the transitive
+        // reachability from target_ref.
+        //
+        // Fix: apply the m086 rewrite eagerly so the classifier operates
+        // on the same edge topology that build_dependencies (line 626)
+        // will emit. Reuse `dropped_main_module_purls` computed above.
+        let m192_prerewritten_relationships: Vec<Relationship> =
+            if !dropped_main_module_purls.is_empty() {
+                let dropped: std::collections::HashSet<&str> = dropped_main_module_purls
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect();
+                relationships
+                    .iter()
+                    .map(|r| {
+                        if dropped.contains(r.from.as_str()) {
+                            Relationship {
+                                from: target_ref.clone(),
+                                to: r.to.clone(),
+                                relationship_type: r.relationship_type.clone(),
+                                provenance: r.provenance.clone(),
+                            }
+                        } else {
+                            r.clone()
+                        }
+                    })
+                    .collect()
+            } else {
+                relationships.to_vec()
+            };
+        let metadata_relationships_augmented: Vec<Relationship> = m192_prerewritten_relationships
             .iter()
             .cloned()
             .chain(m158_workspace_peer_edges.iter().cloned())
             .collect();
 
-        // FR-008 multi-root BFS on the AUGMENTED graph.
+        // FR-008 multi-root BFS on the AUGMENTED + REWRITTEN graph.
         let graph_completeness =
             crate::generate::graph_completeness::compute_graph_completeness(
                 effective_components,


### PR DESCRIPTION
## Summary

Follow-up to m192 (#569 / commit 14a7073). **The m192 bfs.rs fix alone was insufficient for real-world scans.** I validated m192 against a synthetic 2-component Go project which bypassed the actual customer bug shape. On the Kusari pico test corpus (353 components, real Go+npm mainmod detection + operator override), the classifier STILL reported `partial` — reason code changed from `multi-ecosystem-partial-root` to `orphaned-components-detected: 276`, but value stayed `partial`.

**Apologies for shipping the incomplete fix in alpha.61.** This PR completes it.

## Root cause (second layer)

When `--root-name X` is passed against a project where mikebom detected native Go/npm mainmod components, those mainmod components are DROPPED from `effective_components` by `apply_main_module_drop_or_demote`. BUT the pre-emission `Relationship` vector still contains 91+ DependsOn edges whose `.from` is the dropped mainmod's PURL.

The m086 rewrite block at `builder.rs:578-602` re-anchors those edges onto `target_ref` — but that block ran AFTER `compute_graph_completeness` at line 488. The classifier saw the STALE edges pointing FROM the dropped mainmod, but its BFS seed set contained `pico@2c2f9719` (the operator's synthetic target_ref). BFS couldn't traverse from `pico@2c2f9719` through those stale edges to reach the transitive graph.

## Fix

Add an m192-specific pre-rewrite pass at `builder.rs:487-528` that mirrors the m086 rewrite logic BEFORE the classifier runs. The classifier now operates on the same edge topology that `build_dependencies` (m086's original site) later emits, so BFS reachability matches wire-format reachability.

## Verification against the Kusari pico corpus

| Scenario | Reachable | Orphans | Value |
|---|---|---|---|
| Native scan (no `--root-name`) | 278 | 63 | partial |
| `--root-name pico` — **THIS FIX** | 276 | 63 | partial |
| `--root-name pico` — pre-fix (alpha.61) | 63 | 276 | partial |
| `--root-name pico` — pre-m192 (alpha.60) | 63 | 276 | partial (with `multi-ecosystem-partial-root`) |

The 2-component delta between native and operator-override equals the 2 dropped mainmods. Otherwise IDENTICAL reachability. **Fix restores parity between operator-override and native scans.**

## About the remaining 63 orphans

They're PRE-EXISTING and affect native scans equally. Mostly npm sub-workspace transitives (`chalk`, `commander`, `debug`, `extract-pg-schema`, `stdlib`) that mikebom emits but has no dep-graph edges for. Fixing them is outside this scope — will file as a separate issue for a subsequent milestone.

Consumers who want a fully-complete signal for pico-style repos should scan without `--root-name` (which reaches 278) OR after m193/m194 addresses the npm sub-workspace graph gap.

## Test plan

- [x] Full workspace regression suite (37 tests including cdx/spdx/spdx3 across 11 ecosystems) — byte-identical, zero drift
- [x] All 4 m192 integration tests still pass unchanged
- [x] Manual pico reproduction: `--root-name pico --root-version 2c2f9719` post-fix → 276 reachable / 63 orphans (was 63/276 pre-fix)
- [x] `cargo +stable clippy --workspace --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)