### PR TITLE
fix(release.yml): pin cosign legacy bundle format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -656,8 +656,14 @@ jobs:
       - name: Sign SBOM via cosign sign-blob (Sigstore keyless, GHA ambient OIDC)
         run: |
           set -euo pipefail
+          # cosign 2.6+ made --new-bundle-format the default, which silently
+          # ignores --output-signature/--output-certificate and requires
+          # --bundle=<path>. Pin the legacy format explicitly so the
+          # detached .sig/.pem outputs (and the consumer `cosign verify-blob`
+          # recipe in RELEASING.md) stay stable.
           cosign sign-blob \
             --yes \
+            --new-bundle-format=false \
             --output-signature waybill-source.cdx.json.sig \
             --output-certificate waybill-source.cdx.json.pem \
             waybill-source.cdx.json


### PR DESCRIPTION
## Summary

- Cosign 2.6+ made `--new-bundle-format=true` the default; in that mode
  the deprecated `--output-signature` / `--output-certificate` flags are
  silently ignored and the tool tries to open the unset `--bundle` path.
- Add `--new-bundle-format=false` so the detached `.sig`/`.pem` outputs
  (which the RELEASING.md consumer verify recipe references) stay stable.

## Context

Discovered while dispatching the third attempt of `release.yml` for
`v0.2.0` (workflow run 31219757986): all 4 platform builds succeeded;
the release job failed at the signing step with:

```
Error: signing waybill-source.cdx.json:
create bundle file: open : no such file or directory
```

This is the second release-workflow hotfix in the v0.2.0 push (following
#673 which switched from waybill --sign to cosign sign-blob).

## Test plan

- [x] YAML change is a single-line flag addition (no logic change)
- [ ] After merge, re-dispatch `release.yml` against `v0.2.0` and
      verify the `Create GitHub release` job completes green
- [ ] Verify `cosign verify-blob --certificate waybill-source.cdx.json.pem
      --signature waybill-source.cdx.json.sig ...` succeeds against the
      published assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)