### PR TITLE
feat(m663 US3): cache-probe — npm + Python probes with metadata reads

### DIFF
--- a/waybill-cli/src/resolve/resolvers/cache_probe/npm.rs
+++ b/waybill-cli/src/resolve/resolvers/cache_probe/npm.rs
@@ -1,10 +1,187 @@
-//! Milestone 663 — npm/pnpm cache probe.
-//! Concrete impl lands in US3 (T028).
+//! Milestone 663 US3 — npm cache probe (node_modules variant).
+//!
+//! Path shape: `.../node_modules/<name>/package.json`
+//! or `.../node_modules/@<scope>/<name>/package.json`.
+//!
+//! Extraction: `<name>` (or `@<scope>/<name>`) from the path,
+//! `<version>` from a bounded metadata read of `package.json`
+//! (max 64 KiB, parse via `serde_json`).
+//!
+//! Q1 clarification: metadata unreadable / missing / malformed →
+//! log warn + decline. Never emits at reduced confidence.
+//!
+//! Pnpm content-addressed store (`~/.local/share/pnpm/store/v3/files/...`)
+//! is deferred per plan R3 — requires `.package-lock.json`
+//! cross-reference that MVP doesn't ship.
 
 use std::path::Path;
-use waybill_common::types::purl::Purl;
 
-pub(super) fn try_match_npm_pnpm(_path: &Path) -> Option<Purl> {
-    // US3 stub.
+use waybill_common::types::purl::{encode_purl_segment, Purl};
+
+const MAX_PACKAGE_JSON_BYTES: u64 = 64 * 1024;
+
+/// Locate the `node_modules/<name>[/@scope]/package.json` pattern.
+/// Returns `(name, scope_or_none)` where `name` is the package name
+/// (without scope prefix) and `scope_or_none` is `Some("scope")` for
+/// scoped packages.
+fn extract_name_from_path(path: &Path) -> Option<(String, Option<String>)> {
+    let components: Vec<&std::ffi::OsStr> =
+        path.components().map(|c| c.as_os_str()).collect();
+    // Path must end in `package.json`.
+    let last = components.last()?.to_str()?;
+    if last != "package.json" {
+        return None;
+    }
+    // Search for `node_modules` segment. The segments AFTER it are
+    // either `[<name>, package.json]` (unscoped, 2 tail segments) or
+    // `[@<scope>, <name>, package.json]` (scoped, 3 tail segments).
+    for i in 0..components.len() {
+        if components[i].to_str()? == "node_modules" && i + 2 < components.len() {
+            let a = components[i + 1].to_str()?;
+            if a.starts_with('@') {
+                // Scoped: [@scope, name, package.json].
+                if i + 3 >= components.len() {
+                    return None;
+                }
+                let scope = a.trim_start_matches('@').to_string();
+                let name = components[i + 2].to_str()?.to_string();
+                return Some((name, Some(scope)));
+            } else {
+                // Unscoped: [name, package.json].
+                return Some((a.to_string(), None));
+            }
+        }
+    }
     None
+}
+
+/// Bounded read of `package.json`. Returns the `"version"` field
+/// or `None` on any failure per Q1 clarification.
+fn read_version_from_package_json(path: &Path) -> Option<String> {
+    let meta = std::fs::metadata(path).ok()?;
+    if meta.len() > MAX_PACKAGE_JSON_BYTES {
+        tracing::warn!(
+            path = %path.display(),
+            size = meta.len(),
+            "cache_probe/npm: package.json exceeds 64 KiB; declining",
+        );
+        return None;
+    }
+    let bytes = std::fs::read(path).ok()?;
+    let json: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %err,
+                "cache_probe/npm: package.json parse failed; declining",
+            );
+            return None;
+        }
+    };
+    let version = json.get("version").and_then(|v| v.as_str())?;
+    Some(version.to_string())
+}
+
+pub(super) fn try_match_npm_pnpm(path: &Path) -> Option<Purl> {
+    let (name, scope) = extract_name_from_path(path)?;
+    let version = match read_version_from_package_json(path) {
+        Some(v) => v,
+        None => {
+            tracing::warn!(
+                path = %path.display(),
+                "cache_probe/npm: version extraction failed; declining",
+            );
+            return None;
+        }
+    };
+
+    let purl_str = match scope {
+        Some(s) => format!(
+            "pkg:npm/%40{}/{}@{}",
+            encode_purl_segment(&s),
+            encode_purl_segment(&name),
+            encode_purl_segment(&version),
+        ),
+        None => format!(
+            "pkg:npm/{}@{}",
+            encode_purl_segment(&name),
+            encode_purl_segment(&version),
+        ),
+    };
+    match Purl::new(&purl_str) {
+        Ok(p) => Some(p),
+        Err(err) => {
+            tracing::warn!(
+                path = %path.display(),
+                purl = %purl_str,
+                error = %err,
+                "cache_probe/npm: PURL construction failed; declining",
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn m663_npm_unscoped_package_json_extracts_purl() {
+        let td = tempfile::tempdir().unwrap();
+        let dir = td.path().join("node_modules").join("waybill-fixture-npm");
+        std::fs::create_dir_all(&dir).unwrap();
+        let pj = dir.join("package.json");
+        std::fs::write(&pj, r#"{"name":"waybill-fixture-npm","version":"1.0.0"}"#).unwrap();
+
+        let purl = try_match_npm_pnpm(&pj).expect("extract");
+        assert_eq!(purl.as_str(), "pkg:npm/waybill-fixture-npm@1.0.0");
+    }
+
+    #[test]
+    fn m663_npm_scoped_package_json_extracts_url_encoded_purl() {
+        let td = tempfile::tempdir().unwrap();
+        let dir = td
+            .path()
+            .join("node_modules")
+            .join("@waybillfixture")
+            .join("scoped-lib");
+        std::fs::create_dir_all(&dir).unwrap();
+        let pj = dir.join("package.json");
+        std::fs::write(&pj, r#"{"name":"@waybillfixture/scoped-lib","version":"2.0.0"}"#)
+            .unwrap();
+
+        let purl = try_match_npm_pnpm(&pj).expect("extract");
+        assert_eq!(purl.as_str(), "pkg:npm/%40waybillfixture/scoped-lib@2.0.0");
+    }
+
+    #[test]
+    fn m663_npm_malformed_json_declines() {
+        let td = tempfile::tempdir().unwrap();
+        let dir = td.path().join("node_modules").join("waybill-fixture-npm");
+        std::fs::create_dir_all(&dir).unwrap();
+        let pj = dir.join("package.json");
+        std::fs::write(&pj, "not valid json").unwrap();
+
+        assert!(try_match_npm_pnpm(&pj).is_none());
+    }
+
+    #[test]
+    fn m663_npm_missing_version_declines() {
+        let td = tempfile::tempdir().unwrap();
+        let dir = td.path().join("node_modules").join("waybill-fixture-npm");
+        std::fs::create_dir_all(&dir).unwrap();
+        let pj = dir.join("package.json");
+        std::fs::write(&pj, r#"{"name":"waybill-fixture-npm"}"#).unwrap();
+
+        assert!(try_match_npm_pnpm(&pj).is_none());
+    }
+
+    #[test]
+    fn m663_npm_non_node_modules_path_declines() {
+        let purl = try_match_npm_pnpm(Path::new("/tmp/random/package.json"));
+        assert!(purl.is_none());
+    }
 }

--- a/waybill-cli/src/resolve/resolvers/cache_probe/pypi.rs
+++ b/waybill-cli/src/resolve/resolvers/cache_probe/pypi.rs
@@ -1,10 +1,161 @@
-//! Milestone 663 — PyPi cache probe.
-//! Concrete impl lands in US3 (T031).
+//! Milestone 663 US3 — Python cache probe.
+//!
+//! Two path variants:
+//!   A. Installed dist-info: `.../site-packages/<name>-<version>.dist-info/METADATA`
+//!      Uses the METADATA `Version:` header as authoritative
+//!      (the filename split gives us the name).
+//!   B. Wheel cache: `.../wheels/.../<name>-<version>-<pyver>-<abi>-<platform>.whl`
+//!      Filename stem split only; no metadata read.
+//!
+//! Extraction: name normalization per PEP 503 (underscores → hyphens,
+//! lowercase). Emit `pkg:pypi/<name>@<version>`.
+//!
+//! Q1 clarification: METADATA unreadable / missing Version: header
+//! (variant A) or filename stem malformed (variant B) → log warn +
+//! decline.
 
 use std::path::Path;
-use waybill_common::types::purl::Purl;
+use std::sync::OnceLock;
 
-pub(super) fn try_match_pypi(_path: &Path) -> Option<Purl> {
-    // US3 stub.
+use regex::Regex;
+use waybill_common::types::purl::{encode_purl_segment, Purl};
+
+const MAX_METADATA_BYTES: u64 = 64 * 1024;
+
+fn normalize_pypi_name(raw: &str) -> String {
+    raw.to_lowercase().replace(['_', '.'], "-")
+}
+
+fn name_version_split() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^(?P<name>.+?)-(?P<version>\d+\.\d+.*)$").expect("valid regex")
+    })
+}
+
+fn extract_name_version(stem: &str) -> Option<(String, String)> {
+    let caps = name_version_split().captures(stem)?;
+    Some((caps["name"].to_string(), caps["version"].to_string()))
+}
+
+fn read_version_from_metadata(path: &Path) -> Option<String> {
+    let meta = std::fs::metadata(path).ok()?;
+    if meta.len() > MAX_METADATA_BYTES {
+        tracing::warn!(
+            path = %path.display(),
+            size = meta.len(),
+            "cache_probe/pypi: METADATA exceeds 64 KiB; declining",
+        );
+        return None;
+    }
+    let contents = std::fs::read_to_string(path).ok()?;
+    for line in contents.lines() {
+        if let Some(rest) = line.strip_prefix("Version:") {
+            let v = rest.trim();
+            if !v.is_empty() {
+                return Some(v.to_string());
+            }
+        }
+    }
+    tracing::warn!(
+        path = %path.display(),
+        "cache_probe/pypi: no Version: header in METADATA; declining",
+    );
     None
+}
+
+fn try_dist_info(path: &Path) -> Option<Purl> {
+    if path.file_name()?.to_str()? != "METADATA" {
+        return None;
+    }
+    let parent = path.parent()?;
+    let dir_name = parent.file_name()?.to_str()?;
+    let stem = dir_name.strip_suffix(".dist-info")?;
+    let (raw_name, _stem_version) = extract_name_version(stem)?;
+    let version = read_version_from_metadata(path)?;
+    let name = normalize_pypi_name(&raw_name);
+    let purl_str = format!(
+        "pkg:pypi/{}@{}",
+        encode_purl_segment(&name),
+        encode_purl_segment(&version),
+    );
+    Purl::new(&purl_str).ok()
+}
+
+fn try_wheel_filename(path: &Path) -> Option<Purl> {
+    let filename = path.file_name()?.to_str()?;
+    let stem = filename.strip_suffix(".whl")?;
+    static WHEEL_RE: OnceLock<Regex> = OnceLock::new();
+    let re = WHEEL_RE.get_or_init(|| {
+        // Wheel PEP 427: {name}-{version}(-{build tag})?-{pyver}-{abi}-{platform}.whl
+        // MVP regex: name-version-pyver-abi-platform. Version regex is
+        // enough for common cases (\d+.\d+ + optional suffix).
+        Regex::new(
+            r"^(?P<name>.+?)-(?P<version>\d+\.\d+(?:\.\d+)?[^\-]*)-[^\-]+-[^\-]+-[^\-]+$",
+        )
+        .expect("valid regex")
+    });
+    let caps = re.captures(stem)?;
+    let raw_name = &caps["name"];
+    let version = &caps["version"];
+    let name = normalize_pypi_name(raw_name);
+    let purl_str = format!(
+        "pkg:pypi/{}@{}",
+        encode_purl_segment(&name),
+        encode_purl_segment(version),
+    );
+    Purl::new(&purl_str).ok()
+}
+
+pub(super) fn try_match_pypi(path: &Path) -> Option<Purl> {
+    try_dist_info(path).or_else(|| try_wheel_filename(path))
+}
+
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::unwrap_used))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn m663_pypi_dist_info_extracts_purl() {
+        let td = tempfile::tempdir().unwrap();
+        let dir = td.path().join("waybill_fixture_pip-1.0.0.dist-info");
+        std::fs::create_dir_all(&dir).unwrap();
+        let meta = dir.join("METADATA");
+        std::fs::write(
+            &meta,
+            "Metadata-Version: 2.1\nName: waybill-fixture-pip\nVersion: 1.0.0\n",
+        )
+        .unwrap();
+
+        let purl = try_match_pypi(&meta).expect("extract");
+        // Note: underscore→hyphen normalization on the name.
+        assert_eq!(purl.as_str(), "pkg:pypi/waybill-fixture-pip@1.0.0");
+    }
+
+    #[test]
+    fn m663_pypi_wheel_cache_extracts_purl() {
+        let path = Path::new(
+            "/home/user/.cache/pip/wheels/ab/cd/ef/waybill_fixture_pip-1.0.0-py3-none-any.whl",
+        );
+        let purl = try_match_pypi(path).expect("extract");
+        assert_eq!(purl.as_str(), "pkg:pypi/waybill-fixture-pip@1.0.0");
+    }
+
+    #[test]
+    fn m663_pypi_missing_version_header_declines() {
+        let td = tempfile::tempdir().unwrap();
+        let dir = td.path().join("waybill_fixture_pip-1.0.0.dist-info");
+        std::fs::create_dir_all(&dir).unwrap();
+        let meta = dir.join("METADATA");
+        std::fs::write(&meta, "Metadata-Version: 2.1\nName: waybill-fixture-pip\n").unwrap();
+
+        assert!(try_match_pypi(&meta).is_none());
+    }
+
+    #[test]
+    fn m663_pypi_non_cache_path_declines() {
+        let purl = try_match_pypi(Path::new("/tmp/random.txt"));
+        assert!(purl.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Extends m663 cache-probe coverage to the last two ecosystems in the launch scope. **All 6 cache-probe ecosystems now live** (Maven + Go + Cargo + Ruby + npm + Python). Q1 decline-on-metadata-failure semantics honored.

Builds on PR #708 (US1 Maven+Go) and PR #709 (US2 Cargo+Ruby).

## What lands

- **npm probe** (\`node_modules\` variant):
  - Unscoped: \`.../node_modules/<name>/package.json\` → \`pkg:npm/<name>@<ver>\`
  - Scoped: \`.../node_modules/@<scope>/<name>/package.json\` → \`pkg:npm/%40<scope>/<name>@<ver>\`
  - Bounded ≤64 KiB read of \`package.json\`; Q1 decline on unreadable / malformed JSON / missing \"version\".
  - Pnpm content-addressed store deferred per plan R3 (needs \`.package-lock.json\` cross-ref).

- **Python probe** (2 variants):
  - Dist-info: \`.../site-packages/<name>-<version>.dist-info/METADATA\` → bounded read + \`Version:\` header scan
  - Wheel cache: \`.../wheels/.../<name>-<version>-py3-none-any.whl\` → filename regex split
  - PEP 503 name normalization (\`_\` and \`.\` → \`-\`, lowercase): \`waybill_fixture_pip\` → \`waybill-fixture-pip\`.

## Test plan

- [x] 9 new per-probe unit tests (5 npm + 4 Python)
- [x] All 21 m663 cache_probe tests pass in parallel (5 US1 + 7 US2 + 9 US3)
- [x] \`./scripts/pre-pr.sh\` green

## Follow-on (Polish PR)

- SC-003 6-ecosystem integration test
- SC-004 env-var override test
- SC-005 non-cache-path fall-through test
- SC-006 microbenchmark (p95 ≤ 5 ms across ≥100k paths)
- Spec close-out + memory reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)