### PR TITLE
chore(m234): record upstream + tracking links in bpf-linker.env

### DIFF
--- a/.github/env/bpf-linker.env
+++ b/.github/env/bpf-linker.env
@@ -16,3 +16,10 @@
 # docs/development/ebpf-toolchain.md for the full flow.
 
 BPF_LINKER_VERSION=0.10.4
+
+# m234 US1b — upstream investigation active. Do NOT bump the pin
+# until the un-pin readiness command (`scripts/verify-ebpf.sh`)
+# passes against a candidate version.
+BPF_LINKER_UPSTREAM_ISSUE=https://github.com/aya-rs/bpf-linker/issues/399
+BPF_LINKER_TRACKING_ISSUE=https://github.com/kusari-oss/waybill/issues/683
+BPF_LINKER_FALLBACK_DEADLINE=2026-09-12


### PR DESCRIPTION
## Summary

Small metadata-only PR — populates the T015 optional fields on `.github/env/bpf-linker.env`. Signals to future triagers that the un-pin investigation is active and links to the relevant issues.

## Values recorded

- \`BPF_LINKER_UPSTREAM_ISSUE\` → https://github.com/aya-rs/bpf-linker/issues/399
- \`BPF_LINKER_TRACKING_ISSUE\` → https://github.com/kusari-oss/waybill/issues/683
- \`BPF_LINKER_FALLBACK_DEADLINE\` → \`2026-09-12\`

## Behavioral impact

None. The composite action only reads \`BPF_LINKER_VERSION\`; the new fields are informational metadata.

## Test plan

- [x] Local — pin-consistency guard verified: env file + Dockerfile ARG both still at 0.10.4 (untouched)
- [ ] CI — pin-consistency workflow runs on this PR and passes

## Refs

- Upstream: aya-rs/bpf-linker#399
- Internal tracking: #683
- Prior: #682 (durable resilience), #681 (interim hotfix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)