### PR TITLE
add(ci): test-signing.yml — cosign smoke test for release-flow

### DIFF
--- a/.github/workflows/test-signing.yml
+++ b/.github/workflows/test-signing.yml
@@ -1,0 +1,78 @@
+# Feature 229 follow-up — signing-path smoke test.
+#
+# Purpose: reproduce the cosign sign-blob + verify-blob round-trip from
+# release.yml in ~90 seconds so we don't burn 7-minute full release matrices
+# on flag-syntax bugs when upstream cosign-installer bumps the tool.
+#
+# Trigger: workflow_dispatch only. Runs on ubuntu-latest, needs id-token: write
+# for Sigstore keyless OIDC. Creates a throwaway text blob, signs it, verifies
+# it, and asserts on the outputs. No release-tag side effects; no artifacts
+# uploaded to any release; nothing published to a registry.
+#
+# Use this workflow to lock in a known-good cosign invocation before touching
+# release.yml. When upstream cosign-installer bumps cosign to a version whose
+# defaults change, this workflow will fail first — cheaply, on a throwaway
+# blob — instead of failing during a real tagged release.
+
+name: Test signing (cosign sign-blob smoke test)
+
+on:
+  workflow_dispatch:
+    inputs:
+      cosign_installer_ref:
+        description: >-
+          Optional override for the sigstore/cosign-installer version pin.
+          Defaults to the same SHA pin release.yml uses.
+        required: false
+        default: "6f9f17788090df1f26f669e9d70d6ae9567deba6"  # v4.1.2
+
+permissions:
+  contents: read
+  id-token: write  # required for Sigstore keyless OIDC token exchange
+
+jobs:
+  smoke-test:
+    name: Sign + verify round-trip
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Print cosign version
+        run: |
+          set -euo pipefail
+          cosign version
+
+      - name: Create scratch blob to sign
+        run: |
+          set -euo pipefail
+          printf 'waybill test-signing smoke test — %s\n' "$(date -u +%Y%m%dT%H%M%SZ)" > scratch.txt
+          echo "Blob:"
+          cat scratch.txt
+
+      - name: Sign scratch blob (mirrors release.yml invocation)
+        run: |
+          set -euo pipefail
+          cosign sign-blob \
+            --yes \
+            --bundle scratch.txt.bundle \
+            scratch.txt
+          test -s scratch.txt.bundle
+          echo "Bundle size: $(wc -c < scratch.txt.bundle) bytes"
+
+      - name: Verify scratch blob (mirrors RELEASING.md verify recipe)
+        run: |
+          set -euo pipefail
+          cosign verify-blob \
+            --certificate-identity-regexp "https://github.com/kusari-oss/waybill/.*" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --bundle scratch.txt.bundle \
+            scratch.txt
+
+      - name: Report success
+        run: |
+          set -euo pipefail
+          echo "cosign sign-blob + verify-blob round-trip: OK"
+          echo "This workflow-run's invocation is safe to use in release.yml."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -133,7 +133,12 @@ gh release view v<X>.<Y>.<Z> --json isPrerelease,assets
 # expect: isPrerelease: false; assets includes 4 platform archives +
 # SHA256SUMS + waybill-source.cdx.json + waybill-source.cdx.json.bundle
 
-# Download the SBOM + Sigstore bundle from the release, then verify:
+# Download the SBOM + Sigstore bundle from the release, then verify.
+# If your cosign install has a stale TUF cache (last used against
+# Rekor v1), refresh the trust root first — v0.2.0+ bundles are logged
+# to Rekor v2 and need the newer log key:
+cosign initialize
+
 cosign verify-blob \
   --certificate-identity-regexp "https://github.com/kusari-oss/waybill/.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \


### PR DESCRIPTION
## Summary

- workflow_dispatch-only test workflow that reproduces the cosign
  sign-blob + verify-blob round-trip from release.yml in ~90 seconds
- Ubuntu-latest, id-token:write, no side effects — creates a scratch
  text file, signs it, verifies it, done
- Provides a fast dev loop for future cosign-installer bumps so we
  don't burn 7-min full release matrices on shell-flag bugs

## Context

v0.2.0 required five release-workflow hotfixes to work through cosign
2.6+ default flag deprecations (#673 → #674 → #675 → …). Root cause:
we were iterating on the signing step against a real release tag,
which meant every 30-second flag bug consumed a 7-minute platform
matrix.

With this workflow: when cosign-installer bumps, dispatch this first,
iterate here, only touch release.yml once the smoke test passes.

## Test plan

- [x] YAML syntax valid (verified via `python3 -c "import yaml; ..."`)
- [ ] After merge, dispatch via `gh workflow run test-signing.yml
      --ref main --repo kusari-oss/waybill`
- [ ] Confirm workflow completes green (~90 seconds expected)
- [ ] Confirm cosign version in log matches release.yml's expectation
- [ ] Confirm `cosign verify-blob` step exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)