### PR TITLE
test(m235 T044): SC-005 subprocess timeout fallback test

### DIFF
--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/timeout_wrapper/build.gradle
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/timeout_wrapper/build.gradle
@@ -1,0 +1,8 @@
+// m235 T044 fixture — sleepy-gradlew scenario for the timeout
+// fallback test. The mock `./gradlew` in this dir sleeps for 15s on
+// `dependencies` invocations so that a `--gradle-timeout-secs 3`
+// scan hits the timeout path and degrades cleanly.
+
+plugins {
+    id 'java'
+}

--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/timeout_wrapper/gradlew
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/timeout_wrapper/gradlew
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# m235 T044 fixture — mock ./gradlew that sleeps forever on
+# `:dependencies` invocations. Used to prove waybill's subprocess
+# timeout kills the child cleanly and the ladder degrades to
+# LockfileOnly (SC-005).
+#
+# `projects` returns immediately so waybill's subproject enumeration
+# succeeds. Only the `dependencies` call sleeps, so timeout fires
+# exactly on the subprocess resolver's per-config invocation.
+set -euo pipefail
+
+CMD=""
+prev=""
+for arg in "$@"; do
+    case "$arg" in
+        projects) CMD="projects" ;;
+        dependencies|:dependencies) CMD="dependencies" ;;
+    esac
+    prev="$arg"
+done
+
+case "$CMD" in
+    projects)
+        # Empty (single-project build) — resolves immediately.
+        exit 0
+        ;;
+    dependencies)
+        # Sleep well beyond the test's timeout so waybill's
+        # spawn_with_timeout hits its Duration and returns Timeout.
+        # 15s gives comfortable margin for a 3s timeout + subprocess
+        # kill grace + CI runner startup jitter.
+        sleep 15
+        exit 0
+        ;;
+    *)
+        echo "mock timeout-gradlew: unknown args" >&2
+        exit 1
+        ;;
+esac

--- a/waybill-cli/tests/fixtures/golden_inputs/gradle/timeout_wrapper/settings.gradle
+++ b/waybill-cli/tests/fixtures/golden_inputs/gradle/timeout_wrapper/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'waybill-fixture-timeout'

--- a/waybill-cli/tests/gradle_ladder.rs
+++ b/waybill-cli/tests/gradle_ladder.rs
@@ -436,3 +436,103 @@ fn mixed_tier_fixture_produces_mixed_tier_annotation() {
         "expected `mixed` tier annotation when subprojects differ; got {tier:?}"
     );
 }
+
+// -----------------------------------------------------------
+// SC-005 — subprocess timeout: scan completes without hanging;
+// ladder degrades to `LockfileOnly` when subprocess is killed.
+// -----------------------------------------------------------
+
+#[test]
+fn sc005_subprocess_timeout_degrades_gracefully() {
+    // Fixture's mock `./gradlew` sleeps 15s on any `:dependencies`
+    // call. With `--gradle-timeout-secs 3` the scan MUST return
+    // within a bounded time (5s cap gives generous CI headroom over
+    // the 3s timeout + wait-thread + walker overhead) AND fall back
+    // to `LockfileOnly` since no components were parsed.
+
+    let workdir = tempfile::tempdir().expect("workdir tempdir");
+    let fake_home = tempfile::tempdir().expect("fake-home tempdir");
+    let out_path = workdir.path().join("sbom.cdx.json");
+    let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("golden_inputs")
+        .join("gradle")
+        .join("timeout_wrapper");
+    assert!(
+        fixture_path.is_dir(),
+        "fixture missing at {}",
+        fixture_path.display()
+    );
+
+    let mut cmd = Command::new(bin());
+    apply_fake_home_env(&mut cmd, fake_home.path());
+    cmd.env("WAYBILL_FIXED_TIMESTAMP", "2026-01-01T00:00:00Z");
+    cmd.args([
+        "--offline",
+        "sbom",
+        "scan",
+        "--path",
+        fixture_path.to_str().unwrap(),
+        "--format",
+        "cyclonedx-json",
+        "--output",
+        out_path.to_str().unwrap(),
+        "--gradle-resolve",
+        "--gradle-timeout-secs",
+        "3",
+        "--no-deep-hash",
+    ]);
+
+    let start = std::time::Instant::now();
+    let output = cmd.output().expect("spawn waybill");
+    let elapsed = start.elapsed();
+
+    assert!(
+        output.status.success(),
+        "scan MUST succeed even when subprocess times out (fail-closed → LockfileOnly \
+         graceful degrade). stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // Two `:dependencies` invocations at 3s each = ~6s upper bound
+    // for subprocess-side wall time (default configs =
+    // runtimeClasspath + testRuntimeClasspath per clarify Q1).
+    // Extra 4s headroom accommodates walker + CI cold-start jitter.
+    // Well under the 15s sleep the mock uses — proves the timeout
+    // actually kills the subprocess rather than waiting for its
+    // natural exit.
+    let upper_bound = std::time::Duration::from_secs(10);
+    assert!(
+        elapsed < upper_bound,
+        "scan MUST complete within {upper_bound:?} of --gradle-timeout-secs 3 \
+         (would take 15s+ if timeout didn't kill subprocess); took {elapsed:?}"
+    );
+
+    let bytes = std::fs::read(&out_path).expect("read emitted SBOM");
+    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("parse JSON");
+
+    // FR-003 / FR-015: on subprocess timeout, ladder degrades to
+    // `LockfileOnly`. Since the fixture has no gradle.lockfile
+    // either, the tier annotation MUST reflect the LockfileOnly
+    // sentinel (recorded by the walker via the ladder's empty
+    // fallback graph).
+    let tier = doc_scope_property(&json, "waybill:gradle-resolution-tier");
+    assert_eq!(
+        tier.as_deref(),
+        Some("lockfile-only"),
+        "expected `lockfile-only` tier after subprocess timeout \
+         (ladder degrades gracefully); got {tier:?}"
+    );
+
+    // No fixture components should appear (the mock never emitted any).
+    let purls = maven_purls(&json);
+    let fixture_maven: Vec<&String> = purls
+        .iter()
+        .filter(|p| p.contains("waybillfixture"))
+        .collect();
+    assert!(
+        fixture_maven.is_empty(),
+        "timed-out subprocess must not contribute components; got: {fixture_maven:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the SC-005 verification gap on \`main\`. Proves waybill's subprocess timeout actually kills the child AND the ladder degrades to \`LockfileOnly\` when it fires.

## Fixture

\`timeout_wrapper/\` — bash mock \`./gradlew\` that returns fast on \`projects\` (single-project enumeration) but sleeps 15s on \`:dependencies\` (so waybill's timeout fires before any output).

## Test

\`sc005_subprocess_timeout_degrades_gracefully\` — asserts:
1. Elapsed time < 10s (2 configs × 3s timeout + overhead; well under 15s natural sleep)
2. Scan exits successfully (fail-closed graceful degrade, not crash)
3. Doc-scope \`waybill:gradle-resolution-tier = "lockfile-only"\`
4. No fixture components emitted

## Verification

- ✅ 7/7 \`tests/gradle_ladder.rs\` tests pass; new SC-005 test runs in ~4.4s
- ✅ Pre-PR gate green
- ✅ Zero source changes — tests + fixture only

## Refs

- Spec: FR-003 + SC-005
- Prior: #688, #689, #690, #691, #692, #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)