### PR TITLE
feat(m235 T042/T043 subset): lockfile-only + mixed tier fixtures/tests

### DIFF
--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/mixed_tier/lockfile_project/build.gradle
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/mixed_tier/lockfile_project/build.gradle
@@ -1,7 +1,0 @@
-// m235 US4 mixed-tier fixture — subproject B (no wrapper, has
-// gradle.lockfile → LockfileOnly tier). The absence of a `gradlew`
-// script here forces the ladder to record LockfileOnly for this
-// project even when --gradle-resolve is set.
-plugins {
-    id 'java'
-}

--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/mixed_tier/lockfile_project/build.gradle
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/mixed_tier/lockfile_project/build.gradle
@@ -1,0 +1,7 @@
+// m235 US4 mixed-tier fixture — subproject B (no wrapper, has
+// gradle.lockfile → LockfileOnly tier). The absence of a `gradlew`
+// script here forces the ladder to record LockfileOnly for this
+// project even when --gradle-resolve is set.
+plugins {
+    id 'java'
+}

--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/mixed_tier/lockfile_project/gradle.lockfile
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/mixed_tier/lockfile_project/gradle.lockfile
@@ -1,0 +1,7 @@
+# m235 US4 mixed-tier fixture — lockfile-only subproject.
+# Synthetic package coordinates per memory feedback_fixture_synthetic_package_names.
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+com.example.waybillfixture:mixed-lockfile-dep:2.0.0=runtimeClasspath
+empty=annotationProcessor

--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/mixed_tier/wrapper_project/build.gradle
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/mixed_tier/wrapper_project/build.gradle
@@ -1,0 +1,4 @@
+// m235 US4 mixed-tier fixture — subproject A (has mock gradlew → Subprocess tier).
+plugins {
+    id 'java'
+}

--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/mixed_tier/wrapper_project/gradlew
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/mixed_tier/wrapper_project/gradlew
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# m235 US4 mixed-tier fixture — mock ./gradlew for wrapper_project.
+# Emits canned ASCII-tree output identical shape to
+# wrapper_single_subproject's mock. Distinct fixture coordinates so
+# the mixed test can differentiate this project's components from
+# the lockfile_project's components.
+set -euo pipefail
+
+CMD=""
+CONFIG=""
+prev=""
+for arg in "$@"; do
+    case "$arg" in
+        projects) CMD="projects" ;;
+        dependencies|:dependencies) CMD="dependencies" ;;
+    esac
+    if [ "$prev" = "--configuration" ]; then
+        CONFIG="$arg"
+    fi
+    prev="$arg"
+done
+
+case "$CMD" in
+    projects) exit 0 ;;
+    dependencies)
+        case "$CONFIG" in
+            runtimeClasspath)
+                cat <<'GRADLE_OUTPUT'
+runtimeClasspath - Runtime classpath of source set 'main'.
++--- com.example.waybillfixture:wrapper-direct:1.0.0
+GRADLE_OUTPUT
+                ;;
+            testRuntimeClasspath) : ;;
+        esac
+        exit 0
+        ;;
+    *)
+        echo "mock gradlew: unknown args" >&2
+        exit 1
+        ;;
+esac

--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/mixed_tier/wrapper_project/settings.gradle
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/mixed_tier/wrapper_project/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'waybill-fixture-wrapper-project'

--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/no_wrapper_with_lockfile/build.gradle
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/no_wrapper_with_lockfile/build.gradle
@@ -1,0 +1,17 @@
+// m235 US4 fixture — no wrapper, has gradle.lockfile.
+//
+// This shape represents a Gradle project that has enabled
+// dependency-locking (m106 US3) but the operator scanning it either
+// (a) doesn't have --gradle-resolve set OR (b) doesn't have gradlew.
+// In either case the m235 ladder falls back to `LockfileOnly` tier
+// and the FR-009 non-regression contract requires the emitted
+// components to match pre-m235 (m106 lockfile reader) output exactly.
+//
+// The `is_gradle_project` detection in gradle::read looks for
+// build.gradle presence to know whether the directory is a Gradle
+// project; the actual DSL content is not parsed by waybill in this
+// tier — the gradle.lockfile beside this file is authoritative.
+
+plugins {
+    id 'java'
+}

--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/no_wrapper_with_lockfile/gradle.lockfile
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/no_wrapper_with_lockfile/gradle.lockfile
@@ -1,0 +1,7 @@
+# m235 US4 fixture — lockfile-only tier verification.
+# Synthetic package coordinates per memory feedback_fixture_synthetic_package_names.
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+com.example.waybillfixture:lockfile-dep:1.0.0=runtimeClasspath,testRuntimeClasspath
+empty=annotationProcessor

--- a/waybill-cli/tests/gradle_ladder.rs
+++ b/waybill-cli/tests/gradle_ladder.rs
@@ -297,3 +297,142 @@ fn fr014_summary_log_emits_once_per_scan() {
         "expected `subprocess` in FR-014 summary; got:\n{stderr}"
     );
 }
+
+// -----------------------------------------------------------
+// FR-009 non-regression + tier annotation — no-wrapper-with-lockfile
+// fixture emits m106 components AND doc-scope tier=`lockfile-only`.
+// -----------------------------------------------------------
+
+fn scan_fixture_no_flag(name: &str) -> serde_json::Value {
+    let workdir = tempfile::tempdir().expect("workdir tempdir");
+    let fake_home = tempfile::tempdir().expect("fake-home tempdir");
+    let out_path = workdir.path().join("sbom.cdx.json");
+    let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("golden_inputs")
+        .join("gradle")
+        .join(name);
+    assert!(fixture_path.is_dir(), "fixture missing at {}", fixture_path.display());
+
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    cmd.env("WAYBILL_FIXED_TIMESTAMP", "2026-01-01T00:00:00Z");
+    cmd.args([
+        "--offline",
+        "sbom",
+        "scan",
+        "--path",
+        fixture_path.to_str().unwrap(),
+        "--format",
+        "cyclonedx-json",
+        "--output",
+        out_path.to_str().unwrap(),
+        "--no-deep-hash",
+    ]);
+    let output = cmd.output().expect("spawn waybill");
+    assert!(
+        output.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let bytes = std::fs::read(&out_path).expect("read emitted SBOM");
+    serde_json::from_slice(&bytes).expect("parse JSON")
+}
+
+#[test]
+fn no_wrapper_with_lockfile_emits_lockfile_only_tier() {
+    // Fixture has NO gradlew AND has `gradle.lockfile`. The m106
+    // reader emits the lockfile components; the m235 ladder falls
+    // through to `LockfileOnly` with the walker recording the
+    // lockfile-only entry. Tier annotation MUST be `lockfile-only`.
+    let json = scan_fixture_no_flag("no_wrapper_with_lockfile");
+
+    // FR-009: m106 lockfile components MUST appear (byte-identity
+    // preserved for pre-m235 scan behavior).
+    let purls = maven_purls(&json);
+    assert!(
+        purls
+            .iter()
+            .any(|p| p == "pkg:maven/com.example.waybillfixture/lockfile-dep@1.0.0"),
+        "expected m106 lockfile-dep component; got: {purls:?}"
+    );
+
+    // FR-006: tier annotation MUST be `lockfile-only`.
+    let tier = doc_scope_property(&json, "waybill:gradle-resolution-tier");
+    assert_eq!(
+        tier.as_deref(),
+        Some("lockfile-only"),
+        "expected `lockfile-only` tier; got {tier:?}"
+    );
+}
+
+// -----------------------------------------------------------
+// FR-007 aggregate — mixed_tier fixture (one subproject with mock
+// gradlew, one with lockfile-only) produces `mixed` tier value.
+// -----------------------------------------------------------
+
+#[test]
+fn mixed_tier_fixture_produces_mixed_tier_annotation() {
+    let workdir = tempfile::tempdir().expect("workdir tempdir");
+    let fake_home = tempfile::tempdir().expect("fake-home tempdir");
+    let out_path = workdir.path().join("sbom.cdx.json");
+    let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("golden_inputs")
+        .join("gradle")
+        .join("mixed_tier");
+
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    cmd.env("WAYBILL_FIXED_TIMESTAMP", "2026-01-01T00:00:00Z");
+    cmd.args([
+        "--offline",
+        "sbom",
+        "scan",
+        "--path",
+        fixture_path.to_str().unwrap(),
+        "--format",
+        "cyclonedx-json",
+        "--output",
+        out_path.to_str().unwrap(),
+        "--gradle-resolve",
+        "--gradle-timeout-secs",
+        "30",
+        "--no-deep-hash",
+    ]);
+    let output = cmd.output().expect("spawn waybill");
+    assert!(
+        output.status.success(),
+        "scan failed:\n  stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let bytes = std::fs::read(&out_path).expect("read emitted SBOM");
+    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("parse JSON");
+
+    // Both subprojects' expected components should appear (FR-009 for
+    // the lockfile-only side; US1 subprocess for the wrapper side).
+    let purls = maven_purls(&json);
+    assert!(
+        purls
+            .iter()
+            .any(|p| p == "pkg:maven/com.example.waybillfixture/wrapper-direct@1.0.0"),
+        "expected subprocess-tier wrapper-direct component; got: {purls:?}"
+    );
+    assert!(
+        purls
+            .iter()
+            .any(|p| p == "pkg:maven/com.example.waybillfixture/mixed-lockfile-dep@2.0.0"),
+        "expected lockfile-tier mixed-lockfile-dep component; got: {purls:?}"
+    );
+
+    // FR-006 + FR-007: aggregate tier MUST be `mixed` when subprojects
+    // resolved via different tiers.
+    let tier = doc_scope_property(&json, "waybill:gradle-resolution-tier");
+    assert_eq!(
+        tier.as_deref(),
+        Some("mixed"),
+        "expected `mixed` tier annotation when subprojects differ; got {tier:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Extends m235 US4 tier-annotation verification beyond the `subprocess` case shipped in #691. Two new fixtures cover the two other tier values MVP can produce (`lockfile-only`, `mixed`) — closes the FR-006 tier-value coverage gap AND FR-007 aggregate-detection for `mixed`.

## What ships

**Fixtures**:
- `no_wrapper_with_lockfile/` — has `gradle.lockfile`, no wrapper → `lockfile-only` tier
- `mixed_tier/{wrapper_project,lockfile_project}/` — sibling subprojects producing different tiers → `mixed`

**Integration tests** (2 new, 4 pre-existing intact):
- `no_wrapper_with_lockfile_emits_lockfile_only_tier` (FR-006 + FR-009)
- `mixed_tier_fixture_produces_mixed_tier_annotation` (FR-006 + FR-007)

## Verification

- ✅ 6/6 `tests/gradle_ladder.rs` integration tests pass
- ✅ Pre-PR gate green
- ✅ Zero source changes (tests + fixtures only)

## Refs

- Spec: FR-006, FR-007, FR-009
- Prior: #688, #689, #690, #691, #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)