### PR TITLE
fix(tests): serialize env-var-mutating tests via shared EnvGuard

### DIFF
--- a/waybill-cli/src/attestation/signer.rs
+++ b/waybill-cli/src/attestation/signer.rs
@@ -660,6 +660,7 @@ fn _unused_but_reserved(_s: Option<SigStoreSigner>) {}
 #[cfg_attr(test, allow(clippy::unwrap_used))]
 mod tests {
     use super::*;
+    use crate::testing::EnvGuard;
     use std::io::Write;
 
     fn minimal_statement() -> InTotoStatement {
@@ -1066,34 +1067,12 @@ mod tests {
         }
     }
 
-    /// RAII guard that snapshots + replaces env vars for the duration of
-    /// a test. Restores originals on drop.
-    struct EnvGuard {
-        originals: Vec<(String, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn setup(vars: &[(&str, Option<&str>)]) -> Self {
-            let mut originals = Vec::new();
-            for (k, v) in vars {
-                originals.push((k.to_string(), std::env::var(k).ok()));
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-            Self { originals }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (k, v) in &self.originals {
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-        }
-    }
+    // NB: the ad-hoc `EnvGuard` that used to live here was promoted
+    // to the shared workspace helper at `waybill-cli/src/testing/env_guard.rs`
+    // when the pattern was needed by tests outside this file — the
+    // shared version adds a process-global mutex that serializes
+    // env-var-mutating tests across the whole binary, fixing the
+    // podman + cargo m205 flake class. Import shape:
+    // `use crate::testing::EnvGuard;` (see the top-level `use` in
+    // this `mod tests { ... }` block).
 }

--- a/waybill-cli/src/lib.rs
+++ b/waybill-cli/src/lib.rs
@@ -59,3 +59,13 @@ pub mod binding;
 /// git_submodule, ...}`) call into it. Per Constitution Principle VI, only
 /// pure-function code lives here; no I/O, no state.
 pub mod identifiers;
+
+/// Internal testing utilities shared between src-side `#[cfg(test)]`
+/// blocks and integration test binaries under `tests/`. Currently
+/// exposes `testing::EnvGuard`, a save-and-restore RAII guard that
+/// serializes env-var-mutating tests inside a single binary process
+/// (fixes the flake class documented by memories
+/// `reference_podman_test_flake` + `reference_m205_cargo_metadata_env_flake`).
+/// Exposed at lib root because integration test binaries can't see
+/// `#[cfg(test)]`-only items in the parent crate.
+pub mod testing;

--- a/waybill-cli/src/main.rs
+++ b/waybill-cli/src/main.rs
@@ -43,6 +43,8 @@ mod resolve;
 mod sbom;
 mod scan_fs;
 mod supplement;
+#[cfg(test)]
+mod testing;
 mod trace;
 
 #[derive(Parser)]

--- a/waybill-cli/src/scan_fs/package_db/cargo.rs
+++ b/waybill-cli/src/scan_fs/package_db/cargo.rs
@@ -3231,57 +3231,45 @@ version = "0.1.0"
 
     // ── T007 m205 (#593) — cargo metadata resolver + failure enum ──
     //
-    // Env-var-mutating tests require serial execution. Invoke via
-    // `cargo test ... -- --test-threads=1` when running the full
-    // suite; individual `-- resolve_cargo_metadata_timeout` invocations
-    // naturally serialize matching tests. Matches m203 pattern.
-
-    fn with_cargo_metadata_timeout_env<F: FnOnce()>(value: Option<&str>, f: F) {
-        let prev = std::env::var("WAYBILL_CARGO_METADATA_TIMEOUT_SECS").ok();
-        match value {
-            Some(v) => std::env::set_var("WAYBILL_CARGO_METADATA_TIMEOUT_SECS", v),
-            None => std::env::remove_var("WAYBILL_CARGO_METADATA_TIMEOUT_SECS"),
-        }
-        f();
-        match prev {
-            Some(v) => std::env::set_var("WAYBILL_CARGO_METADATA_TIMEOUT_SECS", v),
-            None => std::env::remove_var("WAYBILL_CARGO_METADATA_TIMEOUT_SECS"),
-        }
-    }
+    // Env-var-mutating tests use the workspace-shared `EnvGuard` at
+    // `waybill-cli/src/testing/env_guard.rs` — the guard holds a
+    // process-global mutex that serializes every env-var-mutating
+    // test in the `waybill` bin. Fixes the m205 flake documented by
+    // memory `reference_m205_cargo_metadata_env_flake`.
 
     #[test]
     fn resolve_cargo_metadata_timeout_default_when_env_var_absent_m205() {
-        with_cargo_metadata_timeout_env(None, || {
-            assert_eq!(resolve_cargo_metadata_timeout(), Duration::from_secs(60));
-        });
+        let mut g = crate::testing::EnvGuard::acquire();
+        g.remove("WAYBILL_CARGO_METADATA_TIMEOUT_SECS");
+        assert_eq!(resolve_cargo_metadata_timeout(), Duration::from_secs(60));
     }
 
     #[test]
     fn resolve_cargo_metadata_timeout_honors_env_var_m205() {
-        with_cargo_metadata_timeout_env(Some("42"), || {
-            assert_eq!(resolve_cargo_metadata_timeout(), Duration::from_secs(42));
-        });
+        let mut g = crate::testing::EnvGuard::acquire();
+        g.set("WAYBILL_CARGO_METADATA_TIMEOUT_SECS", "42");
+        assert_eq!(resolve_cargo_metadata_timeout(), Duration::from_secs(42));
     }
 
     #[test]
     fn resolve_cargo_metadata_timeout_clamps_below_min_m205() {
-        with_cargo_metadata_timeout_env(Some("0"), || {
-            assert_eq!(resolve_cargo_metadata_timeout(), Duration::from_secs(1));
-        });
+        let mut g = crate::testing::EnvGuard::acquire();
+        g.set("WAYBILL_CARGO_METADATA_TIMEOUT_SECS", "0");
+        assert_eq!(resolve_cargo_metadata_timeout(), Duration::from_secs(1));
     }
 
     #[test]
     fn resolve_cargo_metadata_timeout_clamps_above_max_m205() {
-        with_cargo_metadata_timeout_env(Some("99999"), || {
-            assert_eq!(resolve_cargo_metadata_timeout(), Duration::from_secs(3600));
-        });
+        let mut g = crate::testing::EnvGuard::acquire();
+        g.set("WAYBILL_CARGO_METADATA_TIMEOUT_SECS", "99999");
+        assert_eq!(resolve_cargo_metadata_timeout(), Duration::from_secs(3600));
     }
 
     #[test]
     fn resolve_cargo_metadata_timeout_ignores_parse_error_m205() {
-        with_cargo_metadata_timeout_env(Some("notanumber"), || {
-            assert_eq!(resolve_cargo_metadata_timeout(), Duration::from_secs(60));
-        });
+        let mut g = crate::testing::EnvGuard::acquire();
+        g.set("WAYBILL_CARGO_METADATA_TIMEOUT_SECS", "notanumber");
+        assert_eq!(resolve_cargo_metadata_timeout(), Duration::from_secs(60));
     }
 
     #[test]

--- a/waybill-cli/src/scan_fs/podman_source.rs
+++ b/waybill-cli/src/scan_fs/podman_source.rs
@@ -845,13 +845,10 @@ mod tests {
         )
         .unwrap();
 
-        let prev_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", temp_home.path());
+        let mut g = crate::testing::EnvGuard::acquire();
+        g.set("HOME", temp_home.path().as_os_str());
         let result = discover_storage_root(true);
-        match prev_home {
-            Some(v) => std::env::set_var("HOME", v),
-            None => std::env::remove_var("HOME"),
-        }
+        drop(g);
         assert_eq!(result.unwrap(), graphroot);
     }
 
@@ -864,13 +861,10 @@ mod tests {
             .join(".local/share/containers/storage");
         std::fs::create_dir_all(&default_gr).unwrap();
 
-        let prev_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", temp_home.path());
+        let mut g = crate::testing::EnvGuard::acquire();
+        g.set("HOME", temp_home.path().as_os_str());
         let result = discover_storage_root(true);
-        match prev_home {
-            Some(v) => std::env::set_var("HOME", v),
-            None => std::env::remove_var("HOME"),
-        }
+        drop(g);
         assert_eq!(result.unwrap(), default_gr);
     }
 
@@ -1095,13 +1089,10 @@ mod tests {
         std::fs::create_dir_all(&unreachable).unwrap();
         std::fs::set_permissions(&unreachable, std::fs::Permissions::from_mode(0o000)).unwrap();
 
-        let prev_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", temp_home.path());
+        let mut g = crate::testing::EnvGuard::acquire();
+        g.set("HOME", temp_home.path().as_os_str());
         let result = discover_storage_root(true);
-        match prev_home {
-            Some(v) => std::env::set_var("HOME", v),
-            None => std::env::remove_var("HOME"),
-        }
+        drop(g);
 
         // Restore perms so tempdir cleanup works.
         std::fs::set_permissions(&unreachable, std::fs::Permissions::from_mode(0o755)).unwrap();

--- a/waybill-cli/src/testing/env_guard.rs
+++ b/waybill-cli/src/testing/env_guard.rs
@@ -1,0 +1,222 @@
+//! Serialized, save-and-restore RAII guard for tests that mutate
+//! process env vars.
+//!
+//! Rust's default `cargo test` runs test functions on multiple
+//! threads within a single binary process. Because env vars are
+//! process-global (not per-thread), two tests that concurrently
+//! set/read the same env var race — one sees the other's write
+//! partway through, or restores the wrong prior value.
+//!
+//! Two documented flakes trace back to this pattern:
+//! - `podman_source.rs::discover_storage_root_returns_unreachable_when_directory_unreadable_m206`
+//!   (memory `reference_podman_test_flake`)
+//! - `cargo.rs::resolve_cargo_metadata_timeout_clamps_above_max_m205`
+//!   (memory `reference_m205_cargo_metadata_env_flake`)
+//!
+//! Both are documented as "green in isolation, flakes under
+//! `cargo test --workspace` parallel load". This module is the
+//! systemic fix.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use waybill::testing::EnvGuard;
+//!
+//! #[test]
+//! fn my_test() {
+//!     let mut g = EnvGuard::acquire();
+//!     g.set("HOME", "/tmp/test-home");
+//!     g.remove("SOME_OTHER_VAR");
+//!     // ... test body reads/writes env freely, but no other
+//!     // EnvGuard-using test in this binary can run concurrently ...
+//! } // guard drops: HOME + SOME_OTHER_VAR restored, mutex released
+//! ```
+//!
+//! # Scope
+//!
+//! The mutex is per-binary (a `OnceLock<Mutex<()>>` in this module).
+//! - Src-side `#[cfg(test)]` tests + integration test binaries that
+//!   import `waybill::testing::EnvGuard` share the src-side mutex.
+//!   Tests inside the `waybill` bin's test build (cargo.rs,
+//!   podman_source.rs, signer.rs) all serialize against each other.
+//! - Different integration test binaries under `tests/*.rs` run in
+//!   separate PROCESSES (cargo spawns a fresh binary per integration
+//!   test file). Different processes each have their own env-var
+//!   namespace, so cross-binary races don't exist.
+//!
+//! # Poison recovery
+//!
+//! If a test panics while holding the guard, the mutex becomes
+//! poisoned. This guard treats the panic as recoverable — subsequent
+//! callers extract the inner value via `PoisonError::into_inner`
+//! rather than propagating the poison. Rationale: tests are already
+//! panicking-halt-the-run territory; refusing to acquire the lock
+//! would cascade failures across unrelated tests.
+
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+/// Process-global mutex serializing env-var-mutating tests within a
+/// single binary. Per-process (not per-thread) as documented above.
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn env_lock() -> &'static Mutex<()> {
+    ENV_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// RAII guard that (1) holds the per-binary env-mutation mutex for
+/// its lifetime and (2) restores every env var it set/removed back
+/// to its prior state on `Drop`.
+pub struct EnvGuard {
+    // Held for the lifetime of the guard. Field name starts with an
+    // underscore to signal "unused local, present for RAII side
+    // effects only" to future readers.
+    _lock: MutexGuard<'static, ()>,
+    originals: Vec<(String, Option<String>)>,
+}
+
+impl EnvGuard {
+    /// Acquire the mutex and return a guard with an empty
+    /// restore-list. Call `set` / `remove` to record and mutate.
+    ///
+    /// Blocks if another `EnvGuard` in the same binary is live.
+    /// Recovers from mutex poison silently (see module docs).
+    pub fn acquire() -> Self {
+        let _lock = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        Self {
+            _lock,
+            originals: Vec::new(),
+        }
+    }
+
+    /// Convenience constructor for the "batch-apply many vars up front"
+    /// pattern used by attestation/signer.rs's pre-existing EnvGuard.
+    /// Semantically equivalent to `acquire()` + a loop of `set`/`remove`.
+    pub fn setup(vars: &[(&str, Option<&str>)]) -> Self {
+        let mut g = Self::acquire();
+        for (k, v) in vars {
+            match v {
+                Some(val) => g.set(k, val),
+                None => g.remove(k),
+            }
+        }
+        g
+    }
+
+    /// Set an env var, recording its prior value for restore on drop.
+    ///
+    /// If the same key is set twice through this guard, only the
+    /// FIRST recorded prior value is restored (the intermediate
+    /// values were transient inside the same test).
+    pub fn set(&mut self, key: &str, value: impl AsRef<std::ffi::OsStr>) {
+        self.record_prior(key);
+        std::env::set_var(key, value);
+    }
+
+    /// Remove an env var, recording its prior value for restore on drop.
+    pub fn remove(&mut self, key: &str) {
+        self.record_prior(key);
+        std::env::remove_var(key);
+    }
+
+    fn record_prior(&mut self, key: &str) {
+        if !self.originals.iter().any(|(k, _)| k == key) {
+            self.originals.push((key.to_string(), std::env::var(key).ok()));
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, v) in &self.originals {
+            match v {
+                Some(val) => std::env::set_var(k, val),
+                None => std::env::remove_var(k),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    // NB: these tests intentionally use a WAYBILL_ENVGUARD_TEST_*
+    // prefix to avoid colliding with real env vars anywhere in the
+    // test suite. They ARE subject to the same serialization mutex
+    // as every other EnvGuard-using test, so they don't race with
+    // podman_source / cargo / signer tests either.
+
+    #[test]
+    fn set_records_prior_value_and_restores_on_drop() {
+        let key = "WAYBILL_ENVGUARD_TEST_SET_1";
+        std::env::set_var(key, "initial");
+        {
+            let mut g = EnvGuard::acquire();
+            g.set(key, "modified");
+            assert_eq!(std::env::var(key).unwrap(), "modified");
+        }
+        assert_eq!(std::env::var(key).unwrap(), "initial");
+        std::env::remove_var(key); // test cleanup outside guard
+    }
+
+    #[test]
+    fn set_records_absence_when_var_did_not_exist() {
+        let key = "WAYBILL_ENVGUARD_TEST_SET_2";
+        std::env::remove_var(key); // ensure absent
+        {
+            let mut g = EnvGuard::acquire();
+            g.set(key, "modified");
+            assert_eq!(std::env::var(key).unwrap(), "modified");
+        }
+        assert!(std::env::var(key).is_err());
+    }
+
+    #[test]
+    fn remove_restores_prior_value_on_drop() {
+        let key = "WAYBILL_ENVGUARD_TEST_REMOVE_1";
+        std::env::set_var(key, "initial");
+        {
+            let mut g = EnvGuard::acquire();
+            g.remove(key);
+            assert!(std::env::var(key).is_err());
+        }
+        assert_eq!(std::env::var(key).unwrap(), "initial");
+        std::env::remove_var(key);
+    }
+
+    #[test]
+    fn multiple_sets_of_same_key_restore_first_prior_value_only() {
+        let key = "WAYBILL_ENVGUARD_TEST_MULTI";
+        std::env::set_var(key, "initial");
+        {
+            let mut g = EnvGuard::acquire();
+            g.set(key, "first_mod");
+            g.set(key, "second_mod"); // should NOT re-record prior
+            assert_eq!(std::env::var(key).unwrap(), "second_mod");
+        }
+        // Restored to the ORIGINAL "initial", not the intermediate
+        // "first_mod" that came between the two sets.
+        assert_eq!(std::env::var(key).unwrap(), "initial");
+        std::env::remove_var(key);
+    }
+
+    #[test]
+    fn setup_batch_apply_matches_manual_sequence() {
+        let key_a = "WAYBILL_ENVGUARD_TEST_SETUP_A";
+        let key_b = "WAYBILL_ENVGUARD_TEST_SETUP_B";
+        std::env::set_var(key_a, "prior_a");
+        std::env::remove_var(key_b);
+        {
+            let _g = EnvGuard::setup(&[
+                (key_a, Some("batch_a")),
+                (key_b, Some("batch_b")),
+            ]);
+            assert_eq!(std::env::var(key_a).unwrap(), "batch_a");
+            assert_eq!(std::env::var(key_b).unwrap(), "batch_b");
+        }
+        assert_eq!(std::env::var(key_a).unwrap(), "prior_a");
+        assert!(std::env::var(key_b).is_err());
+        std::env::remove_var(key_a);
+    }
+}

--- a/waybill-cli/src/testing/mod.rs
+++ b/waybill-cli/src/testing/mod.rs
@@ -1,0 +1,17 @@
+//! Internal testing utilities shared across the waybill workspace.
+//!
+//! Only meaningful when consumed from `#[cfg(test)]` code — either
+//! src-side `mod tests { ... }` blocks OR integration test binaries
+//! under `waybill-cli/tests/`. The module is `pub` (not
+//! `#[cfg(test)]`-gated) because integration test binaries import
+//! from `waybill` as a normal library dependency and cannot see
+//! `#[cfg(test)]`-only items in the parent crate.
+//!
+//! Non-test callers importing anything from this module get exactly
+//! the semantics documented — no side effects beyond what the docs
+//! state. There is no reason for production code to reach into these
+//! helpers.
+
+pub mod env_guard;
+
+pub use env_guard::EnvGuard;


### PR DESCRIPTION
## Summary

Fixes the two documented CI flake classes that have burned us on the last several PRs:

- **podman_source `discover_storage_root_*` HOME races** (memory `reference_podman_test_flake`) — hit PR #649
- **cargo `resolve_cargo_metadata_timeout_*_m205` env-var races** (memory `reference_m205_cargo_metadata_env_flake`) — hit PR #650

Root cause identical for both: `cargo test` runs tests on multiple threads within one process, env vars are process-global, two tests concurrently reading/writing the same var race and one gets clobbered state. Both memories documented "green in isolation, flakes under parallel load" and the fix has been "rerun the failed lane" — sustainable while rare, unsustainable at 3-flakes-in-3-PRs.

## The fix

New workspace-shared `EnvGuard` at `waybill-cli/src/testing/env_guard.rs`. RAII guard that:
1. Holds a per-binary process-global `OnceLock<Mutex<()>>` for its lifetime
2. Records prior env-var values on `set` / `remove`
3. Restores them on `Drop`

Import shape: `crate::testing::EnvGuard::acquire()` (src-side) or `waybill::testing::EnvGuard::acquire()` (integration tests). All env-var-mutating tests inside a binary serialize against each other via the mutex.

## Files changed

- **New**: `waybill-cli/src/testing/{mod,env_guard}.rs` (~110 LOC + 5 unit tests)
- **Migrated to shared EnvGuard**:
  - `podman_source.rs` (3 tests) — replaces inline prev_home/set_var/restore pattern
  - `cargo.rs` (5 tests) — replaces local `with_cargo_metadata_timeout_env` helper
  - `attestation/signer.rs` (7 tests, 4 setup sites) — replaces the ad-hoc EnvGuard that predated this shared version (that one had NO mutex — was fine when it was the only env-var-mutating test, but has been racing with cargo/podman ever since)
- **Registration**: `pub mod testing;` in `lib.rs` (for integration tests) + `#[cfg(test)] mod testing;` in `main.rs` (for bin-side src files)

Left as-is (already-safe or single-test-per-binary):
- `tests/spdx3_conformance.rs` — has its own local `ENV_LOCK` mutex
- `tests/transitive_parity_cargo.rs` — only 1 env-var-touching test
- `tests/transitive_parity_common_sanity.rs` — same as above

## Test plan

- [x] `cargo +stable test -p waybill --bin waybill testing::env_guard` — 5/5 EnvGuard unit tests pass
- [x] `cargo +stable test -p waybill --bin waybill scan_fs::podman_source` — 19/19 pass (including 3 previously-flaky tests)
- [x] `cargo +stable test -p waybill --bin waybill resolve_cargo_metadata_timeout` — 5/5 pass
- [x] `cargo +stable test -p waybill --bin waybill attestation::signer` — 23/23 pass
- [x] **Stress test**: `cargo +stable test -p waybill --bin waybill scan_fs` × 5 iterations = **2370 tests per run, 0 failures × 5 runs** (previously the m205 tests flaked ~1 in 3 CI runs on Linux)
- [x] Clippy workspace all-targets — zero warnings
- [ ] CI three-lane green — awaiting run

## Design notes

- **Zero new deps** — stdlib `Mutex` + `OnceLock` only. No `serial_test` crate (aligns with Constitution Principle I zero-new-deps posture).
- **Per-binary mutex** — cargo spawns fresh processes per integration test binary, so cross-binary env-var races don't exist. The mutex protects intra-binary races only.
- **Poison recovery** silent (via `PoisonError::into_inner`) — a test panicking mid-mutation is already halt-the-run territory; refusing to acquire the lock would cascade unrelated failures.
- **Module visible from both lib and bin** — `pub mod testing;` in `lib.rs` (for integration test binaries) AND `#[cfg(test)] mod testing;` in `main.rs` (so bin-side `.rs` files access it as `crate::testing::EnvGuard`).

## Follow-ups

- The `keyless_env_lock()` local mutex in `signer.rs` is now belt-and-suspenders (the shared EnvGuard's mutex already covers those tests). Could delete in a future cleanup PR — left alone here to keep the fix scoped.
- If a new env-var-mutating test lands anywhere in the waybill bin, route it through `crate::testing::EnvGuard::acquire()` to inherit serialization. Memories updated to point contributors at the shared helper.

## Memories updated

- `reference_podman_test_flake.md` — marked RESOLVED
- `reference_m205_cargo_metadata_env_flake.md` — marked RESOLVED
- `MEMORY.md` — index blurbs updated to point at the shared helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)