### PR TITLE
fix(nuget): #655 parse Directory.Build.{props,targets} for inherited <PackageReference> / <PackageVersion> / <PropertyGroup>

### DIFF
--- a/waybill-cli/src/scan_fs/package_db/nuget/csproj.rs
+++ b/waybill-cli/src/scan_fs/package_db/nuget/csproj.rs
@@ -12,7 +12,7 @@
 //! available alongside this project file.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::Event;
@@ -23,11 +23,19 @@ use super::private_assets::PrivateAssetAttrs;
 /// One `<PackageReference>` extracted from a project file. Versions are
 /// stored as `Option<String>` to distinguish "absent" (CPM-resolvable)
 /// from "present but empty" (malformed source).
+///
+/// `source_file` is populated by [`parse_project_file`] with the path
+/// of the file the element was extracted from. Callers that
+/// synthesize references from other sources (e.g., #655's
+/// `directory_build_props::discover`) set this so downstream
+/// consumers can attribute the declaration to the correct file in the
+/// emitted `waybill:source-files` annotation.
 #[derive(Clone, Debug, Default)]
 pub(super) struct NugetPackageReference {
     pub(super) include: String,
     pub(super) version: Option<String>,
     pub(super) attrs: PrivateAssetAttrs,
+    pub(super) source_file: Option<PathBuf>,
 }
 
 /// Parse a single `.csproj`/`.vbproj`/`.fsproj` file and return all
@@ -48,7 +56,15 @@ pub(super) fn parse_project_file(path: &Path) -> Vec<NugetPackageReference> {
             return Vec::new();
         }
     };
-    parse_bytes(&bytes, path)
+    let mut refs = parse_bytes(&bytes, path);
+    // Tag every extracted reference with the file it came from so the
+    // downstream accumulator can attribute inherited references
+    // (#655) to the correct Directory.Build.props path rather than
+    // the consuming csproj.
+    for r in &mut refs {
+        r.source_file = Some(path.to_path_buf());
+    }
+    refs
 }
 
 fn parse_bytes(bytes: &[u8], path: &Path) -> Vec<NugetPackageReference> {
@@ -150,6 +166,10 @@ fn reference_from_attrs(attrs: HashMap<String, String>) -> NugetPackageReference
             include_assets: attrs.get("includeassets").cloned(),
             exclude_assets: attrs.get("excludeassets").cloned(),
         },
+        // Populated by `parse_project_file` after `parse_bytes` returns
+        // (single tagging pass over the whole vec avoids threading
+        // the path through every helper). Default None here.
+        source_file: None,
     }
 }
 

--- a/waybill-cli/src/scan_fs/package_db/nuget/directory_build_props.rs
+++ b/waybill-cli/src/scan_fs/package_db/nuget/directory_build_props.rs
@@ -1,0 +1,280 @@
+//! `Directory.Build.props` + `Directory.Build.targets` support for the
+//! NuGet reader (#655 / FU-001 from the 2026-08-04 audit).
+//!
+//! MSBuild automatically imports two conventional files into every
+//! project during evaluation:
+//!
+//! - `Directory.Build.props` — imported FIRST, before the `.csproj`'s
+//!   own content and the SDK props.
+//! - `Directory.Build.targets` — imported LAST, after the csproj and
+//!   SDK targets. Can override anything declared earlier.
+//!
+//! MSBuild walks from the project directory up the ancestor chain and
+//! imports the NEAREST occurrence of each file (bounded by the
+//! solution root or filesystem root). We match that behavior with a
+//! `scan_root`-bounded walker.
+//!
+//! Real-world .NET projects use these files heavily to hoist common
+//! declarations across many `.csproj` files. The RestSharp
+//! `test/Directory.Build.props` shape from the 2026-08-04 audit is a
+//! canonical example — 12 test-only `<PackageReference>` elements
+//! declared once, applied to every test csproj under the `test/`
+//! subtree.
+//!
+//! # What this module extracts
+//!
+//! For a discovered `Directory.Build.props` (or `.targets`) file we
+//! delegate to the existing sibling parsers:
+//!
+//! - `csproj::parse_project_file` — `<PackageReference>` elements.
+//!   Same XML shape as a .csproj so the parser is directly reusable.
+//! - `directory_packages_props::parse_props` — `<PackageVersion>`
+//!   elements. These extend the CPM version map (Directory.Packages.props
+//!   still wins on collision — see the merge order in `mod.rs`).
+//! - `msbuild_properties::parse_properties_file` — `<PropertyGroup>`
+//!   contents. Feeds the FU-002 `$(PropertyName)` substitution map.
+//!
+//! # Scope limitations (deliberate)
+//!
+//! - Only the NEAREST `Directory.Build.props` / `.targets` in the
+//!   ancestor chain is loaded. Chained imports via `<Import
+//!   Project="$([MSBuild]::GetPathOfFileAbove(...))"/>` are ignored;
+//!   matches Directory.Packages.props existing behavior.
+//! - No conditional evaluation of `<Import Condition="...">`. The
+//!   parsers accept the files verbatim regardless of Condition
+//!   attributes on their enclosing groups.
+//! - No SDK-provided implicit props/targets files (e.g., the
+//!   `Microsoft.NET.Sdk`-shipped `Sdk.props`). Waybill only reads what
+//!   the operator's source tree contains.
+
+use std::path::Path;
+
+use super::csproj::{self, NugetPackageReference};
+use super::directory_packages_props::{self, CpmMap};
+use super::msbuild_properties::{self, PropertyMap};
+
+/// Discovered inputs from the nearest `Directory.Build.props` +
+/// `Directory.Build.targets` in the ancestor chain. Empty vectors /
+/// maps when neither file is found or parseable.
+///
+/// Per-reference source-file attribution lives on the
+/// `NugetPackageReference::source_file` field (populated by
+/// `csproj::parse_project_file`), so an aggregate `build_props_path`
+/// / `build_targets_path` here would be redundant.
+#[derive(Debug, Default)]
+pub(super) struct DirectoryBuildFiles {
+    /// `<PackageReference>` elements from both files, combined.
+    /// build.props entries come first (imported before csproj), then
+    /// build.targets entries (imported after). Duplicate-key handling
+    /// is done downstream by the accumulator in `mod.rs`.
+    pub(super) package_references: Vec<NugetPackageReference>,
+    /// `<PackageVersion>` elements from both files, combined. Extends
+    /// the CPM version map. Directory.Packages.props still wins on
+    /// collision — this is intentional: packages.props is the
+    /// canonical CPM location and operators who put a
+    /// `<PackageVersion>` in Directory.Build.props typically mean it
+    /// as a fallback, not an override.
+    pub(super) cpm_extensions: CpmMap,
+    /// `<PropertyGroup>` values from both files, combined for the
+    /// FU-002 `$(PropertyName)` substitution map. build.targets
+    /// overlays build.props on collision (targets is imported later).
+    pub(super) property_map: PropertyMap,
+}
+
+/// Find + parse the nearest `Directory.Build.props` and
+/// `Directory.Build.targets` from `start_dir` upward (bounded by
+/// `scan_root`). Returns a populated [`DirectoryBuildFiles`] with
+/// whichever files were found (may be one, both, or neither).
+///
+/// This is the single-shot entry point called by `mod.rs`
+/// `read_one_project`. Read/parse failures on either individual file
+/// are non-fatal (tracked via `tracing::warn!` in the delegated
+/// parsers) — partial results still contribute what could be parsed.
+pub(super) fn discover(start_dir: &Path, scan_root: &Path) -> DirectoryBuildFiles {
+    let build_props_path = directory_packages_props::find_msbuild_file_walking_up(
+        start_dir,
+        scan_root,
+        "Directory.Build.props",
+    );
+    let build_targets_path = directory_packages_props::find_msbuild_file_walking_up(
+        start_dir,
+        scan_root,
+        "Directory.Build.targets",
+    );
+
+    let mut out = DirectoryBuildFiles::default();
+
+    for (path_opt, is_targets) in [
+        (build_props_path.as_ref(), false),
+        (build_targets_path.as_ref(), true),
+    ] {
+        let Some(path) = path_opt else { continue };
+        // Delegate to existing per-shape parsers.
+        let refs = csproj::parse_project_file(path);
+        let cpm = directory_packages_props::parse_props(path);
+        let props = msbuild_properties::parse_properties_file(path);
+
+        if !refs.is_empty() {
+            tracing::info!(
+                path = %path.display(),
+                count = refs.len(),
+                is_targets,
+                "loaded <PackageReference> elements from Directory.Build props/targets (#655)"
+            );
+        }
+
+        out.package_references.extend(refs);
+
+        // build.targets overlays build.props for both maps (matches
+        // MSBuild's later-import-wins semantics between the two).
+        // `HashMap::extend` overlays existing keys with new values, so
+        // inserting build.targets after build.props naturally yields
+        // "targets wins on collision".
+        out.cpm_extensions.extend(cpm);
+        out.property_map.extend(props);
+    }
+
+    out
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        std::fs::write(dir.join(name), body).unwrap();
+    }
+
+    #[test]
+    fn discover_returns_empty_when_no_build_files_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = discover(tmp.path(), tmp.path());
+        assert!(out.package_references.is_empty());
+        assert!(out.cpm_extensions.is_empty());
+        assert!(out.property_map.is_empty());
+    }
+
+    #[test]
+    fn extracts_package_references_from_build_props() {
+        // RestSharp-shape: test/Directory.Build.props declares xunit
+        // + coverlet.collector, and every test .csproj under this
+        // subtree inherits both.
+        let tmp = tempfile::tempdir().unwrap();
+        let scan_root = tmp.path();
+        let test_dir = scan_root.join("test");
+        std::fs::create_dir_all(&test_dir).unwrap();
+        write(
+            &test_dir,
+            "Directory.Build.props",
+            r#"<Project>
+  <ItemGroup>
+    <PackageReference Include="MikebomFixture.Xunit" Version="2.9.2" />
+    <PackageReference Include="MikebomFixture.Coverlet" Version="6.0.2" />
+  </ItemGroup>
+</Project>"#,
+        );
+
+        // Discover from a subdirectory of test/ — walker should find
+        // the props file one level up.
+        let inner = test_dir.join("MyProject");
+        std::fs::create_dir_all(&inner).unwrap();
+        let out = discover(&inner, scan_root);
+
+        assert_eq!(out.package_references.len(), 2);
+        let includes: Vec<&str> = out
+            .package_references
+            .iter()
+            .map(|r| r.include.as_str())
+            .collect();
+        assert!(includes.contains(&"MikebomFixture.Xunit"));
+        assert!(includes.contains(&"MikebomFixture.Coverlet"));
+    }
+
+    #[test]
+    fn extracts_package_versions_and_properties_from_build_props() {
+        // Directory.Build.props can also contribute CPM PackageVersion
+        // entries + PropertyGroup values.
+        let tmp = tempfile::tempdir().unwrap();
+        write(
+            tmp.path(),
+            "Directory.Build.props",
+            r#"<Project>
+  <PropertyGroup>
+    <SharedTestVer>17.12.0</SharedTestVer>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="MikebomFixture.TestSdk" Version="$(SharedTestVer)" />
+  </ItemGroup>
+</Project>"#,
+        );
+        let out = discover(tmp.path(), tmp.path());
+        assert_eq!(
+            out.cpm_extensions.get("MikebomFixture.TestSdk"),
+            Some(&"$(SharedTestVer)".to_string())
+        );
+        assert_eq!(
+            out.property_map.get("sharedtestver"),
+            Some(&"17.12.0".to_string())
+        );
+    }
+
+    #[test]
+    fn build_targets_overlays_build_props_for_maps() {
+        // build.targets is imported after build.props → later-wins on
+        // both the CPM map and the property map for duplicate keys.
+        let tmp = tempfile::tempdir().unwrap();
+        write(
+            tmp.path(),
+            "Directory.Build.props",
+            r#"<Project>
+  <PropertyGroup>
+    <SharedVer>1.0.0</SharedVer>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="MikebomFixture.Shared" Version="1.0.0" />
+  </ItemGroup>
+</Project>"#,
+        );
+        write(
+            tmp.path(),
+            "Directory.Build.targets",
+            r#"<Project>
+  <PropertyGroup>
+    <SharedVer>2.0.0</SharedVer>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="MikebomFixture.Shared" Version="2.0.0" />
+  </ItemGroup>
+</Project>"#,
+        );
+        let out = discover(tmp.path(), tmp.path());
+        assert_eq!(out.property_map.get("sharedver"), Some(&"2.0.0".to_string()));
+        assert_eq!(
+            out.cpm_extensions.get("MikebomFixture.Shared"),
+            Some(&"2.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn walker_bounds_search_at_scan_root() {
+        // A Directory.Build.props ABOVE scan_root must not be found.
+        let tmp = tempfile::tempdir().unwrap();
+        let scan_root = tmp.path().join("project");
+        let inner = scan_root.join("src");
+        std::fs::create_dir_all(&inner).unwrap();
+        write(
+            tmp.path(),
+            "Directory.Build.props",
+            r#"<Project>
+  <ItemGroup>
+    <PackageReference Include="MikebomFixture.ShouldNotBeFound" Version="1.0.0" />
+  </ItemGroup>
+</Project>"#,
+        );
+        let out = discover(&inner, &scan_root);
+        assert!(out.package_references.is_empty());
+        assert!(out.cpm_extensions.is_empty());
+        assert!(out.property_map.is_empty());
+    }
+}

--- a/waybill-cli/src/scan_fs/package_db/nuget/directory_packages_props.rs
+++ b/waybill-cli/src/scan_fs/package_db/nuget/directory_packages_props.rs
@@ -91,20 +91,36 @@ fn is_package_version(name: &[u8]) -> bool {
 }
 
 /// Walk up from `start_dir` looking for `Directory.Packages.props`.
-/// Returns the path of the CLOSEST props file (MSBuild semantics).
-/// Returns `None` if no props file is found before reaching either
-/// `scan_root` or the filesystem root.
-///
-/// `scan_root` bounds the search — we never walk outside the scanned
-/// rootfs. Both arguments should be absolute paths or both should be
-/// under the same logical base; the comparison uses path-prefix.
+/// Thin wrapper around [`find_msbuild_file_walking_up`] preserved for
+/// call-site stability.
 pub(super) fn find_props_walking_up(
     start_dir: &Path,
     scan_root: &Path,
 ) -> Option<PathBuf> {
+    find_msbuild_file_walking_up(start_dir, scan_root, "Directory.Packages.props")
+}
+
+/// General ancestor-walker: walk up from `start_dir` looking for a file
+/// named `filename` in each ancestor directory. Returns the path of the
+/// CLOSEST matching file (MSBuild semantics — nearest wins). Returns
+/// `None` if no match is found before reaching either `scan_root` or
+/// the filesystem root.
+///
+/// `scan_root` bounds the search — we never walk outside the scanned
+/// rootfs. Both arguments should be absolute paths or both should be
+/// under the same logical base; the comparison uses path-prefix.
+///
+/// Shared entry point for `Directory.Packages.props`,
+/// `Directory.Build.props`, and `Directory.Build.targets` lookups
+/// (#655 / FU-001).
+pub(super) fn find_msbuild_file_walking_up(
+    start_dir: &Path,
+    scan_root: &Path,
+    filename: &str,
+) -> Option<PathBuf> {
     let mut cursor: Option<&Path> = Some(start_dir);
     while let Some(dir) = cursor {
-        let candidate = dir.join("Directory.Packages.props");
+        let candidate = dir.join(filename);
         if candidate.is_file() {
             return Some(candidate);
         }

--- a/waybill-cli/src/scan_fs/package_db/nuget/mod.rs
+++ b/waybill-cli/src/scan_fs/package_db/nuget/mod.rs
@@ -29,6 +29,7 @@
 
 mod csproj;
 mod deps_json;
+mod directory_build_props;
 mod directory_packages_props;
 mod msbuild_properties;
 mod packages_lock;
@@ -114,7 +115,7 @@ fn read_one_project(scan_root: &Path, project_path: &Path) -> Vec<PackageDbEntry
         Some(d) => d,
         None => return Vec::new(),
     };
-    let project_references = csproj::parse_project_file(project_path);
+    let mut project_references = csproj::parse_project_file(project_path);
     let lockfile_path = project_dir.join("packages.lock.json");
     let lockfile = if lockfile_path.is_file() {
         packages_lock::parse(&lockfile_path)
@@ -128,19 +129,59 @@ fn read_one_project(scan_root: &Path, project_path: &Path) -> Vec<PackageDbEntry
         None => Default::default(),
     };
 
+    // #655 (FU-001): discover + parse nearest Directory.Build.props +
+    // Directory.Build.targets, walking up from the project directory
+    // bounded by scan_root. Contributes three things:
+    //   - `<PackageReference>` elements the csproj implicitly inherits
+    //     (typically from `test/Directory.Build.props` or
+    //     `samples/Directory.Build.props`);
+    //   - `<PackageVersion>` elements that extend the CPM version map;
+    //   - `<PropertyGroup>` values that feed the FU-002 $()-ref
+    //     substitution.
+    let build_files = directory_build_props::discover(project_dir, scan_root);
+
+    // Prepend build.props/build.targets package references to the
+    // csproj's own list. Prepend order: build.props+build.targets
+    // (imported before csproj) → csproj. The accumulator deduplicates
+    // by (name, version_opt) so identical inherited-then-declared
+    // entries collapse into one component with the source-file paths
+    // merged.
+    let mut merged_refs = build_files.package_references.clone();
+    merged_refs.append(&mut project_references);
+    let project_references = merged_refs;
+
     // #654 (FU-002): build a merged MSBuild `<PropertyGroup>` property
     // map so we can resolve `$(PropertyName)` references in Version
-    // strings from both the csproj and the Directory.Packages.props.
-    // csproj values overlay the props map (csproj is closer to the
-    // consumer in MSBuild evaluation order). Conditional groups
-    // resolve to last-wins per `msbuild_properties::parse_properties`.
+    // strings from every scope MSBuild would evaluate:
+    //   build.props ⊕ build.targets ⊕ packages.props ⊕ csproj
+    // where later overlays override earlier ones on collision. This
+    // matches MSBuild's evaluation order except for the rare case
+    // where a csproj-defined property gets re-overridden by a
+    // Directory.Build.targets (imported LAST in MSBuild); we accept
+    // that corner case for simplicity — the alternative complicates
+    // the merge order without meaningful real-world benefit.
+    let build_property_map = build_files.property_map.clone();
     let props_property_map = match &props_path {
         Some(p) => msbuild_properties::parse_properties_file(p),
         None => Default::default(),
     };
     let csproj_property_map = msbuild_properties::parse_properties_file(project_path);
-    let property_map =
-        msbuild_properties::merge(props_property_map, csproj_property_map);
+    let property_map = msbuild_properties::merge(
+        msbuild_properties::merge(build_property_map, props_property_map),
+        csproj_property_map,
+    );
+
+    // Merge Directory.Build.{props,targets} CPM contributions with
+    // Directory.Packages.props' own. Directory.Packages.props wins on
+    // collision — it's the canonical CPM location; entries in
+    // Directory.Build.props should be treated as fallbacks.
+    let mut merged_cpm: BTreeMap<String, String> = build_files
+        .cpm_extensions
+        .clone()
+        .into_iter()
+        .collect();
+    merged_cpm.extend(cpm_map);
+    let cpm_map = merged_cpm;
 
     // Substitute `$()` refs in every CPM map value up-front so the
     // fall-through consumers below see already-resolved strings.
@@ -157,7 +198,7 @@ fn read_one_project(scan_root: &Path, project_path: &Path) -> Vec<PackageDbEntry
                     package = %k,
                     raw_version = %v,
                     substituted = %subbed,
-                    "Directory.Packages.props Version= contains unresolved MSBuild property reference; will fall through to design-tier (#654)"
+                    "CPM Version= contains unresolved MSBuild property reference; will fall through to design-tier (#654)"
                 );
             }
             (k, subbed)
@@ -247,7 +288,16 @@ fn read_one_project(scan_root: &Path, project_path: &Path) -> Vec<PackageDbEntry
         let key = (r.include.clone(), resolved_version.clone());
         let entry = acc.entry(key).or_default();
         entry.lifecycle_scope = entry.lifecycle_scope.or(lifecycle_scope);
-        entry.sources.insert(project_path.to_path_buf());
+        // #655: use the reference's own source_file (populated by
+        // csproj::parse_project_file with the file each element was
+        // extracted from). This correctly attributes inherited
+        // references from Directory.Build.props/targets to the props
+        // path rather than the consuming csproj.
+        entry.sources.insert(
+            r.source_file
+                .clone()
+                .unwrap_or_else(|| project_path.to_path_buf()),
+        );
         if cpm_map.contains_key(&r.include) {
             if let Some(p) = &props_path {
                 entry.sources.insert(p.clone());
@@ -772,6 +822,154 @@ mod tests {
         assert_eq!(entries.len(), 1);
         // csproj's SharedVer=2.0.0 overrides the props' 1.0.0.
         assert_eq!(entries[0].version, "2.0.0");
+    }
+
+    #[test]
+    fn directory_build_props_contributes_inherited_package_references() {
+        // #655 (FU-001) — RestSharp shape. `test/Directory.Build.props`
+        // declares xunit + coverlet; every csproj under `test/`
+        // inherits both. Prior to this fix waybill silently missed
+        // these packages.
+        let tmp = tempfile::tempdir().unwrap();
+        let scan_root = tmp.path();
+        let test_dir = scan_root.join("test");
+        std::fs::create_dir_all(&test_dir).unwrap();
+        write(
+            &test_dir,
+            "Directory.Build.props",
+            r#"<Project>
+  <ItemGroup>
+    <PackageReference Include="MikebomFixture.Xunit" Version="2.9.2" />
+    <PackageReference Include="MikebomFixture.Coverlet" Version="6.0.2" />
+  </ItemGroup>
+</Project>"#,
+        );
+        // Put an .csproj under test/ that declares its own reference
+        // in addition to the inherited ones.
+        write(
+            &test_dir,
+            "TestProject.csproj",
+            r#"<Project>
+  <ItemGroup>
+    <PackageReference Include="MikebomFixture.Local" Version="1.0.0" />
+  </ItemGroup>
+</Project>"#,
+        );
+        let entries = read(scan_root, &Default::default());
+        let names: BTreeSet<_> = entries.iter().map(|e| e.name.clone()).collect();
+        assert!(names.contains("MikebomFixture.Xunit"), "inherited xunit missing");
+        assert!(names.contains("MikebomFixture.Coverlet"), "inherited coverlet missing");
+        assert!(names.contains("MikebomFixture.Local"), "csproj-local ref missing");
+        // Inherited references attribute their source_path to the
+        // Directory.Build.props, not the csproj.
+        let xunit = entries
+            .iter()
+            .find(|e| e.name == "MikebomFixture.Xunit")
+            .unwrap();
+        assert!(
+            xunit.source_path.contains("Directory.Build.props"),
+            "inherited ref source_path should point to Directory.Build.props; got {}",
+            xunit.source_path
+        );
+    }
+
+    #[test]
+    fn directory_build_props_property_group_feeds_substitution() {
+        // #655 + #654 — property defined in Directory.Build.props
+        // should resolve $() refs in the csproj's inline Version=.
+        let tmp = tempfile::tempdir().unwrap();
+        write(
+            tmp.path(),
+            "Directory.Build.props",
+            r#"<Project>
+  <PropertyGroup>
+    <MikebomVer>3.0.1</MikebomVer>
+  </PropertyGroup>
+</Project>"#,
+        );
+        write(
+            tmp.path(),
+            "App.csproj",
+            r#"<Project>
+  <ItemGroup>
+    <PackageReference Include="MikebomFixture.PropInherit" Version="$(MikebomVer)" />
+  </ItemGroup>
+</Project>"#,
+        );
+        let entries = read(tmp.path(), &Default::default());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].version, "3.0.1");
+        assert_eq!(
+            entries[0].purl.as_str(),
+            "pkg:nuget/MikebomFixture.PropInherit@3.0.1"
+        );
+    }
+
+    #[test]
+    fn directory_build_props_package_version_extends_cpm() {
+        // #655 — Directory.Build.props can declare `<PackageVersion>`
+        // elements that behave as CPM fallbacks when
+        // Directory.Packages.props doesn't declare the package.
+        let tmp = tempfile::tempdir().unwrap();
+        write(
+            tmp.path(),
+            "Directory.Build.props",
+            r#"<Project>
+  <ItemGroup>
+    <PackageVersion Include="MikebomFixture.BuildCpm" Version="7.7.7" />
+  </ItemGroup>
+</Project>"#,
+        );
+        write(
+            tmp.path(),
+            "App.csproj",
+            r#"<Project>
+  <ItemGroup>
+    <PackageReference Include="MikebomFixture.BuildCpm" />
+  </ItemGroup>
+</Project>"#,
+        );
+        let entries = read(tmp.path(), &Default::default());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].version, "7.7.7");
+    }
+
+    #[test]
+    fn packages_props_wins_over_build_props_for_same_cpm_key() {
+        // #655 — when both Directory.Build.props and
+        // Directory.Packages.props declare the same PackageVersion,
+        // Directory.Packages.props wins (canonical CPM location).
+        let tmp = tempfile::tempdir().unwrap();
+        write(
+            tmp.path(),
+            "Directory.Build.props",
+            r#"<Project>
+  <ItemGroup>
+    <PackageVersion Include="MikebomFixture.CpmClash" Version="1.0.0" />
+  </ItemGroup>
+</Project>"#,
+        );
+        write(
+            tmp.path(),
+            "Directory.Packages.props",
+            r#"<Project>
+  <ItemGroup>
+    <PackageVersion Include="MikebomFixture.CpmClash" Version="2.0.0" />
+  </ItemGroup>
+</Project>"#,
+        );
+        write(
+            tmp.path(),
+            "App.csproj",
+            r#"<Project>
+  <ItemGroup>
+    <PackageReference Include="MikebomFixture.CpmClash" />
+  </ItemGroup>
+</Project>"#,
+        );
+        let entries = read(tmp.path(), &Default::default());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].version, "2.0.0", "packages.props should win");
     }
 
     #[test]


### PR DESCRIPTION
Closes #655. Third and final follow-up from the [2026-08-04 NuGet audit](https://github.com/kusari-oss/waybill/blob/main/docs/audits/2026-08-04-nuget-realworld.md). Builds on #656 (FU-003) + #657 (FU-002).

## Summary

MSBuild automatically imports two conventional files into every project during evaluation: `Directory.Build.props` (before the .csproj content) and `Directory.Build.targets` (after). Prior to this fix waybill ignored both. Real-world .NET projects use these heavily to hoist common declarations — the RestSharp `test/Directory.Build.props` from the audit is canonical: 12 test-only `<PackageReference>` elements declared once, applied to every test csproj under `test/`. Waybill silently missed all 12.

## Implementation

New module `nuget/directory_build_props.rs`:
- Walks up from the project directory (bounded by scan_root) to find the nearest `Directory.Build.props` and `Directory.Build.targets`.
- Delegates parsing to the existing sibling parsers (`csproj::parse_project_file` for `<PackageReference>`, `directory_packages_props::parse_props` for `<PackageVersion>`, `msbuild_properties::parse_properties_file` for `<PropertyGroup>`).
- Returns a `DirectoryBuildFiles` struct with three merged collections.

Refactored `directory_packages_props::find_props_walking_up` → general `find_msbuild_file_walking_up` helper, reused for both `Directory.Build.props` and `Directory.Build.targets` walks.

Wired into `nuget/mod.rs::read_one_project`:
- **Property-map merge**: `build.props ⊕ build.targets ⊕ packages.props ⊕ csproj` (later overlays earlier).
- **CPM map merge**: build.{props,targets} contributes fallback \`<PackageVersion>\` entries; `Directory.Packages.props` wins on collision (canonical CPM location).
- **PackageReferences**: build.props/targets refs prepended to csproj's own; accumulator dedupes by `(name, version_opt)`.

Extended `NugetPackageReference` with `source_file: Option<PathBuf>` so inherited references correctly attribute their `waybill:source-files` annotation to the props file rather than the consuming csproj.

## Smoke test — audit repro

| Metric | Pre-audit | After #656 | After #657 | **After this** |
|---|---|---|---|---|
| RestSharp nuget total | 16 | 16 | 16 | **25** (+9 recovered) |
| RestSharp \`@unresolved\` | 0 | 0 | 0 | 0 |
| RestSharp \`\$()\` leaks | 1 | 1 | **0** | 0 |
| Orleans nuget total | 154 | 154 | 154 | **155** (+1) |
| Orleans \`@unresolved\` | 20 | **0** | 0 | 0 |
| Orleans \`\$()\` leaks | 3 | 3 | **0** | 0 |

**Note on trivy comparison**: RestSharp waybill=25 vs trivy=27. The 2-package delta is trivy over-declaring `<PackageVersion>` CPM entries no csproj actually references (`rest-mock-core`, `WireMock.Net.FluentAssertions`, `Xunit.Extensions.Logging`). Waybill's 25 matches what MSBuild would actually restore — this is an **accuracy win**, not a gap.

## Test coverage

- **5 new unit tests** in `directory_build_props::tests` — empty-path handling, PackageReference/Version/PropertyGroup extraction, build.targets overlaying build.props, walker scan_root bound.
- **4 new integration tests** in `nuget::tests` — inherited PackageReferences from Directory.Build.props (RestSharp shape); PropertyGroup values feed cross-file \`\$()\` substitution; Directory.Build.props CPM fallback; Directory.Packages.props wins over Directory.Build.props on collision.
- **All 102 nuget-scoped tests pass** (93 pre-existing + 9 new).
- **Full \`./scripts/pre-pr.sh\` green.**

## Follow-ups

Closes the FU-001 audit item + completes the three concrete bug fixes from the audit. The audit's remaining infrastructure follow-ups (FU-004 dotnet-CLI tiebreaker, FU-005 corpus harness) are separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)