### PR TITLE
fix(tests): retry spdx3-validate on transient network flakes

### DIFF
--- a/waybill-cli/tests/spdx3_conformance.rs
+++ b/waybill-cli/tests/spdx3_conformance.rs
@@ -102,23 +102,54 @@ fn run_validator(fixture_path: &Path) -> ValidationResult {
         );
         return ValidationResult::Skipped;
     }
-    let output = Command::new(&bin_path)
-        .arg("--quiet")
-        .arg("-j")
-        .arg(fixture_path)
-        .output()
-        .expect("validator command should be invocable when binary exists");
-    let mut combined = Vec::new();
-    combined.extend_from_slice(&output.stdout);
-    combined.extend_from_slice(&output.stderr);
-    let combined_text = String::from_utf8_lossy(&combined).into_owned();
-    let has_violation_marker = combined_text.contains("Violation of type");
-    if output.status.success() && !has_violation_marker {
-        ValidationResult::Pass
-    } else {
-        ValidationResult::Fail {
-            combined_output: combined_text,
+    // Retry wrapper for transient network flakes. `spdx3-validate`
+    // fetches SPDX schemas (spdx-model.ttl, spdx-json-schema.json,
+    // spdx-context.jsonld) from spdx.org on EVERY invocation via
+    // `urllib.request.urlopen` and `rdflib.Graph.parse(url)`. When
+    // the GHA runner sees a transient reset, the tool fails with
+    // `ConnectionResetError: [Errno 104] Connection reset by peer`
+    // and the test panics — but the underlying SBOM output was
+    // fine. Retry up to 3 times with exponential backoff; only
+    // treat the LAST attempt as authoritative.
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut last_combined_text = String::new();
+    for attempt in 1..=MAX_ATTEMPTS {
+        let output = Command::new(&bin_path)
+            .arg("--quiet")
+            .arg("-j")
+            .arg(fixture_path)
+            .output()
+            .expect("validator command should be invocable when binary exists");
+        let mut combined = Vec::new();
+        combined.extend_from_slice(&output.stdout);
+        combined.extend_from_slice(&output.stderr);
+        let combined_text = String::from_utf8_lossy(&combined).into_owned();
+        let has_violation_marker = combined_text.contains("Violation of type");
+        if output.status.success() && !has_violation_marker {
+            return ValidationResult::Pass;
         }
+        last_combined_text = combined_text;
+        // Retry only on transient network signatures. Real
+        // violations don't match — return immediately.
+        let is_transient_network = last_combined_text.contains("ConnectionResetError")
+            || last_combined_text.contains("Connection reset by peer")
+            || last_combined_text.contains("URLError")
+            || last_combined_text.contains("urlopen error")
+            || last_combined_text.contains("TimeoutError")
+            || last_combined_text.contains("temporary failure in name resolution");
+        if !is_transient_network || attempt == MAX_ATTEMPTS {
+            break;
+        }
+        eprintln!(
+            "[spdx3_conformance] transient network failure on attempt {attempt}/{MAX_ATTEMPTS} for {}; retrying after backoff",
+            fixture_path.display(),
+        );
+        std::thread::sleep(std::time::Duration::from_millis(
+            500 * (1 << (attempt - 1)) as u64,
+        ));
+    }
+    ValidationResult::Fail {
+        combined_output: last_combined_text,
     }
 }
 


### PR DESCRIPTION
## Summary

\`spdx3-validate\` fetches SPDX schemas from spdx.org on every invocation via \`urllib.request.urlopen\` + \`rdflib.Graph.parse(url)\`. When the GHA runner sees a transient TCP reset or DNS blip, the tool fails with \`ConnectionResetError: [Errno 104] Connection reset by peer\` — even though the SBOM output is fine.

Bit us on PR #710 (m663 US3) and #712 (m663 Polish). Same code + tests, different network weather. This is CI flake source #1 of 3 identified during m663.

## Fix

\`run_validator\` retries up to 3 times with 500ms/1s/2s exponential backoff when the tool's output matches transient network signatures (\`ConnectionResetError\`, \`Connection reset by peer\`, \`URLError\`, \`urlopen error\`, \`TimeoutError\`, \`temporary failure in name resolution\`).

Real SPDX violations don't match any of these strings and short-circuit on the first attempt.

## Not addressed here

- Persistent network outages still fail after 3 attempts (correct — a real outage shouldn't silently pass conformance).
- Vendoring the schemas would need a fork of upstream \`JPEWdev/spdx3-validate\`; out of scope.

## Follow-on CI flake fixes

- **Flake source #2** — long/stuck ebpf lane (Docker build cache)
- **Flake source #3** — GHA runner image drift (pin to specific version)

## Test plan

- [x] All 15 \`spdx3_conformance\` tests pass locally
- [x] Retry logic only triggers on network signatures (real violations bail immediately)
- [x] \`./scripts/pre-pr.sh\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)