### PR TITLE
feat(m234 US1b): un-pin bpf-linker to 0.11.0 via pre-built binary install

### DIFF
--- a/.github/actions/install-bpf-linker/action.yml
+++ b/.github/actions/install-bpf-linker/action.yml
@@ -1,5 +1,5 @@
 name: 'Install bpf-linker'
-description: 'Install pinned bpf-linker via cargo. Reads version from .github/env/bpf-linker.env by default. Contract: specs/234-fix-ebpf-linker-regression/contracts/install-bpf-linker-action.md'
+description: 'Install pinned bpf-linker via pre-built binary (default) or cargo install. Reads version from .github/env/bpf-linker.env by default. Contract: specs/234-fix-ebpf-linker-regression/contracts/install-bpf-linker-action.md'
 
 inputs:
   version:
@@ -7,9 +7,13 @@ inputs:
     required: false
     default: ''
   toolchain:
-    description: 'Rust toolchain to install bpf-linker under (default: nightly).'
+    description: 'Rust toolchain to install bpf-linker under (cargo install-method only; default: nightly).'
     required: false
     default: 'nightly'
+  install-method:
+    description: 'How to install bpf-linker: "binary" (default; download pre-built release artifact from aya-rs/bpf-linker GH releases) or "cargo" (build from source via cargo install; requires system LLVM 22+ for v0.11+).'
+    required: false
+    default: 'binary'
 
 outputs:
   installed-version:
@@ -47,7 +51,11 @@ runs:
         fi
         echo "target=$target" >> "$GITHUB_OUTPUT"
 
-    - name: Install rust toolchain (${{ inputs.toolchain }})
+    # Only install the rust toolchain when we're going to invoke
+    # `cargo install`. The binary path doesn't need it (the calling
+    # workflow installs its own toolchain for the actual eBPF build).
+    - name: Install rust toolchain (cargo install-method only)
+      if: inputs.install-method == 'cargo'
       shell: bash
       env:
         INPUT_TOOLCHAIN: ${{ inputs.toolchain }}
@@ -56,7 +64,89 @@ runs:
         rustup toolchain install "$INPUT_TOOLCHAIN" --profile minimal
         rustup component add rust-src --toolchain "$INPUT_TOOLCHAIN"
 
-    - name: Install bpf-linker
+    - name: Install bpf-linker (binary — pre-built from GH releases)
+      if: inputs.install-method == 'binary'
+      shell: bash
+      env:
+        TARGET_VERSION: ${{ steps.resolve.outputs.target }}
+      run: |
+        set -euo pipefail
+        target="$TARGET_VERSION"
+
+        # Idempotency short-circuit — if a matching version is already
+        # on PATH, skip the download.
+        if command -v bpf-linker >/dev/null 2>&1; then
+          current=$(bpf-linker --version 2>&1 | awk '{print $2}' || echo "")
+          if [ "$target" != "latest" ] && [ "$current" = "$target" ]; then
+            echo "bpf-linker $current already installed; skipping"
+            exit 0
+          fi
+        fi
+
+        # Resolve `latest` to a concrete release tag via GH API. This
+        # keeps the download URL construction deterministic.
+        if [ "$target" = "latest" ]; then
+          tag=$(curl -sSL --retry 3 \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/aya-rs/bpf-linker/releases/latest \
+              | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+          if [ -z "$tag" ]; then
+            echo "::error::Failed to resolve 'latest' tag from GitHub API"
+            exit 1
+          fi
+          target="${tag#v}"
+          echo "Resolved 'latest' → v${target}"
+        fi
+
+        # Platform triple. bpf-linker publishes musl for Linux, apple
+        # for macOS. Windows is not exercised by waybill CI (eBPF is
+        # Linux-only), but we support it anyway for local dev parity.
+        arch=$(uname -m)
+        os=$(uname -s)
+        case "$os-$arch" in
+          Linux-x86_64|Linux-amd64)    triple="x86_64-unknown-linux-musl" ;;
+          Linux-aarch64|Linux-arm64)   triple="aarch64-unknown-linux-musl" ;;
+          Darwin-x86_64)               triple="x86_64-apple-darwin" ;;
+          Darwin-arm64|Darwin-aarch64) triple="aarch64-apple-darwin" ;;
+          *) echo "::error::Unsupported platform: $os-$arch — use install-method: cargo (requires system LLVM)"; exit 1 ;;
+        esac
+
+        url="https://github.com/aya-rs/bpf-linker/releases/download/v${target}/bpf-linker-${triple}.tar.zst"
+        echo "Downloading: $url"
+
+        # zstd is preinstalled on ubuntu-latest + macos-latest runners.
+        # If missing, apt-get install (Linux only fallback).
+        if ! command -v zstd >/dev/null 2>&1; then
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update -y && sudo apt-get install -y zstd
+          else
+            echo "::error::zstd not available and no apt-get to install it"
+            exit 1
+          fi
+        fi
+
+        install_dir="$HOME/.cargo/bin"
+        mkdir -p "$install_dir"
+        tmp_archive=$(mktemp)
+        trap 'rm -f "$tmp_archive"' EXIT
+        curl -sSL --retry 3 --fail -o "$tmp_archive" "$url"
+        # Extract the `bpf-linker` binary directly to ~/.cargo/bin.
+        # The archive contains a single file named `bpf-linker` at the
+        # top level (verified against v0.11.0 aarch64-apple-darwin).
+        tar --zstd -xf "$tmp_archive" -C "$install_dir" bpf-linker
+        chmod +x "$install_dir/bpf-linker"
+
+        # Confirm PATH pickup — ~/.cargo/bin is on PATH via rustup init
+        # on both runner images.
+        if ! command -v bpf-linker >/dev/null 2>&1; then
+          echo "::error::bpf-linker not on PATH after install; $install_dir is not being picked up"
+          exit 1
+        fi
+        echo "Installed bpf-linker to $install_dir/bpf-linker"
+
+    - name: Install bpf-linker (cargo — build from source; requires system LLVM)
+      if: inputs.install-method == 'cargo'
       shell: bash
       env:
         TARGET_VERSION: ${{ steps.resolve.outputs.target }}
@@ -84,6 +174,19 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        version=$(bpf-linker --version 2>&1 | awk '{print $2}')
+        # Upstream release binaries currently report "0.0.0" from
+        # `bpf-linker --version` (known quirk — the crate-version macro
+        # doesn't propagate through the binary release build). Fall back
+        # to the resolved target-version when the binary reports empty
+        # or "0.0.0".
+        raw=$(bpf-linker --version 2>&1 | awk '{print $2}' || echo "")
+        target="${TARGET_VERSION:-}"
+        if [ -z "$raw" ] || [ "$raw" = "0.0.0" ]; then
+          version="$target"
+        else
+          version="$raw"
+        fi
         echo "version=$version" >> "$GITHUB_OUTPUT"
         echo "installed-version=$version"
+      env:
+        TARGET_VERSION: ${{ steps.resolve.outputs.target }}

--- a/.github/env/bpf-linker.env
+++ b/.github/env/bpf-linker.env
@@ -11,8 +11,11 @@
 # NOT a consumer: .github/workflows/nightly.yml (dispatcher to release.yml;
 # inherits the pin transitively). Guarded by .github/workflows/pin-consistency.yml.
 #
-# To bump: edit the version below in ONE line, verify locally via
-# `scripts/verify-ebpf.sh --version <new>`, open a PR. See
-# docs/development/ebpf-toolchain.md for the full flow.
+# INSTALL METHOD: pre-built binary from aya-rs/bpf-linker GH releases
+# (composite action's default install-method=binary). From v0.11.0
+# onward, `cargo install bpf-linker` requires system LLVM 22, which
+# ubuntu-24.04 GHA runners don't ship. Pre-built musl binaries
+# statically link LLVM 22 in and work out of the box. See
+# docs/development/ebpf-toolchain.md for the un-pin/bump flow.
 
-BPF_LINKER_VERSION=0.10.4
+BPF_LINKER_VERSION=0.11.0

--- a/Dockerfile.ebpf-test
+++ b/Dockerfile.ebpf-test
@@ -16,7 +16,8 @@
 FROM rust:1.88-bookworm
 
 # eBPF build deps + runtime tools the trace-run needs (gcc for the
-# fixture's compiler-invocation traffic; jq for the assertion script).
+# fixture's compiler-invocation traffic; jq for the assertion script;
+# zstd + curl for the bpf-linker binary download below).
 RUN apt-get update && apt-get install -y \
     clang \
     llvm \
@@ -26,19 +27,34 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     gcc \
     jq \
+    curl \
+    zstd \
     && rm -rf /var/lib/apt/lists/*
 
-# m234 (2026-08-12): the pinned bpf-linker version lives at
-# .github/env/bpf-linker.env. CI + local users pass it in via
-# --build-arg BPF_LINKER_VERSION=$(grep '^BPF_LINKER_VERSION=' \
-# .github/env/bpf-linker.env | cut -d= -f2). The ARG default here
-# is a safety net for direct `docker build` without --build-arg —
-# it MUST match the current env-file value (see pin-consistency.yml
-# CI guard, which flags drift between them).
-ARG BPF_LINKER_VERSION=0.10.4
+# m234 US1b (2026-08-13): install method switched from `cargo install`
+# to pre-built binary from aya-rs/bpf-linker GH releases. Rationale:
+# v0.11.0 removed the rustc-llvm-proxy shim and now requires system
+# LLVM 22, which Debian bookworm doesn't ship. The pre-built musl
+# binary statically links LLVM 22 in.
+#
+# The ARG default MUST match .github/env/bpf-linker.env (guarded by
+# .github/workflows/pin-consistency.yml). CI passes the env value in
+# via `docker build --build-arg BPF_LINKER_VERSION=$(...)`.
+ARG BPF_LINKER_VERSION=0.11.0
 RUN rustup toolchain install nightly --profile minimal \
     && rustup component add rust-src --toolchain nightly \
-    && cargo +nightly install bpf-linker --locked --version "${BPF_LINKER_VERSION}"
+    && arch=$(uname -m) \
+    && case "$arch" in \
+         x86_64|amd64) triple="x86_64-unknown-linux-musl" ;; \
+         aarch64|arm64) triple="aarch64-unknown-linux-musl" ;; \
+         *) echo "unsupported arch $arch" && exit 1 ;; \
+       esac \
+    && url="https://github.com/aya-rs/bpf-linker/releases/download/v${BPF_LINKER_VERSION}/bpf-linker-${triple}.tar.zst" \
+    && curl -sSL --retry 3 --fail -o /tmp/bpf-linker.tar.zst "$url" \
+    && tar --zstd -xf /tmp/bpf-linker.tar.zst -C /usr/local/bin bpf-linker \
+    && chmod +x /usr/local/bin/bpf-linker \
+    && rm /tmp/bpf-linker.tar.zst \
+    && bpf-linker --help >/dev/null 2>&1 || true
 
 WORKDIR /waybill
 

--- a/docs/development/ebpf-toolchain.md
+++ b/docs/development/ebpf-toolchain.md
@@ -4,6 +4,26 @@
 **Audience**: waybill release lead, maintainers, contributors touching
 the eBPF build path.
 
+## Install method: pre-built binary (v0.11+)
+
+Starting with `bpf-linker` v0.11.0 (upstream 2026-08-12), the
+`cargo install bpf-linker` install path requires system LLVM 22.
+ubuntu-24.04 (the default `ubuntu-latest` GHA runner) does not ship
+LLVM 22, so `cargo install` fails with `unable to find library -lLLVM`.
+
+**Fix**: install the pre-built musl binary from
+[aya-rs/bpf-linker releases](https://github.com/aya-rs/bpf-linker/releases).
+The pre-built binary statically links LLVM 22 in — no system
+dependency required. This is the composite action's DEFAULT
+(`install-method: binary`).
+
+The `cargo install` path is still available via
+`install-method: cargo` if you have LLVM 22 installed locally and
+want to build from source (e.g., testing a patched fork).
+
+Upstream docs-feedback issue tracking the switch:
+[aya-rs/bpf-linker#399](https://github.com/aya-rs/bpf-linker/issues/399).
+
 ## What lives where
 
 | Path | Purpose |
@@ -36,6 +56,10 @@ rm .github/env/bpf-linker.env.bak  # macOS/BSD sed leaves a backup
 sed -i.bak 's/^ARG BPF_LINKER_VERSION=.*/ARG BPF_LINKER_VERSION=0.12.1/' \
     Dockerfile.ebpf-test
 rm Dockerfile.ebpf-test.bak
+
+# NOTE: no other files to edit. Both the composite action and
+# `scripts/verify-ebpf.sh` read from `.github/env/bpf-linker.env`
+# and download the pre-built binary directly.
 
 # 4. Open the bump PR.
 git checkout -b bump/bpf-linker-0.12.1

--- a/scripts/verify-ebpf.sh
+++ b/scripts/verify-ebpf.sh
@@ -187,35 +187,89 @@ if ! rustup toolchain list | grep -q '^nightly'; then
 fi
 rustup component add rust-src --toolchain nightly >/dev/null 2>&1 || true
 
-# Install bpf-linker at target version.
-if [ "$target_version" = "latest" ]; then
-  echo "verify-ebpf: cargo +nightly install bpf-linker --locked (latest, unpinned)..."
-  install_ok=1
-  cargo +nightly install bpf-linker --locked 2>&1 | tee "$log_file" || install_ok=0
-else
-  echo "verify-ebpf: cargo +nightly install bpf-linker --locked --version $target_version..."
-  install_ok=1
-  cargo +nightly install bpf-linker --locked --version "$target_version" 2>&1 | tee "$log_file" || install_ok=0
+# Install bpf-linker at target version — pre-built binary path.
+# Matches .github/actions/install-bpf-linker/action.yml default
+# (install-method: binary). Rationale: from v0.11.0 upstream, cargo
+# install requires system LLVM 22 which most hosts don't ship; the
+# pre-built musl binary statically links LLVM 22 in.
+
+os=$(uname -s)
+arch=$(uname -m)
+case "$os-$arch" in
+  Linux-x86_64|Linux-amd64)    triple="x86_64-unknown-linux-musl" ;;
+  Linux-aarch64|Linux-arm64)   triple="aarch64-unknown-linux-musl" ;;
+  Darwin-x86_64)               triple="x86_64-apple-darwin" ;;
+  Darwin-arm64|Darwin-aarch64) triple="aarch64-apple-darwin" ;;
+  *)
+    echo "error: unsupported host platform $os-$arch for pre-built bpf-linker binary" >&2
+    exit 1
+    ;;
+esac
+
+resolve_version="$target_version"
+if [ "$resolve_version" = "latest" ]; then
+  echo "verify-ebpf: resolving 'latest' via GitHub API..."
+  tag=$(curl -sSL --retry 3 \
+      -H "Accept: application/vnd.github+json" \
+      https://api.github.com/repos/aya-rs/bpf-linker/releases/latest \
+      | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+  if [ -z "$tag" ]; then
+    echo "error: failed to resolve 'latest' tag from GitHub API" >&2
+    exit 1
+  fi
+  resolve_version="${tag#v}"
+  echo "verify-ebpf: 'latest' → v${resolve_version}"
+fi
+
+url="https://github.com/aya-rs/bpf-linker/releases/download/v${resolve_version}/bpf-linker-${triple}.tar.zst"
+echo "verify-ebpf: downloading pre-built bpf-linker v${resolve_version} for ${triple}..."
+
+if ! command -v zstd >/dev/null 2>&1; then
+  echo "error: zstd not on PATH — install via 'brew install zstd' or 'apt install zstd'" >&2
+  exit 1
+fi
+
+install_dir="${HOME}/.cargo/bin"
+mkdir -p "$install_dir"
+tmp_archive=$(mktemp "${TMPDIR:-/tmp}/bpf-linker-XXXXXXXX")
+trap 'rm -f "$tmp_archive"' EXIT INT TERM
+
+install_ok=1
+if ! curl -sSL --retry 3 --fail -o "$tmp_archive" "$url" 2>&1 | tee "$log_file"; then
+  install_ok=0
+fi
+if [ "$install_ok" -eq 1 ]; then
+  if ! tar --zstd -xf "$tmp_archive" -C "$install_dir" bpf-linker 2>&1 | tee -a "$log_file"; then
+    install_ok=0
+  fi
+fi
+if [ "$install_ok" -eq 1 ]; then
+  chmod +x "$install_dir/bpf-linker"
 fi
 
 if [ "$install_ok" -eq 0 ]; then
   installed_report=$(bpf-linker --version 2>/dev/null | awk '{print $2}' || echo "<install failed>")
   cat <<EOF >&2
 
-verify-ebpf: FAIL — cargo install failed
+verify-ebpf: FAIL — pre-built binary install failed
   Tool: bpf-linker
-  Version requested: $target_version
+  Version requested: $resolve_version
+  Platform: $triple
+  URL: $url
   Version currently on PATH: $installed_report
   Log: $log_file
-  Next step: inspect the log; if it names LLVM path drift or a linker
-             error, file upstream at https://github.com/aya-rs/bpf-linker
+  Next step: check that the release tag + platform triple exist at
+             https://github.com/aya-rs/bpf-linker/releases/tag/v${resolve_version}
 EOF
   trap - EXIT INT TERM
   exit 1
 fi
 
-installed_version=$(bpf-linker --version 2>&1 | awk '{print $2}')
-echo "verify-ebpf: installed bpf-linker $installed_version"
+# The pre-built binary reports "bpf-linker 0.0.0" (upstream quirk —
+# release-build doesn't propagate the crate version). Use the resolved
+# request version instead.
+installed_version="$resolve_version"
+echo "verify-ebpf: installed bpf-linker $installed_version (pre-built binary)"
 echo ""
 
 # Build eBPF kernel object.


### PR DESCRIPTION
## Summary

Executes m234 US1b — un-pins from 0.10.4 to 0.11.0 by switching install method to pre-built binary (option (b) of T018).

## Why this and not `cargo install`

`bpf-linker` v0.11.0 (upstream 2026-08-12) [intentionally removed the rustc-llvm-proxy shim](https://github.com/aya-rs/bpf-linker/pull/382) and now links against system LLVM 22. Ubuntu 24.04 (`ubuntu-latest`) doesn't ship LLVM 22, so `cargo install` fails with `-lLLVM`. Upstream publishes [pre-built musl binaries](https://github.com/aya-rs/bpf-linker/releases/tag/v0.11.0) that statically link LLVM 22 in — this is now the recommended install path.

## What changes

- `.github/actions/install-bpf-linker/action.yml` — new `install-method` input (default `binary`; `cargo` still supported)
- `.github/env/bpf-linker.env` — bumped `0.10.4` → `0.11.0`
- `Dockerfile.ebpf-test` — binary install; ARG default matches env file (pin-consistency guard-happy)
- `scripts/verify-ebpf.sh` — Linux-native path matches composite action's binary install
- `docs/development/ebpf-toolchain.md` — new "Install method" section

## Local verification

`scripts/verify-ebpf.sh --version 0.11.0` — PASS via Docker container path on macOS. Full eBPF + userspace build succeeded inside the container.

Also verified upstream binary works on host: `cargo run -p xtask -- ebpf` → "eBPF programs built successfully" (using the Darwin arm64 binary).

## Test plan

- [x] Local — `scripts/verify-ebpf.sh --version 0.11.0` via container: PASS
- [x] Local — Full container build with new Dockerfile.ebpf-test: PASS
- [x] Local — Darwin binary + `cargo run -p xtask -- ebpf`: PASS
- [ ] CI — `ebpf-tracing` lane (the whole point — validates binary install on ubuntu-24.04)
- [ ] CI — pin-consistency (verifies env file + Dockerfile ARG are in sync)
- [ ] Post-merge — canary continues to pass with `latest` (v0.11.0 currently)

## Constitution

Principle I unchanged — pre-built binary is a static Rust artifact byte-copy; no C source added, no C toolchain, no libbpf bindings.

## Supersedes

- #684 — the tracking-links PR that was going to record we're waiting for upstream. Not needed anymore; we un-pin directly here.

## Refs

- Upstream: aya-rs/bpf-linker#399
- Tracker: #683 (will close on merge)
- Prior: #682 (durable resilience), #681 (interim hotfix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)