### PR TITLE
feat(m236 US2): waybill:unresolved-reason for JVM + tool ecosystems (kotlin_dsl/build_script, scala, gradle_static, helm, yocto)

### DIFF
--- a/waybill-cli/src/scan_fs/package_db/gradle/static_parser.rs
+++ b/waybill-cli/src/scan_fs/package_db/gradle/static_parser.rs
@@ -348,7 +348,19 @@ fn build_entry(
         // semantics for the design/source distinction.
         sbom_tier: Some("design".to_string()),
         shade_relocation: None,
-        extra_annotations: std::collections::BTreeMap::new(),
+        // Milestone 236 (C151): US3 static parser emits design-tier
+        // when the m235 US2 cache reader didn't hit for these seeds.
+        extra_annotations: {
+            let mut m: std::collections::BTreeMap<String, serde_json::Value> =
+                Default::default();
+            m.insert(
+                "waybill:unresolved-reason".to_string(),
+                serde_json::Value::String(
+                    "declared in build.gradle; US2 cache reader had no matching seed".to_string(),
+                ),
+            );
+            m
+        },
         binary_role: None,
     })
 }
@@ -530,6 +542,36 @@ dependencies {
             ],
             "expected 3 BOM imports from platform() + enforcedPlatform(); regular dep NOT included"
         );
+    }
+
+    #[test]
+    fn m236_gradle_static_design_tier_carries_unresolved_reason() {
+        // Milestone 236 (C151): every gradle US3 static component
+        // carries the reason string.
+        let td = TempDir::new().unwrap();
+        std::fs::write(
+            td.path().join("build.gradle"),
+            r#"
+plugins { id 'java' }
+dependencies {
+    implementation 'com.example.waybillfixture:app-dep:1.0.0'
+}
+"#,
+        )
+        .unwrap();
+        let graph = resolve_via_static_parse(td.path()).expect("static parse");
+        assert!(!graph.components.is_empty());
+        for entry in &graph.components {
+            assert_eq!(entry.sbom_tier.as_deref(), Some("design"));
+            let reason = entry
+                .extra_annotations
+                .get("waybill:unresolved-reason")
+                .expect("C151 annotation present");
+            assert_eq!(
+                reason.as_str().unwrap(),
+                "declared in build.gradle; US2 cache reader had no matching seed",
+            );
+        }
     }
 
     #[test]

--- a/waybill-cli/src/scan_fs/package_db/helm.rs
+++ b/waybill-cli/src/scan_fs/package_db/helm.rs
@@ -1029,8 +1029,16 @@ fn build_helm_entry(
     version: String,
     source_path: String,
     evidence_kind: String,
-    extra_annotations: BTreeMap<String, serde_json::Value>,
+    mut extra_annotations: BTreeMap<String, serde_json::Value>,
 ) -> PackageDbEntry {
+    // Milestone 236 (C151): helm components always emit design-tier
+    // (see `sbom_tier` below); tag every one with the reason string.
+    extra_annotations.insert(
+        "waybill:unresolved-reason".to_string(),
+        serde_json::Value::String(
+            "unrendered Chart.yaml dependency; --helm-render subprocess disabled or unavailable".to_string(),
+        ),
+    );
     PackageDbEntry {
         build_inclusion: None,
         purl,
@@ -1360,5 +1368,29 @@ dependencies:
         let bytes = b"only";
         let capped = cap_stderr_lines(bytes, 20);
         assert_eq!(capped, "only");
+    }
+
+    #[test]
+    fn m236_helm_design_tier_carries_unresolved_reason() {
+        // Milestone 236 (C151): every helm-emitted component carries
+        // the reason string.
+        let purl = Purl::new("pkg:helm/example/waybill-fixture-chart@1.0.0").unwrap();
+        let entry = build_helm_entry(
+            purl,
+            "waybill-fixture-chart".to_string(),
+            "1.0.0".to_string(),
+            "/tmp/Chart.yaml".to_string(),
+            "chart-yaml".to_string(),
+            BTreeMap::new(),
+        );
+        assert_eq!(entry.sbom_tier.as_deref(), Some("design"));
+        let reason = entry
+            .extra_annotations
+            .get("waybill:unresolved-reason")
+            .expect("C151 annotation present");
+        assert_eq!(
+            reason.as_str().unwrap(),
+            "unrendered Chart.yaml dependency; --helm-render subprocess disabled or unavailable",
+        );
     }
 }

--- a/waybill-cli/src/scan_fs/package_db/kotlin_dsl/build_script.rs
+++ b/waybill-cli/src/scan_fs/package_db/kotlin_dsl/build_script.rs
@@ -263,6 +263,15 @@ pub(super) fn resolve_and_emit(
             "waybill:source-files".to_string(),
             JsonValue::String(source_path_str.clone()),
         );
+        // Milestone 236 (C151): buildscript-classpath declarations
+        // always emit design-tier (see sbom_tier below); tag every
+        // component with the Kotlin DSL buildscript reason string.
+        extra_annotations.insert(
+            "waybill:unresolved-reason".to_string(),
+            JsonValue::String(
+                "Kotlin DSL buildscript declaration; --include-declared-deps enables emission".to_string(),
+            ),
+        );
         // Record the source-set hit BEFORE pushing the entry; the
         // tracker's finalize() runs later and stamps the merged array
         // onto every duplicate.
@@ -440,5 +449,35 @@ mod tests {
             config_to_lifecycle_scope("ksp"),
             Some(LifecycleScope::Build)
         );
+    }
+
+    #[test]
+    fn m236_kotlin_dsl_buildscript_design_tier_carries_unresolved_reason() {
+        // Milestone 236 (C151): every buildscript-derived component
+        // carries the reason string.
+        let entries = extract_deps(
+            r#"dependencies {
+    implementation("com.example.waybillfixture:kts-dep:1.0.0")
+}"#,
+        );
+        let mut tracker = KmpSourceSetTracker::default();
+        let out = resolve_and_emit(
+            entries,
+            None,
+            std::path::Path::new("/tmp/build.gradle.kts"),
+            &mut tracker,
+        );
+        assert!(!out.is_empty(), "expected ≥1 kotlin_dsl component");
+        for e in &out {
+            assert_eq!(e.sbom_tier.as_deref(), Some("design"));
+            let reason = e
+                .extra_annotations
+                .get("waybill:unresolved-reason")
+                .unwrap_or_else(|| panic!("C151 annotation present on {}", e.name));
+            assert_eq!(
+                reason.as_str().unwrap(),
+                "Kotlin DSL buildscript declaration; --include-declared-deps enables emission",
+            );
+        }
     }
 }

--- a/waybill-cli/src/scan_fs/package_db/scala.rs
+++ b/waybill-cli/src/scan_fs/package_db/scala.rs
@@ -1130,6 +1130,16 @@ fn build_main_module_component(
     );
 
     let sbom_tier = if doc_has_lockfile { "source" } else { "design" };
+    // Milestone 236 (C151): tag design-tier main-module with the
+    // reader-specific resolution boundary.
+    if sbom_tier == "design" {
+        extra_annotations.insert(
+            "waybill:unresolved-reason".to_string(),
+            serde_json::Value::String(
+                "declared in build.sbt; no coursier-resolved lockfile".to_string(),
+            ),
+        );
+    }
 
     Some(PackageDbEntry {
         purl,
@@ -1215,6 +1225,14 @@ fn build_design_tier_component(
             serde_json::Value::String(scala_version_source.to_annotation_value().to_string()),
         );
     }
+    // Milestone 236 (C151): sbt %/%% dep components always emit
+    // design-tier (see sbom_tier below); tag with reason string.
+    extra_annotations.insert(
+        "waybill:unresolved-reason".to_string(),
+        serde_json::Value::String(
+            "declared in build.sbt; no coursier-resolved lockfile".to_string(),
+        ),
+    );
 
     let lifecycle_scope = match dep.configuration.as_deref() {
         Some("Test") => LifecycleScope::Development,
@@ -1552,5 +1570,37 @@ object Dependencies {
         let c1 = build_lockfile_component(&cats_2_13);
         let c2 = build_lockfile_component(&cats_3);
         assert_ne!(c1.purl.as_str(), c2.purl.as_str());
+    }
+
+    #[test]
+    fn m236_scala_design_tier_carries_unresolved_reason() {
+        // Milestone 236 (C151): scala design-tier %/%% deps must carry
+        // the reason string.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("build.sbt"),
+            r#"
+name := "waybill-fixture-scala"
+scalaVersion := "2.13.12"
+libraryDependencies += "com.example.waybillfixture" %% "scala-dep" % "1.0.0"
+"#,
+        )
+        .unwrap();
+        let entries = read(tmp.path(), false, &Default::default());
+        let design_entries: Vec<_> = entries
+            .iter()
+            .filter(|e| e.sbom_tier.as_deref() == Some("design"))
+            .collect();
+        assert!(!design_entries.is_empty(), "expected ≥1 scala design-tier component");
+        for e in design_entries {
+            let reason = e
+                .extra_annotations
+                .get("waybill:unresolved-reason")
+                .unwrap_or_else(|| panic!("C151 annotation present on {}", e.name));
+            assert_eq!(
+                reason.as_str().unwrap(),
+                "declared in build.sbt; no coursier-resolved lockfile",
+            );
+        }
     }
 }

--- a/waybill-cli/src/scan_fs/package_db/yocto/recipe.rs
+++ b/waybill-cli/src/scan_fs/package_db/yocto/recipe.rs
@@ -192,6 +192,14 @@ fn build_layer_root_entry(layer: &super::layer_conf::LayerConf) -> PackageDbEntr
         "waybill:source-mechanism".to_string(),
         serde_json::Value::String("yocto-layer-root".to_string()),
     );
+    // Milestone 236 (C151): yocto layer-root components always emit
+    // design-tier (see sbom_tier below); tag with reason string.
+    extra_annotations.insert(
+        "waybill:unresolved-reason".to_string(),
+        serde_json::Value::String(
+            "recipe .bb declaration; no PV/PR resolution".to_string(),
+        ),
+    );
     // FR-007 / milestone-127 interaction: the root selector's
     // `is_workspace_root` heuristic compares the PARENT of
     // `source-files[0]` to the scan root. For a layer rooted at
@@ -506,6 +514,14 @@ fn process_recipe(
     extra_annotations.insert(
         "waybill:source-mechanism".to_string(),
         serde_json::Value::String("bitbake-recipe".to_string()),
+    );
+    // Milestone 236 (C151): yocto recipe components always emit
+    // design-tier (see sbom_tier below); tag with reason string.
+    extra_annotations.insert(
+        "waybill:unresolved-reason".to_string(),
+        serde_json::Value::String(
+            "recipe .bb declaration; no PV/PR resolution".to_string(),
+        ),
     );
     if let Some(layer) = &layer_name {
         extra_annotations.insert(
@@ -1110,5 +1126,32 @@ mod tests {
         let entries = read(tmp.path(), &Default::default());
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].version, "1.2.3+git0abc123");
+    }
+
+    #[test]
+    fn m236_yocto_design_tier_carries_unresolved_reason() {
+        // Milestone 236 (C151): every yocto design-tier component MUST
+        // carry `waybill:unresolved-reason` naming the recipe boundary.
+        let tmp = tempfile::tempdir().unwrap();
+        touch(
+            &tmp.path()
+                .join("meta-waybill-fixture")
+                .join("recipes-waybill")
+                .join("waybill-fixture-lib")
+                .join("waybill-fixture-lib_1.0.bb"),
+        );
+        let entries = read(tmp.path(), &Default::default());
+        for e in &entries {
+            assert_eq!(e.sbom_tier.as_deref(), Some("design"));
+            let reason = e
+                .extra_annotations
+                .get("waybill:unresolved-reason")
+                .unwrap_or_else(|| panic!("C151 annotation present on {}", e.name));
+            assert_eq!(
+                reason.as_str().unwrap(),
+                "recipe .bb declaration; no PV/PR resolution",
+            );
+        }
+        assert!(!entries.is_empty(), "at least one component expected");
     }
 }


### PR DESCRIPTION
## Summary

Extends m236 C151 coverage to 5 additional design-tier-emitting readers (US2 P2 batch). Builds on PR #703 (US1 MVP — maven/npm-walk/pip).

## Readers modified

| Reader | Reason string |
|---|---|
| kotlin_dsl/build_script | \`Kotlin DSL buildscript declaration; --include-declared-deps enables emission\` |
| scala (main-module + %/%% deps — 2 call-sites) | \`declared in build.sbt; no coursier-resolved lockfile\` |
| gradle/static_parser | \`declared in build.gradle; US2 cache reader had no matching seed\` |
| helm | \`unrendered Chart.yaml dependency; --helm-render subprocess disabled or unavailable\` |
| yocto/recipe (layer-root + recipe — 2 call-sites) | \`recipe .bb declaration; no PV/PR resolution\` |

## Test plan

- [x] 5 new per-reader unit tests: \`m236_kotlin_dsl_buildscript_...\`, \`m236_scala_...\`, \`m236_gradle_static_...\`, \`m236_helm_...\`, \`m236_yocto_...\`
- [x] All 9 m236 tests pass (5 US2 + 4 pre-existing US1)
- [x] No regressions in the 130 pre-existing tests across the 5 modified readers
- [x] Full pre-PR gate green

## Cumulative m236 progress

- ✅ US1 (PR #703, merged): maven, npm/walk, pip — 3 readers
- ✅ US2 (this PR): kotlin_dsl/build_script, scala, gradle_static, helm, yocto — 5 readers
- ⏳ US3: cocoapods, composer, dart, elixir, erlang, haskell, pants_shell, pants_go — 8 readers
- ⏳ Polish: cross-reader integration test, FR-010 blacklist scan, docs + close-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)