### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 for GHSA-4w2j-m93h-cj5j

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,9 +2878,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary

- Bumps `quinn-proto` `0.11.14` → `0.11.15` in the workspace `Cargo.lock` (2-line diff, semver-compatible patch, nothing else moves).
- Unblocks the milestone-089 **Production-deps vuln gate**, which started failing on *every* open PR once `GHSA-4w2j-m93h-cj5j` (HIGH — Quinn: remote memory exhaustion from unbounded out-of-order stream reassembly, `< 0.11.15`) landed in the Trivy advisory DB after main's last CI run.

## Why a bump rather than a `known-acceptances.md` entry

`specs/089-bump-sigstore-vulns/known-acceptances.md` is reserved for genuinely-unfixable transitives (today: the `rustls-webpki@0.102.8` cluster rooted at sigstore 0.11.0's non-optional dep). This one has an upstream patch, so we take it.

Worth noting for reviewers: waybill is **not exposed** to this advisory even pre-bump. `quinn-proto` reaches the lockfile only via `reqwest 0.12.28` → `quinn 0.11.9`, gated behind reqwest's optional `http3` feature, which we do not enable:

```
$ cargo tree -i quinn-proto
warning: nothing to print.
$ cargo tree -e normal | grep -c quinn
0
```

Cargo records optional transitives in the lockfile regardless of feature activation, and the vuln gate is feature-blind — so it flags entries that are never compiled. The bump is the cheapest way to keep the gate honest.

## Test plan

- [x] `cargo check --workspace --all-targets` — exit 0
- [ ] CI green (this PR's own vuln-gate run is the real assertion)