### PR TITLE
feat(m236 US3): waybill:unresolved-reason for long-tail ecosystems (cocoapods/composer/dart/elixir/erlang/haskell/pants_shell/pants_go)

### DIFF
--- a/waybill-cli/src/scan_fs/package_db/cocoapods.rs
+++ b/waybill-cli/src/scan_fs/package_db/cocoapods.rs
@@ -688,6 +688,13 @@ fn emit_design_tier_components(
             "waybill:source-type".to_string(),
             serde_json::Value::String("cocoapods-trunk".to_string()),
         );
+        // Milestone 236 (C151): cocoapods design-tier reason.
+        extra_annotations.insert(
+            "waybill:unresolved-reason".to_string(),
+            serde_json::Value::String(
+                "no matching entry in Podfile.lock".to_string(),
+            ),
+        );
 
         out.push(PackageDbEntry {
             purl,

--- a/waybill-cli/src/scan_fs/package_db/composer.rs
+++ b/waybill-cli/src/scan_fs/package_db/composer.rs
@@ -693,6 +693,13 @@ fn emit_design_tier_components(
             "waybill:source-type".to_string(),
             serde_json::Value::String("composer-packagist".to_string()),
         );
+        // Milestone 236 (C151): composer design-tier reason.
+        extra_annotations.insert(
+            "waybill:unresolved-reason".to_string(),
+            serde_json::Value::String(
+                "no matching entry in composer.lock".to_string(),
+            ),
+        );
 
         out.push(PackageDbEntry {
             purl,

--- a/waybill-cli/src/scan_fs/package_db/dart.rs
+++ b/waybill-cli/src/scan_fs/package_db/dart.rs
@@ -520,6 +520,13 @@ fn emit_design_tier_components(
             "waybill:source-type".to_string(),
             serde_json::Value::String("pub-hosted".to_string()),
         );
+        // Milestone 236 (C151): dart design-tier reason.
+        extra_annotations.insert(
+            "waybill:unresolved-reason".to_string(),
+            serde_json::Value::String(
+                "no matching entry in pubspec.lock".to_string(),
+            ),
+        );
 
         out.push(PackageDbEntry {
             purl,

--- a/waybill-cli/src/scan_fs/package_db/elixir.rs
+++ b/waybill-cli/src/scan_fs/package_db/elixir.rs
@@ -952,6 +952,15 @@ fn emit_main_module(
     }
 
     let sbom_tier = if doc_has_lockfile { "source" } else { "design" };
+    // Milestone 236 (C151): elixir main-module design-tier reason.
+    if sbom_tier == "design" {
+        extra_annotations.insert(
+            "waybill:unresolved-reason".to_string(),
+            serde_json::Value::String(
+                "no matching entry in mix.lock".to_string(),
+            ),
+        );
+    }
 
     Some(PackageDbEntry {
         purl,
@@ -1171,6 +1180,13 @@ fn emit_design_tier_components(
                 serde_json::Value::String("conditional-flattened".to_string()),
             );
         }
+        // Milestone 236 (C151): elixir declared-dep design-tier reason.
+        extra_annotations.insert(
+            "waybill:unresolved-reason".to_string(),
+            serde_json::Value::String(
+                "no matching entry in mix.lock".to_string(),
+            ),
+        );
 
         let (version_field, requirement_ranges) = match &decl.source_kind {
             DeclaredDepSource::Hex => (

--- a/waybill-cli/src/scan_fs/package_db/erlang.rs
+++ b/waybill-cli/src/scan_fs/package_db/erlang.rs
@@ -1322,6 +1322,15 @@ fn build_main_module_component(
     );
 
     let sbom_tier = if doc_has_lockfile { "source" } else { "design" };
+    // Milestone 236 (C151): erlang main-module design-tier reason.
+    if sbom_tier == "design" {
+        extra_annotations.insert(
+            "waybill:unresolved-reason".to_string(),
+            serde_json::Value::String(
+                "no matching entry in rebar.lock".to_string(),
+            ),
+        );
+    }
 
     Some(PackageDbEntry {
         purl,
@@ -1617,6 +1626,13 @@ fn build_design_tier_component(decl: &DeclaredDep, config_dir: &Path) -> Option<
     for (k, v) in source_anns {
         extra_annotations.insert(k, v);
     }
+    // Milestone 236 (C151): erlang declared-dep design-tier reason.
+    extra_annotations.insert(
+        "waybill:unresolved-reason".to_string(),
+        serde_json::Value::String(
+            "no matching entry in rebar.lock".to_string(),
+        ),
+    );
 
     // Profile-scoped → waybill:lifecycle-scope per FR-008.
     let lifecycle_scope = match decl.profile.as_deref() {

--- a/waybill-cli/src/scan_fs/package_db/haskell.rs
+++ b/waybill-cli/src/scan_fs/package_db/haskell.rs
@@ -953,6 +953,13 @@ fn build_freeze_component(entry: &CabalFreezeEntry) -> PackageDbEntry {
             let purl = Purl::new(&purl_str).unwrap_or_else(|_| fallback_purl());
             let mut extra_annotations = base_annotations("hackage-freeze");
             apply_ghc_stdlib_annotation(&mut extra_annotations, name);
+            // Milestone 236 (C151): haskell cabal-freeze range design-tier reason.
+            extra_annotations.insert(
+                "waybill:unresolved-reason".to_string(),
+                serde_json::Value::String(
+                    "declared in stack.yaml / .cabal; no stack.yaml.lock fallback".to_string(),
+                ),
+            );
             PackageDbEntry {
                 purl,
                 name: name.clone(),
@@ -1206,6 +1213,13 @@ fn build_design_tier_components(
             serde_json::json!([dep.range.clone().unwrap_or_default()]),
         );
         apply_ghc_stdlib_annotation(&mut extra_annotations, &dep.name);
+        // Milestone 236 (C151): haskell cabal design-tier reason.
+        extra_annotations.insert(
+            "waybill:unresolved-reason".to_string(),
+            serde_json::Value::String(
+                "declared in stack.yaml / .cabal; no stack.yaml.lock fallback".to_string(),
+            ),
+        );
         out.push(PackageDbEntry {
             purl,
             name: dep.name.clone(),

--- a/waybill-cli/src/scan_fs/package_db/pants_go/mod.rs
+++ b/waybill-cli/src/scan_fs/package_db/pants_go/mod.rs
@@ -176,6 +176,11 @@ pub fn read(scan_root: &Path, _exclude_set: &ExclusionSet) -> Vec<PackageDbEntry
         .unwrap_or_else(|_| "pants.toml".to_string());
     let mut extra_annotations = BTreeMap::new();
     extra_annotations.insert("waybill:source-file".to_string(), json!(rel));
+    // Milestone 236 (C151): pants_go expected_version design-tier reason.
+    extra_annotations.insert(
+        "waybill:unresolved-reason".to_string(),
+        json!("pants_go expected_version declared; no matching go corpus component"),
+    );
     vec![PackageDbEntry {
         purl,
         name: "go".to_string(),

--- a/waybill-cli/src/scan_fs/package_db/pants_shell/component_emit.rs
+++ b/waybill-cli/src/scan_fs/package_db/pants_shell/component_emit.rs
@@ -197,6 +197,11 @@ pub(crate) fn tool_to_package_db_entry(
         "waybill:source-file".to_string(),
         json!(rel),
     );
+    // Milestone 236 (C151): pants_shell tool-pin design-tier reason.
+    extra_annotations.insert(
+        "waybill:unresolved-reason".to_string(),
+        json!("pants shell tool pin without version specifier"),
+    );
 
     Some(PackageDbEntry {
         purl,
@@ -369,6 +374,25 @@ mod tests {
         let out = tool_to_package_db_entry("shfmt", "3.7.0", &pants_toml, dir.path())
             .expect("emit ok");
         assert_eq!(out.purl.as_str(), "pkg:generic/shfmt@3.7.0");
+    }
+
+    #[test]
+    fn m236_pants_shell_design_tier_carries_unresolved_reason() {
+        // Milestone 236 (C151): pants_shell tool pins carry the reason string.
+        let dir = tempdir().unwrap();
+        let pants_toml = dir.path().join("pants.toml");
+        std::fs::write(&pants_toml, "").unwrap();
+        let out = tool_to_package_db_entry("shellcheck", "v0.9.0", &pants_toml, dir.path())
+            .expect("emit ok");
+        assert_eq!(out.sbom_tier.as_deref(), Some("design"));
+        let reason = out
+            .extra_annotations
+            .get("waybill:unresolved-reason")
+            .expect("C151 annotation present");
+        assert_eq!(
+            reason.as_str().unwrap(),
+            "pants shell tool pin without version specifier",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Extends m236 C151 coverage to the 8 remaining design-tier-emitting readers (US3 P3 batch). **Every design-tier-emitting reader in the codebase now carries `waybill:unresolved-reason`.** Builds on PR #703 (US1) and PR #704 (US2).

## Readers modified

| Reader | Reason string |
|---|---|
| cocoapods | \`no matching entry in Podfile.lock\` |
| composer | \`no matching entry in composer.lock\` |
| dart | \`no matching entry in pubspec.lock\` |
| elixir (main-module + declared-dep — 2 sites) | \`no matching entry in mix.lock\` |
| erlang (main-module + declared-dep — 2 sites) | \`no matching entry in rebar.lock\` |
| haskell (freeze range + cabal-design — 2 sites) | \`declared in stack.yaml / .cabal; no stack.yaml.lock fallback\` |
| pants_shell | \`pants shell tool pin without version specifier\` |
| pants_go | \`pants_go expected_version declared; no matching go corpus component\` |

## Test plan

- [x] New inline test: \`m236_pants_shell_design_tier_carries_unresolved_reason\`
- [x] All 10 m236 tests pass (1 US3 + 5 US2 + 4 US1)
- [x] All 193 pre-existing tests across the 8 modified readers pass — no regressions
- [x] Full pre-PR gate green

The remaining 7 readers (cocoapods/composer/dart/elixir/erlang/haskell/pants_go) rely on the Phase 6 cross-reader integration test (planned as T054) for structural coverage rather than adding 7 more fixture-scaffolding tests.

## Cumulative m236 progress after this PR

- ✅ US1 (#703): maven, npm/walk, pip — 3 readers
- ✅ US2 (#704): kotlin_dsl/build_script, scala, gradle_static, helm, yocto — 5 readers
- ✅ US3 (this PR): cocoapods, composer, dart, elixir, erlang, haskell, pants_shell, pants_go — 8 readers
- **Total: 16 readers universalized**, matching the trimmed spec scope.

## Remaining (Polish PR)

- Cross-reader integration test (T054 → SC-001)
- FR-010 blacklist scan
- Spec close-out + memory ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)