### PR TITLE
feat(m235): US1 e2e proof + fix edges dropping at emission (T017–T018)

### DIFF
--- a/waybill-cli/src/scan_fs/package_db/gradle/subprocess.rs
+++ b/waybill-cli/src/scan_fs/package_db/gradle/subprocess.rs
@@ -404,7 +404,14 @@ fn assemble_graph(
 
     let mut components: Vec<PackageDbEntry> = Vec::new();
     let mut edges: Vec<super::ladder::GradleEdge> = Vec::new();
+    // (group, artifact, version) → index into `components` for the
+    // first emission of that coord. Used to populate `depends` on the
+    // parent when a child edge is discovered — the scan_fs pipeline at
+    // `waybill-cli/src/scan_fs/mod.rs:868` resolves `entry.depends`
+    // (Vec<String> of `group:artifact` names) against a per-scan
+    // name→purl index into concrete SBOM Relationship edges.
     let mut seen: HashMap<(String, String, String), Purl> = HashMap::new();
+    let mut coord_to_component_idx: HashMap<(String, String, String), usize> = HashMap::new();
     let mut depth_stack: Vec<(String, String, String)> = Vec::new();
 
     for entry in parsed {
@@ -418,8 +425,10 @@ fn assemble_graph(
                 continue;
             };
             let purl = pkg.purl.clone();
+            let idx = components.len();
             components.push(pkg);
             seen.insert(coord_key.clone(), purl.clone());
+            coord_to_component_idx.insert(coord_key.clone(), idx);
             purl
         };
 
@@ -428,13 +437,27 @@ fn assemble_graph(
 
         // If there's a parent at depth-1, emit an edge.
         if entry.depth > 0 {
-            if let Some(parent_key) = depth_stack.last() {
-                if let Some(parent_purl) = seen.get(parent_key) {
+            if let Some(parent_key) = depth_stack.last().cloned() {
+                if let Some(parent_purl) = seen.get(&parent_key) {
                     edges.push(super::ladder::GradleEdge {
                         source: parent_purl.clone(),
                         target: purl.clone(),
                         edge_scope,
                     });
+                }
+                // ALSO populate the parent component's `depends` field
+                // with this child's `group:artifact` name. The scan_fs
+                // dispatcher at `waybill-cli/src/scan_fs/mod.rs:868`
+                // walks `entry.depends` and resolves each name against
+                // the per-scan name→purl index to synthesize a
+                // Relationship in the emitted SBOM. Without this line
+                // the m235 ladder's edges vanish at emission time
+                // (until US4's separate emitter lands).
+                if let Some(&parent_idx) = coord_to_component_idx.get(&parent_key) {
+                    let child_name = format!("{}:{}", entry.group, entry.artifact);
+                    if !components[parent_idx].depends.contains(&child_name) {
+                        components[parent_idx].depends.push(child_name);
+                    }
                 }
             }
         }

--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/wrapper_single_subproject/build.gradle
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/wrapper_single_subproject/build.gradle
@@ -1,0 +1,22 @@
+// m235 US1 fixture — mocked build script.
+//
+// The mock `./gradlew` script in this directory doesn't actually parse
+// this file; it emits canned ASCII-tree output for `:dependencies`
+// invocations. This file exists so waybill's `is_gradle_project`
+// detection at `waybill-cli/src/scan_fs/package_db/gradle/mod.rs`
+// recognizes the directory as a Gradle project.
+//
+// If you're reading this as a template for a real Gradle project:
+// don't. Real projects use plugin blocks and dependency declarations.
+//
+// Synthetic package names per memory
+// feedback_fixture_synthetic_package_names.
+
+plugins {
+    id 'java'
+}
+
+dependencies {
+    implementation 'com.example.waybillfixture:direct:1.0.0'
+    testImplementation 'com.example.waybillfixture:test-only:2.0.0'
+}

--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/wrapper_single_subproject/gradlew
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/wrapper_single_subproject/gradlew
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# m235 US1 fixture — mock ./gradlew for wrapper_single_subproject.
+#
+# Emits canned ASCII-tree output that matches Gradle 8.x's
+# `:dependencies` shape. Does NOT require a JDK; runs anywhere bash
+# runs. Waybill's subprocess resolver at
+# `waybill-cli/src/scan_fs/package_db/gradle/subprocess.rs`
+# discovers this script via `discover_wrapper` and treats it as the
+# project's Gradle wrapper.
+#
+# Recognized invocations (matching the subprocess resolver's calls):
+#   ./gradlew projects --no-daemon --quiet
+#     → empty output (waybill parses this as "single-project build").
+#
+#   ./gradlew dependencies --configuration runtimeClasspath --no-daemon --quiet
+#     → tree with direct + transitive dep.
+#
+#   ./gradlew dependencies --configuration testRuntimeClasspath --no-daemon --quiet
+#     → tree with test-scope dep.
+#
+#   ./gradlew dependencies --configuration <other> ...
+#     → empty output (unknown config).
+#
+# Synthetic package coordinates per memory
+# feedback_fixture_synthetic_package_names.
+
+set -euo pipefail
+
+CMD=""
+CONFIG=""
+prev=""
+for arg in "$@"; do
+    case "$arg" in
+        projects) CMD="projects" ;;
+        dependencies|:dependencies) CMD="dependencies" ;;
+    esac
+    if [ "$prev" = "--configuration" ]; then
+        CONFIG="$arg"
+    fi
+    prev="$arg"
+done
+
+case "$CMD" in
+    projects)
+        # Single-project build — no subprojects. Waybill's
+        # enumerate_subprojects parser will return vec![""] on empty output.
+        exit 0
+        ;;
+    dependencies)
+        case "$CONFIG" in
+            runtimeClasspath)
+                cat <<'GRADLE_OUTPUT'
+runtimeClasspath - Runtime classpath of source set 'main'.
++--- com.example.waybillfixture:direct:1.0.0
+|    \--- com.example.waybillfixture:transitive:0.5.0
+GRADLE_OUTPUT
+                ;;
+            testRuntimeClasspath)
+                cat <<'GRADLE_OUTPUT'
+testRuntimeClasspath - Runtime classpath of source set 'test'.
++--- com.example.waybillfixture:test-only:2.0.0
+GRADLE_OUTPUT
+                ;;
+            *)
+                # Unknown config — empty output.
+                ;;
+        esac
+        exit 0
+        ;;
+    *)
+        echo "mock gradlew: unknown command in args: $*" >&2
+        exit 1
+        ;;
+esac

--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/wrapper_single_subproject/settings.gradle
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/wrapper_single_subproject/settings.gradle
@@ -1,0 +1,3 @@
+// m235 US1 fixture — settings for waybill-fixture-app.
+// Synthetic project name (per memory feedback_fixture_synthetic_package_names).
+rootProject.name = 'waybill-fixture-app'

--- a/waybill-cli/tests/gradle_ladder.rs
+++ b/waybill-cli/tests/gradle_ladder.rs
@@ -1,0 +1,212 @@
+//! Milestone 235 US1 subprocess resolver — end-to-end integration test.
+//!
+//! Companion to the unit tests in
+//! `scan_fs::package_db::gradle::subprocess::tests` (which exercise the
+//! ASCII-tree parser + PURL construction directly). This test invokes
+//! the `waybill sbom scan --path <fixture> --gradle-resolve` binary
+//! against the `wrapper_single_subproject/` fixture and asserts the
+//! emitted CDX contains:
+//!
+//! - A component for the direct dep (`waybillfixture:direct@1.0.0`)
+//! - A component for the mock's transitive dep
+//!   (`waybillfixture:transitive@0.5.0`)
+//! - A component for the test-scope dep
+//!   (`waybillfixture:test-only@2.0.0`)
+//! - A `dependencies[]` edge from direct → transitive
+//!
+//! The fixture's `./gradlew` is a bash mock (no JDK required); it
+//! emits canned ASCII-tree output for the configurations the m235
+//! subprocess resolver requests by default (runtimeClasspath +
+//! testRuntimeClasspath per clarify Q1).
+//!
+//! Golden fixture pinning (T019) is deferred to a follow-on PR;
+//! structural assertions here cover SC-001's "transitive edge
+//! present" acceptance criterion.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+mod common;
+use common::bin;
+use common::normalize::apply_fake_home_env;
+
+fn fixture() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("golden_inputs")
+        .join("gradle")
+        .join("wrapper_single_subproject")
+}
+
+fn run_scan_with_gradle_resolve() -> serde_json::Value {
+    let workdir = tempfile::tempdir().expect("workdir tempdir");
+    let fake_home = tempfile::tempdir().expect("fake-home tempdir");
+    let out_path = workdir.path().join("sbom.cdx.json");
+    let fixture_path = fixture();
+    assert!(
+        fixture_path.is_dir(),
+        "fixture missing at {}",
+        fixture_path.display()
+    );
+
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    cmd.env("WAYBILL_FIXED_TIMESTAMP", "2026-01-01T00:00:00Z");
+    cmd.args([
+        "--offline",
+        "sbom",
+        "scan",
+        "--path",
+        fixture_path.to_str().unwrap(),
+        "--format",
+        "cyclonedx-json",
+        "--output",
+        out_path.to_str().unwrap(),
+        "--gradle-resolve",
+        "--gradle-timeout-secs",
+        "30",
+        "--no-deep-hash",
+    ]);
+    let output = cmd.output().expect("spawn waybill");
+    assert!(
+        output.status.success(),
+        "gradle-resolve scan failed:\n  stdout={}\n  stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let bytes = std::fs::read(&out_path).expect("read emitted SBOM");
+    serde_json::from_slice(&bytes).expect("parse JSON")
+}
+
+/// Extract all `pkg:maven/*` PURLs from an SBOM's `components[]` array
+/// AND the top-level metadata.component (waybill's main-module
+/// placement varies by ecosystem).
+fn maven_purls(json: &serde_json::Value) -> Vec<String> {
+    let mut out: Vec<String> = json["components"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|c| c["purl"].as_str())
+                .filter(|p| p.starts_with("pkg:maven/"))
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    if let Some(main) = json["metadata"]["component"]["purl"].as_str() {
+        if main.starts_with("pkg:maven/") {
+            out.push(main.to_string());
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Return `true` iff there exists an edge with `ref == source_purl`
+/// AND `target_purl` present in the `dependsOn` array.
+fn has_edge(json: &serde_json::Value, source_purl: &str, target_purl: &str) -> bool {
+    let Some(deps) = json["dependencies"].as_array() else {
+        return false;
+    };
+    for dep in deps {
+        if dep["ref"].as_str() == Some(source_purl) {
+            let Some(depends_on) = dep["dependsOn"].as_array() else {
+                continue;
+            };
+            for t in depends_on {
+                if t.as_str() == Some(target_purl) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+// -----------------------------------------------------------
+// SC-001 — US1 fixture emits transitive edge in CDX
+// -----------------------------------------------------------
+
+#[test]
+fn us1_wrapper_single_subproject_transitive_edge() {
+    let json = run_scan_with_gradle_resolve();
+
+    let purls = maven_purls(&json);
+    let direct = "pkg:maven/com.example.waybillfixture/direct@1.0.0";
+    let transitive = "pkg:maven/com.example.waybillfixture/transitive@0.5.0";
+    let test_only = "pkg:maven/com.example.waybillfixture/test-only@2.0.0";
+
+    assert!(
+        purls.iter().any(|p| p == direct),
+        "expected direct dep component; got: {purls:?}"
+    );
+    assert!(
+        purls.iter().any(|p| p == transitive),
+        "expected transitive dep component (proves ASCII-tree parser recorded child of direct); got: {purls:?}"
+    );
+    assert!(
+        purls.iter().any(|p| p == test_only),
+        "expected testRuntimeClasspath dep component (Clarifications Q1 default set); got: {purls:?}"
+    );
+
+    // SC-001 acceptance — the transitive edge is emitted in
+    // `dependencies[]`. This is the m235 US1 promise: subprocess
+    // tier surfaces parent → child relationships that m106 lockfile
+    // reading cannot.
+    assert!(
+        has_edge(&json, direct, transitive),
+        "expected dependencies[] edge {direct} -> {transitive}; got: {}",
+        serde_json::to_string_pretty(&json["dependencies"]).unwrap_or_default()
+    );
+}
+
+// -----------------------------------------------------------
+// FR-009 non-regression — scan WITHOUT --gradle-resolve emits
+// zero m235 components (the fixture has no gradle.lockfile).
+// -----------------------------------------------------------
+
+#[test]
+fn without_gradle_resolve_the_fixture_produces_no_maven_components() {
+    // Verifies the m106-only path: without --gradle-resolve, waybill
+    // looks for `gradle.lockfile` (absent in this fixture) and finds
+    // nothing. FR-009 non-regression.
+    let workdir = tempfile::tempdir().expect("workdir tempdir");
+    let fake_home = tempfile::tempdir().expect("fake-home tempdir");
+    let out_path = workdir.path().join("sbom.cdx.json");
+    let fixture_path = fixture();
+
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    cmd.env("WAYBILL_FIXED_TIMESTAMP", "2026-01-01T00:00:00Z");
+    cmd.args([
+        "--offline",
+        "sbom",
+        "scan",
+        "--path",
+        fixture_path.to_str().unwrap(),
+        "--format",
+        "cyclonedx-json",
+        "--output",
+        out_path.to_str().unwrap(),
+        "--no-deep-hash",
+    ]);
+    let output = cmd.output().expect("spawn waybill");
+    assert!(
+        output.status.success(),
+        "no-flag scan failed unexpectedly:\n  stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let bytes = std::fs::read(&out_path).expect("read emitted SBOM");
+    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("parse JSON");
+    let purls = maven_purls(&json);
+    let fixture_maven: Vec<&String> = purls
+        .iter()
+        .filter(|p| p.contains("waybillfixture"))
+        .collect();
+    assert!(
+        fixture_maven.is_empty(),
+        "expected zero m235-fixture components without --gradle-resolve; got: {fixture_maven:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-on to #688. Adds fixture + integration test that prove m235 US1 subprocess resolver emits transitive edges end-to-end. **Caught + fixed a real bug**: edges were being computed but dropped at emission time.

## The bug

`subprocess::assemble_graph` built `Vec<GradleEdge>` correctly, but `gradle::read` was discarding `graph.edges` and only merging `graph.components`. Result: components appeared in the SBOM but the `dependencies[]` array had zero Gradle-derived edges.

## The fix

Populate `PackageDbEntry.depends` on each parent at graph-assembly time. The existing scan_fs resolver at `mod.rs:868` walks `depends` and synthesizes CDX `dependencies[]` / SPDX `DEPENDS_ON` edges via the per-scan name→purl index. Same mechanism m106 lockfile reader uses.

## What ships

- **T017 fixture** — `waybill-cli/tests/fixtures/golden_inputs/gradle/wrapper_single_subproject/` with `settings.gradle` + `build.gradle` + executable bash mock `gradlew` (no JDK required; deterministic canned output)
- **T018 integration test** — `waybill-cli/tests/gradle_ladder.rs` with 2 tests:
  - Positive: transitive edge present with `--gradle-resolve` (SC-001)
  - Negative: zero fixture components without the flag (FR-009 non-regression)
- **subprocess.rs fix** — `depends` population in `assemble_graph`

## T019 (byte-equal goldens) deferred

Structural assertions in T018 cover the SC-001 acceptance criterion. Byte-equal CDX/SPDX 2.3/SPDX 3 goldens layer regression protection on top; can ship as follow-on.

## Verification

- ✅ New `tests/gradle_ladder.rs` — 2/2 pass
- ✅ 26 gradle module tests + 2 m106 integration tests still pass
- ✅ Pre-PR gate green
- ✅ Zero new Cargo deps

## Refs

- Prior: #688 (US1 code), #689 (docs)
- Spec: `specs/235-gradle-transitive-ladder/spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)