### PR TITLE
docs(m235): spec close-out — five-SC pass, C147 shipped, per-component deferred

### DIFF
--- a/specs/235-gradle-transitive-ladder/spec.md
+++ b/specs/235-gradle-transitive-ladder/spec.md
@@ -442,3 +442,88 @@ Pre-PR Verification posture — CI stays fast + hermetic).
   prefers the user cache. If the operator has ONLY the project
   cache warm, that's a lower-tier variant we may or may not
   address (plan-phase decision).
+
+## Close-out (post-implementation) *(2026-08-15)*
+
+Milestone 235 shipped across six PRs. The critical operator-facing
+signals (ladder tier + fallback-reason) are live end-to-end; the
+per-component annotations remain deferred per plan-phase scoping.
+
+### PRs
+
+- **Phase 3 US1 (subprocess)** — #688 `feat(m235): Gradle transitive
+  dep-graph ladder — Phase 3 US1 subprocess`
+- **Phase 4 US2 (cache reader)** — #695 `feat(m235 Phase 4 US2):
+  Gradle cache reader (POM + transitive walker)`
+- **Phase 5 US3 (static parser)** — #696 `feat(m235 Phase 5 US3):
+  Gradle static parser — direct-dep emission for cold-clone`
+- **Phase 6 US4 (transparency annotations)** — #697
+  `feat(m235 Phase 6 US4): Gradle fallback-reason doc-scope
+  annotation (C147)` — also lit up C146
+  `waybill:gradle-resolution-tier` doc-scope across CDX / SPDX 2.3
+  / SPDX 3, plus FR-014 INFO log summary
+- **Docs** — #689 `docs(m235): CLAUDE.md flag subsection + CLI
+  reference + ecosystems companion` and #694 `test(m235 T044): SC-005
+  subprocess timeout fallback test`
+
+### Final CLI flag surface
+
+All five flags are opt-in (all default `false` / `300s` / `[]`).
+None fire without the operator explicitly passing `--gradle-resolve`:
+
+- `--gradle-resolve` — enable the US1 subprocess tier
+  (`./gradlew :sub:dependencies --no-daemon`). Without it, the
+  ladder skips US1 (records `OperatorOptOut`, filtered from C147)
+  and starts at US2 cache. The other four flags require this one
+  (clap `requires = "gradle_resolve"`).
+- `--gradle-daemon` — opt out of `--no-daemon` (default is
+  daemon-off per Q2 clarification).
+- `--gradle-resolve-buildscript` — also resolve plugin classpath
+  (`buildscript.dependencies`) in addition to the default
+  `runtimeClasspath` + `testRuntimeClasspath`.
+- `--gradle-timeout-secs <N>` — per-subprocess timeout (default
+  `300`; `0` rejected at parse-time).
+- `--gradle-extra-configurations <name>` — repeatable; adds
+  configurations beyond the Q1 default set. Shell-metacharacter
+  validation rejects `; \` \` $ | & > <`.
+
+### Deviations from the plan
+
+- **T017/T018/T019 golden CDX/SPDX 2.3/SPDX 3** — shipped without
+  three-format goldens. Integration tests structurally assert
+  emitted `dependencies[]` edges + tier annotations. Deferred to a
+  follow-on if operators need byte-equivalent regression guards.
+- **T038 per-component annotations** — `waybill:gradle-subproject-tier`,
+  `waybill:cache-freshness`, `waybill:gradle-platform-import` all
+  deferred. Would require populating `GradleScanSummary.subprojects`
+  for real (currently `Vec::new()` per m235 mod.rs:151). The
+  doc-scope tier (C146) + doc-scope fallback (C147) cover the
+  aggregate signal; per-component detail is a future enrichment.
+- **T042/T043 additional fixture scenarios** — three of the four
+  planned fixtures shipped (`wrapper_single_subproject`,
+  `no_wrapper_with_lockfile`, `mixed_tier`); a fourth
+  (`wrapper_multi_subproject` distinct from `mixed_tier`) landed
+  as part of the m235 test corpus but isn't goldened.
+
+### SC verification
+
+- **SC-001** (US1 transitive edge) — ✅ verified by
+  `us1_wrapper_single_subproject_transitive_edge` at
+  `waybill-cli/tests/gradle_ladder.rs`.
+- **SC-002** (US2 cache byte-equivalence) — ✅ verified by
+  `us2_warm_cache_produces_transitive_edge_and_cache_tier`.
+- **SC-003** (US3 direct-dep coverage ≥90%) — ✅ verified by
+  `us3_cold_clone_static_emits_direct_components_and_static_tier`
+  (fixture has 3 declared deps; scan emits all 3).
+- **SC-004** (every Gradle scan carries C146) — ✅ verified by
+  `us4_tier_annotation_present_on_subprocess_scan` +
+  `mixed_tier_fixture_produces_mixed_tier_annotation` + the
+  m071 parity extractor for C146.
+- **SC-005** (subprocess timeout bounded) — ✅ verified by
+  `sc005_subprocess_timeout_degrades_gracefully` (`5s` cap;
+  fixture sleeps `15s`; 3s subprocess timeout).
+
+All five Success Criteria pass. C147 (out-of-plan-but-shipped)
+covers a diagnostic gap operators asked about at plan-phase
+review: "which tier did we try and lose before the winning one
+won?"

--- a/specs/235-gradle-transitive-ladder/tasks.md
+++ b/specs/235-gradle-transitive-ladder/tasks.md
@@ -172,8 +172,8 @@ Repository root is `/Users/mlieberman/Projects/mikebom/`. All paths below are re
 - [ ] T046 [P] Update `CLAUDE.md` `## Active Technologies` to reference m235 (auto-added by `update-agent-context.sh claude` run during plan phase; verify the line is correctly formatted and not truncated per the m234 experience).
 - [ ] T047 Run pre-PR gate locally: `./scripts/pre-pr.sh`. MUST pass clean (zero clippy warnings; every test suite green with `ok. N passed; 0 failed`). Per Constitution `Pre-PR Verification` section.
 - [ ] T048 Open PR titled `feat(m235): Gradle transitive dependency resolution ladder` with description linking spec + plan + tasks + the SC-verification checklist. Include a "Test plan" section enumerating the fixtures + goldens + tier-annotation verification. Include a "Deferred" section naming T3 (network POM fetch) as out of scope.
-- [ ] T049 Add spec close-out note to `specs/235-gradle-transitive-ladder/spec.md` under a new `## Close-out (post-implementation)` section (per FR-010 tradition): (a) final CLI flag surface as landed; (b) any deviations from the plan; (c) link to the merged PR; (d) SC verification pass/fail per SC.
-- [ ] T050 Add `memory/reference_gradle_ladder.md` auto-memory entry: SoT locations (composite paths + CLI flags), which tier fires when, tie-in with m106.
+- [X] T049 Add spec close-out note to `specs/235-gradle-transitive-ladder/spec.md` under a new `## Close-out (post-implementation)` section (per FR-010 tradition): (a) final CLI flag surface as landed; (b) any deviations from the plan; (c) link to the merged PR; (d) SC verification pass/fail per SC.
+- [X] T050 Add `memory/reference_gradle_ladder.md` auto-memory entry: SoT locations (composite paths + CLI flags), which tier fires when, tie-in with m106.
 
 ---
 


### PR DESCRIPTION
## Summary

Standard T049 close-out for milestone 235 (Gradle transitive dependency resolution ladder). Documents the final state, SC verification, and what's deferred.

## SC verification (all ✅)

- **SC-001** US1 transitive edge — \`us1_wrapper_single_subproject_transitive_edge\`
- **SC-002** US2 cache byte-equivalence — \`us2_warm_cache_produces_transitive_edge_and_cache_tier\`
- **SC-003** US3 direct-dep coverage ≥90% — \`us3_cold_clone_static_emits_direct_components_and_static_tier\`
- **SC-004** every Gradle scan carries C146 — \`us4_tier_annotation_present_on_subprocess_scan\` + parity extractor
- **SC-005** subprocess timeout bounded — \`sc005_subprocess_timeout_degrades_gracefully\`

## Bonus (out of plan)

- **C147** \`waybill:gradle-fallback-reason\` — the "why did the winner win" diagnostic operators asked for at plan review
- **FR-014** INFO log summary — one-line greppable tier record

## Deferred

- Per-component annotations (\`waybill:gradle-subproject-tier\` / \`waybill:cache-freshness\` / \`waybill:gradle-platform-import\`) — need \`GradleScanSummary.subprojects\` populated for real; currently \`Vec::new()\` stub at \`gradle/mod.rs:151\`
- 3-format goldens for the two US3/US1 fixtures

## Also lands

- \`memory/reference_gradle_ladder.md\` — auto-memory entry describing the four-tier decision order, CLI flag surface, and doc-scope annotation shape

## Test plan

- [x] No code changes; docs + memory only
- [ ] Merge cleanly on top of #697 (m235 Phase 6 US4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)