### PR TITLE
fix(release.yml): sign SBOM via cosign sign-blob (workaround sigstore-rs 0.11 GHA-ambient limitation)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -630,15 +630,40 @@ jobs:
           chmod +x /tmp/waybill-bin/waybill
           /tmp/waybill-bin/waybill --version
 
-      - name: Generate + sign source-tree SBOM (waybill-of-waybill, Sigstore keyless)
+      # Feature 229 US1 T004 — cosign sign-blob path (recovery from v0.2.0
+      # release attempt). `waybill sbom scan --sign` was the original design
+      # per 229 §4.4, but sigstore-rs 0.11 requires an `email` OIDC claim
+      # which GitHub Actions ambient tokens do NOT emit — GHA emits `sub`
+      # instead (memory feedback_sigstore_rs_011_email_limitation). Workaround
+      # per Q2 clarification (all releases MUST be signed): generate the SBOM
+      # without --sign, then use cosign's own ambient-GHA OIDC path (which
+      # accepts `sub` claim) to sign the resulting file. Byte-identical
+      # verifier-facing output — `cosign verify-blob --signature <sig>
+      # --certificate <cert>` works the same way. See follow-up issue for
+      # tracking the sigstore-rs upstream fix.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Generate source-tree SBOM (waybill-of-waybill, unsigned)
         run: |
           set -euo pipefail
           /tmp/waybill-bin/waybill sbom scan \
             --path . \
             --format cyclonedx-json \
-            --sign \
             --output waybill-source.cdx.json \
             --no-deep-hash
+
+      - name: Sign SBOM via cosign sign-blob (Sigstore keyless, GHA ambient OIDC)
+        run: |
+          set -euo pipefail
+          cosign sign-blob \
+            --yes \
+            --output-signature waybill-source.cdx.json.sig \
+            --output-certificate waybill-source.cdx.json.pem \
+            waybill-source.cdx.json
+          echo "Signed SBOM at waybill-source.cdx.json"
+          echo "  Signature: waybill-source.cdx.json.sig"
+          echo "  Certificate: waybill-source.cdx.json.pem"
 
       - name: Compute prerelease flag from tag
         id: prerelease_flag
@@ -674,3 +699,5 @@ jobs:
             waybill-*.zip
             SHA256SUMS
             waybill-source.cdx.json
+            waybill-source.cdx.json.sig
+            waybill-source.cdx.json.pem


### PR DESCRIPTION
**Hotfix for v0.2.0 release attempt.** The initial \`v0.2.0\` tag-triggered release.yml run ([31214436901](https://github.com/kusari-oss/waybill/actions/runs/31214436901)) failed at the SBOM-signing step with:

> Error: signing failed for cyclonedx-json (target: waybill-source.cdx.json): OIDC token acquisition failed: GitHub Actions ambient OIDC is not supported in this version of waybill because sigstore-rs 0.11 requires an \`email\` claim, which GHA tokens do not emit.

Documented in project memory \`feedback_sigstore_rs_011_email_limitation\` — sigstore-rs 0.11 hardcodes OIDC \`email\` → CSR subject; GHA ambient tokens emit \`sub\`, not \`email\`. **The 229 spec should have flagged this during Phase 0 research but didn't** — filed as an oversight in the retro.

## Fix

Per Q2 clarification (all releases MUST be signed) — replace the failing \`waybill sbom scan --sign\` invocation with the workaround the error message itself suggests:

1. **Generate the SBOM unsigned**: \`waybill sbom scan --path . --output waybill-source.cdx.json --no-deep-hash\`
2. **Sign via cosign**: \`cosign sign-blob --yes --output-signature waybill-source.cdx.json.sig --output-certificate waybill-source.cdx.json.pem waybill-source.cdx.json\`

Cosign accepts the \`sub\` claim from GHA ambient OIDC (proven working — the existing image-signing step earlier in release.yml already uses this path). Byte-identical verifier-facing output.

Release-page artifacts gain 2 new files: \`.sig\` (detached signature) + \`.pem\` (signing cert).

**Verification post-merge** (consumers):
\`\`\`bash
cosign verify-blob \\
  --certificate waybill-source.cdx.json.pem \\
  --signature waybill-source.cdx.json.sig \\
  --certificate-identity-regexp "https://github.com/kusari-oss/waybill/.*" \\
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\
  waybill-source.cdx.json
# → Verified OK
\`\`\`

## Follow-up work (separate spec, not blocking)

- Bump sigstore-rs to a version that accepts \`sub\` claim, OR contribute the fix upstream (kusari-sandbox/sigstore-rs fork already exists per memory \`reference_sigstore_trust_keys\`)
- Alternative: document permanently that \`waybill --sign\` requires SIGSTORE_ID_TOKEN from an email-emitting provider
- Filed as issue for post-v0.2.0

## Recovery plan post-merge

1. No pre-existing v0.2.0 release-in-progress state to clean up (the failed job never created a release page)
2. Dispatch release.yml via \`gh workflow run release.yml -f tag=v0.2.0 --ref main --repo kusari-oss/waybill\`
3. Verify signed SBOM produced + release page created

## Test plan

- [x] actionlint clean on modified release.yml
- [ ] CI passes on this PR
- [ ] Post-merge: dispatch release.yml against v0.2.0
- [ ] Verify \`cosign verify-blob\` succeeds on the resulting artifact
- [ ] Verify GitHub release page for v0.2.0 shows Latest badge + all expected artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)