### PR TITLE
feat(m235 T044a): FR-014 per-scan summary log

### DIFF
--- a/waybill-cli/src/scan_fs/package_db/gradle/mod.rs
+++ b/waybill-cli/src/scan_fs/package_db/gradle/mod.rs
@@ -84,7 +84,11 @@ pub fn read(
     // `GradleScanSummary` on `ScanDiagnostics` — the m235 US4 emitters
     // read the aggregate and emit `waybill:gradle-resolution-tier` at
     // document scope.
-    let mut per_project_tiers: Vec<tier::GradleResolutionTier> = Vec::new();
+    //
+    // Also drives the FR-014 per-scan INFO log summary — the pairs
+    // below (project-dir → tier) are formatted into the one-line
+    // summary at the end of the walker.
+    let mut per_project_pairs: Vec<(std::path::PathBuf, tier::GradleResolutionTier)> = Vec::new();
 
     crate::scan_fs::walk::safe_walk(rootfs, &cfg, |project_dir| {
         if !project_dir.is_dir() {
@@ -105,7 +109,7 @@ pub fn read(
             let graph = ladder::resolve(project_dir, &ladder_config);
             let ladder_tier = graph.tier;
             out.extend(graph.components);
-            per_project_tiers.push(ladder_tier);
+            per_project_pairs.push((project_dir.to_path_buf(), ladder_tier));
             ladder_ran = true;
         }
 
@@ -125,19 +129,50 @@ pub fn read(
             saw_lockfile = true;
         }
         if saw_lockfile && !ladder_ran {
-            per_project_tiers.push(tier::GradleResolutionTier::LockfileOnly);
+            per_project_pairs.push((
+                project_dir.to_path_buf(),
+                tier::GradleResolutionTier::LockfileOnly,
+            ));
         }
     });
 
     // Compute the aggregate summary for the doc-scope annotation.
-    if !per_project_tiers.is_empty() {
-        let first_tier = per_project_tiers[0];
-        let all_same = per_project_tiers.iter().all(|t| *t == first_tier);
+    if !per_project_pairs.is_empty() {
+        let first_tier = per_project_pairs[0].1;
+        let all_same = per_project_pairs.iter().all(|(_, t)| *t == first_tier);
         diagnostics.gradle_scan_summary = Some(ladder::GradleScanSummary {
             subprojects: Vec::new(), // per-subproject detail is a follow-on
             aggregate_tier: first_tier,
             aggregate_mixed: !all_same,
         });
+
+        // FR-014: emit a single INFO-level summary line naming which
+        // tier fired for each project this scan touched. Format is
+        // designed to be greppable (`gradle-resolver:` prefix + a
+        // simple `,`-separated list of `<project-dir>=<tier>` pairs).
+        // Project dirs are made scan-root-relative for readability
+        // when possible; absolute paths otherwise.
+        let items: Vec<String> = per_project_pairs
+            .iter()
+            .map(|(dir, tier_val)| {
+                let display = dir
+                    .strip_prefix(rootfs)
+                    .map(|p| {
+                        if p.as_os_str().is_empty() {
+                            std::path::PathBuf::from(".")
+                        } else {
+                            p.to_path_buf()
+                        }
+                    })
+                    .unwrap_or_else(|_| dir.clone());
+                format!("{}={}", display.display(), tier_val.as_annotation_str())
+            })
+            .collect();
+        tracing::info!(
+            target: "waybill::gradle",
+            "gradle-resolver: {}",
+            items.join(", "),
+        );
     }
 
     out

--- a/waybill-cli/tests/gradle_ladder.rs
+++ b/waybill-cli/tests/gradle_ladder.rs
@@ -240,3 +240,60 @@ fn us4_tier_annotation_present_on_subprocess_scan() {
         "expected doc-scope waybill:gradle-resolution-tier=subprocess; got {tier:?}"
     );
 }
+
+// -----------------------------------------------------------
+// FR-014 — per-scan INFO log summary lines emit once per scan
+// with a `gradle-resolver:` prefix + per-project `<dir>=<tier>` pairs.
+// -----------------------------------------------------------
+
+#[test]
+fn fr014_summary_log_emits_once_per_scan() {
+    let workdir = tempfile::tempdir().expect("workdir tempdir");
+    let fake_home = tempfile::tempdir().expect("fake-home tempdir");
+    let out_path = workdir.path().join("sbom.cdx.json");
+    let fixture_path = fixture();
+
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    cmd.env("WAYBILL_FIXED_TIMESTAMP", "2026-01-01T00:00:00Z");
+    // Enable INFO-level tracing so the FR-014 summary line reaches
+    // stderr where the test can inspect it. Only the gradle target
+    // is enabled to keep the stderr scrubbable.
+    cmd.env("RUST_LOG", "waybill::gradle=info");
+    cmd.args([
+        "--offline",
+        "sbom",
+        "scan",
+        "--path",
+        fixture_path.to_str().unwrap(),
+        "--format",
+        "cyclonedx-json",
+        "--output",
+        out_path.to_str().unwrap(),
+        "--gradle-resolve",
+        "--gradle-timeout-secs",
+        "30",
+        "--no-deep-hash",
+    ]);
+    let output = cmd.output().expect("spawn waybill");
+    assert!(
+        output.status.success(),
+        "scan failed:\n  stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let count = stderr.matches("gradle-resolver:").count();
+    assert_eq!(
+        count, 1,
+        "expected exactly ONE `gradle-resolver:` summary log line per scan (FR-014); got {count}. \
+         stderr:\n{stderr}"
+    );
+    // The wrapper_single_subproject fixture has one project directory
+    // and the ladder ran (--gradle-resolve set + mock gradlew emits
+    // real output) → tier MUST be `subprocess`.
+    assert!(
+        stderr.contains("subprocess"),
+        "expected `subprocess` in FR-014 summary; got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

m235 T044a — closes the FR-014 gap. `gradle::read` now emits a single INFO-level tracing line per scan, naming each Gradle project directory + the winning ladder tier.

## Format

\`gradle-resolver: :app=subprocess, ./lib=cache, ./legacy=lockfile-only\`

Project directories are scan-root-relative when possible; absolute paths for out-of-root cases. Log target: `waybill::gradle`.

## Verification

- ✅ 4/4 `tests/gradle_ladder.rs` integration tests pass (3 pre-existing + new `fr014_summary_log_emits_once_per_scan`)
- ✅ Test verifies exactly ONE `gradle-resolver:` line per scan (fires at scan end, not per-project)
- ✅ Pre-PR gate green
- ✅ Zero new Cargo dependencies (uses `RUST_LOG=waybill::gradle=info` env + stderr scan — no `tracing_test` crate added)

## Refs

- Spec: `specs/235-gradle-transitive-ladder/spec.md` FR-014
- Prior: #688, #689, #690, #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)