### PR TITLE
docs(m235): CLAUDE.md flag subsection + CLI reference + ecosystems companion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,26 @@ Auto-generated from all feature plans. Last updated: 2026-08-13
   `specs/020-ebpf-feature-gate/contracts/feature-flag.md` for the full
   contract.
 
+### Gradle transitive resolution (m235; Phase 3 US1 live on main)
+
+The `--gradle-resolve` opt-in flag enables the m235 subprocess tier
+of the Gradle resolution ladder — invokes `./gradlew :sub:dependencies
+--no-daemon` per subproject × configuration and parses the ASCII-tree
+output into transitive edges. Default configurations resolved:
+`runtimeClasspath` + `testRuntimeClasspath` (per clarify Q1). Without
+the flag, waybill falls back to m106 lockfile reading (byte-identical
+pre-m235 behavior; FR-009).
+
+Companion flags: `--gradle-daemon` (opts out of `--no-daemon` default),
+`--gradle-resolve-buildscript` (also resolves plugin classpath),
+`--gradle-timeout-secs <N>` (default 300), `--gradle-extra-configurations
+<c>` (repeatable). All 4 require `--gradle-resolve`.
+
+Ladder tiers not yet wired: US2 cache reader (stubs at
+`gradle/cache_reader.rs`), US3 full static parser (stubs at
+`gradle/static_parser.rs`), US4 tier annotations. Spec:
+`specs/235-gradle-transitive-ladder/spec.md`.
+
 ### eBPF toolchain pin (m234)
 
 The `bpf-linker` version consumed by every eBPF build site is pinned

--- a/docs/ecosystems.md
+++ b/docs/ecosystems.md
@@ -374,9 +374,12 @@ scan:
   alongside the project.
 - **pip** — `uv lock` (or `pip-compile` / `poetry lock`) writes a resolved
   lockfile waybill's pip reader can consume.
-- **kotlin** — `--include-declared-deps` opts into design-tier emission (this
-  is the "trigger", not an upgrade). Full source-tier requires either a
-  Gradle daemon (waybill can't invoke) OR external supplementation.
+- **kotlin** — `--include-declared-deps` opts into design-tier emission
+  (this is the "trigger", not an upgrade). Full source-tier is
+  available via milestone-235 `--gradle-resolve` (invokes the Gradle
+  wrapper — requires JDK on `$PATH`) OR by committing a
+  `gradle.lockfile` (milestone-106 flat-list). External
+  supplementation via `--supplement-cdx` remains available.
 - **yocto** — Recipe scope is inherently design-tier; source-tier is provided
   separately by the yocto opkg installed-DB reader when a built image is
   available.
@@ -959,7 +962,71 @@ comma-joined configuration list (informational; downstream filterable
 by `compileClasspath` / `testRuntimeClasspath` / etc.).
 
 **Dep graph:** flat. Gradle lockfiles don't encode parent → child
-edges; each row is an already-resolved coord.
+edges; each row is an already-resolved coord. The transitive-edge
+gap is closed by milestone 235's subprocess resolver (below).
+
+### Gradle transitive resolution (milestone 235; US1 subprocess live)
+
+**Module:** `waybill-cli/src/scan_fs/package_db/gradle/` (siblings to
+the milestone-106 `lockfile.rs`: `subprocess.rs`, `ladder.rs`,
+`tier.rs`, plus stubs for the follow-on US2/US3 tiers).
+
+**Opt-in:** `--gradle-resolve` — see the [CLI reference](user-guide/cli-reference.md#--gradle-resolve).
+Absent the flag, Gradle projects fall through to milestone-106
+lockfile reading (byte-identical pre-m235 behavior; FR-009
+non-regression).
+
+**Ladder** (spec: `specs/235-gradle-transitive-ladder/`):
+
+| Tier | Mechanism | State |
+|---|---|---|
+| US1 subprocess | `./gradlew :<sub>:dependencies --no-daemon` → ASCII-tree parse | ✅ Live on `main` |
+| US2 cache | Walks `~/.gradle/caches/modules-2/` cached POMs | 🟡 Stub; follow-on |
+| US3 static | Regex-scoped extract from `build.gradle(.kts)` | 🟡 Partial (direct-dep helper only) |
+| US4 annotations | `waybill:gradle-resolution-tier` transparency | 🟡 Follow-on |
+
+**Detection:** any directory containing `build.gradle`,
+`build.gradle.kts`, `settings.gradle`, or `settings.gradle.kts`.
+
+**Subprocess flow (US1):**
+
+1. Discover `./gradlew` in the project dir (or `gradlew.bat` on
+   Windows). Fall back to `gradle` on `$PATH`.
+2. Enumerate subprojects: `./gradlew projects --no-daemon --quiet`
+   — parses `+--- Project ':<name>'` / `\--- Project ':<name>'`
+   lines. Empty list → single-project build.
+3. Per subproject × configuration (default set:
+   `runtimeClasspath` + `testRuntimeClasspath` per clarify Q1):
+   `./gradlew :<sub>:dependencies --configuration <config>
+   --no-daemon --quiet`
+4. Parse ASCII tree (`+--- g:a:v`, `\--- g:a:v (*)`, `g:a:v -> resolved`).
+   Depth-based parent-child edge reconstruction. `(*)` dedup-marker
+   entries record the coord but don't descend; `(c)` constraint
+   markers are skipped entirely.
+5. Assemble `Vec<PackageDbEntry>` + edges. Configurations map to
+   `LifecycleScope`: `runtime*` → `Runtime`, `test*` → `Test`.
+
+**Timeout:** 5 minutes per subprocess call by default; configurable
+via `--gradle-timeout-secs`. On timeout: SIGTERM → 2s grace → SIGKILL,
+then fall through to the next tier (m106 lockfile if present,
+otherwise no components for that project).
+
+**PURL format:** `pkg:maven/<group>/<name>@<version>` — same as m106
+and the Maven ecosystem, so downstream deps.dev enrichment applies
+unchanged.
+
+**Configurations resolved:** default `runtimeClasspath` +
+`testRuntimeClasspath`. Extend via `--gradle-extra-configurations
+<name>` (repeatable). Buildscript classpath (Gradle plugins) reached
+via `--gradle-resolve-buildscript`.
+
+**Daemon:** default `--no-daemon` — waybill doesn't want to leave a
+JVM in the operator's process list after a scan (see clarify Q2).
+`--gradle-daemon` opts out for iterative local scanning.
+
+**Constitution:** Principle I preserved. JDK is a runtime prerequisite
+of the invoked wrapper, not a compile-time waybill dep — same posture
+as m173's `go` shell-out and m053's `git describe` ladder.
 
 ---
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -505,6 +505,118 @@ one-line `go-mod-why classification: …` summary on stderr. See the
 matrix. With `--offline`, the `go` children are pinned to `GOPROXY=off`,
 `GOFLAGS=-mod=mod`, `GOTOOLCHAIN=local`.
 
+### `--gradle-resolve`
+
+Opt in to the milestone-235 Gradle transitive dependency resolver.
+
+Without this flag, waybill's Gradle support is milestone-106's
+lockfile reader only: `gradle.lockfile` +
+`buildscript-gradle.lockfile` produce flat resolved components with
+no transitive-edge information. Gradle projects WITHOUT a lockfile
+produce zero components.
+
+With `--gradle-resolve` set, waybill discovers each Gradle project
+directory (any dir containing `build.gradle(.kts)` or
+`settings.gradle(.kts)`), locates the `./gradlew` wrapper (or a
+`gradle` on `$PATH`), and spawns `./gradlew :<sub>:dependencies
+--configuration <config> --no-daemon` per subproject × configuration.
+The ASCII-tree output is parsed into transitive dependency edges.
+
+Default configurations resolved: `runtimeClasspath` +
+`testRuntimeClasspath` — extendable via
+`--gradle-extra-configurations`.
+
+Requires a JDK on `$PATH`. If the wrapper isn't found, `gradle`
+isn't on `$PATH`, or the subprocess times out (default 5 min per
+call), waybill falls back to the milestone-106 lockfile reader
+(when a lockfile is present) or emits nothing for that project
+(when it's not). No silent failure — the future milestone-235 US4
+`waybill:gradle-resolution-tier` annotation will surface the
+outcome per-scan.
+
+```bash
+waybill sbom scan --path ./my-gradle-project \
+    --gradle-resolve \
+    --output my-project.cdx.json
+```
+
+The other four `--gradle-*` flags (below) are inert without
+`--gradle-resolve`.
+
+### `--gradle-daemon`
+
+By default, waybill passes `--no-daemon` to every `./gradlew`
+invocation so it doesn't leave a Gradle JVM sitting in the
+operator's process list after a scan. Each subprocess call pays
+the ~20–30s JVM cold-start cost.
+
+`--gradle-daemon` opts out of `--no-daemon`. Subprocess calls
+after the first become significantly faster (the daemon reuses
+the same JVM), but a Gradle daemon may keep running after the
+scan exits. Useful for iterative local scanning; not recommended
+for CI.
+
+Requires `--gradle-resolve`.
+
+### `--gradle-resolve-buildscript`
+
+Also resolves the buildscript classpath (Gradle plugins the build
+itself uses) via `./gradlew :<sub>:buildEnvironment`. Doubles the
+subprocess-call count. Default off; the buildscript classpath is
+functionally distinct from the runtime classpath — it doesn't
+ship in the artifact.
+
+The pre-existing milestone-106 `buildscript-gradle.lockfile`
+reader remains the primary path for buildscript coverage when a
+lockfile is present (FR-009 non-regression). This flag adds
+subprocess-tier coverage for projects without buildscript
+lockfiles.
+
+Requires `--gradle-resolve`.
+
+### `--gradle-timeout-secs <SECONDS>`
+
+Per-subprocess timeout for each `./gradlew :sub:dependencies`
+invocation. Default: `300` (5 minutes). Minimum: `1`.
+
+When a subprocess exceeds the timeout, waybill sends SIGTERM,
+waits 2 seconds, then sends SIGKILL. The project's resolution
+degrades to the next ladder tier (m106 lockfile if present;
+otherwise no components for that project). Larger values are
+appropriate when scanning a project whose Gradle wrapper points
+at a distribution that isn't yet downloaded locally (first
+invocation stalls on Gradle distribution download):
+
+```bash
+waybill sbom scan --path ./stale-wrapper-project \
+    --gradle-resolve \
+    --gradle-timeout-secs 900 \
+    --output project.cdx.json
+```
+
+### `--gradle-extra-configurations <NAME>`
+
+Extend the default `runtimeClasspath` + `testRuntimeClasspath`
+configuration set with additional Gradle configurations. Repeatable:
+
+```bash
+waybill sbom scan --path ./my-gradle-project \
+    --gradle-resolve \
+    --gradle-extra-configurations compileClasspath \
+    --gradle-extra-configurations testCompileClasspath \
+    --output my-project.cdx.json
+```
+
+Total subprocess invocations = (subprojects) × (default configs +
+extras). Each configuration adds ~3–5s of daemon-hot scan time.
+
+Configuration names are validated to reject shell metacharacters
+(space, `;`, backtick, `$`, `|`, `&`, `>`, `<`, newlines) so
+attacker-controlled values can't reach the shell. Empty values
+are rejected.
+
+Requires `--gradle-resolve`.
+
 ---
 
 ## `waybill sbom scan`


### PR DESCRIPTION
## Summary

Closes the docs gap from #688 (m235 Phase 3 US1). The 5 `--gradle-*` flags shipped without operator-facing docs; this docs-only PR adds them.

## What ships

- **`CLAUDE.md`** — new `### Gradle transitive resolution (m235)` subsection under `## Feature flags`
- **`docs/user-guide/cli-reference.md`** — 5 new per-flag sections placed after `--no-go-mod-why`
- **`docs/ecosystems.md`** — stale "Gradle daemon waybill can't invoke" note updated + new m235 companion subsection with ladder-tier state table

## Verification

- ✅ Docs-only diff (3 markdown files)
- ✅ Pre-PR gate not required (no source changes)

## Deferred

- `docs/reference/sbom-format-mapping.md` C-row for `waybill:gradle-resolution-tier` — lands with Phase 6 US4 parity extractor per memory `feedback_sbom_format_mapping_extractor_gate`
- Spec close-out — deferred until US2/US3/US4 ship

## Refs

- Prior: #688 (m235 US1 subprocess)
- Spec: `specs/235-gradle-transitive-ladder/spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)