### PR TITLE
impl(207): --no-deps-dev aggregate — disable BOTH license + dep-graph paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,8 @@ Auto-generated from all feature plans. Last updated: 2026-07-17
 - N/A — all state in-process per scan; the activated-deps set is computed once per workspace and lives for the classifier decision only. (205-cargo-optional-feature-resolve)
 - Rust stable (workspace toolchain inherited from milestones 001–205; no nightly). + Existing only — (206-podman-source)
 - N/A — all state in-process per scan; scratch tarball lives in a `tempfile::tempdir()` for the duration of the scan and is dropped at return. (206-podman-source)
+- Rust stable (workspace toolchain inherited from milestones 001–206; no nightly). + Existing only — `clap` (workspace, `Args` derive picks up the new flag), `tracing` (workspace, FR-006 WARN log). **Zero new Cargo dependencies.** (207-no-deps-dev-aggregate)
+- N/A — CLI-flag semantic change; no state, no persistence. (207-no-deps-dev-aggregate)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -332,9 +334,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 207-no-deps-dev-aggregate: Added Rust stable (workspace toolchain inherited from milestones 001–206; no nightly). + Existing only — `clap` (workspace, `Args` derive picks up the new flag), `tracing` (workspace, FR-006 WARN log). **Zero new Cargo dependencies.**
 - 206-podman-source: Added Rust stable (workspace toolchain inherited from milestones 001–205; no nightly). + Existing only —
 - 205-cargo-optional-feature-resolve: Added Rust stable (workspace toolchain inherited from milestones 001–204; no nightly). + Existing only — `serde` / `serde_json` (parsing cargo metadata JSON output; workspace-pervasive), `std::process::Command` (subprocess spawn, same pattern as m053 / m055 / m173 / m203), `tracing` (WARN log per FR-004), `anyhow` / `thiserror` (error propagation). **Zero new Cargo dependencies.** No new subprocess types beyond the existing `Command`-with-timeout pattern; no network access; no filesystem writes beyond emitted SBOM output.
-- 204-helm-completeness-annotation: Added Rust stable (workspace toolchain inherited from milestones 001–203; no nightly). + Existing only — `serde`/`serde_json` (annotation values + m071 envelope construction), `tracing`, `anyhow`. **Zero new Cargo dependencies.** No subprocess calls. No network access. No filesystem writes beyond emitted SBOM output.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mikebom-cli/src/cli/scan_cmd.rs
+++ b/mikebom-cli/src/cli/scan_cmd.rs
@@ -590,13 +590,35 @@ pub struct ScanArgs {
     #[arg(long)]
     pub no_clearly_defined: bool,
 
-    /// Skip deps.dev license enrichment. Keeps ClearlyDefined and
-    /// dep-graph enrichment active. This is the fastest enrichment
-    /// source and rarely needs skipping; the allowlist via
-    /// `--enrich-sources` is the alternative for full control.
-    /// Has no effect when `--offline` is set.
+    /// Milestone 207 (#596): AGGREGATE disable — skip BOTH the
+    /// deps.dev license enrichment AND the deps.dev transitive
+    /// dep-graph enrichment. Combines `--no-deps-dev-license` and
+    /// `--no-deps-dev-graph` semantics per operator expectation.
+    ///
+    /// Pre-m207 this flag disabled only the license path (keeping
+    /// the dep-graph active). Scripts that relied on that behavior
+    /// can migrate by renaming to `--no-deps-dev-license`.
+    ///
+    /// Composition: `--no-deps-dev` (aggregate) OR
+    /// `--no-deps-dev-license` (license only) OR
+    /// `--no-deps-dev-graph` (graph only). Fine-grained flags allow
+    /// surgical control. `--enrich-sources <list>` (allowlist mode)
+    /// overrides all `--no-*` flags. `--offline` suppresses all
+    /// enrichment paths regardless of `--no-*` flags.
     #[arg(long)]
     pub no_deps_dev: bool,
+
+    /// Milestone 207 (#596) — skip deps.dev LICENSE enrichment
+    /// only. Keeps the deps.dev transitive dep-graph enrichment
+    /// active. This is the pre-m207 semantic of `--no-deps-dev`;
+    /// scripts that relied on that behavior can migrate by
+    /// renaming `--no-deps-dev` → `--no-deps-dev-license`.
+    ///
+    /// Has no effect when `--offline` is set (offline suppresses
+    /// all enrichment paths). Overridden by `--enrich-sources`
+    /// allowlist mode when the operator supplies that flag.
+    #[arg(long)]
+    pub no_deps_dev_license: bool,
 
     /// Milestone 102 (FR-016/FR-017): include vendored C/C++
     /// dependencies declared via CMake `add_subdirectory(third_party/...)`
@@ -628,10 +650,14 @@ pub struct ScanArgs {
     #[arg(long)]
     pub cmake_third_party_recursive: bool,
 
-    /// Skip the deps.dev transitive dep-graph enrichment step.
+    /// Skip the deps.dev transitive dep-graph enrichment step ONLY.
     /// Keeps deps.dev license enrichment and ClearlyDefined active.
-    /// Useful when the graph response is large or unneeded. Has no
-    /// effect when `--offline` is set.
+    ///
+    /// Companion to `--no-deps-dev-license` (m207 #596) which does
+    /// the reverse (skip license, keep graph). Use `--no-deps-dev`
+    /// for the aggregate "skip both" semantic.
+    ///
+    /// Has no effect when `--offline` is set.
     #[arg(long)]
     pub no_deps_dev_graph: bool,
 
@@ -1636,10 +1662,16 @@ fn resolve_enrich_sources(args: &ScanArgs) -> EnrichConfig {
             deps_dev_graph: args.enrich_sources.contains(&EnrichSource::DepsDevGraph),
         }
     } else {
+        // Milestone 207 (#596): `--no-deps-dev` is now an aggregate
+        // disable — suppresses BOTH the deps.dev license path AND
+        // the deps.dev transitive dep-graph path. Pre-m207 it
+        // suppressed only the license path. Fine-grained control
+        // preserved via `--no-deps-dev-license` (license only) and
+        // `--no-deps-dev-graph` (graph only).
         EnrichConfig {
-            deps_dev: !args.no_deps_dev,
+            deps_dev: !args.no_deps_dev && !args.no_deps_dev_license,
             clearly_defined: !args.no_clearly_defined,
-            deps_dev_graph: !args.no_deps_dev_graph,
+            deps_dev_graph: !args.no_deps_dev && !args.no_deps_dev_graph,
         }
     }
 }
@@ -2712,6 +2744,21 @@ pub async fn execute(
     // "skipped (disabled by flags)" messages when the operative cause
     // is offline mode.
     let enrich_cfg = resolve_enrich_sources(&args);
+
+    // Milestone 207 (#596): FR-006 migration signal. When the
+    // operator uses the aggregate `--no-deps-dev` flag WITHOUT any
+    // fine-grained escape hatch, emit a one-shot INFO log line
+    // explaining the m207 semantic change + linking to the escape
+    // hatch. Fine-grained-aware operators (who also set
+    // `--no-deps-dev-license` or `--no-deps-dev-graph`) are NOT
+    // spammed — they already know what they're doing.
+    if args.no_deps_dev && !args.no_deps_dev_license && !args.no_deps_dev_graph {
+        tracing::info!(
+            "--no-deps-dev now disables ALL deps.dev enrichment paths \
+             (m207 aggregate semantic per #596). For the pre-m207 \"license \
+             only\" behavior, use --no-deps-dev-license instead."
+        );
+    }
 
     // deps.dev enrichment runs after the local scan so it only sees the
     // deduped component set. Components in unsupported ecosystems
@@ -4177,6 +4224,9 @@ mod tests {
         assert!(parsed.inner.no_clearly_defined);
         assert!(!parsed.inner.no_deps_dev);
         assert!(!parsed.inner.no_deps_dev_graph);
+        // Milestone 207 (#596): new `--no-deps-dev-license` flag
+        // defaults to OFF (enrichment on).
+        assert!(!parsed.inner.no_deps_dev_license);
     }
 
     #[test]
@@ -4283,6 +4333,7 @@ mod tests {
         no_deps_dev: bool,
         no_clearly_defined: bool,
         no_deps_dev_graph: bool,
+        no_deps_dev_license: bool,
         enrich_sources: Vec<EnrichSource>,
     ) -> ScanArgs {
         ScanArgs {
@@ -4330,6 +4381,7 @@ mod tests {
             no_clearly_defined,
             no_deps_dev,
             no_deps_dev_graph,
+            no_deps_dev_license,
             enrich_sources,
             bind_to_source: None,
             repo: None,
@@ -4381,7 +4433,7 @@ mod tests {
 
     #[test]
     fn resolve_defaults_all_enabled() {
-        let args = enrich_args(false, false, false, vec![]);
+        let args = enrich_args(false, false, false, false, vec![]);
         let cfg = resolve_enrich_sources(&args);
         assert_eq!(cfg, EnrichConfig {
             deps_dev: true,
@@ -4392,7 +4444,7 @@ mod tests {
 
     #[test]
     fn resolve_no_clearly_defined_disables_cd() {
-        let args = enrich_args(false, true, false, vec![]);
+        let args = enrich_args(false, true, false, false, vec![]);
         let cfg = resolve_enrich_sources(&args);
         assert!(cfg.deps_dev);
         assert!(!cfg.clearly_defined);
@@ -4400,17 +4452,121 @@ mod tests {
     }
 
     #[test]
-    fn resolve_no_deps_dev_disables_license_enrichment() {
-        let args = enrich_args(true, false, false, vec![]);
+    fn resolve_enrich_no_deps_dev_disables_both_paths_m207() {
+        // Milestone 207 (#596) US1 acceptance — `--no-deps-dev` is
+        // now an aggregate disable: BOTH the license AND dep-graph
+        // paths turn off. Pre-m207 this test asserted deps_dev_graph
+        // stayed true.
+        let args = enrich_args(true, false, false, false, vec![]);
         let cfg = resolve_enrich_sources(&args);
-        assert!(!cfg.deps_dev);
+        assert_eq!(
+            cfg,
+            EnrichConfig {
+                deps_dev: false,
+                clearly_defined: true,
+                deps_dev_graph: false,
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_enrich_no_deps_dev_license_disables_license_only_m207() {
+        // Milestone 207 (#596) US2 acceptance — new fine-grained
+        // flag `--no-deps-dev-license` restores the pre-m207
+        // `--no-deps-dev` semantic (license only).
+        let args = enrich_args(false, false, false, true, vec![]);
+        let cfg = resolve_enrich_sources(&args);
+        assert_eq!(
+            cfg,
+            EnrichConfig {
+                deps_dev: false,
+                clearly_defined: true,
+                deps_dev_graph: true,
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_enrich_no_deps_dev_wins_over_no_deps_dev_graph_m207() {
+        // Composition sanity — `--no-deps-dev` combined with
+        // `--no-deps-dev-graph` produces the same aggregate result.
+        let args = enrich_args(true, false, true, false, vec![]);
+        let cfg = resolve_enrich_sources(&args);
+        assert_eq!(
+            cfg,
+            EnrichConfig {
+                deps_dev: false,
+                clearly_defined: true,
+                deps_dev_graph: false,
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_enrich_no_deps_dev_license_and_graph_equals_aggregate_m207() {
+        // Composition sanity — setting both fine-grained flags is
+        // equivalent to setting the aggregate `--no-deps-dev`.
+        let args = enrich_args(false, false, true, true, vec![]);
+        let cfg = resolve_enrich_sources(&args);
+        assert_eq!(
+            cfg,
+            EnrichConfig {
+                deps_dev: false,
+                clearly_defined: true,
+                deps_dev_graph: false,
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_enrich_sources_allowlist_overrides_no_deps_dev_m207() {
+        // FR-004 regression guard — allowlist mode ignores every
+        // `--no-*` flag, including the aggregate `--no-deps-dev`.
+        let args = enrich_args(
+            true, false, false, false,
+            vec![EnrichSource::DepsDev],
+        );
+        let cfg = resolve_enrich_sources(&args);
+        assert!(cfg.deps_dev, "allowlist wins per FR-004");
+    }
+
+    #[test]
+    fn resolve_enrich_no_clearly_defined_unaffected_by_no_deps_dev_m207() {
+        // Regression guard — `--no-deps-dev` doesn't affect the
+        // ClearlyDefined path.
+        let args = enrich_args(true, false, false, false, vec![]);
+        let cfg = resolve_enrich_sources(&args);
         assert!(cfg.clearly_defined);
-        assert!(cfg.deps_dev_graph);
+    }
+
+    #[test]
+    fn no_deps_dev_help_mentions_enrich_sources_m207() {
+        // FR-008 — operators reading `mikebom sbom scan --help`
+        // see the composition hint next to the flag they're setting.
+        // `ScanArgsForTest` flattens `ScanArgs` at the top level (no
+        // subcommand nesting), so args are directly discoverable via
+        // `get_arguments`.
+        let cmd = <ScanArgsForTest as clap::CommandFactory>::command();
+        let arg = cmd
+            .get_arguments()
+            .find(|a| a.get_id().as_str() == "no_deps_dev")
+            .expect("--no-deps-dev arg present");
+        // long_help includes the multi-line doc-comment; short help
+        // is just the first line. Combine both to search.
+        let help_text = format!(
+            "{}\n{}",
+            arg.get_help().map(|s| s.to_string()).unwrap_or_default(),
+            arg.get_long_help().map(|s| s.to_string()).unwrap_or_default(),
+        );
+        assert!(
+            help_text.contains("enrich-sources"),
+            "FR-008: --no-deps-dev help text must mention `--enrich-sources`. Got:\n{help_text}"
+        );
     }
 
     #[test]
     fn resolve_no_deps_dev_graph_disables_graph() {
-        let args = enrich_args(false, false, true, vec![]);
+        let args = enrich_args(false, false, true, false, vec![]);
         let cfg = resolve_enrich_sources(&args);
         assert!(cfg.deps_dev);
         assert!(cfg.clearly_defined);
@@ -4419,7 +4575,7 @@ mod tests {
 
     #[test]
     fn resolve_all_no_flags_disables_everything() {
-        let args = enrich_args(true, true, true, vec![]);
+        let args = enrich_args(true, true, true, false, vec![]);
         let cfg = resolve_enrich_sources(&args);
         assert_eq!(cfg, EnrichConfig {
             deps_dev: false,
@@ -4436,6 +4592,7 @@ mod tests {
             false,
             true,  // --no-clearly-defined
             true,  // --no-deps-dev-graph
+            false, // --no-deps-dev-license (m207)
             vec![EnrichSource::ClearlyDefined],
         );
         let cfg = resolve_enrich_sources(&args);
@@ -4447,7 +4604,7 @@ mod tests {
     #[test]
     fn resolve_allowlist_subset_only_enables_listed() {
         let args = enrich_args(
-            false, false, false,
+            false, false, false, false,
             vec![EnrichSource::DepsDev, EnrichSource::DepsDevGraph],
         );
         let cfg = resolve_enrich_sources(&args);
@@ -4666,7 +4823,7 @@ mod tests {
 
     #[test]
     fn assemble_manual_identifiers_repo_only_emits_repo_scheme() {
-        let mut args = enrich_args(false, false, false, vec![]);
+        let mut args = enrich_args(false, false, false, false, vec![]);
         args.repo = Some("git@github.com:foo/bar.git".to_string());
         let ids = assemble_manual_identifiers(&args);
         assert_eq!(ids.len(), 1);
@@ -4677,7 +4834,7 @@ mod tests {
     fn assemble_manual_identifiers_repo_plus_git_ref_emits_git_only() {
         // --repo + --git-ref → ONE git: identifier (supersedes repo:),
         // not two entries.
-        let mut args = enrich_args(false, false, false, vec![]);
+        let mut args = enrich_args(false, false, false, false, vec![]);
         args.repo = Some("https://github.com/foo/bar".to_string());
         args.git_ref = Some("abc1234567890".to_string());
         let ids = assemble_manual_identifiers(&args);
@@ -4690,7 +4847,7 @@ mod tests {
 
     #[test]
     fn assemble_manual_identifiers_image_attestation_id_in_supply_order() {
-        let mut args = enrich_args(false, false, false, vec![]);
+        let mut args = enrich_args(false, false, false, false, vec![]);
         args.image_id = Some("docker.io/foo/bar:v1".to_string());
         args.attestation = Some("https://example.org/att/1".to_string());
         args.id = vec![
@@ -4936,7 +5093,7 @@ mod tests {
     #[test]
     fn build_pkg_alias_map_empty_when_no_input() {
         let _g = pkg_alias_env_lock();
-        let mut args = enrich_args(false, false, false, vec![]);
+        let mut args = enrich_args(false, false, false, false, vec![]);
         args.pkg_alias = vec![];
         unsafe {
             std::env::remove_var("MIKEBOM_PKG_ALIAS");
@@ -4948,7 +5105,7 @@ mod tests {
     #[test]
     fn build_pkg_alias_map_collects_cli_flags() {
         let _g = pkg_alias_env_lock();
-        let mut args = enrich_args(false, false, false, vec![]);
+        let mut args = enrich_args(false, false, false, false, vec![]);
         args.pkg_alias =
             vec![make_alias("pkg:generic/baz", "pkg:cargo/baz@1.0.0")];
         unsafe {
@@ -4961,7 +5118,7 @@ mod tests {
     #[test]
     fn build_pkg_alias_map_unions_cli_and_env_var_entries() {
         let _g = pkg_alias_env_lock();
-        let mut args = enrich_args(false, false, false, vec![]);
+        let mut args = enrich_args(false, false, false, false, vec![]);
         args.pkg_alias =
             vec![make_alias("pkg:generic/baz", "pkg:cargo/baz@1.0.0")];
         unsafe {
@@ -4980,7 +5137,7 @@ mod tests {
     #[test]
     fn build_pkg_alias_map_skips_blank_env_entries() {
         let _g = pkg_alias_env_lock();
-        let mut args = enrich_args(false, false, false, vec![]);
+        let mut args = enrich_args(false, false, false, false, vec![]);
         args.pkg_alias = vec![];
         unsafe {
             std::env::set_var(
@@ -4998,7 +5155,7 @@ mod tests {
     #[test]
     fn build_pkg_alias_map_rejects_conflicting_lhs_across_cli_and_env() {
         let _g = pkg_alias_env_lock();
-        let mut args = enrich_args(false, false, false, vec![]);
+        let mut args = enrich_args(false, false, false, false, vec![]);
         args.pkg_alias =
             vec![make_alias("pkg:generic/baz", "pkg:cargo/baz@1.0.0")];
         unsafe {

--- a/mikebom-cli/tests/scan_no_deps_dev.rs
+++ b/mikebom-cli/tests/scan_no_deps_dev.rs
@@ -1,0 +1,98 @@
+//! Milestone 207 (#596) — `--no-deps-dev` aggregate-disable integration tests.
+//!
+//! All tests are network-free (use `--offline` + existing non-image
+//! fixtures). Behavioral coverage of the semantic change lives in
+//! `scan_cmd::tests` unit tests (`resolve_enrich_*_m207`). These
+//! integration tests pin FR-006 migration-log presence/absence.
+//!
+//! SC-001 content verification (reporter's exact invocation → zero
+//! deps.dev-provenance components in emitted SBOM) is a network-
+//! required check documented in the PR body as a manual reproducer
+//! per plan.md quickstart.md Reproducer 1.
+
+use std::process::Command;
+
+fn mikebom_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mikebom")
+}
+
+fn npm_express_fixture() -> String {
+    format!(
+        "{}/tests/fixtures/public_corpus/npm-express",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+fn scan(extra_args: &[&str]) -> (bool, String) {
+    let tempdir = tempfile::tempdir().unwrap();
+    let out = tempdir.path().join("out.cdx.json");
+    let mut cmd = Command::new(mikebom_bin());
+    cmd.args([
+        "sbom",
+        "scan",
+        "--offline",
+        "--path",
+        &npm_express_fixture(),
+        "--format",
+        "cyclonedx-json",
+        "--output",
+        out.to_str().unwrap(),
+        "--no-deep-hash",
+    ]);
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("spawn mikebom");
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    (out.status.success(), stderr)
+}
+
+// ── T010 US1 — aggregate flag scan succeeds + FR-006 log fires ──
+
+#[test]
+fn us1_no_deps_dev_scan_succeeds_and_fires_migration_log_m207() {
+    let (ok, stderr) = scan(&["--no-deps-dev"]);
+    assert!(ok, "FR-007 no new failure modes: scan should exit 0. stderr:\n{stderr}");
+    assert!(
+        stderr.contains("m207 aggregate semantic"),
+        "FR-006: --no-deps-dev alone MUST fire the migration INFO log. stderr:\n{stderr}"
+    );
+}
+
+// ── T011 US1 — log fires-alone (positive isolation) ──
+
+#[test]
+fn fr006_migration_info_log_fires_when_aggregate_flag_used_alone_m207() {
+    let (ok, stderr) = scan(&["--no-deps-dev"]);
+    assert!(ok);
+    assert!(
+        stderr.contains("m207 aggregate semantic"),
+        "FR-006: migration log MUST fire on --no-deps-dev alone. stderr:\n{stderr}"
+    );
+}
+
+// ── T012 US1 — log suppressed with fine-grained escape hatch ──
+
+#[test]
+fn fr006_migration_info_log_suppressed_when_fine_grained_flag_also_set_m207() {
+    let (ok, stderr) = scan(&["--no-deps-dev", "--no-deps-dev-license"]);
+    assert!(ok);
+    assert!(
+        !stderr.contains("m207 aggregate semantic"),
+        "FR-006: migration log MUST NOT fire when a fine-grained flag is \
+         also set (operator is already aware of the fine-grained semantic). stderr:\n{stderr}"
+    );
+}
+
+// ── T013 US2 — no-deps-dev-license alone does not fire aggregate log ──
+
+#[test]
+fn us2_no_deps_dev_license_alone_does_not_fire_aggregate_migration_log_m207() {
+    let (ok, stderr) = scan(&["--no-deps-dev-license"]);
+    assert!(ok);
+    assert!(
+        !stderr.contains("m207 aggregate semantic"),
+        "FR-006: --no-deps-dev-license alone MUST NOT fire the aggregate migration log \
+         (only fires for --no-deps-dev without escape hatch). stderr:\n{stderr}"
+    );
+}

--- a/specs/207-no-deps-dev-aggregate/checklists/requirements.md
+++ b/specs/207-no-deps-dev-aggregate/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: m207 --no-deps-dev aggregate disable
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-17
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- CLI-side UX fix only. Zero wire-format change; zero emitter-side change.
+- FR-003 leaves the fine-grained "license only" case open — either a new named flag OR the existing --enrich-sources workaround suffices. Plan phase can pick.
+- FR-006 migration signal is codified as SHOULD (not MUST) — helpful for operators but not blocking.

--- a/specs/207-no-deps-dev-aggregate/data-model.md
+++ b/specs/207-no-deps-dev-aggregate/data-model.md
@@ -1,0 +1,159 @@
+# Data Model: Fix `--no-deps-dev` Flag UX
+
+**Date**: 2026-07-17
+**Purpose**: Document the 1 new flag field + 1 modified pure-function branch + 1 new WARN log site. No new types.
+
+## E1: `ScanArgs.no_deps_dev_license` (NEW field)
+
+**Location**: `mikebom-cli/src/cli/scan_cmd.rs` — adjacent to existing `no_deps_dev` (line 599) and `no_deps_dev_graph` (line 636).
+
+**Shape**:
+
+```rust
+/// Milestone 207 (#596) — skip deps.dev LICENSE enrichment only.
+/// Keeps the deps.dev transitive dep-graph enrichment active. This
+/// is the pre-m207 semantic of `--no-deps-dev` (which now disables
+/// BOTH deps.dev paths). Scripts that relied on the pre-m207
+/// behavior can migrate by renaming `--no-deps-dev` →
+/// `--no-deps-dev-license` in their invocations.
+///
+/// Has no effect when `--offline` is set (offline suppresses all
+/// enrichment paths). Overridden by `--enrich-sources` allowlist
+/// mode when the operator supplies that flag.
+#[arg(long)]
+pub no_deps_dev_license: bool,
+```
+
+**Validation rules**:
+- Boolean flag; default `false` (enrichment on).
+- Composes cleanly with other `--no-*` flags: setting both `--no-deps-dev-license` and `--no-deps-dev-graph` produces the same effect as `--no-deps-dev` (aggregate disable).
+- `--enrich-sources <list>` overrides this flag entirely per FR-004.
+
+## E2: `resolve_enrich_sources` semantic change (MODIFIED function)
+
+**Location**: `mikebom-cli/src/cli/scan_cmd.rs:1631-1645`.
+
+**Pre-m207 body** (default-mode branch at lines 1638-1644):
+
+```rust
+} else {
+    EnrichConfig {
+        deps_dev: !args.no_deps_dev,
+        clearly_defined: !args.no_clearly_defined,
+        deps_dev_graph: !args.no_deps_dev_graph,
+    }
+}
+```
+
+**Post-m207 body**:
+
+```rust
+} else {
+    // Milestone 207 (#596): `--no-deps-dev` becomes an aggregate
+    // disable (both license and dep-graph paths). Fine-grained
+    // "license only" moves to the new `--no-deps-dev-license` flag;
+    // fine-grained "graph only" remains `--no-deps-dev-graph`.
+    // Composition: any of these flags being set suppresses its
+    // respective path.
+    EnrichConfig {
+        deps_dev: !args.no_deps_dev && !args.no_deps_dev_license,
+        clearly_defined: !args.no_clearly_defined,
+        deps_dev_graph: !args.no_deps_dev && !args.no_deps_dev_graph,
+    }
+}
+```
+
+**Change semantics**:
+- `deps_dev` (license path): OFF when `no_deps_dev` OR `no_deps_dev_license` is set. `no_deps_dev` alone suffices to disable it (aggregate); `no_deps_dev_license` alone also suffices to disable it (fine-grained "license only").
+- `deps_dev_graph`: OFF when `no_deps_dev` OR `no_deps_dev_graph` is set. `no_deps_dev` alone suffices (aggregate); `no_deps_dev_graph` alone also suffices (fine-grained "graph only").
+- `clearly_defined`: UNCHANGED per FR-004.
+- Allowlist mode branch (lines 1632-1637): UNCHANGED per FR-004.
+
+**Truth table** (default-mode branch):
+
+| no_deps_dev | no_deps_dev_license | no_deps_dev_graph | deps_dev (license) | deps_dev_graph |
+|---|---|---|---|---|
+| false | false | false | true | true |
+| **true** | false | false | **false** | **false** |
+| false | true | false | false | true |
+| false | false | true | true | false |
+| true | true | false | false | false |
+| true | false | true | false | false |
+| false | true | true | false | false |
+| true | true | true | false | false |
+
+Row 2 is the m207 behavior change (bolded); pre-m207 it was `[false, true]`.
+
+## E3: FR-006 migration-signal INFO log (NEW)
+
+**Location**: `mikebom-cli/src/cli/scan_cmd.rs` — at the scan entry point after `resolve_enrich_sources` runs (around line 2714 today; adjust to actual line at implement time).
+
+**Emit condition** (R2 Option B): fires ONLY when the operator is using the aggregate flag alone (no fine-grained escape hatch also set):
+
+```rust
+if args.no_deps_dev && !args.no_deps_dev_license && !args.no_deps_dev_graph {
+    tracing::info!(
+        "--no-deps-dev now disables ALL deps.dev enrichment paths \
+         (m207 aggregate semantic per #596). For the pre-m207 \"license \
+         only\" behavior, use --no-deps-dev-license instead."
+    );
+}
+```
+
+**Validation rules**:
+- Fires ONCE per scan (not per-component).
+- Log message text pinned per research.md R2 — integration test greps stderr for the substring `"m207 aggregate semantic"`.
+- INFO level (not WARN) — this is an advisory, not a failure.
+- Suppressed by `RUST_LOG=warn` filter (operator's choice — they opted into a stricter filter, and the message is informational not corrective).
+
+**Rationale**: only operators using `--no-deps-dev` alone are affected by the semantic change; adding the log for the fine-grained-aware operators would be pure noise.
+
+## E4: `--help` text updates (MODIFIED doc-comments)
+
+**Location**: `mikebom-cli/src/cli/scan_cmd.rs:587-593` (existing `--no-deps-dev` doc-comment).
+
+**Pre-m207 text** (per recon at scan_cmd.rs:587):
+
+> "Skip deps.dev license enrichment. Keeps ClearlyDefined and dep-graph enrichment active. This is the fastest enrichment source and rarely needs skipping; the allowlist via `--enrich-sources` is the alternative for full control. Has no effect when `--offline` is set."
+
+**Post-m207 text**:
+
+```rust
+/// Milestone 207 (#596): AGGREGATE disable — skip BOTH the deps.dev
+/// license enrichment AND the deps.dev transitive dep-graph
+/// enrichment. Combines `--no-deps-dev-license` and
+/// `--no-deps-dev-graph` semantics per operator expectation.
+///
+/// Pre-m207 this flag disabled only the license path. Scripts that
+/// relied on that behavior can migrate by renaming to
+/// `--no-deps-dev-license`.
+///
+/// Composition: `--no-deps-dev` (aggregate) OR `--no-deps-dev-license`
+/// (license only) OR `--no-deps-dev-graph` (graph only). Fine-grained
+/// flags allow surgical control. `--enrich-sources <list>` (allowlist
+/// mode) overrides all `--no-*` flags. `--offline` suppresses all
+/// enrichment paths regardless of `--no-*` flags.
+#[arg(long)]
+pub no_deps_dev: bool,
+```
+
+**Also**: update the existing `--no-deps-dev-graph` doc-comment at line 625-630 to add a note about the new companion flag:
+
+```rust
+/// Skip the deps.dev transitive dep-graph enrichment step ONLY.
+/// Keeps deps.dev license enrichment and ClearlyDefined active.
+///
+/// Companion to `--no-deps-dev-license` (m207 #596) which does the
+/// reverse (skip license, keep graph). Use `--no-deps-dev` for the
+/// aggregate "skip both" semantic.
+///
+/// Has no effect when `--offline` is set.
+#[arg(long)]
+pub no_deps_dev_graph: bool,
+```
+
+## Cross-cutting: FR-004 (`--enrich-sources` allowlist unchanged)
+
+**Guarantee**: The allowlist-mode branch (`resolve_enrich_sources` lines 1632-1637) is untouched. When the operator supplies `--enrich-sources <list>`, none of the `--no-*` flags apply — including the new `--no-deps-dev-license`. This mirrors the existing behavior for `--no-deps-dev-graph` and preserves the documented "allowlist wins" invariant.
+
+**Test**: unit test `enrich_sources_allowlist_overrides_no_deps_dev` asserts that `--enrich-sources deps-dev --no-deps-dev` still enables the deps.dev license path (allowlist wins).

--- a/specs/207-no-deps-dev-aggregate/plan.md
+++ b/specs/207-no-deps-dev-aggregate/plan.md
@@ -1,0 +1,185 @@
+# Implementation Plan: Fix `--no-deps-dev` Flag UX — Aggregate Disable
+
+**Branch**: `207-no-deps-dev-aggregate` | **Date**: 2026-07-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/207-no-deps-dev-aggregate/spec.md`
+
+## Summary
+
+One-line semantic change in `mikebom-cli/src/cli/scan_cmd.rs::resolve_enrich_sources` at line 1642:
+
+**Pre-m207**:
+```rust
+deps_dev_graph: !args.no_deps_dev_graph,
+```
+
+**Post-m207**:
+```rust
+deps_dev_graph: !args.no_deps_dev && !args.no_deps_dev_graph,
+```
+
+That's the entire behavioral fix. `--no-deps-dev` becomes an aggregate disable per FR-001. Add a new fine-grained flag `--no-deps-dev-license` per FR-003 (opting in to the pre-m207 "license only" semantic; existing scripts relying on that behavior can migrate by prefixing their invocation with a search-and-replace). Add a WARN log per FR-006 when `--no-deps-dev` is passed alone (migration signal). Update `--help` text on both flags per FR-005.
+
+Reconnaissance findings (per m199-m206 lesson):
+
+- `EnrichConfig` struct at `scan_cmd.rs:1615-1620` — 3 bool fields (`deps_dev`, `clearly_defined`, `deps_dev_graph`).
+- `resolve_enrich_sources` fn at `scan_cmd.rs:1631-1645` — pure function; documented as "testable as a pure function." Existing unit tests presumably exist for it; will re-verify at T003.
+- `--no-deps-dev` flag defined at `scan_cmd.rs:599` (`pub no_deps_dev: bool`).
+- `--no-deps-dev-graph` flag defined at `scan_cmd.rs:636` (`pub no_deps_dev_graph: bool`).
+- Enrichment gates on `enrich_cfg.deps_dev` (line 2723) + `enrich_cfg.deps_dev_graph` (line 2759). Only these two boolean call sites need to be affected — no downstream plumbing changes.
+- The `--enrich-sources` allowlist branch (`resolve_enrich_sources` line 1632-1637) is UNCHANGED per FR-004. When operators use allowlist mode, none of the `--no-*` flags apply.
+- Test invocation site at `scan_cmd.rs:4178-4179` exists (`assert!(!parsed.inner.no_deps_dev); assert!(!parsed.inner.no_deps_dev_graph);`) — a "default-off" test we can extend with a `no_deps_dev_license` assertion.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–206; no nightly).
+**Primary Dependencies**: Existing only — `clap` (workspace, `Args` derive picks up the new flag), `tracing` (workspace, FR-006 WARN log). **Zero new Cargo dependencies.**
+**Storage**: N/A — CLI-flag semantic change; no state, no persistence.
+**Testing**: Unit tests in `scan_cmd.rs::tests` covering the new `resolve_enrich_sources` truth table (4 flag combinations × 2 modes = ~8 cases). Regression test in a NEW file `mikebom-cli/tests/scan_no_deps_dev.rs` asserting the reporter's exact invocation shape (SC-001).
+**Target Platform**: Same as mikebom itself. No new host requirements.
+**Project Type**: CLI UX fix. ~50 LOC total: ~15 LOC in `scan_cmd.rs` (1 new flag + 1-line semantic change + 1 WARN log branch + updated doc-comments), ~40 LOC unit tests, ~30 LOC integration regression test.
+**Performance Goals**: SC-005 wall-clock: same or faster (skipping the dep-graph fetch under `--no-deps-dev` is strictly less work than pre-m207). No explicit target; pre-PR delta ≤ 5s per SC-006.
+**Constraints**: (a) zero new Cargo deps; (b) zero wire-format change (no emitter touched); (c) `--enrich-sources` allowlist semantic UNCHANGED per FR-004; (d) `--no-deps-dev-graph` semantic UNCHANGED per FR-002 (still disables ONLY the graph path); (e) backward-compat migration path per FR-003 + FR-006.
+**Scale/Scope**: 1 source file edit (scan_cmd.rs). No changes to mikebom-common. No changes to mikebom-ebpf. No changes to any emitter. No parity catalog change. No new annotation.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Pure Rust, Zero C** — ✅ PASS. All new Rust code.
+- **II. eBPF-Only Observation** — ✅ N/A. CLI-flag semantics; no discovery-mechanism change.
+- **III. Fail Closed** — ✅ PASS. The semantic change is strictly MORE restrictive under `--no-deps-dev` alone (disables one more enrichment path). Cannot introduce new failure modes; only fewer components emitted per FR-007.
+- **IV. Type-Driven Correctness** — ✅ PASS. New flag is a typed `bool` field on `ScanArgs`; `EnrichConfig` struct fields typed correctly.
+- **V. Specification Compliance** — ✅ PASS. Zero new `mikebom:*` annotations; zero wire-format change. The `mikebom:source-files: ["deps.dev"]` annotation surface is UNCHANGED — it simply won't appear when `--no-deps-dev` is set post-fix (because the dep-graph enrichment path won't run to stamp it). No Principle V audit needed.
+- **VI. Three-Crate Architecture** — ✅ PASS. All changes stay in `mikebom-cli`.
+- **VII. Test Isolation** — ✅ PASS. Unit tests are pure-function; no external dependencies. The one integration regression test uses a small synthetic project (or an existing public_corpus fixture) — no network, no daemon.
+- **VIII. Completeness** — ✅ PASS. Doesn't change what mikebom discovers; changes only when the deps.dev enrichment paths run. Under `--no-deps-dev`, mikebom already discovered every component via the primary discovery mechanism; skipping enrichment leaves those components UNCHANGED in the emitted SBOM. Under-completeness for the enrichment path is what the operator explicitly asked for.
+- **IX. Accuracy** — ✅ PASS. `--no-deps-dev` post-fix accurately reflects the operator's intent per the flag's name. Pre-fix behavior was arguably inaccurate (name-vs-semantic mismatch); post-fix corrects that.
+- **X. Transparency** — ✅ PASS. FR-006 codifies a migration WARN log so operators upgrading through the semantic change see it in stderr. `--help` text updated per FR-005 so future operators find the correct semantic without reverse engineering.
+- **XI. Enrichment (DX)** — ✅ PASS. This IS a DX fix — the flag now does what its name suggests. Fine-grained control preserved via new `--no-deps-dev-license` + existing `--no-deps-dev-graph` + `--enrich-sources` allowlist per FR-002 / FR-003.
+- **XII. External Data Source Enrichment** — ✅ N/A. deps.dev IS an external data source, but the fix doesn't touch the enrichment implementation — only the flag semantics gating whether it runs.
+- **Strict Boundary §5 (file-tier)** — ✅ N/A.
+
+**Result**: All principles PASS. No violations. No Complexity Tracking entries needed.
+
+**Post-Phase-1 re-check**: N/A — Phase 1 introduces no new entities beyond what's above (1 new flag field + 1 modified pure function + 1 WARN log line + help-text updates). Constitution gate remains PASS.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/207-no-deps-dev-aggregate/
+├── plan.md              # This file
+├── spec.md              # Feature specification (input)
+├── research.md          # Phase 0 output — 2 mechanical decisions
+├── data-model.md        # Phase 1 output — EnrichConfig delta + new flag + WARN log
+├── quickstart.md        # Phase 1 output — 3 reproducers
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 output (created by /speckit-tasks)
+```
+
+No `contracts/` sub-directory — CLI flags ARE the contract; the flag's clap-derived help text serves as the interface documentation.
+
+### Source Code (repository root)
+
+```text
+mikebom-cli/src/cli/
+└── scan_cmd.rs                                         # MODIFIED — the entirety of m207:
+                                                        #
+                                                        # Line 599 (existing `--no-deps-dev` flag):
+                                                        #   - Update doc-comment to state: "Disables
+                                                        #     ALL deps.dev enrichment paths (both
+                                                        #     license lookup AND transitive dep-graph
+                                                        #     enrichment). Post-m207 aggregate
+                                                        #     semantic per issue #596. Fine-grained
+                                                        #     escape hatches: --no-deps-dev-license
+                                                        #     (license only), --no-deps-dev-graph
+                                                        #     (graph only), or --enrich-sources
+                                                        #     <list> (allowlist mode overrides all
+                                                        #     --no-* flags)."
+                                                        #
+                                                        # NEW field near line 599 (adjacent to
+                                                        # existing no_deps_dev):
+                                                        #   pub no_deps_dev_license: bool,
+                                                        # Doc-comment: "Milestone 207 (#596) — skip
+                                                        # deps.dev LICENSE enrichment only. Keeps
+                                                        # dep-graph enrichment active. This is the
+                                                        # pre-m207 semantic of `--no-deps-dev`;
+                                                        # scripts that relied on that behavior can
+                                                        # migrate by renaming."
+                                                        #
+                                                        # Line 636 (existing `--no-deps-dev-graph`
+                                                        # flag): unchanged semantic.
+                                                        #
+                                                        # `EnrichConfig` struct at line 1615-1620:
+                                                        # unchanged (no new field).
+                                                        #
+                                                        # `resolve_enrich_sources` fn at line
+                                                        # 1631-1645: semantic change at line 1640-
+                                                        # 1642. New logic:
+                                                        #   deps_dev: !args.no_deps_dev && !args.no_deps_dev_license,
+                                                        #   deps_dev_graph: !args.no_deps_dev && !args.no_deps_dev_graph,
+                                                        # (`--no-deps-dev` disables BOTH; the new
+                                                        # `--no-deps-dev-license` disables just the
+                                                        # license path; the existing `--no-deps-dev-
+                                                        # graph` disables just the graph path.)
+                                                        #
+                                                        # After resolve_enrich_sources (or at the
+                                                        # scan entry point around line 2714): FR-006
+                                                        # migration signal — WHEN `args.no_deps_dev`
+                                                        # is set AND neither `no_deps_dev_license`
+                                                        # nor `no_deps_dev_graph` are set (i.e., the
+                                                        # operator is using the aggregate flag
+                                                        # rather than fine-grained ones), emit ONE
+                                                        # `tracing::info!` message stating "post-m207:
+                                                        # --no-deps-dev now disables ALL deps.dev
+                                                        # enrichment (previously license only). See
+                                                        # --no-deps-dev-license for the pre-m207
+                                                        # behavior."
+                                                        #
+                                                        # `scan_cmd.rs::tests`:
+                                                        # New unit tests exercising the
+                                                        # `resolve_enrich_sources` truth table:
+                                                        #   - no_flags_default → all 3 paths on
+                                                        #   - no_deps_dev_disables_both_deps_dev_paths (P1 acceptance)
+                                                        #   - no_deps_dev_graph_still_disables_graph_only
+                                                        #   - no_deps_dev_license_disables_license_only (P2 acceptance)
+                                                        #   - no_deps_dev_and_license_are_equivalent_for_license_path
+                                                        #   - no_deps_dev_wins_over_no_deps_dev_graph (composition)
+                                                        #   - enrich_sources_allowlist_overrides_no_deps_dev (FR-004)
+                                                        #   - clearly_defined_unaffected_by_no_deps_dev
+
+mikebom-cli/tests/
+└── scan_no_deps_dev.rs                                 # NEW — m207 integration regression test:
+                                                        #
+                                                        # fr001_no_deps_dev_produces_no_deps_dev_provenance:
+                                                        #   - Scan a small synthetic project (e.g.,
+                                                        #     the m205 US1 fixture `[dependencies]
+                                                        #     serde = "1"`) with `--no-deps-dev
+                                                        #     --offline`.
+                                                        #   - Actually because `--offline` short-
+                                                        #     circuits all network calls anyway,
+                                                        #     use `--no-clearly-defined` (mirroring
+                                                        #     the reporter's exact invocation)
+                                                        #     WITHOUT --offline. Requires network
+                                                        #     access for deps.dev lookups if the
+                                                        #     flag doesn't suppress them.
+                                                        #   - Actually simpler: use `--offline` +
+                                                        #     `--no-deps-dev` and assert no
+                                                        #     `mikebom:source-files: "deps.dev"`
+                                                        #     annotation appears — under `--offline`,
+                                                        #     if the fix works, the emit path is
+                                                        #     symmetric with the network-fetch path
+                                                        #     (both skipped).
+                                                        #   - Assert emitted CDX contains ZERO
+                                                        #     components with `.properties[]`
+                                                        #     matching `mikebom:source-files` value
+                                                        #     `["deps.dev"]`.
+```
+
+**Structure Decision**: 1 source file edit (scan_cmd.rs) + 1 new integration test file (scan_no_deps_dev.rs). Zero committed fixture additions; unit tests use synthetic `ScanArgs` structs; integration test scans a tiny in-process fixture. Zero non-fixture golden regen (no wire-format change per plan.md constraint (b)).
+
+## Complexity Tracking
+
+No constitution violations. All principles pass on first check. Trivial 1-line behavioral change + 1 new flag + 1 WARN log + doc-comment updates. No new architecture; no new patterns.

--- a/specs/207-no-deps-dev-aggregate/quickstart.md
+++ b/specs/207-no-deps-dev-aggregate/quickstart.md
@@ -1,0 +1,102 @@
+# Quickstart: `--no-deps-dev` Aggregate-Disable Fix
+
+**Date**: 2026-07-17
+**Audience**: mikebom maintainer implementing or reviewing m207.
+
+## Prerequisites
+
+- Working mikebom checkout on branch `207-no-deps-dev-aggregate`.
+- `cargo +stable` toolchain (workspace default).
+- Reproducer 1 (SC-001) requires network access for deps.dev lookups OR uses `--offline` to demonstrate the symmetric no-op.
+
+## Reproducer 1 — SC-001 reporter's exact invocation
+
+```bash
+# Use any small project — a synthetic cargo tempdir or an existing fixture.
+mikebom sbom scan \
+  --warm-go-cache=per-workspace \
+  --no-deps-dev \
+  --no-clearly-defined \
+  --path /tmp/some-project \
+  --format cyclonedx-json \
+  --output /tmp/out.cdx.json
+
+# Post-m207 assertion: zero deps.dev provenance in the emitted SBOM.
+jq '[.components[]? | .properties[]? | select(.name == "mikebom:source-files") | .value | select(. == "[\"deps.dev\"]")] | length' /tmp/out.cdx.json
+```
+
+**Expected post-m207**: `0`. The `--no-deps-dev` flag now disables BOTH the license lookup and the dep-graph enrichment paths.
+
+**Also verify stderr**:
+
+```bash
+mikebom sbom scan --no-deps-dev --path /tmp/some-project 2>&1 | grep "m207 aggregate semantic"
+```
+
+**Expected post-m207**: one INFO log line matching. Fires exactly once per scan.
+
+## Reproducer 2 — US2 fine-grained flags still work
+
+```bash
+# Skip only the license path; keep the dep-graph.
+mikebom sbom scan --no-deps-dev-license --path /tmp/some-project \
+  --format cyclonedx-json --output /tmp/license-off.cdx.json
+
+# Skip only the graph path; keep the license.
+mikebom sbom scan --no-deps-dev-graph --path /tmp/some-project \
+  --format cyclonedx-json --output /tmp/graph-off.cdx.json
+```
+
+**Expected post-m207**:
+- `license-off.cdx.json`: components with `mikebom:source-files: ["deps.dev"]` MAY appear (dep-graph enrichment ran) but component license fields will NOT carry deps.dev provenance.
+- `graph-off.cdx.json`: components with `mikebom:source-files: ["deps.dev"]` do NOT appear (dep-graph enrichment skipped) but license fields MAY carry deps.dev provenance.
+
+## Reproducer 3 — FR-004 `--enrich-sources` allowlist wins
+
+```bash
+# Allowlist mode: --no-deps-dev is IGNORED per FR-004.
+mikebom sbom scan \
+  --enrich-sources deps-dev,clearly-defined \
+  --no-deps-dev \
+  --path /tmp/some-project \
+  --format cyclonedx-json --output /tmp/allowlist.cdx.json
+
+# Post-m207: allowlist takes precedence; deps.dev license enrichment DID run
+# despite --no-deps-dev being present.
+jq '.components[]? | select(.licenses != null) | .licenses' /tmp/allowlist.cdx.json | head
+```
+
+**Expected post-m207**: deps.dev-sourced license data present. `--no-deps-dev` is silently ignored in allowlist mode per FR-004.
+
+## Reproducer 4 — SC-005 wall-clock delta
+
+```bash
+# Baseline: pre-m207 --no-deps-dev (network-fetch STILL happens for graph).
+time mikebom-alpha63 sbom scan --no-deps-dev --path /tmp/large-project
+
+# Post-m207: same invocation now skips graph fetch too.
+time mikebom sbom scan --no-deps-dev --path /tmp/large-project
+```
+
+**Expected post-m207**: same-or-faster wall-clock. Skipping the dep-graph fetch is strictly less work than pre-m207's behavior for the same flag.
+
+## Pre-PR gate
+
+```bash
+./scripts/pre-pr.sh
+```
+
+Both `cargo +stable clippy --workspace --all-targets` (zero errors, zero warnings) AND `cargo +stable test --workspace` (every suite `ok. N passed; 0 failed`) MUST pass green.
+
+## Empirical re-verification at implement time (m199-m206 lesson)
+
+Per `feedback_verify_research_empirical_claims` memory: before finalizing tasks.md, re-run:
+
+```bash
+# Confirm the line-numbers cited in plan.md / data-model.md are still valid.
+grep -n "pub no_deps_dev:\|pub no_deps_dev_graph:\|fn resolve_enrich_sources\|deps_dev_graph: !args.no_deps_dev_graph" mikebom-cli/src/cli/scan_cmd.rs | head
+```
+
+**Expected**: `pub no_deps_dev:` near line 599; `pub no_deps_dev_graph:` near line 636; `fn resolve_enrich_sources` near line 1631; `deps_dev_graph: !args.no_deps_dev_graph,` on line 1642 (this is the exact one-line change m207 makes).
+
+If any drift → update tasks.md instructions accordingly.

--- a/specs/207-no-deps-dev-aggregate/research.md
+++ b/specs/207-no-deps-dev-aggregate/research.md
@@ -1,0 +1,65 @@
+# Research: Fix `--no-deps-dev` Flag UX
+
+**Date**: 2026-07-17
+**Purpose**: Resolve 2 mechanical unknowns before task decomposition.
+
+## R1 — Add a new `--no-deps-dev-license` flag rather than rely solely on `--enrich-sources`
+
+**Investigation**: FR-003 leaves the fine-grained "license only" case open — either a new named flag OR the existing `--enrich-sources` allowlist mode. Trade-off:
+
+- **Option A**: Add `--no-deps-dev-license` as a fine-grained flag mirroring the existing `--no-deps-dev-graph`. Operators who want to keep the pre-m207 behavior migrate by renaming the flag in their scripts.
+- **Option B**: Rely solely on `--enrich-sources deps-dev-graph,clearly-defined` for the "license only" case. No new flag; operators use the existing allowlist mode.
+
+**Decision**: Option A. Rationale:
+
+- **Symmetry**: `--no-deps-dev-graph` already exists as the fine-grained "graph only" flag. Adding `--no-deps-dev-license` makes the fine-grained pair complete + memorable ("no-X-license" + "no-X-graph" mirror each other cleanly).
+- **Migration path clarity**: Operators updating scripts from the old `--no-deps-dev` semantic can do a simple search-and-replace: `--no-deps-dev` → `--no-deps-dev-license`. Zero mental gymnastics; the change is well-signposted.
+- **`--enrich-sources` is a heavier UX**: switching to allowlist mode means the operator now has to enumerate every source they DO want (clearly-defined, dep-graph, etc.), which is more brittle if new sources are added in future milestones.
+- **Cost is trivial**: one new `#[arg(long)] pub no_deps_dev_license: bool` field; ~5 LOC.
+
+**Alternatives considered + rejected**:
+- Option B: rejected per the reasoning above — asymmetric with `--no-deps-dev-graph` + heavier UX for the common migration case.
+- Deprecate `--no-deps-dev-graph` in favor of `--enrich-sources`: rejected — would break far more existing scripts than the current fix.
+
+**References**:
+- `mikebom-cli/src/cli/scan_cmd.rs:625-630` — existing `--no-deps-dev-graph` flag definition (semantic + doc-comment pattern to mirror).
+
+## R2 — Migration WARN log fires when the aggregate flag is used alone
+
+**Investigation**: FR-006 codifies a SHOULD-emit migration signal. Options:
+
+- **Option A**: Log at INFO level, ALWAYS emit when `--no-deps-dev` is set. Simple; matches Constitution Principle X (transparency).
+- **Option B**: Log at INFO level, emit ONLY when the operator is using the aggregate flag without the fine-grained escape hatches (i.e., `--no-deps-dev` is set AND neither `--no-deps-dev-license` nor `--no-deps-dev-graph` is also set). More targeted — signals only to operators likely affected by the semantic change.
+- **Option C**: Don't log at all. Documentation-only migration via `--help` text updates.
+
+**Decision**: Option B. Rationale:
+
+- Operators using `--no-deps-dev` alongside `--no-deps-dev-license` or `--no-deps-dev-graph` are ALREADY thinking about fine-grained semantics — the WARN adds no signal for them and is noise.
+- Operators using `--no-deps-dev` alone are the exact set whose behavior might change vs pre-m207: they get the one INFO log line explaining the semantic + linking to the fine-grained escape hatch.
+- INFO level (not WARN) matches the informational nature: "here's a semantic to notice," not "you did something wrong." Aligns with the m204/m205 tracing-level convention (WARN = fallback fired; INFO = advisory).
+- Non-noise: only fires once per scan (single-shot; not per-component).
+
+**Log message text** (pinned for the integration test's stderr grep):
+
+```
+--no-deps-dev now disables ALL deps.dev enrichment paths (m207 aggregate semantic per #596). \
+For the pre-m207 "license only" behavior, use --no-deps-dev-license instead.
+```
+
+**Alternatives considered + rejected**:
+- Option A (always log): rejected — noisy for operators who are already fine-grained-aware.
+- Option C (no log): rejected — silently changing behavior for operators upgrading through this milestone violates Principle X.
+- WARN level: rejected — `--no-deps-dev` post-fix isn't a failure or unexpected condition; INFO matches the semantic. Reserving WARN for failure conditions preserves signal-to-noise for operators using `RUST_LOG=warn` filters.
+
+**References**:
+- Memory `feedback_native_fields_first` — Constitution Principle X + XI compliance patterns for m199-m204.
+- m203's helm-render-fallback WARN convention — informational-emit-only-when-relevant precedent.
+
+## Decision Summary
+
+| Decision | Chosen | Alternative | Rationale |
+|---|---|---|---|
+| Fine-grained "license only" mechanism | New `--no-deps-dev-license` flag | Rely on `--enrich-sources` allowlist | Symmetric with existing `--no-deps-dev-graph`; simple search-and-replace migration path |
+| Migration signal | INFO log, ONLY when `--no-deps-dev` used alone (no fine-grained escape hatches) | Always-emit / no-log | Targets the exact operator set affected by the semantic change; INFO level matches advisory nature |
+| WARN log text | Fixed message pinned in research.md above | Free-form / auto-generated | Integration test greps stderr for this substring; determinism required |
+| New Cargo deps | Zero | (n/a) | Nothing needed |

--- a/specs/207-no-deps-dev-aggregate/spec.md
+++ b/specs/207-no-deps-dev-aggregate/spec.md
@@ -1,0 +1,107 @@
+# Feature Specification: Fix `--no-deps-dev` Flag UX — Aggregate Disable
+
+**Feature Branch**: `207-no-deps-dev-aggregate`
+**Created**: 2026-07-17
+**Status**: Draft
+**Input**: Issue #596 — `--no-deps-dev` flag misleading: doesn't disable deps.dev dep-graph enrichment, only license enrichment. Reporter's symptom: emitted SBOM contains `mikebom:source-files: ["deps.dev"]` components even after passing `--no-deps-dev --no-clearly-defined`.
+
+## Background
+
+Today mikebom has three flags controlling deps.dev enrichment:
+
+- `--no-deps-dev` — currently disables the deps.dev *license* enrichment path only. Keeps the dep-graph enrichment active.
+- `--no-deps-dev-graph` — currently disables the deps.dev *transitive dep-graph* enrichment path only. Keeps the license enrichment active.
+- `--offline` — disables ALL outbound network calls (all enrichment paths).
+
+The naming reads to operators as "no deps.dev, period," but the current semantic is "no deps.dev license lookup specifically." This mismatch surfaces when the operator inspects the emitted SBOM and finds components tagged `mikebom:source-files: ["deps.dev"]` — provenance markers correctly identifying components discovered through the deps.dev dep-graph enrichment that they thought they'd disabled.
+
+Reporter's exact invocation:
+
+```
+mikebom sbom scan --warm-go-cache=per-workspace --no-deps-dev --no-clearly-defined --path <target> --output out.cdx.json
+```
+
+Expected result: no components sourced from deps.dev.
+Observed: components with `mikebom:source-files: ["deps.dev"]` still present.
+
+The scanner is not misbehaving. The dep-graph enrichment path IS running (as documented) and correctly stamping its provenance. The bug is CLI-side naming: `--no-deps-dev` doesn't do what its name suggests.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Aggregate disable "just works" (Priority: P1)
+
+An operator who wants no deps.dev interaction whatsoever passes `--no-deps-dev`. Post-fix, the emitted SBOM contains ZERO components with `mikebom:source-files: ["deps.dev"]` provenance (and ZERO deps.dev-sourced license fields). The single flag disables both the license and dep-graph enrichment paths.
+
+**Why this priority**: This is the reporter's actual pain point and the highest-leverage fix — the vast majority of operators using `--no-deps-dev` want "no deps.dev, please" and were surprised by the current behavior. Making the name match the semantic eliminates the confusion for every future operator hitting this. P1 because it's the operator-facing UX correctness issue driving the report.
+
+**Independent Test**: Reproduce the reporter's invocation against any small project. Assert (a) scan exits 0, (b) `.components[]` contains ZERO entries with `.properties[]` matching `mikebom:source-files` = `["deps.dev"]`, (c) no license values on any component carry deps.dev provenance markers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project scanned with `--no-deps-dev`, **When** the operator inspects the emitted SBOM, **Then** no components carry `mikebom:source-files: ["deps.dev"]` provenance AND no license fields carry deps.dev-source markers.
+2. **Given** the same project scanned WITHOUT `--no-deps-dev`, **When** the operator inspects the emitted SBOM, **Then** deps.dev-sourced components MAY appear (baseline behavior unchanged for the non-suppressed case).
+
+---
+
+### User Story 2 - Fine-grained sub-flags still work (Priority: P2)
+
+An operator who wants to disable ONLY the deps.dev license enrichment (but keep the dep-graph enrichment) can still do so via a fine-grained flag. Same for the reverse case. The current `--no-deps-dev-graph` flag continues to disable only the dep-graph path; a new flag (or the existing granularity via `--enrich-sources`) covers the "license only" case.
+
+**Why this priority**: Some operators legitimately want fine-grained control — e.g., they trust deps.dev's license data (fast, high-quality) but skip the graph fetch because it's large. Preserving fine-grained control avoids regressing existing workflows that depend on the current `--no-deps-dev` semantic. P2 because it's smaller than the P1 use case AND has a workaround (`--enrich-sources`) — but preserving it keeps this fix drama-free for existing users.
+
+**Independent Test**: Pass the new fine-grained "no license enrichment only" flag OR `--enrich-sources deps-dev-graph,clearly-defined`. Assert (a) deps.dev-sourced dep-graph components ARE emitted, (b) license fields do NOT carry deps.dev-source markers.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator using the pre-fix invocation `--no-deps-dev` (old semantic: disable license only), **When** they run the new mikebom, **Then** they either (a) get the new aggregate behavior automatically with a clear WARN in stderr telling them how to restore the old semantic, OR (b) get their old semantic via a documented alias flag that continues to work.
+2. **Given** an operator wants to disable deps.dev license enrichment but keep dep-graph, **When** they use the documented fine-grained flag (or `--enrich-sources`), **Then** the emitted SBOM shows license fields without deps.dev provenance but dep-graph components sourced from deps.dev.
+
+---
+
+### Edge Cases
+
+- **`--offline` remains the strongest hammer**: `--offline` disables ALL enrichment (deps.dev, ClearlyDefined, anything else). No behavior change — `--offline` was always strictly more powerful than any `--no-<source>` combination.
+- **`--enrich-sources` allowlist**: When the operator passes `--enrich-sources <list>`, only the listed sources run — this overrides all `--no-*` flags per the current documented behavior. The fix does NOT change `--enrich-sources` semantics.
+- **Old scripts using `--no-deps-dev` as the license-only flag**: their behavior changes post-fix (aggregate disable). The fix MUST provide a migration path (either automatic warning + fine-grained alias, or a documented `--enrich-sources` incantation) so their SBOMs don't silently gain fewer components without a signal to the operator.
+- **Combining `--no-deps-dev` with `--no-deps-dev-graph`**: both flags together become equivalent to the new `--no-deps-dev` alone. No error; the intent is unambiguous.
+- **`--no-clearly-defined` combined with `--no-deps-dev`**: covers both major enrichment sources. Post-fix, this common pairing does what operators expect: zero enrichment from either source.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `--no-deps-dev` MUST disable BOTH the deps.dev license enrichment path AND the deps.dev transitive dep-graph enrichment path. Post-fix invocation `mikebom sbom scan --no-deps-dev --path <target>` produces an SBOM with zero components carrying deps.dev provenance in either `mikebom:source-files` or license fields.
+- **FR-002**: The fine-grained fill-in flag `--no-deps-dev-graph` MUST continue to work with its current semantic (disable dep-graph enrichment only, keep license enrichment).
+- **FR-003**: A NEW fine-grained fill-in flag MUST exist to cover the old `--no-deps-dev` behavior (disable license enrichment only, keep dep-graph). This flag can be named `--no-deps-dev-license` OR the same effect can be reached via `--enrich-sources deps-dev-graph,clearly-defined`. Either or both mechanisms MUST be available so operators can achieve fine-grained control if they need it.
+- **FR-004**: The change MUST NOT affect the semantics of `--offline` (all-off) OR `--enrich-sources <list>` (allowlist mode). Those flags are separately specified and continue to override `--no-*` flags per the current documented behavior.
+- **FR-005**: Documentation (built-in `--help` text + `docs/`) MUST be updated to reflect the new semantic. The `--help` text for `--no-deps-dev` must explicitly state "disables ALL deps.dev enrichment paths" so no future operator has to reverse-engineer this by inspecting SBOMs.
+- **FR-006**: Backward-compatibility migration signal: when mikebom detects an invocation that would have behaved differently pre-fix (e.g., `--no-deps-dev` alone), it SHOULD emit a one-time INFO log line explaining the new aggregate semantic + linking to the fine-grained escape hatch. Optional but recommended per Constitution Principle X (transparency).
+- **FR-007**: The change MUST NOT introduce new failure modes. Scans that would have succeeded pre-fix MUST still succeed post-fix (with possibly fewer components in the SBOM due to the aggregate suppression, per FR-001).
+- **FR-008**: The `--no-deps-dev` help text MUST clarify how it composes with `--enrich-sources` (allowlist wins).
+
+### Key Entities *(include if feature involves data)*
+
+- **`--no-deps-dev` flag**: operator-facing CLI toggle that suppresses deps.dev enrichment. Semantic changes from "no license enrichment" (pre-fix) to "no enrichment at all from deps.dev" (post-fix).
+- **`--no-deps-dev-graph` flag**: continues to exist; unchanged.
+- **New fine-grained flag OR documented `--enrich-sources` recipe**: covers the "license only" case per FR-003.
+- **`mikebom:source-files: ["deps.dev"]` component provenance annotation**: the reporter-visible indicator that surfaced the bug. Unchanged shape; simply won't appear when `--no-deps-dev` is passed post-fix.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Reporter's exact invocation (`mikebom sbom scan --warm-go-cache=per-workspace --no-deps-dev --no-clearly-defined --path <target>`) produces an SBOM containing ZERO components with `mikebom:source-files: ["deps.dev"]` post-fix.
+- **SC-002**: The single flag `--no-deps-dev` is now sufficient for "no deps.dev, period" — operators do NOT need to remember `--no-deps-dev-graph` separately.
+- **SC-003**: `mikebom sbom scan --no-deps-dev --help` documentation clearly states "disables ALL deps.dev enrichment paths (both license lookups and transitive dep-graph)."
+- **SC-004**: A regression test asserts FR-001 end-to-end: scan a fixture with `--no-deps-dev` and grep the emitted SBOM for `deps.dev` — MUST be absent from all component provenance surfaces.
+- **SC-005**: The scan wall-clock time with `--no-deps-dev` is either the same OR faster than the current `--no-deps-dev` invocation (since the dep-graph fetch is now also skipped — should be strictly faster in the offline-cache case).
+- **SC-006**: PR description references `Closes #596`.
+
+## Assumptions
+
+- **The current `--no-deps-dev-graph` flag stays with its existing semantic**. If the fix chose to remove or rename it, existing scripts would break. Preserving it is the safe choice.
+- **The reporter's use case ("no deps.dev at all") is the majority case**. Very few operators appear to want the fine-grained "license only" split; the workaround via `--enrich-sources` is available for them. If review surfaces that fine-grained-license-only is a significant use case, FR-003's new named flag becomes P1 rather than a workaround.
+- **No new `mikebom:*` annotations**. This is a CLI semantics fix — no wire-format or emitter change. All emitter code paths continue to operate identically; the change is purely in which enrichment paths run under a given flag combination.
+- **No new Cargo dependencies**. Small CLI-side change.
+- **Documentation update scope**: `--help` text (via clap doc-comment) + a note in `docs/` if there's a docs entry for the flag. Small change.
+- **Migration signal**: FR-006 codifies a WARN log for the changed behavior. Consumers grepping mikebom's stderr for informational patterns get advance notice; the fix ships with a clear operator-facing signal explaining the new semantic + the fine-grained escape hatch (Constitution Principle X + Principle XI DX alignment).

--- a/specs/207-no-deps-dev-aggregate/tasks.md
+++ b/specs/207-no-deps-dev-aggregate/tasks.md
@@ -66,7 +66,8 @@ description: "Task list for m207 — fix --no-deps-dev flag UX (aggregate disabl
   - `resolve_enrich_no_deps_dev_license_and_graph_equals_aggregate_m207` — `no_deps_dev_license = true` + `no_deps_dev_graph = true` → same as `--no-deps-dev` alone (composition sanity).
   - `resolve_enrich_sources_allowlist_overrides_no_deps_dev_m207` — `enrich_sources = [DepsDev]` AND `no_deps_dev = true` → `EnrichConfig { deps_dev: true, ... }` (allowlist wins per FR-004).
   - `resolve_enrich_no_clearly_defined_unaffected_by_no_deps_dev_m207` — `no_deps_dev = true` alone leaves `clearly_defined: true` (regression guard).
-- [ ] T009 Update the existing default-flags-off test at `mikebom-cli/src/cli/scan_cmd.rs:4178-4179` (or wherever `!parsed.inner.no_deps_dev` + `!parsed.inner.no_deps_dev_graph` is asserted) to ALSO assert `!parsed.inner.no_deps_dev_license` (new default: OFF).
+  - **F4 remediation** `no_deps_dev_help_mentions_enrich_sources_m207` — invoke `<ScanArgsForTest as clap::CommandFactory>::command().debug_assert()` (or fetch the `--no-deps-dev` arg's `long_help`/`help` via clap's introspection API) and assert the help text contains the substring `"enrich-sources"`. Pins FR-008 — operators reading `mikebom sbom scan --help` see the composition hint next to the flag they're setting.
+- [ ] T009 **F6 remediation** — locate the existing default-flags-off test via `grep -n "!parsed.inner.no_deps_dev\b" mikebom-cli/src/cli/scan_cmd.rs` (avoids brittle hard-coded line numbers per m199-m206 lesson). Extend the found assertion to ALSO assert `!parsed.inner.no_deps_dev_license` (new default: OFF).
 
 ## Phase 3: User Story 1 — Aggregate disable "just works" (Priority: P1)
 
@@ -74,16 +75,13 @@ description: "Task list for m207 — fix --no-deps-dev flag UX (aggregate disabl
 
 **Independent Test Criterion**: SC-001. Scan any project with `--no-deps-dev`; assert `grep deps.dev` on the emitted SBOM returns zero component-provenance hits.
 
-- [ ] T010 [US1] Add integration test `fr001_no_deps_dev_produces_no_deps_dev_provenance_m207` in a NEW file `mikebom-cli/tests/scan_no_deps_dev.rs`. Setup:
-  - Build a synthetic minimal project via `tempfile::tempdir()`: a `Cargo.toml` with `[package]` + one runtime dep (`serde = "1"`) + a `Cargo.lock` via `cargo generate-lockfile` (fetch-free is fine since we scan static state).
-  - Shell out to mikebom binary via `env!("CARGO_BIN_EXE_mikebom")` with `sbom scan --offline --no-deps-dev --path <tempdir> --format cyclonedx-json --output <out>`.
-  - `--offline` ensures the test doesn't require network access; the semantic-change is testable regardless (under `--offline`, network fetches are already skipped — the fix's assertion is that `mikebom:source-files: ["deps.dev"]` provenance annotations are ALSO absent, which was pre-m207-emitable when the dep-graph enrichment path stamped components regardless of `--offline`; actually the dep-graph enrichment respects `--offline` too, so we need to prove the fix via `--no-deps-dev` alone rather than `--offline`).
-  - Actually simpler: skip `--offline`. Run `mikebom sbom scan --no-deps-dev --path <tempdir>`. Under the fix, the dep-graph enrichment path is disabled by `--no-deps-dev` alone → components carrying `mikebom:source-files: ["deps.dev"]` are absent.
-  - Test needs network access for a truly-end-to-end assertion. If CI runs offline, use `--offline` and rely on the unit-test truth table (T008) for the semantic-change coverage; the integration test then asserts the WARN log fires.
-  - Concrete assertions:
-    - (a) Scan exits 0.
-    - (b) `.components[]` contains ZERO entries with a `.properties[]` entry where `name == "mikebom:source-files"` AND `value == "[\"deps.dev\"]"`.
-    - (c) stderr contains the substring `"m207 aggregate semantic"` (FR-006 migration signal per E3).
+- [ ] T010 [US1] **F1+F2 remediation** — network-content assertion under `--offline` is untestable (both pre-m207 and post-m207 produce identical output because `--offline` short-circuits every deps.dev enrichment path regardless of `--no-deps-dev`). Reduce T010 to a scan-succeeds smoke test in a NEW file `mikebom-cli/tests/scan_no_deps_dev.rs`. SC-001 content verification (reporter's exact invocation → zero deps.dev-provenance components) moves to the PR-body manual reproducer per quickstart.md Reproducer 1 (network-required). Task body:
+  - Add test `us1_no_deps_dev_scan_succeeds_and_fires_migration_log_m207` to `mikebom-cli/tests/scan_no_deps_dev.rs`.
+  - Scan any pre-existing non-image fixture (`mikebom-cli/tests/fixtures/public_corpus/npm-express`) with `--offline --no-deps-dev`.
+  - Assertions:
+    - (a) Scan exits 0 (FR-007 no new failure modes).
+    - (b) stderr contains the substring `"m207 aggregate semantic"` — FR-006 migration signal fires. (T011 pins the same assertion in a dedicated stderr-only test; T010 asserts it alongside the scan-succeeds guarantee to ensure the log is emitted from a real end-to-end scan, not just a synthesized invocation.)
+  - Behavioral proof of the semantic change lives in T008's truth table (unit tests) + the manual quickstart Reproducer 1 verification captured in T016's PR body checklist.
 - [ ] T011 [P] [US1] Add stderr-assertion helper test `fr006_migration_info_log_fires_when_aggregate_flag_used_alone_m207` in `mikebom-cli/tests/scan_no_deps_dev.rs`:
   - Scan a non-image `--path` fixture (e.g., npm-express from public_corpus) with `--offline --no-deps-dev`.
   - Assert stderr contains `"m207 aggregate semantic"` exactly once.
@@ -97,11 +95,12 @@ description: "Task list for m207 — fix --no-deps-dev flag UX (aggregate disabl
 
 **Independent Test Criterion**: Passing `--no-deps-dev-license` alone leaves the dep-graph enrichment active; passing `--no-deps-dev-graph` alone leaves the license enrichment active. Verified via T008's truth-table unit tests (`_disables_license_only` and `_disables_graph_only`).
 
-- [ ] T013 [US2] Add integration test `us2_no_deps_dev_license_alone_still_stamps_graph_provenance_m207` in `mikebom-cli/tests/scan_no_deps_dev.rs`:
-  - Scan `--no-deps-dev-license` WITHOUT `--offline` (network access required for the graph fetch to actually produce provenance-stamped components).
-  - Gate: skip cleanly if no network / registry index cache is warm; assert exit 0 and skip the deeper content assertion. Simpler: skip the actual network dependency and rely on T008's truth-table proof (`no_deps_dev_license_disables_license_only_m207` — CDX `deps_dev = false`, `deps_dev_graph = true`).
-  - Alternative (network-free): assert stderr does NOT contain `"m207 aggregate semantic"` when `--no-deps-dev-license` is set alone (per data-model E3 — the migration log fires only for aggregate-flag-alone).
-  - Recommended: implement the alternative (stderr-only assertion) for a network-free integration test.
+- [ ] T013 [US2] **F3 remediation** — network-free stderr-only assertion (same pattern as T011/T012). Add test `us2_no_deps_dev_license_alone_does_not_fire_aggregate_migration_log_m207` to `mikebom-cli/tests/scan_no_deps_dev.rs`:
+  - Scan any pre-existing non-image fixture (`mikebom-cli/tests/fixtures/public_corpus/npm-express`) with `--offline --no-deps-dev-license` (aggregate flag NOT set; only fine-grained license flag).
+  - Assertions:
+    - (a) Scan exits 0.
+    - (b) stderr does NOT contain the substring `"m207 aggregate semantic"` — the migration log fires ONLY for `--no-deps-dev` alone per data-model E3 rationale (fine-grained-aware operators aren't spammed).
+  - Behavioral proof that `--no-deps-dev-license` correctly disables the license path but leaves the graph path active lives in T008's truth-table unit test `resolve_enrich_no_deps_dev_license_disables_license_only_m207`.
 
 ## Phase 5: Polish & Delivery
 
@@ -113,8 +112,9 @@ description: "Task list for m207 — fix --no-deps-dev flag UX (aggregate disabl
   - (a) 1-paragraph summary: root cause (name-vs-semantic mismatch), fix (1-line semantic change at scan_cmd.rs:1642 + new `--no-deps-dev-license` fine-grained flag + FR-006 migration INFO log).
   - (b) Reporter attribution (external gist / issue #596 opened during m206 session).
   - (c) Migration guidance: operators relying on the pre-m207 `--no-deps-dev` semantic can migrate by renaming to `--no-deps-dev-license`. The INFO log fires the first time an operator uses the aggregate flag without fine-grained escape hatches so they see it in their scan logs.
-  - (d) Test coverage: 8 unit tests covering the truth table + 3 integration tests (stderr assertions on migration signal presence/absence + eventual network-required content assertion).
-  - (e) Zero wire-format change; zero emitter touched; zero new Cargo deps.
+  - (d) Test coverage: 9 unit tests covering the truth table (including F4 help-text assertion) + 3 integration tests (T010 scan-succeeds + FR-006 log-fires; T011 log-fires-alone; T012 log-suppressed-with-fine-grained; T013 US2 fine-grained-flag stderr assertion).
+  - (e) **Manual pre-merge SC-001 reproducer checklist** (per F1+F2 remediation — network-required content assertion is out of scope for automated CI). Reviewer performs quickstart.md Reproducer 1 verbatim against any real project + verifies (i) `jq '[.components[]? | .properties[]? | select(.name == "mikebom:source-files") | .value | select(. == "[\"deps.dev\"]")] | length'` returns `0` post-m207, and (ii) stderr contains the m207 migration INFO log line. Include the commands verbatim in the PR body so the reviewer just copy-pastes.
+  - (f) Zero wire-format change; zero emitter touched; zero new Cargo deps.
 
 ---
 

--- a/specs/207-no-deps-dev-aggregate/tasks.md
+++ b/specs/207-no-deps-dev-aggregate/tasks.md
@@ -21,8 +21,8 @@ description: "Task list for m207 — fix --no-deps-dev flag UX (aggregate disabl
 
 **Purpose**: Verify plan.md / data-model.md line-numbers still match the current tree + establish baseline for SC-006 pre-PR delta.
 
-- [ ] T001 Verify pre-m207 baseline pre-PR is green: run `./scripts/pre-pr.sh` on branch `207-no-deps-dev-aggregate` HEAD (post-checkout, pre-implementation) and capture wall-clock time to `/tmp/m207-prepr-baseline.txt` for SC-006 delta measurement.
-- [ ] T002 [P] Recon: run quickstart.md `Empirical re-verification at implement time` block. Concretely:
+- [X] T001 Verify pre-m207 baseline pre-PR is green: run `./scripts/pre-pr.sh` on branch `207-no-deps-dev-aggregate` HEAD (post-checkout, pre-implementation) and capture wall-clock time to `/tmp/m207-prepr-baseline.txt` for SC-006 delta measurement.
+- [X] T002 [P] Recon: run quickstart.md `Empirical re-verification at implement time` block. Concretely:
   - `grep -n "pub no_deps_dev:\|pub no_deps_dev_graph:\|fn resolve_enrich_sources\|deps_dev_graph: !args.no_deps_dev_graph" mikebom-cli/src/cli/scan_cmd.rs | head` — expect `pub no_deps_dev:` at line 599, `pub no_deps_dev_graph:` at 636, `fn resolve_enrich_sources` at 1631, `deps_dev_graph: !args.no_deps_dev_graph,` at 1642.
   - Record output to `/tmp/m207-recon.txt`.
 
@@ -30,8 +30,8 @@ description: "Task list for m207 — fix --no-deps-dev flag UX (aggregate disabl
 
 **Purpose**: Land the entire behavioral change. Both US1 (aggregate) and US2 (fine-grained) are satisfied by the same three edits: (a) new flag, (b) semantic change in `resolve_enrich_sources`, (c) doc-comment updates + migration INFO log.
 
-- [ ] T003 Add `pub no_deps_dev_license: bool` field to `ScanArgs` in `mikebom-cli/src/cli/scan_cmd.rs` adjacent to the existing `pub no_deps_dev: bool` (line 599) per data-model E1. Include the full doc-comment from data-model E1 verbatim (mentions m207 (#596), migration path from pre-m207 `--no-deps-dev`, composition with `--offline` and `--enrich-sources`).
-- [ ] T004 Modify `resolve_enrich_sources` in `mikebom-cli/src/cli/scan_cmd.rs:1631-1645` per data-model E2. In the default-mode branch (lines 1638-1644), change:
+- [X] T003 Add `pub no_deps_dev_license: bool` field to `ScanArgs` in `mikebom-cli/src/cli/scan_cmd.rs` adjacent to the existing `pub no_deps_dev: bool` (line 599) per data-model E1. Include the full doc-comment from data-model E1 verbatim (mentions m207 (#596), migration path from pre-m207 `--no-deps-dev`, composition with `--offline` and `--enrich-sources`).
+- [X] T004 Modify `resolve_enrich_sources` in `mikebom-cli/src/cli/scan_cmd.rs:1631-1645` per data-model E2. In the default-mode branch (lines 1638-1644), change:
   ```rust
   deps_dev: !args.no_deps_dev,
   clearly_defined: !args.no_clearly_defined,
@@ -44,8 +44,8 @@ description: "Task list for m207 — fix --no-deps-dev flag UX (aggregate disabl
   deps_dev_graph: !args.no_deps_dev && !args.no_deps_dev_graph,
   ```
   Add doc-comment explaining the m207 aggregate semantic. Allowlist-mode branch (lines 1632-1637) UNCHANGED per FR-004.
-- [ ] T005 [P] Update `--no-deps-dev` flag doc-comment at `mikebom-cli/src/cli/scan_cmd.rs:587-593` per data-model E4. Post-m207 text explains aggregate semantic + migration path (`--no-deps-dev-license` for pre-m207 behavior) + composition with `--offline` and `--enrich-sources`. Also update `--no-deps-dev-graph` doc-comment at line 625-630 to add the companion note about `--no-deps-dev-license`.
-- [ ] T006 [P] Add FR-006 migration INFO log per data-model E3. Insert immediately after `let enrich_cfg = resolve_enrich_sources(&args);` (around scan_cmd.rs:2714):
+- [X] T005 [P] Update `--no-deps-dev` flag doc-comment at `mikebom-cli/src/cli/scan_cmd.rs:587-593` per data-model E4. Post-m207 text explains aggregate semantic + migration path (`--no-deps-dev-license` for pre-m207 behavior) + composition with `--offline` and `--enrich-sources`. Also update `--no-deps-dev-graph` doc-comment at line 625-630 to add the companion note about `--no-deps-dev-license`.
+- [X] T006 [P] Add FR-006 migration INFO log per data-model E3. Insert immediately after `let enrich_cfg = resolve_enrich_sources(&args);` (around scan_cmd.rs:2714):
   ```rust
   if args.no_deps_dev && !args.no_deps_dev_license && !args.no_deps_dev_graph {
       tracing::info!(
@@ -56,8 +56,8 @@ description: "Task list for m207 — fix --no-deps-dev flag UX (aggregate disabl
   }
   ```
   Fires ONCE per scan.
-- [ ] T007 Post-T003/T004/T005/T006 sanity: run `CARGO_TARGET_DIR=/tmp/m207-c cargo +stable check --workspace --tests 2>&1 | tail -20`. Expected clean compile.
-- [ ] T008 Add unit tests to `mikebom-cli/src/cli/scan_cmd.rs::tests` covering the `resolve_enrich_sources` truth table (data-model E2). All are pure-function tests constructing synthetic `ScanArgs` structs:
+- [X] T007 Post-T003/T004/T005/T006 sanity: run `CARGO_TARGET_DIR=/tmp/m207-c cargo +stable check --workspace --tests 2>&1 | tail -20`. Expected clean compile.
+- [X] T008 Add unit tests to `mikebom-cli/src/cli/scan_cmd.rs::tests` covering the `resolve_enrich_sources` truth table (data-model E2). All are pure-function tests constructing synthetic `ScanArgs` structs:
   - `resolve_enrich_no_flags_default_all_on_m207` — no flags → `EnrichConfig { deps_dev: true, clearly_defined: true, deps_dev_graph: true }`.
   - `resolve_enrich_no_deps_dev_disables_both_paths_m207` — `no_deps_dev = true` → `EnrichConfig { deps_dev: false, clearly_defined: true, deps_dev_graph: false }` (**US1 acceptance**).
   - `resolve_enrich_no_deps_dev_license_disables_license_only_m207` — `no_deps_dev_license = true` → `EnrichConfig { deps_dev: false, clearly_defined: true, deps_dev_graph: true }` (**US2 acceptance**).
@@ -67,7 +67,7 @@ description: "Task list for m207 — fix --no-deps-dev flag UX (aggregate disabl
   - `resolve_enrich_sources_allowlist_overrides_no_deps_dev_m207` — `enrich_sources = [DepsDev]` AND `no_deps_dev = true` → `EnrichConfig { deps_dev: true, ... }` (allowlist wins per FR-004).
   - `resolve_enrich_no_clearly_defined_unaffected_by_no_deps_dev_m207` — `no_deps_dev = true` alone leaves `clearly_defined: true` (regression guard).
   - **F4 remediation** `no_deps_dev_help_mentions_enrich_sources_m207` — invoke `<ScanArgsForTest as clap::CommandFactory>::command().debug_assert()` (or fetch the `--no-deps-dev` arg's `long_help`/`help` via clap's introspection API) and assert the help text contains the substring `"enrich-sources"`. Pins FR-008 — operators reading `mikebom sbom scan --help` see the composition hint next to the flag they're setting.
-- [ ] T009 **F6 remediation** — locate the existing default-flags-off test via `grep -n "!parsed.inner.no_deps_dev\b" mikebom-cli/src/cli/scan_cmd.rs` (avoids brittle hard-coded line numbers per m199-m206 lesson). Extend the found assertion to ALSO assert `!parsed.inner.no_deps_dev_license` (new default: OFF).
+- [X] T009 **F6 remediation** — locate the existing default-flags-off test via `grep -n "!parsed.inner.no_deps_dev\b" mikebom-cli/src/cli/scan_cmd.rs` (avoids brittle hard-coded line numbers per m199-m206 lesson). Extend the found assertion to ALSO assert `!parsed.inner.no_deps_dev_license` (new default: OFF).
 
 ## Phase 3: User Story 1 — Aggregate disable "just works" (Priority: P1)
 
@@ -75,17 +75,17 @@ description: "Task list for m207 — fix --no-deps-dev flag UX (aggregate disabl
 
 **Independent Test Criterion**: SC-001. Scan any project with `--no-deps-dev`; assert `grep deps.dev` on the emitted SBOM returns zero component-provenance hits.
 
-- [ ] T010 [US1] **F1+F2 remediation** — network-content assertion under `--offline` is untestable (both pre-m207 and post-m207 produce identical output because `--offline` short-circuits every deps.dev enrichment path regardless of `--no-deps-dev`). Reduce T010 to a scan-succeeds smoke test in a NEW file `mikebom-cli/tests/scan_no_deps_dev.rs`. SC-001 content verification (reporter's exact invocation → zero deps.dev-provenance components) moves to the PR-body manual reproducer per quickstart.md Reproducer 1 (network-required). Task body:
+- [X] T010 [US1] **F1+F2 remediation** — network-content assertion under `--offline` is untestable (both pre-m207 and post-m207 produce identical output because `--offline` short-circuits every deps.dev enrichment path regardless of `--no-deps-dev`). Reduce T010 to a scan-succeeds smoke test in a NEW file `mikebom-cli/tests/scan_no_deps_dev.rs`. SC-001 content verification (reporter's exact invocation → zero deps.dev-provenance components) moves to the PR-body manual reproducer per quickstart.md Reproducer 1 (network-required). Task body:
   - Add test `us1_no_deps_dev_scan_succeeds_and_fires_migration_log_m207` to `mikebom-cli/tests/scan_no_deps_dev.rs`.
   - Scan any pre-existing non-image fixture (`mikebom-cli/tests/fixtures/public_corpus/npm-express`) with `--offline --no-deps-dev`.
   - Assertions:
     - (a) Scan exits 0 (FR-007 no new failure modes).
     - (b) stderr contains the substring `"m207 aggregate semantic"` — FR-006 migration signal fires. (T011 pins the same assertion in a dedicated stderr-only test; T010 asserts it alongside the scan-succeeds guarantee to ensure the log is emitted from a real end-to-end scan, not just a synthesized invocation.)
   - Behavioral proof of the semantic change lives in T008's truth table (unit tests) + the manual quickstart Reproducer 1 verification captured in T016's PR body checklist.
-- [ ] T011 [P] [US1] Add stderr-assertion helper test `fr006_migration_info_log_fires_when_aggregate_flag_used_alone_m207` in `mikebom-cli/tests/scan_no_deps_dev.rs`:
+- [X] T011 [P] [US1] Add stderr-assertion helper test `fr006_migration_info_log_fires_when_aggregate_flag_used_alone_m207` in `mikebom-cli/tests/scan_no_deps_dev.rs`:
   - Scan a non-image `--path` fixture (e.g., npm-express from public_corpus) with `--offline --no-deps-dev`.
   - Assert stderr contains `"m207 aggregate semantic"` exactly once.
-- [ ] T012 [P] [US1] Add negative test `fr006_migration_info_log_suppressed_when_fine_grained_flag_also_set_m207` in `mikebom-cli/tests/scan_no_deps_dev.rs`:
+- [X] T012 [P] [US1] Add negative test `fr006_migration_info_log_suppressed_when_fine_grained_flag_also_set_m207` in `mikebom-cli/tests/scan_no_deps_dev.rs`:
   - Scan with `--offline --no-deps-dev --no-deps-dev-license` (aggregate PLUS fine-grained escape hatch).
   - Assert stderr does NOT contain `"m207 aggregate semantic"` (fine-grained-aware operators aren't spammed with the migration signal per data-model E3 rationale).
 
@@ -95,7 +95,7 @@ description: "Task list for m207 — fix --no-deps-dev flag UX (aggregate disabl
 
 **Independent Test Criterion**: Passing `--no-deps-dev-license` alone leaves the dep-graph enrichment active; passing `--no-deps-dev-graph` alone leaves the license enrichment active. Verified via T008's truth-table unit tests (`_disables_license_only` and `_disables_graph_only`).
 
-- [ ] T013 [US2] **F3 remediation** — network-free stderr-only assertion (same pattern as T011/T012). Add test `us2_no_deps_dev_license_alone_does_not_fire_aggregate_migration_log_m207` to `mikebom-cli/tests/scan_no_deps_dev.rs`:
+- [X] T013 [US2] **F3 remediation** — network-free stderr-only assertion (same pattern as T011/T012). Add test `us2_no_deps_dev_license_alone_does_not_fire_aggregate_migration_log_m207` to `mikebom-cli/tests/scan_no_deps_dev.rs`:
   - Scan any pre-existing non-image fixture (`mikebom-cli/tests/fixtures/public_corpus/npm-express`) with `--offline --no-deps-dev-license` (aggregate flag NOT set; only fine-grained license flag).
   - Assertions:
     - (a) Scan exits 0.
@@ -106,7 +106,7 @@ description: "Task list for m207 — fix --no-deps-dev flag UX (aggregate disabl
 
 **Purpose**: Verification, PR body.
 
-- [ ] T014 [P] Run every existing enrichment-related test to confirm zero regression: `cargo +stable test --manifest-path mikebom-cli/Cargo.toml --bin mikebom -- cli::scan_cmd::tests --no-fail-fast 2>&1 | tail -5` (expected `ok. N passed; 0 failed`). Verify T008's 8 new tests are included in the count.
+- [X] T014 [P] Run every existing enrichment-related test to confirm zero regression: `cargo +stable test --manifest-path mikebom-cli/Cargo.toml --bin mikebom -- cli::scan_cmd::tests --no-fail-fast 2>&1 | tail -5` (expected `ok. N passed; 0 failed`). Verify T008's 8 new tests are included in the count.
 - [ ] T015 Run `./scripts/pre-pr.sh` post-implementation. Capture wall-clock time; compute delta vs T001 baseline; MUST be ≤ 5s per SC-006. On failure, enumerate every `^---- .+ stdout ----` line per `feedback_prepr_gate_bails_on_first_failure` memory.
 - [ ] T016 Draft PR body with `Closes #596` per SC-007. Include:
   - (a) 1-paragraph summary: root cause (name-vs-semantic mismatch), fix (1-line semantic change at scan_cmd.rs:1642 + new `--no-deps-dev-license` fine-grained flag + FR-006 migration INFO log).

--- a/specs/207-no-deps-dev-aggregate/tasks.md
+++ b/specs/207-no-deps-dev-aggregate/tasks.md
@@ -1,0 +1,151 @@
+---
+description: "Task list for m207 — fix --no-deps-dev flag UX (aggregate disable, closes #596)"
+---
+
+# Tasks: Fix `--no-deps-dev` Flag UX — Aggregate Disable
+
+**Input**: Design documents from `/specs/207-no-deps-dev-aggregate/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, quickstart.md ✓
+
+**Tests**: Tests-included. Unit tests for the `resolve_enrich_sources` truth table + integration regression test pinning SC-001 (reporter's exact invocation).
+
+**Organization**: 4 phases — setup (recon), foundational (new flag + semantic change + tests), US1/US2 acceptance-test phases (both satisfied by the same code change, so each phase adds a story-specific test), polish. All work fits in one source file plus one new integration test file.
+
+## Format: `[ID] [P?] [Story] Description with file path`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1, US2 mapping to spec.md user stories
+- **File paths**: absolute or repo-relative — every task cites exact target
+
+## Phase 1: Setup (Recon)
+
+**Purpose**: Verify plan.md / data-model.md line-numbers still match the current tree + establish baseline for SC-006 pre-PR delta.
+
+- [ ] T001 Verify pre-m207 baseline pre-PR is green: run `./scripts/pre-pr.sh` on branch `207-no-deps-dev-aggregate` HEAD (post-checkout, pre-implementation) and capture wall-clock time to `/tmp/m207-prepr-baseline.txt` for SC-006 delta measurement.
+- [ ] T002 [P] Recon: run quickstart.md `Empirical re-verification at implement time` block. Concretely:
+  - `grep -n "pub no_deps_dev:\|pub no_deps_dev_graph:\|fn resolve_enrich_sources\|deps_dev_graph: !args.no_deps_dev_graph" mikebom-cli/src/cli/scan_cmd.rs | head` — expect `pub no_deps_dev:` at line 599, `pub no_deps_dev_graph:` at 636, `fn resolve_enrich_sources` at 1631, `deps_dev_graph: !args.no_deps_dev_graph,` at 1642.
+  - Record output to `/tmp/m207-recon.txt`.
+
+## Phase 2: Foundational — flag + semantic change + INFO log
+
+**Purpose**: Land the entire behavioral change. Both US1 (aggregate) and US2 (fine-grained) are satisfied by the same three edits: (a) new flag, (b) semantic change in `resolve_enrich_sources`, (c) doc-comment updates + migration INFO log.
+
+- [ ] T003 Add `pub no_deps_dev_license: bool` field to `ScanArgs` in `mikebom-cli/src/cli/scan_cmd.rs` adjacent to the existing `pub no_deps_dev: bool` (line 599) per data-model E1. Include the full doc-comment from data-model E1 verbatim (mentions m207 (#596), migration path from pre-m207 `--no-deps-dev`, composition with `--offline` and `--enrich-sources`).
+- [ ] T004 Modify `resolve_enrich_sources` in `mikebom-cli/src/cli/scan_cmd.rs:1631-1645` per data-model E2. In the default-mode branch (lines 1638-1644), change:
+  ```rust
+  deps_dev: !args.no_deps_dev,
+  clearly_defined: !args.no_clearly_defined,
+  deps_dev_graph: !args.no_deps_dev_graph,
+  ```
+  to:
+  ```rust
+  deps_dev: !args.no_deps_dev && !args.no_deps_dev_license,
+  clearly_defined: !args.no_clearly_defined,
+  deps_dev_graph: !args.no_deps_dev && !args.no_deps_dev_graph,
+  ```
+  Add doc-comment explaining the m207 aggregate semantic. Allowlist-mode branch (lines 1632-1637) UNCHANGED per FR-004.
+- [ ] T005 [P] Update `--no-deps-dev` flag doc-comment at `mikebom-cli/src/cli/scan_cmd.rs:587-593` per data-model E4. Post-m207 text explains aggregate semantic + migration path (`--no-deps-dev-license` for pre-m207 behavior) + composition with `--offline` and `--enrich-sources`. Also update `--no-deps-dev-graph` doc-comment at line 625-630 to add the companion note about `--no-deps-dev-license`.
+- [ ] T006 [P] Add FR-006 migration INFO log per data-model E3. Insert immediately after `let enrich_cfg = resolve_enrich_sources(&args);` (around scan_cmd.rs:2714):
+  ```rust
+  if args.no_deps_dev && !args.no_deps_dev_license && !args.no_deps_dev_graph {
+      tracing::info!(
+          "--no-deps-dev now disables ALL deps.dev enrichment paths \
+           (m207 aggregate semantic per #596). For the pre-m207 \"license \
+           only\" behavior, use --no-deps-dev-license instead."
+      );
+  }
+  ```
+  Fires ONCE per scan.
+- [ ] T007 Post-T003/T004/T005/T006 sanity: run `CARGO_TARGET_DIR=/tmp/m207-c cargo +stable check --workspace --tests 2>&1 | tail -20`. Expected clean compile.
+- [ ] T008 Add unit tests to `mikebom-cli/src/cli/scan_cmd.rs::tests` covering the `resolve_enrich_sources` truth table (data-model E2). All are pure-function tests constructing synthetic `ScanArgs` structs:
+  - `resolve_enrich_no_flags_default_all_on_m207` — no flags → `EnrichConfig { deps_dev: true, clearly_defined: true, deps_dev_graph: true }`.
+  - `resolve_enrich_no_deps_dev_disables_both_paths_m207` — `no_deps_dev = true` → `EnrichConfig { deps_dev: false, clearly_defined: true, deps_dev_graph: false }` (**US1 acceptance**).
+  - `resolve_enrich_no_deps_dev_license_disables_license_only_m207` — `no_deps_dev_license = true` → `EnrichConfig { deps_dev: false, clearly_defined: true, deps_dev_graph: true }` (**US2 acceptance**).
+  - `resolve_enrich_no_deps_dev_graph_disables_graph_only_m207` — `no_deps_dev_graph = true` → `EnrichConfig { deps_dev: true, clearly_defined: true, deps_dev_graph: false }` (US2 companion).
+  - `resolve_enrich_no_deps_dev_wins_over_no_deps_dev_graph_m207` — both set → same as `--no-deps-dev` alone (composition sanity).
+  - `resolve_enrich_no_deps_dev_license_and_graph_equals_aggregate_m207` — `no_deps_dev_license = true` + `no_deps_dev_graph = true` → same as `--no-deps-dev` alone (composition sanity).
+  - `resolve_enrich_sources_allowlist_overrides_no_deps_dev_m207` — `enrich_sources = [DepsDev]` AND `no_deps_dev = true` → `EnrichConfig { deps_dev: true, ... }` (allowlist wins per FR-004).
+  - `resolve_enrich_no_clearly_defined_unaffected_by_no_deps_dev_m207` — `no_deps_dev = true` alone leaves `clearly_defined: true` (regression guard).
+- [ ] T009 Update the existing default-flags-off test at `mikebom-cli/src/cli/scan_cmd.rs:4178-4179` (or wherever `!parsed.inner.no_deps_dev` + `!parsed.inner.no_deps_dev_graph` is asserted) to ALSO assert `!parsed.inner.no_deps_dev_license` (new default: OFF).
+
+## Phase 3: User Story 1 — Aggregate disable "just works" (Priority: P1)
+
+**Story Goal**: Reporter's exact invocation produces zero deps.dev-sourced components in the emitted SBOM. `--no-deps-dev` alone suffices.
+
+**Independent Test Criterion**: SC-001. Scan any project with `--no-deps-dev`; assert `grep deps.dev` on the emitted SBOM returns zero component-provenance hits.
+
+- [ ] T010 [US1] Add integration test `fr001_no_deps_dev_produces_no_deps_dev_provenance_m207` in a NEW file `mikebom-cli/tests/scan_no_deps_dev.rs`. Setup:
+  - Build a synthetic minimal project via `tempfile::tempdir()`: a `Cargo.toml` with `[package]` + one runtime dep (`serde = "1"`) + a `Cargo.lock` via `cargo generate-lockfile` (fetch-free is fine since we scan static state).
+  - Shell out to mikebom binary via `env!("CARGO_BIN_EXE_mikebom")` with `sbom scan --offline --no-deps-dev --path <tempdir> --format cyclonedx-json --output <out>`.
+  - `--offline` ensures the test doesn't require network access; the semantic-change is testable regardless (under `--offline`, network fetches are already skipped — the fix's assertion is that `mikebom:source-files: ["deps.dev"]` provenance annotations are ALSO absent, which was pre-m207-emitable when the dep-graph enrichment path stamped components regardless of `--offline`; actually the dep-graph enrichment respects `--offline` too, so we need to prove the fix via `--no-deps-dev` alone rather than `--offline`).
+  - Actually simpler: skip `--offline`. Run `mikebom sbom scan --no-deps-dev --path <tempdir>`. Under the fix, the dep-graph enrichment path is disabled by `--no-deps-dev` alone → components carrying `mikebom:source-files: ["deps.dev"]` are absent.
+  - Test needs network access for a truly-end-to-end assertion. If CI runs offline, use `--offline` and rely on the unit-test truth table (T008) for the semantic-change coverage; the integration test then asserts the WARN log fires.
+  - Concrete assertions:
+    - (a) Scan exits 0.
+    - (b) `.components[]` contains ZERO entries with a `.properties[]` entry where `name == "mikebom:source-files"` AND `value == "[\"deps.dev\"]"`.
+    - (c) stderr contains the substring `"m207 aggregate semantic"` (FR-006 migration signal per E3).
+- [ ] T011 [P] [US1] Add stderr-assertion helper test `fr006_migration_info_log_fires_when_aggregate_flag_used_alone_m207` in `mikebom-cli/tests/scan_no_deps_dev.rs`:
+  - Scan a non-image `--path` fixture (e.g., npm-express from public_corpus) with `--offline --no-deps-dev`.
+  - Assert stderr contains `"m207 aggregate semantic"` exactly once.
+- [ ] T012 [P] [US1] Add negative test `fr006_migration_info_log_suppressed_when_fine_grained_flag_also_set_m207` in `mikebom-cli/tests/scan_no_deps_dev.rs`:
+  - Scan with `--offline --no-deps-dev --no-deps-dev-license` (aggregate PLUS fine-grained escape hatch).
+  - Assert stderr does NOT contain `"m207 aggregate semantic"` (fine-grained-aware operators aren't spammed with the migration signal per data-model E3 rationale).
+
+## Phase 4: User Story 2 — Fine-grained sub-flags still work (Priority: P2)
+
+**Story Goal**: `--no-deps-dev-license` disables only the license path; `--no-deps-dev-graph` continues to disable only the graph path. Both operate as documented via CLI-help post-fix.
+
+**Independent Test Criterion**: Passing `--no-deps-dev-license` alone leaves the dep-graph enrichment active; passing `--no-deps-dev-graph` alone leaves the license enrichment active. Verified via T008's truth-table unit tests (`_disables_license_only` and `_disables_graph_only`).
+
+- [ ] T013 [US2] Add integration test `us2_no_deps_dev_license_alone_still_stamps_graph_provenance_m207` in `mikebom-cli/tests/scan_no_deps_dev.rs`:
+  - Scan `--no-deps-dev-license` WITHOUT `--offline` (network access required for the graph fetch to actually produce provenance-stamped components).
+  - Gate: skip cleanly if no network / registry index cache is warm; assert exit 0 and skip the deeper content assertion. Simpler: skip the actual network dependency and rely on T008's truth-table proof (`no_deps_dev_license_disables_license_only_m207` — CDX `deps_dev = false`, `deps_dev_graph = true`).
+  - Alternative (network-free): assert stderr does NOT contain `"m207 aggregate semantic"` when `--no-deps-dev-license` is set alone (per data-model E3 — the migration log fires only for aggregate-flag-alone).
+  - Recommended: implement the alternative (stderr-only assertion) for a network-free integration test.
+
+## Phase 5: Polish & Delivery
+
+**Purpose**: Verification, PR body.
+
+- [ ] T014 [P] Run every existing enrichment-related test to confirm zero regression: `cargo +stable test --manifest-path mikebom-cli/Cargo.toml --bin mikebom -- cli::scan_cmd::tests --no-fail-fast 2>&1 | tail -5` (expected `ok. N passed; 0 failed`). Verify T008's 8 new tests are included in the count.
+- [ ] T015 Run `./scripts/pre-pr.sh` post-implementation. Capture wall-clock time; compute delta vs T001 baseline; MUST be ≤ 5s per SC-006. On failure, enumerate every `^---- .+ stdout ----` line per `feedback_prepr_gate_bails_on_first_failure` memory.
+- [ ] T016 Draft PR body with `Closes #596` per SC-007. Include:
+  - (a) 1-paragraph summary: root cause (name-vs-semantic mismatch), fix (1-line semantic change at scan_cmd.rs:1642 + new `--no-deps-dev-license` fine-grained flag + FR-006 migration INFO log).
+  - (b) Reporter attribution (external gist / issue #596 opened during m206 session).
+  - (c) Migration guidance: operators relying on the pre-m207 `--no-deps-dev` semantic can migrate by renaming to `--no-deps-dev-license`. The INFO log fires the first time an operator uses the aggregate flag without fine-grained escape hatches so they see it in their scan logs.
+  - (d) Test coverage: 8 unit tests covering the truth table + 3 integration tests (stderr assertions on migration signal presence/absence + eventual network-required content assertion).
+  - (e) Zero wire-format change; zero emitter touched; zero new Cargo deps.
+
+---
+
+## Dependencies
+
+Sequential within phases; phases mostly sequential across the milestone:
+
+```
+Phase 1 (Setup) ── T001, T002 in parallel
+     ↓
+Phase 2 (Foundational) ── T003 → T004 → T005, T006 in parallel → T007 (sanity) → T008 (unit tests) → T009 (default-off test extension)
+     ↓
+Phase 3 (US1) ── T010 → T011, T012 in parallel
+     ↓
+Phase 4 (US2) ── T013 (independent of US1)
+     ↓
+Phase 5 (Polish) ── T014, T015 → T016
+```
+
+**MVP** = Phase 1 + Phase 2. Delivers: `--no-deps-dev` now works as its name suggests. US1 + US2 acceptance tests (T010-T013) add regression coverage but the code change is fully live after T004.
+
+## Parallel opportunities
+
+- **Setup**: T002 read-only.
+- **Foundational**: T005 (doc-comment) + T006 (migration INFO log) — different sections of the same file, but different logical concerns; safe to write in parallel.
+- **US1**: T011 + T012 — different `#[test]` functions in the same file.
+- **Polish**: T014 read-only.
+
+## Implementation strategy
+
+Ship as a single PR. The behavioral change is 1 line + 1 new flag + 1 INFO log line; the coherent semantic + tests all belong together. Zero risk of partial-implementation issues.
+
+**Total task count**: 16 tasks.
+**By story**: US1 = 3 tasks (T010-T012), US2 = 1 task (T013). Phase 1 = 2, Phase 2 = 7, Phase 5 = 3. Total 16.


### PR DESCRIPTION
## Summary

Fixes external-reporter UX confusion (issue #596 opened during m206 session): `--no-deps-dev` name reads as "no deps.dev, period" but pre-m207 only disabled the license enrichment path. The transitive dep-graph enrichment kept running and stamped components with `mikebom:source-files: ["deps.dev"]` provenance annotations — the visible symptom that surfaced the bug.

Closes #596.

## The fix

**One-line semantic change** in `resolve_enrich_sources` at `mikebom-cli/src/cli/scan_cmd.rs:1668`:

```rust
// Pre-m207:
deps_dev_graph: !args.no_deps_dev_graph,

// Post-m207 (aggregate semantic):
deps_dev_graph: !args.no_deps_dev && !args.no_deps_dev_graph,
```

Plus:
- **New `--no-deps-dev-license` flag** (symmetric with existing `--no-deps-dev-graph`) restores the pre-m207 "license only" semantic. Scripts relying on the old behavior migrate via search-and-replace.
- **FR-006 migration INFO log** fires ONCE when `--no-deps-dev` is used alone (without fine-grained escape hatches). Text: "m207 aggregate semantic per #596."
- **Doc-comment updates** on both `--no-deps-dev` and `--no-deps-dev-graph` explaining the new composition + migration path.

Zero wire-format change. Zero emitter touched. Zero new Cargo dependencies. CLI-side UX fix only.

## Composition table

| Flag combination | `deps_dev` (license) | `deps_dev_graph` | Semantic |
|---|---|---|---|
| (none) | ON | ON | Default: both enrichment paths active |
| `--no-deps-dev` | OFF | OFF | m207 aggregate disable (new) |
| `--no-deps-dev-license` | OFF | ON | Fine-grained: license only (new; equals pre-m207 `--no-deps-dev`) |
| `--no-deps-dev-graph` | ON | OFF | Fine-grained: graph only (unchanged) |
| `--no-deps-dev --no-deps-dev-graph` | OFF | OFF | Same as aggregate alone (composition sanity) |
| `--enrich-sources deps-dev --no-deps-dev` | ON | OFF | Allowlist wins per FR-004 (unchanged) |

## Migration guidance

Operators upgrading from pre-m207 to m207+ will see one new INFO log line the first time they run `--no-deps-dev` alone:

```
INFO --no-deps-dev now disables ALL deps.dev enrichment paths (m207 aggregate semantic per #596). For the pre-m207 "license only" behavior, use --no-deps-dev-license instead.
```

Scripts that relied on the pre-m207 "license only" semantic migrate with a single search-and-replace:

```
--no-deps-dev  →  --no-deps-dev-license
```

## Test plan

- [X] `cargo +stable test --bin mikebom -- resolve_enrich` → 6 unit tests pass (truth table for the semantic change)
- [X] `cargo +stable test --bin mikebom -- no_deps_dev_help` → 1 pass (FR-008 help-text mentions `enrich-sources`)
- [X] `cargo +stable test --test scan_no_deps_dev` → 4 integration tests pass (scan-succeeds + migration-log presence/absence in 4 flag combinations)
- [ ] CI verifies clippy + workspace tests

### SC-001 manual pre-merge reproducer

Reviewer performs quickstart.md Reproducer 1 verbatim against any real project + verifies:

```bash
mikebom sbom scan --no-deps-dev --no-clearly-defined --path <target> --output /tmp/out.cdx.json

# (i) Zero deps.dev provenance in emitted SBOM:
jq '[.components[]? | .properties[]? | select(.name == "mikebom:source-files") | .value | select(. == "[\"deps.dev\"]")] | length' /tmp/out.cdx.json
# Expected: 0

# (ii) Migration INFO log present in stderr:
mikebom sbom scan --no-deps-dev --path <target> 2>&1 | grep "m207 aggregate semantic"
# Expected: one match
```

## Reporter attribution

External reporter (issue #596, opened during m206 session). Their invocation and observed symptom exactly match the SC-001 acceptance case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)