### PR TITLE
fix(release.yml): switch cosign sign-blob to --bundle output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -656,20 +656,17 @@ jobs:
       - name: Sign SBOM via cosign sign-blob (Sigstore keyless, GHA ambient OIDC)
         run: |
           set -euo pipefail
-          # cosign 2.6+ made --new-bundle-format the default, which silently
-          # ignores --output-signature/--output-certificate and requires
-          # --bundle=<path>. Pin the legacy format explicitly so the
-          # detached .sig/.pem outputs (and the consumer `cosign verify-blob`
-          # recipe in RELEASING.md) stay stable.
+          # cosign 2.6+ requires --bundle for keyless signing under the
+          # active signing-config path. The bundle is a self-contained
+          # JSON blob carrying both signature and certificate; consumers
+          # verify via `cosign verify-blob --bundle <path> <blob>` (see
+          # RELEASING.md §Step 9).
           cosign sign-blob \
             --yes \
-            --new-bundle-format=false \
-            --output-signature waybill-source.cdx.json.sig \
-            --output-certificate waybill-source.cdx.json.pem \
+            --bundle waybill-source.cdx.json.bundle \
             waybill-source.cdx.json
           echo "Signed SBOM at waybill-source.cdx.json"
-          echo "  Signature: waybill-source.cdx.json.sig"
-          echo "  Certificate: waybill-source.cdx.json.pem"
+          echo "  Bundle: waybill-source.cdx.json.bundle"
 
       - name: Compute prerelease flag from tag
         id: prerelease_flag
@@ -705,5 +702,4 @@ jobs:
             waybill-*.zip
             SHA256SUMS
             waybill-source.cdx.json
-            waybill-source.cdx.json.sig
-            waybill-source.cdx.json.pem
+            waybill-source.cdx.json.bundle

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -131,12 +131,13 @@ git push origin v<X>.<Y>.<Z>
 ```bash
 gh release view v<X>.<Y>.<Z> --json isPrerelease,assets
 # expect: isPrerelease: false; assets includes 4 platform archives +
-# SHA256SUMS + waybill-source.cdx.json (with embedded Sigstore signature)
+# SHA256SUMS + waybill-source.cdx.json + waybill-source.cdx.json.bundle
 
+# Download the SBOM + Sigstore bundle from the release, then verify:
 cosign verify-blob \
   --certificate-identity-regexp "https://github.com/kusari-oss/waybill/.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --signature waybill-source.cdx.json \
+  --bundle waybill-source.cdx.json.bundle \
   waybill-source.cdx.json
 # expect: Verified OK
 ```


### PR DESCRIPTION
## Summary

- cosign 2.6+ rejects `--new-bundle-format=false` (added in #674) when
  `--signing-config` is active — the new bundle format is mandatory
  under the default keyless signing path.
- Switch to `--bundle waybill-source.cdx.json.bundle` (self-contained
  JSON blob carrying signature + certificate).
- Update `files:` list and RELEASING.md verify recipe to match.

## Context

Discovered while dispatching the fourth attempt of `release.yml` for
`v0.2.0` (workflow run 31221929841): all 4 builds succeeded; the
release job failed at the signing step with:

```
Error: must provide --new-bundle-format or --bundle where applicable
with --signing-config or --use-signing-config
```

Fourth release-workflow hotfix in the v0.2.0 push:
- #670 (release-flow infra) → #672 (workspace bump) → attempt #1 failed
  at sigstore-rs OIDC email claim → #673 (switch to cosign sign-blob) →
  attempt #2 upload flake → attempt #3 hit cosign 2.6 default → #674
  (add `--new-bundle-format=false`) → attempt #4 failed the above → #675
  (this — switch to `--bundle`).

## Test plan

- [x] Compile check (workflow YAML syntax)
- [ ] Merge, re-dispatch `release.yml` against `v0.2.0`
- [ ] Verify `Create GitHub release` completes green
- [ ] Verify `cosign verify-blob --bundle waybill-source.cdx.json.bundle
      --certificate-identity-regexp "https://github.com/kusari-oss/waybill/.*"
      --certificate-oidc-issuer https://token.actions.githubusercontent.com
      waybill-source.cdx.json` returns "Verified OK"

🤖 Generated with [Claude Code](https://claude.com/claude-code)