### PR TITLE
refactor: promote pants BUILD-walker helpers to shared pants_common/

### DIFF
--- a/waybill-cli/src/scan_fs/package_db/mod.rs
+++ b/waybill-cli/src/scan_fs/package_db/mod.rs
@@ -43,6 +43,7 @@ pub mod npm;
 pub mod nuget;
 pub mod opkg;
 pub mod pants;
+pub mod pants_common;
 pub mod pants_go;
 pub mod pants_jvm;
 pub mod pants_shell;

--- a/waybill-cli/src/scan_fs/package_db/pants_common/mod.rs
+++ b/waybill-cli/src/scan_fs/package_db/pants_common/mod.rs
@@ -1,0 +1,166 @@
+//! Shared helpers for Pants-family readers (m225 pants_shell + m226
+//! pants_go, plus any future Pants BUILD-walker consumer).
+//!
+//! Extracted from m225/m226 after those two milestones shipped
+//! byte-identical implementations of the two functions in this
+//! module. Per m225/m226 §Follow-ups, the promotion trigger was
+//! "when 2+ Pants readers exist" — that threshold is now met.
+//!
+//! What's shared (this module):
+//! - [`discover_build_files`] — walks the scan root via `safe_walk`,
+//!   returns every path whose file name is exactly `"BUILD"`.
+//!   Respects symlink-cycle guard, `--exclude-path`, depth limits.
+//! - [`find_matching_close_paren`] — byte-level scanner that finds
+//!   the matching `)` for an opening paren, respecting single- and
+//!   double-quoted string literals (with `\` escape). Used by each
+//!   reader's regex-scoped target-declaration extractor to locate
+//!   call-body boundaries without a full Python parser
+//!   (Constitution Principle I — no embedded interpreter).
+//!
+//! What stays per-reader:
+//! - The regex-anchored target-type match (`pants_shell` recognizes
+//!   `shell_source`/`shell_sources`/`shunit2_test`/`shunit2_tests`;
+//!   `pants_go` recognizes `go_mod`/`go_third_party_package`/
+//!   `go_binary`/`go_package`).
+//! - Per-kwarg regex extraction — the two readers extract different
+//!   kwarg sets (`source=`/`sources=[...]` vs `import_path=`/`main=`).
+//! - The typed `TargetKind` / `TargetDeclaration` / `TargetParseError`
+//!   enums — each reader's target-type list is closed and distinct,
+//!   so a generic version would either lose type safety or gain
+//!   awkward `&'static str` dispatch.
+
+use std::path::{Path, PathBuf};
+
+use super::exclude_path::ExclusionSet;
+use crate::scan_fs::walk::{safe_walk, WalkConfig};
+
+/// Discover every `BUILD` file under `scan_root` via `safe_walk`
+/// (respects symlink-cycle guard, `--exclude-path`, depth limits).
+/// Callers filter the results by target-type further downstream.
+pub(crate) fn discover_build_files(
+    scan_root: &Path,
+    exclude_set: &ExclusionSet,
+) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let cfg = WalkConfig {
+        max_depth: 32,
+        should_skip: &|_candidate, _rootfs| false,
+        exclude_set,
+    };
+    safe_walk(scan_root, &cfg, |path| {
+        if path.is_file()
+            && path.file_name().and_then(|s| s.to_str()) == Some("BUILD")
+        {
+            out.push(path.to_path_buf());
+        }
+    });
+    out
+}
+
+/// Walk `bytes` from `start` (which MUST point at an opening `(`)
+/// and return the byte offset of the matching closing `)`. Respects
+/// string literals: single- and double-quoted (with `\` escape).
+/// Returns `None` on unbalanced parens / EOF-in-string.
+///
+/// Used by each Pants reader's regex-scoped extractor to locate the
+/// call-body of a target-function invocation without a full Python
+/// parser (Constitution Principle I).
+pub(crate) fn find_matching_close_paren(bytes: &[u8], start: usize) -> Option<usize> {
+    debug_assert_eq!(bytes.get(start), Some(&b'('));
+    let mut depth: i32 = 0;
+    let mut i = start;
+    let mut in_str: Option<u8> = None;
+    let mut escape = false;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if let Some(q) = in_str {
+            if escape {
+                escape = false;
+            } else if c == b'\\' {
+                escape = true;
+            } else if c == q {
+                in_str = None;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'"' | b'\'' => {
+                in_str = Some(c);
+            }
+            b'(' | b'[' | b'{' => {
+                depth += 1;
+            }
+            b')' | b']' | b'}' => {
+                depth -= 1;
+                if depth == 0 && c == b')' {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_matching_close_paren_simple() {
+        let s = b"foo(bar)";
+        assert_eq!(find_matching_close_paren(s, 3), Some(7));
+    }
+
+    #[test]
+    fn find_matching_close_paren_nested() {
+        let s = b"foo(bar(baz)qux)";
+        assert_eq!(find_matching_close_paren(s, 3), Some(15));
+    }
+
+    #[test]
+    fn find_matching_close_paren_string_literal_hides_paren() {
+        let s = br#"foo(bar=")")"#;
+        // Outer `(` at 3; the `)` at 9 is inside a string literal
+        // and must be skipped; the outer `)` at 11 is the match.
+        assert_eq!(find_matching_close_paren(s, 3), Some(11));
+    }
+
+    #[test]
+    fn find_matching_close_paren_single_quoted() {
+        let s = br#"foo(bar=')' )"#;
+        assert_eq!(find_matching_close_paren(s, 3), Some(12));
+    }
+
+    #[test]
+    fn find_matching_close_paren_escape_in_string() {
+        let s = br#"foo(bar="a\"b" )"#;
+        // Escaped quote inside string must NOT close the string.
+        assert_eq!(find_matching_close_paren(s, 3), Some(15));
+    }
+
+    #[test]
+    fn find_matching_close_paren_unbalanced_returns_none() {
+        let s = b"foo(bar";
+        assert_eq!(find_matching_close_paren(s, 3), None);
+    }
+
+    #[test]
+    fn find_matching_close_paren_eof_in_string_returns_none() {
+        let s = br#"foo(bar="unterminated"#;
+        assert_eq!(find_matching_close_paren(s, 3), None);
+    }
+
+    #[test]
+    fn discover_build_files_returns_empty_for_nonexistent_dir() {
+        let exclude_set = ExclusionSet::new_empty();
+        let files = discover_build_files(
+            Path::new("/nonexistent-path-xyzzy"),
+            &exclude_set,
+        );
+        assert!(files.is_empty());
+    }
+}

--- a/waybill-cli/src/scan_fs/package_db/pants_go/build_dsl.rs
+++ b/waybill-cli/src/scan_fs/package_db/pants_go/build_dsl.rs
@@ -15,6 +15,7 @@ use std::sync::OnceLock;
 
 use regex::Regex;
 
+use super::super::pants_common::find_matching_close_paren;
 use super::{GoTargetDeclaration, GoTargetKind, GoTargetParseError};
 
 /// Anchoring regex — matches `<target_type>(` at line-start.
@@ -79,49 +80,6 @@ fn main_key_regex() -> &'static Regex {
         Regex::new(r"(?m)(?:^|[,\s(])main\s*=\s*")
             .expect("valid main-key regex")
     })
-}
-
-/// Walk `bytes` from `start` (must point at an opening `(`) and
-/// return the byte offset of the matching closing `)`. Respects
-/// single- + double-quoted string literals (with `\` escapes).
-/// Returns `None` on unbalanced parens / EOF-in-string.
-fn find_matching_close_paren(bytes: &[u8], start: usize) -> Option<usize> {
-    debug_assert_eq!(bytes.get(start), Some(&b'('));
-    let mut depth: i32 = 0;
-    let mut i = start;
-    let mut in_str: Option<u8> = None;
-    let mut escape = false;
-    while i < bytes.len() {
-        let c = bytes[i];
-        if let Some(q) = in_str {
-            if escape {
-                escape = false;
-            } else if c == b'\\' {
-                escape = true;
-            } else if c == q {
-                in_str = None;
-            }
-            i += 1;
-            continue;
-        }
-        match c {
-            b'"' | b'\'' => {
-                in_str = Some(c);
-            }
-            b'(' | b'[' | b'{' => {
-                depth += 1;
-            }
-            b')' | b']' | b'}' => {
-                depth -= 1;
-                if depth == 0 && c == b')' {
-                    return Some(i);
-                }
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-    None
 }
 
 /// Extract every recognized Pants Go target declaration from a

--- a/waybill-cli/src/scan_fs/package_db/pants_go/mod.rs
+++ b/waybill-cli/src/scan_fs/package_db/pants_go/mod.rs
@@ -26,8 +26,8 @@ use waybill_common::resolution::{LifecycleScope, ResolvedComponent};
 use waybill_common::types::purl::{encode_purl_segment, Purl};
 
 use super::exclude_path::ExclusionSet;
+use super::pants_common;
 use super::PackageDbEntry;
-use crate::scan_fs::walk::{safe_walk, WalkConfig};
 
 /// The four built-in Pants Go backend target types we recognize.
 ///
@@ -118,26 +118,6 @@ pub(crate) enum GoTargetParseError {
     NonStringLiteralValue { line: u32, snippet: String },
     #[error("unbalanced parens starting at line {line}")]
     UnbalancedParens { line: u32 },
-}
-
-/// Discover every `BUILD` file under `scan_root` via `safe_walk`
-/// (respects symlink-cycle guard, `--exclude-path`, depth limits).
-/// Copy of m225 pants_shell's discovery helper.
-fn discover_build_files(scan_root: &Path, exclude_set: &ExclusionSet) -> Vec<PathBuf> {
-    let mut out: Vec<PathBuf> = Vec::new();
-    let cfg = WalkConfig {
-        max_depth: 32,
-        should_skip: &|_candidate, _rootfs| false,
-        exclude_set,
-    };
-    safe_walk(scan_root, &cfg, |path| {
-        if path.is_file()
-            && path.file_name().and_then(|s| s.to_str()) == Some("BUILD")
-        {
-            out.push(path.to_path_buf());
-        }
-    });
-    out
 }
 
 /// Public entry — emits the design-tier `pkg:generic/go@<version>`
@@ -242,7 +222,7 @@ pub fn enrich(
     exclude_set: &ExclusionSet,
     components: &mut [ResolvedComponent],
 ) {
-    let build_files = discover_build_files(scan_root, exclude_set);
+    let build_files = pants_common::discover_build_files(scan_root, exclude_set);
     let pants_toml_present = scan_root.join("pants.toml").is_file();
     if build_files.is_empty() && !pants_toml_present {
         return;

--- a/waybill-cli/src/scan_fs/package_db/pants_shell/build_dsl.rs
+++ b/waybill-cli/src/scan_fs/package_db/pants_shell/build_dsl.rs
@@ -20,6 +20,7 @@ use std::sync::OnceLock;
 
 use regex::Regex;
 
+use super::super::pants_common::find_matching_close_paren;
 use super::{ShellTargetKind, TargetDeclaration, TargetParseError, TargetSource};
 
 /// Anchoring regex — matches `<target_type>(` at the start of a line
@@ -82,49 +83,6 @@ fn list_element_regex() -> &'static Regex {
     RE.get_or_init(|| {
         Regex::new(r#""([^"]*)"|'([^']*)'"#).expect("valid list-element regex")
     })
-}
-
-/// Walk `bytes` from `start` (which must point at an opening `(`)
-/// and return the byte offset of the matching closing `)`. Respects
-/// string literals: single- and double-quoted (with `\` escape). Returns
-/// `None` on unbalanced parens / EOF-in-string.
-fn find_matching_close_paren(bytes: &[u8], start: usize) -> Option<usize> {
-    debug_assert_eq!(bytes.get(start), Some(&b'('));
-    let mut depth: i32 = 0;
-    let mut i = start;
-    let mut in_str: Option<u8> = None;
-    let mut escape = false;
-    while i < bytes.len() {
-        let c = bytes[i];
-        if let Some(q) = in_str {
-            if escape {
-                escape = false;
-            } else if c == b'\\' {
-                escape = true;
-            } else if c == q {
-                in_str = None;
-            }
-            i += 1;
-            continue;
-        }
-        match c {
-            b'"' | b'\'' => {
-                in_str = Some(c);
-            }
-            b'(' | b'[' | b'{' => {
-                depth += 1;
-            }
-            b')' | b']' | b'}' => {
-                depth -= 1;
-                if depth == 0 && c == b')' {
-                    return Some(i);
-                }
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-    None
 }
 
 /// Extract all recognized shell target declarations from a BUILD-file

--- a/waybill-cli/src/scan_fs/package_db/pants_shell/mod.rs
+++ b/waybill-cli/src/scan_fs/package_db/pants_shell/mod.rs
@@ -32,8 +32,8 @@ use std::path::{Path, PathBuf};
 use waybill_common::resolution::LifecycleScope;
 
 use super::exclude_path::ExclusionSet;
+use super::pants_common;
 use super::PackageDbEntry;
-use crate::scan_fs::walk::{safe_walk, WalkConfig};
 
 /// The four built-in Pants shell backend target types we recognize.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -123,32 +123,13 @@ pub(crate) enum TargetParseError {
     UnbalancedParens { line: u32 },
 }
 
-/// Discover every `BUILD` file under `scan_root`. Uses `safe_walk`
-/// (respects symlink-cycle guard, `--exclude-path`, depth limits).
-fn discover_build_files(scan_root: &Path, exclude_set: &ExclusionSet) -> Vec<PathBuf> {
-    let mut out: Vec<PathBuf> = Vec::new();
-    let cfg = WalkConfig {
-        max_depth: 32,
-        should_skip: &|_candidate, _rootfs| false,
-        exclude_set,
-    };
-    safe_walk(scan_root, &cfg, |path| {
-        if path.is_file()
-            && path.file_name().and_then(|s| s.to_str()) == Some("BUILD")
-        {
-            out.push(path.to_path_buf());
-        }
-    });
-    out
-}
-
 /// Public entry — orchestrates BUILD-file discovery, regex extraction,
 /// target resolution, component emission, and `pants.toml` tool-pin
 /// discovery. Returns `Vec::new()` and emits NO log line when zero
 /// BUILD files are discovered AND no `pants.toml` is present at the
 /// scan root (byte-identity guarantee per FR-011 / SC-003).
 pub fn read(scan_root: &Path, exclude_set: &ExclusionSet) -> Vec<PackageDbEntry> {
-    let build_files = discover_build_files(scan_root, exclude_set);
+    let build_files = pants_common::discover_build_files(scan_root, exclude_set);
     let pants_toml_path = scan_root.join("pants.toml");
     let pants_toml_present = pants_toml_path.is_file();
     if build_files.is_empty() && !pants_toml_present {


### PR DESCRIPTION
## Summary

- Extract two byte-identical helpers from m225 pants_shell + m226 pants_go into a shared `pants_common/` module.
- Both m225 and m226 §Follow-ups flagged this promotion; the "2+ consumer" trigger is now met.
- **Net LOC: +7 / −129** across the two readers (new pants_common adds ~110 LOC of code + tests; readers shrink by ~120 LOC of duplicated fn bodies + imports).
- **Zero user-facing behavior change.** No new CLI flags, no new catalog rows, no new dependencies. Existing tests validate: pants_shell 33 unit + 11 integration + pants_go 30 unit + 12 integration all green post-refactor.

## What was extracted

- `discover_build_files(scan_root, exclude_set) -> Vec<PathBuf>` — walks scan root via `safe_walk`, returns every path whose file name is exactly `"BUILD"`. Identical implementation in m225 + m226.
- `find_matching_close_paren(bytes, start) -> Option<usize>` — byte-level scanner locating the matching `)` for an opening paren, respecting single/double-quoted string literals with `\` escape. Identical implementation in m225 + m226.

Verified byte-identical via `diff` before extraction.

## What was NOT extracted (deliberately)

- The regex-anchored target-type match — each reader recognizes a different closed set (pants_shell: 4 shell target types; pants_go: 4 Go target types).
- Per-kwarg regex extraction — the readers extract disjoint kwarg sets (`source=`/`sources=[...]` vs `import_path=`/`main=`).
- The typed `TargetKind`/`TargetDeclaration`/`TargetParseError` enums — each reader's target-type list is closed and distinct. A generic version would either lose type safety or gain awkward `&'static str` dispatch.

The wider extraction (Option D from the scoping question) was rejected — the callback API needed to bridge the two readers' distinct `TargetKind`/`ParseError` types would be more code than the duplication it eliminates.

## Test plan

- [x] `cargo +stable test -p waybill --bin waybill pants_common` — 8/8 new unit tests passing
- [x] `cargo +stable test -p waybill --test pants_shell_reader` — 11/11 integration tests still passing
- [x] `cargo +stable test -p waybill --test pants_go_reader` — 12/12 integration tests still passing
- [x] `cargo +stable test -p waybill --bin waybill pants_shell` — 33/33 unit tests still passing
- [x] `cargo +stable test -p waybill --bin waybill pants_go` — 30/30 unit tests still passing
- [x] `cargo +stable clippy --workspace --all-targets` — zero warnings
- [ ] CI three-lane green (lint/test/integration) — awaiting run

## Files changed

- **New**: `waybill-cli/src/scan_fs/package_db/pants_common/mod.rs` (~170 LOC incl. 8 unit tests)
- **Modified** (4 files): register module in `package_db/mod.rs`; delete duplicated fns from `pants_shell/{mod,build_dsl}.rs` + `pants_go/{mod,build_dsl}.rs`; update imports + call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)