### PR TITLE
feat(m663 US2): cache-probe — Cargo + RubyGems

### DIFF
--- a/waybill-cli/src/resolve/resolvers/cache_probe/cargo.rs
+++ b/waybill-cli/src/resolve/resolvers/cache_probe/cargo.rs
@@ -1,10 +1,169 @@
-//! Milestone 663 — cargo cache probe.
-//! Concrete impl lands in US-phase per tasks.md.
+//! Milestone 663 US2 — Cargo `~/.cargo/registry/` cache probe.
+//!
+//! Two path variants:
+//!   A. `<root>/registry/cache/<registry-hash>/<name>-<version>.crate`
+//!   B. `<root>/registry/src/<registry-hash>/<name>-<version>/...`
+//!
+//! Extraction: filename stem (variant A) or last-cache-relative-dir
+//! (variant B) equals `<name>-<version>`. Split on the LAST `-`
+//! before a semver-shaped suffix (`\d+\.\d+\.\d+`).
+//!
+//! Q1 clarification: no semver suffix → log warn + decline.
 
-use std::path::Path;
-use waybill_common::types::purl::Purl;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
-pub(super) fn try_match_cargo(_path: &Path) -> Option<Purl> {
-    // Stub.
-    None
+use regex::Regex;
+use waybill_common::types::purl::{encode_purl_segment, Purl};
+
+/// Compute the Cargo registry root: `$CARGO_HOME/registry` if set,
+/// else `~/.cargo/registry`.
+fn cache_root() -> Option<PathBuf> {
+    if let Some(cargo_home) = std::env::var_os("CARGO_HOME") {
+        return Some(PathBuf::from(cargo_home).join("registry"));
+    }
+    super::home_dir().map(|h| h.join(".cargo").join("registry"))
+}
+
+/// Regex to find the `-<semver>` boundary in a `<name>-<version>`
+/// stem. Uses the LAST match since names may contain hyphens
+/// (`serde-json-1.0.100` → name=`serde-json`, version=`1.0.100`).
+fn name_version_split() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^(?P<name>.+?)-(?P<version>\d+\.\d+\.\d+.*)$").expect("valid regex")
+    })
+}
+
+fn extract_name_version(stem: &str) -> Option<(String, String)> {
+    let caps = name_version_split().captures(stem)?;
+    Some((caps["name"].to_string(), caps["version"].to_string()))
+}
+
+pub(super) fn try_match_cargo(path: &Path) -> Option<Purl> {
+    let root = cache_root()?;
+    let rel = path.strip_prefix(&root).ok()?;
+
+    let components: Vec<&std::ffi::OsStr> =
+        rel.components().map(|c| c.as_os_str()).collect();
+    if components.len() < 3 {
+        return None;
+    }
+
+    // First component must be "cache" (variant A) or "src" (variant B).
+    let stem = match components[0].to_str()? {
+        "cache" => {
+            // Variant A: cache/<registry-hash>/<name>-<version>.crate
+            let filename = components[components.len() - 1].to_str()?;
+            let stem = filename.strip_suffix(".crate")?;
+            stem.to_string()
+        }
+        "src" => {
+            // Variant B: src/<registry-hash>/<name>-<version>/...
+            // Locate the `<registry-hash>` at [1]; the next segment is the
+            // `<name>-<version>` dir. Its position depends on how deep
+            // the path is; we take the segment IMMEDIATELY AFTER the
+            // registry-hash (index 2).
+            if components.len() < 3 {
+                return None;
+            }
+            components[2].to_str()?.to_string()
+        }
+        _ => return None,
+    };
+
+    let (name, version) = match extract_name_version(&stem) {
+        Some(nv) => nv,
+        None => {
+            tracing::warn!(
+                path = %path.display(),
+                stem = %stem,
+                "cache_probe/cargo: stem doesn't match <name>-<semver>; declining",
+            );
+            return None;
+        }
+    };
+
+    let purl_str = format!(
+        "pkg:cargo/{}@{}",
+        encode_purl_segment(&name),
+        encode_purl_segment(&version),
+    );
+    match Purl::new(&purl_str) {
+        Ok(p) => Some(p),
+        Err(err) => {
+            tracing::warn!(
+                path = %path.display(),
+                purl = %purl_str,
+                error = %err,
+                "cache_probe/cargo: PURL construction failed; declining",
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    use crate::testing::EnvGuard;
+
+    #[test]
+    fn m663_cargo_cache_variant_a_crate_file() {
+        let td = tempfile::tempdir().unwrap();
+        let mut env = EnvGuard::acquire();
+        env.set("CARGO_HOME", td.path().to_str().unwrap());
+        let full_path = td
+            .path()
+            .join("registry")
+            .join("cache")
+            .join("github.com-1ecc6299db9ec823")
+            .join("waybill-fixture-crate-1.2.3.crate");
+        let purl = try_match_cargo(&full_path).expect("extract");
+        assert_eq!(purl.as_str(), "pkg:cargo/waybill-fixture-crate@1.2.3");
+    }
+
+    #[test]
+    fn m663_cargo_cache_variant_b_src_dir() {
+        let td = tempfile::tempdir().unwrap();
+        let mut env = EnvGuard::acquire();
+        env.set("CARGO_HOME", td.path().to_str().unwrap());
+        let full_path = td
+            .path()
+            .join("registry")
+            .join("src")
+            .join("github.com-1ecc6299db9ec823")
+            .join("waybill-fixture-crate-1.2.3")
+            .join("Cargo.toml");
+        let purl = try_match_cargo(&full_path).expect("extract");
+        assert_eq!(purl.as_str(), "pkg:cargo/waybill-fixture-crate@1.2.3");
+    }
+
+    #[test]
+    fn m663_cargo_non_cache_path_declines() {
+        let mut env = EnvGuard::acquire();
+        env.remove("CARGO_HOME");
+        env.remove("HOME");
+        env.remove("USERPROFILE");
+        let purl = try_match_cargo(Path::new("/tmp/random.crate"));
+        assert!(purl.is_none());
+    }
+
+    #[test]
+    fn m663_cargo_malformed_stem_declines() {
+        let td = tempfile::tempdir().unwrap();
+        let mut env = EnvGuard::acquire();
+        env.set("CARGO_HOME", td.path().to_str().unwrap());
+        // Missing semver in stem → decline.
+        let full_path = td
+            .path()
+            .join("registry")
+            .join("cache")
+            .join("github.com-1ecc")
+            .join("no-version-here.crate");
+        let purl = try_match_cargo(&full_path);
+        assert!(purl.is_none());
+    }
 }

--- a/waybill-cli/src/resolve/resolvers/cache_probe/golang.rs
+++ b/waybill-cli/src/resolve/resolvers/cache_probe/golang.rs
@@ -93,14 +93,14 @@ pub(super) fn try_match_golang(path: &Path) -> Option<Purl> {
 mod tests {
     use super::*;
 
+    use crate::testing::EnvGuard;
+
     #[test]
     fn m663_golang_cache_hit_extracts_module_coord() {
         let td = tempfile::tempdir().unwrap();
-        // SAFETY: single-threaded test.
-        unsafe {
-            std::env::set_var("GOMODCACHE", td.path());
-            std::env::remove_var("GOPATH");
-        }
+        let mut env = EnvGuard::acquire();
+        env.set("GOMODCACHE", td.path().to_str().unwrap());
+        env.remove("GOPATH");
         let full_path = td
             .path()
             .join("example.com")
@@ -113,18 +113,15 @@ mod tests {
             purl.as_str(),
             "pkg:golang/example.com/waybill/fixture@v2.0.0"
         );
-
-        unsafe {
-            std::env::remove_var("GOMODCACHE");
-        }
     }
 
     #[test]
     fn m663_golang_non_cache_path_declines() {
-        unsafe {
-            std::env::remove_var("GOMODCACHE");
-            std::env::remove_var("GOPATH");
-        }
+        let mut env = EnvGuard::acquire();
+        env.remove("GOMODCACHE");
+        env.remove("GOPATH");
+        env.remove("HOME");
+        env.remove("USERPROFILE");
         let purl = try_match_golang(std::path::Path::new("/tmp/random/main.go"));
         assert!(purl.is_none());
     }

--- a/waybill-cli/src/resolve/resolvers/cache_probe/maven.rs
+++ b/waybill-cli/src/resolve/resolvers/cache_probe/maven.rs
@@ -88,13 +88,13 @@ pub(super) fn try_match_maven(path: &Path) -> Option<Purl> {
 mod tests {
     use super::*;
 
+    use crate::testing::EnvGuard;
+
     #[test]
     fn m663_maven_cache_hit_extracts_gav() {
         let td = tempfile::tempdir().unwrap();
-        // SAFETY: single-threaded test; env var reset in teardown below.
-        unsafe {
-            std::env::set_var("M2_HOME", td.path());
-        }
+        let mut env = EnvGuard::acquire();
+        env.set("M2_HOME", td.path().to_str().unwrap());
 
         let full_path = td
             .path()
@@ -111,18 +111,15 @@ mod tests {
             purl.as_str(),
             "pkg:maven/com.example.waybillfixture/waybill-fixture-lib@1.0.0"
         );
-
-        unsafe {
-            std::env::remove_var("M2_HOME");
-        }
     }
 
     #[test]
     fn m663_maven_non_cache_path_declines() {
-        // Guarantee no M2_HOME set for this test.
-        unsafe {
-            std::env::remove_var("M2_HOME");
-        }
+        let mut env = EnvGuard::acquire();
+        env.remove("M2_HOME");
+        // Also remove HOME so the fallback ~/.m2/repository doesn't accidentally match.
+        env.remove("HOME");
+        env.remove("USERPROFILE");
         let purl = try_match_maven(std::path::Path::new("/tmp/random/file.jar"));
         assert!(purl.is_none());
     }

--- a/waybill-cli/src/resolve/resolvers/cache_probe/rubygems.rs
+++ b/waybill-cli/src/resolve/resolvers/cache_probe/rubygems.rs
@@ -1,10 +1,143 @@
-//! Milestone 663 — rubygems cache probe.
-//! Concrete impl lands in US-phase per tasks.md.
+//! Milestone 663 US2 — RubyGems cache probe.
+//!
+//! Two path variants:
+//!   A. User gem cache: `$GEM_HOME/specs/rubygems.org%443/<name>-<version>.gemspec`
+//!      or `~/.gem/specs/rubygems.org%443/<name>-<version>.gemspec`.
+//!   B. Bundler bundle: any path containing `vendor/bundle/ruby/<x>/gems/<name>-<version>/...`.
+//!
+//! Extraction: same `<name>-<version>` split on last `-` before semver,
+//! mirroring Cargo. Emit `pkg:gem/<name>@<version>`.
+//!
+//! Q1 clarification: no semver split → log warn + decline.
 
-use std::path::Path;
-use waybill_common::types::purl::Purl;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
-pub(super) fn try_match_rubygems(_path: &Path) -> Option<Purl> {
-    // Stub.
+use regex::Regex;
+use waybill_common::types::purl::{encode_purl_segment, Purl};
+
+fn user_gem_cache_root() -> Option<PathBuf> {
+    if let Some(gem_home) = std::env::var_os("GEM_HOME") {
+        return Some(PathBuf::from(gem_home).join("specs").join("rubygems.org%443"));
+    }
+    super::home_dir().map(|h| h.join(".gem").join("specs").join("rubygems.org%443"))
+}
+
+fn name_version_split() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^(?P<name>.+?)-(?P<version>\d+\.\d+\.\d+.*)$").expect("valid regex")
+    })
+}
+
+fn extract_name_version(stem: &str) -> Option<(String, String)> {
+    let caps = name_version_split().captures(stem)?;
+    Some((caps["name"].to_string(), caps["version"].to_string()))
+}
+
+/// Try variant B: any path containing `vendor/bundle/ruby/<x>/gems/`.
+/// The segment IMMEDIATELY after `gems/` is `<name>-<version>`.
+fn try_bundler_variant(path: &Path) -> Option<String> {
+    let components: Vec<&std::ffi::OsStr> =
+        path.components().map(|c| c.as_os_str()).collect();
+    if components.len() < 6 {
+        return None;
+    }
+    for i in 0..=components.len() - 6 {
+        if components[i].to_str()? == "vendor"
+            && components[i + 1].to_str()? == "bundle"
+            && components[i + 2].to_str()? == "ruby"
+            && components[i + 4].to_str()? == "gems"
+        {
+            return Some(components[i + 5].to_str()?.to_string());
+        }
+    }
     None
+}
+
+pub(super) fn try_match_rubygems(path: &Path) -> Option<Purl> {
+    // Try variant A (user gem cache).
+    let stem_from_user_cache: Option<String> = user_gem_cache_root()
+        .and_then(|r| {
+            path.strip_prefix(&r).ok().and_then(|rel| {
+                rel.file_name()
+                    .and_then(|f| f.to_str())
+                    .and_then(|f| f.strip_suffix(".gemspec").map(str::to_string))
+            })
+        });
+
+    let stem = stem_from_user_cache
+        .or_else(|| try_bundler_variant(path))?;
+
+    let (name, version) = match extract_name_version(&stem) {
+        Some(nv) => nv,
+        None => {
+            tracing::warn!(
+                path = %path.display(),
+                stem = %stem,
+                "cache_probe/rubygems: stem doesn't match <name>-<semver>; declining",
+            );
+            return None;
+        }
+    };
+
+    let purl_str = format!(
+        "pkg:gem/{}@{}",
+        encode_purl_segment(&name),
+        encode_purl_segment(&version),
+    );
+    match Purl::new(&purl_str) {
+        Ok(p) => Some(p),
+        Err(err) => {
+            tracing::warn!(
+                path = %path.display(),
+                purl = %purl_str,
+                error = %err,
+                "cache_probe/rubygems: PURL construction failed; declining",
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    use crate::testing::EnvGuard;
+
+    #[test]
+    fn m663_rubygems_variant_a_user_cache() {
+        let td = tempfile::tempdir().unwrap();
+        let mut env = EnvGuard::acquire();
+        env.set("GEM_HOME", td.path().to_str().unwrap());
+        let full_path = td
+            .path()
+            .join("specs")
+            .join("rubygems.org%443")
+            .join("waybill-fixture-gem-1.2.3.gemspec");
+        let purl = try_match_rubygems(&full_path).expect("extract");
+        assert_eq!(purl.as_str(), "pkg:gem/waybill-fixture-gem@1.2.3");
+    }
+
+    #[test]
+    fn m663_rubygems_variant_b_bundler() {
+        // Bundler layout — doesn't use GEM_HOME; path-based match.
+        let path = Path::new(
+            "/proj/vendor/bundle/ruby/3.1.0/gems/waybill-fixture-gem-1.2.3/lib/foo.rb",
+        );
+        let purl = try_match_rubygems(path).expect("extract");
+        assert_eq!(purl.as_str(), "pkg:gem/waybill-fixture-gem@1.2.3");
+    }
+
+    #[test]
+    fn m663_rubygems_non_cache_path_declines() {
+        let mut env = EnvGuard::acquire();
+        env.remove("GEM_HOME");
+        env.remove("HOME");
+        env.remove("USERPROFILE");
+        let purl = try_match_rubygems(Path::new("/tmp/random.gemspec"));
+        assert!(purl.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Extends m663 cache-probe resolver coverage to Cargo (2 variants) and RubyGems (2 variants). Env-var races between per-probe tests routed through the shared \`EnvGuard\`.

Builds on PR #708 (US1 MVP — Maven + Go).

## Readers modified

| Ecosystem | Variants | Env-var override |
|---|---|---|
| **Cargo** | \`registry/cache/<hash>/name-version.crate\` + \`registry/src/<hash>/name-version/\` | \`CARGO_HOME\` |
| **RubyGems** | \`.gem/specs/rubygems.org%443/name-version.gemspec\` + \`vendor/bundle/ruby/<x>/gems/name-version/\` (Bundler) | \`GEM_HOME\` |

Both use the same regex-based split (\`-(\d+\.\d+\.\d+.*)$\`) so hyphenated names (\`serde-json\`) yield the correct \`<name>-<version>\` boundary.

## Env-var race fix

Per memory \`reference_podman_test_flake\`, env-var-mutating tests must route through \`crate::testing::EnvGuard::acquire()\`. Rewrote all cache_probe tests (US1 Maven+Go + US2 Cargo+Ruby) to use \`EnvGuard\`. Previously parallel test runs raced on \`CARGO_HOME\` / \`M2_HOME\` etc.

## Test plan

- [x] 7 new per-probe unit tests (4 Cargo + 3 RubyGems)
- [x] All 12 m663 tests pass in parallel
- [x] \`./scripts/pre-pr.sh\` green

## Follow-on

- **US3**: npm + Python probes (with Q1 metadata-read decline semantics)
- **Polish**: SC-003 6-ecosystem integration + SC-004/005/006 tests + close-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)