### PR TITLE
docs: cross-link component-tiers.md → ecosystems.md tier section (closes #662)

### DIFF
--- a/docs/reference/component-tiers.md
+++ b/docs/reference/component-tiers.md
@@ -15,6 +15,9 @@ source of truth.
 > axis** (design / source / analyzed / deployed / build — how strongly
 > the resolved *version* is pinned) is orthogonal and documented at
 > [reading-a-waybill-sbom.md → Design-tier components](reading-a-waybill-sbom.md).
+> For the per-ecosystem story on when each `sbom_tier` value fires,
+> see [ecosystems.md → SBOM tiers: source, design, binary](../ecosystems.md#sbom-tiers-source-design-binary)
+> (concept + jq detection recipes + per-ecosystem breakdown).
 > Milestone 175 adds an INFO-level advisory log at scan time when the
 > scan produces ≥1 `sbom_tier = "design"` component; the advisory can
 > be suppressed in CI via `WAYBILL_NO_DESIGN_TIER_ADVISORY=1`.


### PR DESCRIPTION
## Summary

Closes #662. Adds the reverse link from \`docs/reference/component-tiers.md\` → \`docs/ecosystems.md#sbom-tiers-source-design-binary\`. The forward link (ecosystems.md → component-tiers.md) already exists at line 57.

Placement: in the existing \`sbom_tier\` axis-distinction callout that already warned readers about the two orthogonal axes.

## Deferred

The issue mentioned "possibly consolidate under a unified tiers-explained doc if the two grow apart." Not done here — the two docs serve distinct audiences (contributors vs SBOM consumers). Revisit if they grow.

## Test plan

- [x] Docs-only change; no code impact
- [ ] Renders cleanly on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)