### PR TITLE
fix(m666): eliminate walk_registry test flake via per-test VisitSink pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # waybill Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-08-23
+Auto-generated from all feature plans. Last updated: 2026-08-26
 
 ## Active Technologies
 - Rust stable (user-space only; no eBPF touched in this milestone) (002-python-npm-ecosystem)
@@ -323,6 +323,8 @@ Auto-generated from all feature plans. Last updated: 2026-08-23
 - Rust stable (workspace toolchain inherited from milestones 001–663; no nightly required for this user-space-only work). + Existing only — `globset = "0.4"` (already a direct workspace dep since milestones 113 + 118; used here for filename-pattern matching), `std::path::{Path, PathBuf}`, `std::fs::{read_dir, canonicalize}`, `std::collections::{HashMap, HashSet}`, `tracing` (INFO-level FR-009 diagnostic log), `anyhow`/`thiserror` (error surface), `serde`/`serde_json` (existing — no new schema). **Zero new Cargo dependencies.** (664-single-pass-walker)
 - N/A — the (directory → filenames) index is in-process per scan; dropped at `read_all` return. Mirrors every scan_fs milestone since 002. (664-single-pass-walker)
 - Rust stable (workspace toolchain inherited from milestones 001–664; no nightly required) + Existing only — `clap` (workspace; `ValueEnum` derive for the mode enum), `serde`/`serde_json` (annotation values), `tracing` (FR-005 diagnostic log). **Zero new Cargo dependencies.** (665-no-binary-scan-flag)
+- Rust stable (workspace toolchain inherited from milestones 001–665; no nightly required for this user-space test-only fix). + Existing only — `std::sync::{Arc, Mutex}` (stdlib), `ReaderRegistration.state: Option<Arc<dyn Any + Send + Sync>>` (m664 contract C4 slot at `waybill-cli/src/scan_fs/walk_registry/mod.rs:378-385`), `SharedWalkerContext::state::<T>(reader_id) -> Option<&T>` (accessor at `walk_context.rs:53`). **Zero new Cargo dependencies at any layer (production or dev).** (666-walker-test-flake-fix)
+- N/A — per-test in-memory sink dropped at test-scope exit. (666-walker-test-flake-fix)
 
 - Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`) + aya, aya-ebpf, aya-build, tokio, clap, reqwest, serde/serde_json, cyclonedx-bom, packageurl, sha2, chrono, thiserror, anyhow, tracing (001-build-trace-pipeline)
 
@@ -416,9 +418,9 @@ of CI-readiness — they are not equivalent.
 Rust stable (user-space) + nightly (eBPF target via `aya-ebpf`): Follow standard conventions
 
 ## Recent Changes
+- 666-walker-test-flake-fix: Added Rust stable (workspace toolchain inherited from milestones 001–665; no nightly required for this user-space test-only fix). + Existing only — `std::sync::{Arc, Mutex}` (stdlib), `ReaderRegistration.state: Option<Arc<dyn Any + Send + Sync>>` (m664 contract C4 slot at `waybill-cli/src/scan_fs/walk_registry/mod.rs:378-385`), `SharedWalkerContext::state::<T>(reader_id) -> Option<&T>` (accessor at `walk_context.rs:53`). **Zero new Cargo dependencies at any layer (production or dev).**
 - 665-no-binary-scan-flag: Added Rust stable (workspace toolchain inherited from milestones 001–664; no nightly required) + Existing only — `clap` (workspace; `ValueEnum` derive for the mode enum), `serde`/`serde_json` (annotation values), `tracing` (FR-005 diagnostic log). **Zero new Cargo dependencies.**
 - 664-single-pass-walker: Added Rust stable (workspace toolchain inherited from milestones 001–663; no nightly required for this user-space-only work). + Existing only — `globset = "0.4"` (already a direct workspace dep since milestones 113 + 118; used here for filename-pattern matching), `std::path::{Path, PathBuf}`, `std::fs::{read_dir, canonicalize}`, `std::collections::{HashMap, HashSet}`, `tracing` (INFO-level FR-009 diagnostic log), `anyhow`/`thiserror` (error surface), `serde`/`serde_json` (existing — no new schema). **Zero new Cargo dependencies.**
-- 663-cache-probe-resolver: Added Rust stable (workspace toolchain inherited from milestones 001–236; no nightly required). + Existing only —
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/666-walker-test-flake-fix/checklists/requirements.md
+++ b/specs/666-walker-test-flake-fix/checklists/requirements.md
@@ -1,0 +1,50 @@
+# Specification Quality Checklist: Fix walk_registry test flake
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+  - **Note**: Rust-specific type names (`Mutex<Vec<String>>`, `Box<dyn Any + Send + Sync>`) DO appear in the Key Entities section and in an Assumption, but only as identity anchors for the specific code artifacts the spec constrains — the fix scope is deliberately named at the type-signature level because the observable behavior we're preserving (per-test isolation of the visit log) is inseparable from the specific `SEMANTICS_LOG` static we're removing. FR-006 explicitly constrains implementation choice (must use existing extension points, not new API surface) without prescribing which one.
+- [X] Focused on user value and business needs
+  - The user is a waybill maintainer; the value is "CI never spuriously fails on the walker tests." No feature functionality is added; a stability property is restored.
+- [X] Written for non-technical stakeholders
+  - The User Story 1 narrative is readable without Rust expertise. FR-005/006 use Rust type names because the spec's core constraint (respect m664 contract C4) is Rust-specific. This is appropriate for a bugfix on a Rust codebase.
+- [X] All mandatory sections completed
+  - User Scenarios, Requirements (functional), Success Criteria all populated.
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+  - FR-001 through FR-008 each name a specific verifiable property (parallelism-safe, no new deps, no golden churn, etc.).
+- [X] Success criteria are measurable
+  - SC-001 (100 iterations pass), SC-002 (same test count), SC-003 (zero golden diff), SC-004 (pre-PR gate passes), SC-005 (single-file-read discoverability), SC-006 (issue auto-closes).
+- [X] Success criteria are technology-agnostic (no implementation details)
+  - Where SC-001 names `--test-threads=8` and SC-004 names `./scripts/pre-pr.sh`, these are the *testing methodology* (how we verify), not implementation prescriptions for the fix itself. Every SC could be re-worded as an outcome ("tests pass reliably in parallel") without changing meaning; the specific commands are helpful for reproducibility.
+- [X] All acceptance scenarios are defined
+  - Three scenarios in User Story 1 cover: local 100-iteration harness, CI parallel scheduling, future-maintainer-adds-a-fourth-test extensibility.
+- [X] Edge cases are identified
+  - Multi-threaded walker (future), test-panics-mid-run recovery, Windows-lane `#[cfg(unix)]` guards.
+- [X] Scope is clearly bounded
+  - FR-003 (only own walker's visits), FR-004 (assertions unchanged), FR-005 (no new production deps), FR-006 (no walker API surface change), FR-007 (byte-identical runtime), FR-008 (pattern generalizes). Explicit non-scope: latent test-invariant bugs (deferred), walker's own threading model change (deferred).
+- [X] Dependencies and assumptions identified
+  - Five Assumption bullets cover: cargo-parallelism as sole race source, test invariants correctness, local reproduction feasibility, m664 contract C4 as extension mechanism, standalone-PR scope.
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+  - FR-001 ↔ SC-001 (100-iteration harness); FR-002 ↔ SC-004 (no `--test-threads=1` workaround); FR-005 ↔ SC-002 (no new deps → no dependency-graph regression); FR-007 ↔ SC-003 (zero golden diff); FR-008 ↔ SC-005 (single-file-read discoverability).
+- [X] User scenarios cover primary flows
+  - Local reproduction (Scenario 1), CI parallel scheduling (Scenario 2), pattern extensibility (Scenario 3).
+- [X] Feature meets measurable outcomes defined in Success Criteria
+  - Delivering the fix per FR-001 through FR-008 satisfies SC-001 through SC-006 in aggregate.
+- [X] No implementation details leak into specification
+  - Rust type names in Key Entities + FR-006 are identity anchors (see Content Quality note above), not prescriptions.
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.
+- All items pass on first-pass validation. Ready for `/speckit.plan` (no `/speckit.clarify` needed — the spec is tight enough at 8 FRs + 6 SCs that no clarification questions surface).

--- a/specs/666-walker-test-flake-fix/contracts/test-visit-sink.md
+++ b/specs/666-walker-test-flake-fix/contracts/test-visit-sink.md
@@ -1,0 +1,137 @@
+# Contract: Test-visit-sink pattern for walk_registry unit tests
+
+## Interface
+
+### `VisitSink` type alias (test-scope only)
+
+```rust
+type VisitSink = std::sync::Arc<std::sync::Mutex<Vec<String>>>;
+```
+
+**Scope**: `#[cfg(test)] mod tests { ... }` inside `waybill-cli/src/scan_fs/walk_registry/walker.rs`.
+
+**Ownership contract**: each `#[test]` fn that needs to observe walker file visits MUST construct its own `VisitSink` on its stack frame. Sinks MUST NOT be `static`, MUST NOT be `thread_local!`, and MUST NOT be reused across tests.
+
+### `push_visit_to_sink` helper
+
+```rust
+fn push_visit_to_sink(path: &Path, ctx: &SharedWalkerContext<'_>, reader_id: ReaderId);
+```
+
+**Behavior**: fetches the sink from `ctx.state::<Mutex<Vec<String>>>(reader_id)`. If the sink is present, pushes `path.file_name().unwrap().to_string_lossy().into_owned()` onto the guarded Vec. If the sink is absent (reader_id mismatch, no state populated, downcast failure), returns silently — a defensive no-op that keeps the walker's dispatch loop unblocked.
+
+**Signature MUST match** `FileCallback`'s expected shape for the wrapper fn pointers to satisfy the walker's callback typedef.
+
+### Per-test callback wrapper family
+
+Every `#[test]` fn that consumes the sink MUST register a distinct fn-pointer callback that hardcodes its own `ReaderId` at compile time:
+
+```rust
+fn record_visit_<test-slug>(path: &Path, ctx: &SharedWalkerContext<'_>) {
+    push_visit_to_sink(path, ctx, ReaderId::new("visitor-<test-slug>"));
+}
+```
+
+Where `<test-slug>` is unique per test (`loop` / `exclude` / `noise` for the three existing tests). The `ReaderId::new(...)` string MUST match the registration's `reader_id` in the same `#[test]` body.
+
+## Behavioral contract
+
+### C1: Isolation guarantee
+
+Two tests running concurrently MUST observe:
+- Their own visit-log entries only.
+- Zero visits from sibling tests.
+- Zero effects from sibling tests' `sink.lock()` calls.
+
+Enforced by construction: each test's Arc points at a distinct `Mutex<Vec<String>>` allocation. There is no path through which one test's writes reach another test's sink.
+
+### C2: Panic safety
+
+If a test panics mid-run (assertion failure, walker callback panic caught by `dispatch_file`'s `catch_unwind`, tempfile teardown panic, etc.), that test's sink drops with its stack frame. Sibling tests observe no residue and no cross-test lock poisoning because they hold different `Mutex` identities.
+
+### C3: Reader_id uniqueness
+
+Every `#[test]` that consumes a sink MUST use a `ReaderId::new(...)` string distinct from the other tests' `ReaderId::new(...)` strings. Two tests sharing a reader_id would produce a scenario where a callback resolves to the WRONG test's sink (both registrations sit in the same registration slice; `SharedWalkerContext::state` picks the first match). While the tests would still run in isolation of sink writes (they hold separate Arcs), the LOOKUP would silently misroute — a latent bug for anyone extending the pattern.
+
+Regression guard: `grep -c 'ReaderId::new("visitor-' waybill-cli/src/scan_fs/walk_registry/walker.rs` should return exactly the count of test wrappers, and `sort -u` on the extracted strings should equal that count (no dupes).
+
+### C4: No walker API surface change
+
+The fix MUST NOT:
+- Extend `ReaderRegistration` with new fields.
+- Extend `SharedWalker` with new methods.
+- Extend `SharedWalkerContext` with new accessors.
+- Change the `FileCallback` typedef signature.
+
+Every extension point used by the fix (`ReaderRegistration.state`, `SharedWalkerContext::state::<T>()`, `FileCallback`) exists at the pre-fix code (grep-verified at `walk_registry/mod.rs:378`, `walk_context.rs:53`, `walk_registry/mod.rs:360` respectively).
+
+### C5: Zero production code changes
+
+The fix MUST NOT modify any code outside `#[cfg(test)]` blocks in `walk_registry/walker.rs`. No other file in the workspace changes.
+
+### C6: Assertion-shape preservation
+
+The three tests' post-walker assertions MUST retain the same logical shape as pre-fix:
+
+- `walker_survives_symlink_loop`: `assert_eq!(log.iter().filter(|s| s.as_str() == "target.marker").count(), 1, ...)`
+- `walker_respects_exclusion_set`: `assert!(!log.iter().any(|s| s == "in_excluded.marker"), ...); assert!(log.iter().any(|s| s == "in_kept.marker"), ...);`
+- `walker_skips_default_noise_dirs`: `assert!(!log.iter().any(|s| s == "in_git.marker"), ...); assert!(!log.iter().any(|s| s == "in_nm.marker"), ...); assert!(log.iter().any(|s| s == "top.marker"), ...);`
+
+The `.iter()` / `.any()` / `.filter()` / `.count()` shape stays. Only the `log` binding source shifts from `SEMANTICS_LOG.lock().unwrap()` to `sink.lock().unwrap()`.
+
+## Test-authoring rules
+
+### T1: Adding a fourth test
+
+To add a `walker_XYZ` test that observes visits, the maintainer:
+
+1. Chooses a unique reader_id string: `"visitor-xyz"`.
+2. Writes a callback wrapper immediately after the existing three:
+   ```rust
+   fn record_visit_xyz(path: &Path, ctx: &SharedWalkerContext<'_>) {
+       push_visit_to_sink(path, ctx, ReaderId::new("visitor-xyz"));
+   }
+   ```
+3. In the test body, constructs the sink:
+   ```rust
+   let sink: VisitSink = Arc::new(Mutex::new(Vec::new()));
+   ```
+4. Registers the walker with the sink threaded via the `state` slot:
+   ```rust
+   .register(ReaderRegistration {
+       reader_id: ReaderId::new("visitor-xyz"),
+       state: Some(sink.clone()),   // implicit Arc<T> → Arc<dyn Any + Send + Sync> coercion
+       // ... patterns, on_file: Some(record_visit_xyz), etc.
+   })
+   ```
+5. After `walker.run()`, asserts via `let log = sink.lock().unwrap(); assert!(...)`.
+
+Time-to-add: ~10 lines. No new module, no memory to reference.
+
+### T2: Constructor pattern for the state Arc coercion
+
+The registration's `state: Some(sink.clone())` line relies on Rust's `CoerceUnsized` to convert `Arc<Mutex<Vec<String>>>` to `Arc<dyn Any + Send + Sync>` at the field-assignment site. This works because `Mutex<Vec<String>>: Any + Send + Sync` (all three traits derived structurally from the type's contents). If a future test needs a sink type that's NOT `Any + Send + Sync` (unlikely but possible), the coercion fails at compile time — surfacing the constraint immediately.
+
+### T3: 100-iteration verification harness (implementation-time only, not shipped)
+
+At implementation time, the maintainer verifies FR-001/SC-001 via:
+
+```bash
+for i in $(seq 1 100); do
+  cargo +stable test -p waybill --lib -- \
+      scan_fs::walk_registry::walker::tests::walker_survives_symlink_loop \
+      scan_fs::walk_registry::walker::tests::walker_respects_exclusion_set \
+      scan_fs::walk_registry::walker::tests::walker_skips_default_noise_dirs \
+      --test-threads=8 --nocapture 2>&1 | grep -q "test result: ok. 3 passed" || { echo "FAIL at iter $i"; exit 1; }
+done
+echo "PASS: 100 iterations, 0 failures"
+```
+
+Not shipped as a persistent CI harness (per research R3): the fix's correctness is verified once at implementation time; ongoing regression detection relies on cargo's standard parallel scheduler catching any future re-introduction of shared state.
+
+## Non-contracts
+
+- **`walker_survives_symlink_loop` remains `#[cfg(unix)]`-gated.** The fix does not restore that test on Windows lanes; that's a separate concern.
+- **`empty_registry_produces_empty_output` is unchanged.** That test doesn't touch `SEMANTICS_LOG` (it verifies the walker's zero-registration path), so it needs no changes.
+- **The `record_visit` fn from pre-fix code is removed, not renamed.** Any grep for `fn record_visit(` in the codebase should return zero hits post-fix.
+- **`SEMANTICS_LOG` static is removed, not renamed.** Any grep for `SEMANTICS_LOG` should return zero hits post-fix.

--- a/specs/666-walker-test-flake-fix/data-model.md
+++ b/specs/666-walker-test-flake-fix/data-model.md
@@ -1,0 +1,112 @@
+# Data Model: Fix walk_registry test flake
+
+## Entities
+
+### `VisitSink` (test-owned, per-test-instance)
+
+Per-test observation buffer for the walker's file-visit callback.
+
+```rust
+type VisitSink = std::sync::Arc<std::sync::Mutex<Vec<String>>>;
+```
+
+**Ownership**: created on the test's stack frame at test-body entry; two `Arc` clones exist for the duration of the walker's run — one held by the test (for post-run assertions), one held by the `ReaderRegistration.state` slot (for the walker's callback lookup). Both drop when the test exits.
+
+**Lifecycle**:
+1. Test body: `let sink: VisitSink = Arc::new(Mutex::new(Vec::new()));`
+2. Registration: `state: Some(sink.clone() as Arc<dyn Any + Send + Sync>)` — Rust's `CoerceUnsized` implicitly coerces `Arc<Mutex<Vec<String>>>` to `Arc<dyn Any + Send + Sync>` at the field-assignment site.
+3. Walker run: dispatches file events to the test's callback fn, which fetches `ctx.state::<Mutex<Vec<String>>>(reader_id)` and pushes visited filenames.
+4. Test assertions: `let log = sink.lock().unwrap(); assert!(log.iter().any(|s| s == "expected"));`
+5. Test exit: both Arc clones drop, sink deallocates.
+
+**No cross-test sharing**: each test constructs its own sink. Two tests running concurrently hold two DIFFERENT `Arc`s pointing at two DIFFERENT `Mutex<Vec<String>>` allocations.
+
+### `record_visit_*` callback family (test-scope fn pointers)
+
+Three near-identical fn pointers, one per test. Each hardcodes the test's own `ReaderId` and dispatches to a shared helper.
+
+```rust
+fn push_visit_to_sink(path: &Path, ctx: &SharedWalkerContext, reader_id: ReaderId) {
+    let Some(sink) = ctx.state::<Mutex<Vec<String>>>(reader_id) else { return };
+    sink.lock().unwrap().push(path.file_name().unwrap().to_string_lossy().into_owned());
+}
+
+fn record_visit_loop(p: &Path, ctx: &SharedWalkerContext) {
+    push_visit_to_sink(p, ctx, ReaderId::new("visitor-loop"));
+}
+fn record_visit_exclude(p: &Path, ctx: &SharedWalkerContext) {
+    push_visit_to_sink(p, ctx, ReaderId::new("visitor-exclude"));
+}
+fn record_visit_noise(p: &Path, ctx: &SharedWalkerContext) {
+    push_visit_to_sink(p, ctx, ReaderId::new("visitor-noise"));
+}
+```
+
+**Why three separate callbacks and not one shared callback**: `FileCallback` is a bare `fn(&Path, &SharedWalkerContext)` pointer (defined at `walk_registry/mod.rs:360`). A callback cannot capture the current reader's id at runtime — the walker's dispatch loop invokes the pointer without passing the reader_id (`dispatch.rs:60`, `on_file(path_ref, ctx_ref)`). So the reader_id must be baked in at compile time via distinct fn pointers.
+
+**Registration → callback binding table** (per-test):
+
+| Test | reader_id | callback | Sink identity |
+|------|-----------|----------|---------------|
+| `walker_survives_symlink_loop` | `"visitor-loop"` | `record_visit_loop` | test-local `Arc` |
+| `walker_respects_exclusion_set` | `"visitor-exclude"` | `record_visit_exclude` | test-local `Arc` |
+| `walker_skips_default_noise_dirs` | `"visitor-noise"` | `record_visit_noise` | test-local `Arc` |
+
+### `ReaderRegistration.state` slot (existing entity, unchanged)
+
+The m664 contract C4 mechanism (`walk_registry/mod.rs:378-385`):
+
+```rust
+pub struct ReaderRegistration {
+    pub reader_id: ReaderId,
+    pub patterns: globset::GlobSet,
+    pub state: Option<Arc<dyn Any + Send + Sync>>,   // ← THE FIX'S EXTENSION POINT
+    pub on_file: Option<FileCallback>,
+    pub on_dir: Option<DirCallback>,
+    pub descend_into: Option<globset::GlobSet>,
+}
+```
+
+**Not modified by this fix.** The tests just populate the `state` field where they previously left it `None`.
+
+### `SharedWalkerContext::state` accessor (existing entity, unchanged)
+
+Type-erased downcast lookup (`walk_context.rs:53-59`):
+
+```rust
+pub fn state<T: 'static>(&self, reader_id: ReaderId) -> Option<&T> {
+    self.registrations
+        .iter()
+        .find(|r| r.reader_id == reader_id)
+        .and_then(|r| r.state.as_ref())
+        .and_then(|arc| arc.downcast_ref::<T>())
+}
+```
+
+**Not modified by this fix.** Test callbacks use it with `T = Mutex<Vec<String>>`. The Arc peels via `downcast_ref` — you get `&Mutex<Vec<String>>` from `Arc<dyn Any>::downcast_ref::<Mutex<Vec<String>>>()`.
+
+## Removed Entities
+
+### `static SEMANTICS_LOG: Mutex<Vec<String>>` (REMOVED)
+
+Was: file-scoped shared mutable state at `walker.rs:477`. Populated by `record_visit` (fn ptr registered by all three tests) and asserted against by each test after clearing it at test-body entry.
+
+**Why removed**: root cause of the flake filed as #720. Three tests calling `.clear()` and `.iter()` on the same static Mutex race each other under cargo's parallel test scheduler.
+
+### `fn record_visit(path, _ctx)` (REMOVED)
+
+Was: single shared callback (`walker.rs:479`) that pushed to `SEMANTICS_LOG`.
+
+**Why removed**: replaced by the per-test `record_visit_*` family (see above).
+
+## Validation Rules
+
+- **V1 — Sink ownership**: each test MUST create its own `VisitSink` via `Arc::new(Mutex::new(Vec::new()))`. Tests MUST NOT reuse sinks across `#[test]` fns. Enforced by code review; violations are visually obvious (a shared `static SINK: VisitSink` would restore the flake).
+- **V2 — Unique reader_id per test**: each test MUST use a reader_id string distinct from the other tests. Reason: the `SharedWalkerContext::state` lookup keys on reader_id, so two tests reusing the same reader_id would produce a scenario where a callback resolves to the WRONG test's sink. Enforced at construction time — if two tests both use `"visitor-loop"`, one test's callback would find the other's sink and write to it, tripping cross-test assertions. Verified by grep for `ReaderId::new("visitor-...")` in the test module.
+- **V3 — Callback fn pointer per test**: each test MUST register a callback fn pointer whose baked-in reader_id matches the test's registration reader_id. Violating this (test A's registration wired to test B's callback) would produce silent no-ops (`ctx.state::<T>(reader_id) = None` because the reader_id doesn't match A's registration). Enforced by the shape of the code — a maintainer would have to actively cross-wire.
+- **V4 — Callback type parameter consistency**: every test's callback MUST call `ctx.state::<Mutex<Vec<String>>>(reader_id)` with the SAME `T`. Reason: the `state` slot stores the sink as `Mutex<Vec<String>>`; downcasting to any other type returns `None`. If the fix pattern generalizes to sinks of other types (e.g., `Mutex<Vec<PathBuf>>`), that would need a separate helper.
+- **V5 — Sink drop-on-exit**: tests MUST NOT `mem::forget` or otherwise leak their sink. The two Arc clones MUST both drop at test-scope exit so cargo can wall-off the tests. Enforced by not calling `mem::forget`.
+
+## State Transitions
+
+Not applicable — the `VisitSink` has one state ("live within a test's stack frame"). Transitions are limited to `Arc::clone` (increments strong count) and `Arc::drop` (decrements).

--- a/specs/666-walker-test-flake-fix/plan.md
+++ b/specs/666-walker-test-flake-fix/plan.md
@@ -1,0 +1,85 @@
+# Implementation Plan: Fix walk_registry test flake
+
+**Branch**: `666-walker-test-flake-fix` | **Date**: 2026-08-26 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/666-walker-test-flake-fix/spec.md`
+
+## Summary
+
+Replace the file-scoped `static SEMANTICS_LOG: Mutex<Vec<String>>` in `waybill-cli/src/scan_fs/walk_registry/walker.rs`'s test module with per-test-owned `Arc<Mutex<Vec<String>>>` sinks threaded through the walker's existing m664 contract C4 state slot (`ReaderRegistration.state: Option<Arc<dyn Any + Send + Sync>>`). Each test creates its own sink on its stack frame, passes an `Arc` clone as the registration's state, and asserts against its own copy of the `Arc` after the walker returns. Result: three tests can run in genuine parallel (cargo default `--test-threads = nproc`) without racing on shared mutable state.
+
+Zero new deps, zero new API surface, single-file change, no golden churn. The fix reuses the same `state` slot every migrated production reader (dart, cocoapods, go_binary, cmake, cargo, ...) already threads its per-scan config through — the pattern is already established; tests just adopt it.
+
+## Technical Context
+
+**Language/Version**: Rust stable (workspace toolchain inherited from milestones 001–665; no nightly required for this user-space test-only fix).
+**Primary Dependencies**: Existing only — `std::sync::{Arc, Mutex}` (stdlib), `ReaderRegistration.state: Option<Arc<dyn Any + Send + Sync>>` (m664 contract C4 slot at `waybill-cli/src/scan_fs/walk_registry/mod.rs:378-385`), `SharedWalkerContext::state::<T>(reader_id) -> Option<&T>` (accessor at `walk_context.rs:53`). **Zero new Cargo dependencies at any layer (production or dev).**
+**Storage**: N/A — per-test in-memory sink dropped at test-scope exit.
+**Testing**: `cargo +stable test -p waybill --test-threads=<N>` for parallelism verification. 100-iteration harness for SC-001 verification (run at implementation time; not shipped as a persistent CI test).
+**Target Platform**: macOS-arm64, Linux-x86_64, Linux-aarch64, Windows-x86_64 (all four release-lane targets). `walker_survives_symlink_loop` remains `#[cfg(unix)]`-gated per pre-fix state.
+**Project Type**: Unit-test-only fix inside the `waybill` binary crate's `#[cfg(test)]` module. Not a feature; not a refactor.
+**Performance Goals**: No runtime perf impact — this is test-only. Test wall-time change should be within statistical noise (each test's setup is unchanged; the sink lookup adds one `HashMap`-scan-then-downcast per file visit, which the m664 SC-005 microbenchmark already covers under production loads).
+**Constraints**: Zero net golden churn (SC-003). Zero pre-existing test regressions (SC-002). Fix survives both `--test-threads=1` (deterministic serial) AND `--test-threads=8` (aggressive parallel), per SC-004.
+**Scale/Scope**: 3 tests refactored. 1 file touched (`walker.rs`). ~30 lines net delta (remove ~5 lines `SEMANTICS_LOG` + `record_visit`; add ~25 lines of per-test sink wiring + 3 per-test callbacks).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+All 12 principles evaluated. Every principle either does not apply to test-only fixes or is satisfied by this fix.
+
+| # | Principle | Applies? | Verdict |
+|---|-----------|----------|---------|
+| I | Pure Rust, Zero C | N/A — test-only, no language-stack changes | PASS |
+| II | eBPF-Only Observation | N/A — no discovery mechanism touched | PASS |
+| III | Fail Closed | N/A — no runtime behavior change | PASS |
+| IV | Type-Driven Correctness | Marginal — the sink type `Arc<Mutex<Vec<String>>>` is not a "domain value" (not a PURL, hash, or license), so Principle IV's newtype-wrapping rule does not apply. Production code's `.unwrap()` ban does not apply to `#[cfg(test)]` blocks (existing precedent: `waybill-cli` crate already `#[cfg_attr(test, allow(clippy::unwrap_used))]` per CLAUDE.md; this fix follows the same convention). | PASS |
+| V | Specification Compliance | N/A — no SBOM emission changes | PASS |
+| VI | Three-Crate Architecture | N/A — no crate structure change | PASS |
+| VII | **Test Isolation** | **HIGH RELEVANCE**. This principle mandates that unit tests "MUST run without elevated privileges in standard CI environments" — implicitly, MUST run reliably (a flaky test that intermittently fails in CI is a violation of "runs" for the purposes of the fast-feedback-loop guarantee). The current `SEMANTICS_LOG` shared static VIOLATES this because the tests intermittently fail under cargo's parallel scheduler. **This fix RESTORES conformance** by making each test's observation state per-test-owned. | PASS (fix restores compliance) |
+| VIII | Completeness | N/A — no SBOM emission | PASS |
+| IX | Accuracy | N/A — no SBOM emission | PASS |
+| X | Transparency | N/A — no SBOM emission | PASS |
+| XI | Enrichment | N/A — no SBOM emission | PASS |
+| XII | External Data Source Enrichment | N/A — no external data sources touched | PASS |
+
+**No constitution violations to justify.** Complexity tracking section stays empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/666-walker-test-flake-fix/
+├── plan.md                        # This file
+├── research.md                    # Phase 0 output — technical decisions
+├── data-model.md                  # Phase 1 output — entity + relationships
+├── contracts/
+│   └── test-visit-sink.md         # Phase 1 output — test-pattern contract
+├── quickstart.md                  # Phase 1 output — "how to add a 4th test"
+├── checklists/
+│   └── requirements.md            # Spec-quality checklist (pre-existing)
+└── tasks.md                       # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+waybill-cli/src/scan_fs/walk_registry/
+├── mod.rs                         # Unchanged. Hosts ReaderRegistration + FileCallback typedef.
+├── walker.rs                      # ← ONLY file touched by this fix.
+│                                  #   Removes: `static SEMANTICS_LOG` (line 477) +
+│                                  #            `fn record_visit` (line 479).
+│                                  #   Adds:    3 per-test sink helpers + 3 per-test callbacks.
+│                                  #   Modifies: 3 `#[test]` fn bodies (loop / exclusion / noise-dirs).
+├── walk_context.rs                # Unchanged. Existing `SharedWalkerContext::state::<T>()` reused verbatim.
+├── registry.rs                    # Unchanged.
+├── dispatch.rs                    # Unchanged.
+├── dir_index.rs                   # Unchanged.
+└── perf_metrics.rs                # Unchanged.
+```
+
+**Structure Decision**: Single-file change in `waybill-cli/src/scan_fs/walk_registry/walker.rs`. No new module. No new file. No `waybill-cli/src/testing/` helper crate. FR-006's constraint on API surface + SC-005's discoverability-in-one-file-read gate both point at same-file changes.
+
+## Complexity Tracking
+
+> No constitution violations to justify. This section is intentionally empty.

--- a/specs/666-walker-test-flake-fix/quickstart.md
+++ b/specs/666-walker-test-flake-fix/quickstart.md
@@ -1,0 +1,154 @@
+# Quickstart: Adding a walk_registry unit test after the flake fix
+
+**Audience**: waybill maintainer writing a new `#[test]` inside `waybill-cli/src/scan_fs/walk_registry/walker.rs` that needs to observe the walker's file-visit callbacks.
+
+## 5-step recipe
+
+### Step 1 — Choose a unique reader_id string
+
+Every existing sink-observing test uses a `"visitor-<slug>"` reader_id. Pick a slug that hasn't been used:
+
+```bash
+grep -oE 'ReaderId::new\("visitor-[^"]+"\)' waybill-cli/src/scan_fs/walk_registry/walker.rs | sort -u
+```
+
+Existing (as of the m666 fix): `visitor-loop`, `visitor-exclude`, `visitor-noise`. Pick `visitor-<your-slug>` where `<your-slug>` names what your test verifies (e.g., `visitor-max-depth` for a max-descent test).
+
+### Step 2 — Add a per-test callback wrapper
+
+Immediately after the existing callback family (right after `fn record_visit_noise`), add:
+
+```rust
+fn record_visit_<your_slug_snake_case>(path: &Path, ctx: &SharedWalkerContext<'_>) {
+    push_visit_to_sink(path, ctx, ReaderId::new("visitor-<your-slug>"));
+}
+```
+
+The `push_visit_to_sink` helper handles the state lookup, downcast, lock, and push.
+
+### Step 3 — Construct a per-test sink in your test body
+
+```rust
+#[test]
+fn walker_verifies_your_property() {
+    let sink: VisitSink = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+    // ... your fixture setup (tempdir, files, symlinks, etc.) ...
+```
+
+The sink lives on the test's stack frame. Cargo's parallel scheduler cannot cause races because each test's sink is a distinct `Arc<Mutex<Vec<String>>>` allocation.
+
+### Step 4 — Wire the walker with the sink threaded via the `state` slot
+
+```rust
+    let registry = ReaderRegistryBuilder::new()
+        .register(ReaderRegistration {
+            reader_id: ReaderId::new("visitor-<your-slug>"),
+            state: Some(sink.clone()),   // Arc<Mutex<Vec<String>>> → Arc<dyn Any + Send + Sync> via CoerceUnsized
+            patterns: globset_from_patterns(&["**/*.marker"]).unwrap(),
+            on_file: Some(record_visit_<your_slug_snake_case>),
+            on_dir: None,
+            descend_into: None,
+        })
+        .build()
+        .unwrap();
+
+    let excludes = ExclusionSet::new_empty();
+    let mut walker = SharedWalker::new(root, &registry, &excludes);
+    walker.run();
+    let _ = walker.finish();
+```
+
+The `sink.clone()` at the `state` field is a cheap Arc increment. The Rust compiler implicitly coerces `Arc<Mutex<Vec<String>>>` to `Arc<dyn Any + Send + Sync>` — no `as ...` needed.
+
+### Step 5 — Assert against your own sink
+
+```rust
+    let log = sink.lock().unwrap();
+    assert!(
+        log.iter().any(|s| s == "expected.marker"),
+        "your assertion; log={:?}",
+        *log,
+    );
+}
+```
+
+That's it. Total ceremony: ~10 new lines including the wrapper fn.
+
+## Verification recipe (implementation-time only)
+
+After adding your test, verify it survives cargo's parallel scheduler by running the 100-iteration loop:
+
+```bash
+for i in $(seq 1 100); do
+  cargo +stable test -p waybill --lib -- \
+      scan_fs::walk_registry::walker::tests::walker_verifies_your_property \
+      --test-threads=8 --nocapture 2>&1 | grep -q "1 passed; 0 failed" || { echo "FAIL at iter $i"; exit 1; }
+done
+echo "PASS: 100 iterations"
+```
+
+Then run the FULL walker test set to confirm your test doesn't accidentally race against a sibling:
+
+```bash
+for i in $(seq 1 100); do
+  cargo +stable test -p waybill --lib -- \
+      scan_fs::walk_registry::walker::tests:: \
+      --test-threads=8 --nocapture 2>&1 | grep "test result: ok" || { echo "FAIL at iter $i"; exit 1; }
+done
+```
+
+## Anti-patterns to avoid
+
+### Don't: reintroduce shared static state
+
+```rust
+// ❌ WRONG — re-creates the exact flake #720 filed
+static SHARED_SINK: Mutex<Vec<String>> = Mutex::new(Vec::new());
+```
+
+Each test MUST own its own sink. The whole point of the fix is that no `static` mutable state exists in the test module.
+
+### Don't: reuse another test's reader_id
+
+```rust
+// ❌ WRONG — silently misroutes state lookup
+#[test]
+fn walker_verifies_your_property() {
+    let sink: VisitSink = Arc::new(Mutex::new(Vec::new()));
+    let registry = ReaderRegistryBuilder::new()
+        .register(ReaderRegistration {
+            reader_id: ReaderId::new("visitor-loop"),  // ← already used by walker_survives_symlink_loop
+            state: Some(sink.clone()),
+            // ...
+        })
+```
+
+If two tests share a reader_id and both run concurrently, the walker's registration slice contains two entries with the same id. `SharedWalkerContext::state::<T>(reader_id)` returns the FIRST match — which may be the wrong test's sink. Silent misrouting. Always use a unique slug (see Step 1).
+
+### Don't: capture the sink in a closure and try to use it as `on_file`
+
+```rust
+// ❌ WRONG — FileCallback is `fn`, not `Fn`
+on_file: Some(|path, ctx| {
+    sink.lock().unwrap().push(...);   // captures `sink` — closures don't fit fn-pointer type
+}),
+```
+
+`FileCallback` is a bare `fn(&Path, &SharedWalkerContext)` pointer (defined at `walk_registry/mod.rs:360`), not a closure trait. Captures aren't allowed. Use the wrapper-fn pattern (Step 2) instead.
+
+### Don't: extract the pattern to a separate `waybill-cli/src/testing/` helper module
+
+The fix deliberately keeps everything in `walker.rs`'s test module (per SC-005 discoverability-in-one-file-read). If a maintainer reading the tests for the first time has to cross-reference an external helper, the pattern's readability drops. Add the ~10-line ceremony inline.
+
+## Reference
+
+- Spec: [`spec.md`](./spec.md)
+- Plan: [`plan.md`](./plan.md)
+- Research: [`research.md`](./research.md)
+- Data model: [`data-model.md`](./data-model.md)
+- Contract: [`contracts/test-visit-sink.md`](./contracts/test-visit-sink.md)
+- Issue: [#720](https://github.com/kusari-oss/waybill/issues/720)
+- m664 contract C4 (state slot) definition: `waybill-cli/src/scan_fs/walk_registry/mod.rs:378-385`
+- `SharedWalkerContext::state::<T>()` accessor: `waybill-cli/src/scan_fs/walk_registry/walk_context.rs:53-59`
+- Production reader precedents using the state slot: `dart.rs:155`, `cocoapods.rs:137`, `go_binary.rs:561`, `cargo.rs:224`, etc.

--- a/specs/666-walker-test-flake-fix/research.md
+++ b/specs/666-walker-test-flake-fix/research.md
@@ -1,0 +1,92 @@
+# Research: Fix walk_registry test flake — Phase 0 outputs
+
+## R1: Fix shape — per-test-owned sink threaded via existing state slot
+
+**Decision**: Each test creates its own `Arc<Mutex<Vec<String>>>` on the test's stack frame. The Arc is passed as `ReaderRegistration.state = Some(sink.clone() as Arc<dyn Any + Send + Sync>)`. Each test's file-callback fn hardcodes its own unique `ReaderId::new("visitor-...")` and looks up the sink via `ctx.state::<Mutex<Vec<String>>>(reader_id)`. Test's post-walker assertions read from its own `Arc` clone (held on the stack).
+
+**Rationale**:
+- **Reuses m664 contract C4 verbatim.** `ReaderRegistration.state: Option<Arc<dyn Any + Send + Sync>>` (defined at `waybill-cli/src/scan_fs/walk_registry/mod.rs:378-385`) and `SharedWalkerContext::state::<T>(reader_id)` (defined at `walk_context.rs:53`) are the exact mechanism every production reader already uses to thread per-scan state through the walker. 10+ production sites (dart, cocoapods, go_binary, cmake, cargo, vcpkg, conan, composer, erlang, scala) grep-verified using this pattern. Tests joining the same pattern makes them discoverable and pattern-consistent with production code.
+- **Genuine parallelism-safe.** Each test owns its own `Arc`; sinks are never shared across tests. Cargo can schedule the three tests concurrently without any race — each writes to its own `Mutex<Vec<String>>`.
+- **Zero API surface change** — satisfies FR-006. The `state` slot type stays `Option<Arc<dyn Any + Send + Sync>>`; nothing added to `ReaderRegistration`, `SharedWalker`, or `SharedWalkerContext`.
+- **Zero new deps** — satisfies FR-005. `Arc`, `Mutex`, `Vec<String>` are stdlib. `Any + Send + Sync` are stdlib traits.
+- **Panic-safe for FR edge-case cleanup**: `Arc<Mutex<Vec<String>>>` on a test's stack frame drops when the test's stack unwinds. If a test panics mid-run, its sink is destroyed with the stack frame; sibling tests observe no residue because they never had a reference to it. (Contrast with `static SEMANTICS_LOG` where a panicking test could leave stale entries visible to sibling tests.)
+
+**Alternatives considered**:
+
+- **File-scoped `SERIALIZE: Mutex<()>` static + retain `SEMANTICS_LOG`.** Fixes the flake by disallowing interleaving. Rejected: violates FR-002 ("MUST NOT rely on serializing the tests via a global lock or by disabling cargo's parallel test execution"). Even a per-file serialize-lock is a global lock at the scope where the race lives; it also slows total wall-time linearly in test count.
+- **`serial_test` crate `#[serial]` attribute.** Standard idiomatic solution. Rejected: adds a dev-dependency the workspace does not currently use (violates FR-005's spirit even in the "test-only dev-dep" carve-out — the crate's Purpose does not stop at m664 walker tests; adopting it globally would be a larger surface). Also violates FR-002 (it's a serialization mechanism, not a genuine-parallelism fix).
+- **mpsc channel-based collector: `let (tx, rx) = mpsc::channel(); ... state: Some(Arc::new(tx))`; test asserts on `rx.iter().collect()`.** Rejected: `mpsc::Sender<T>` is not `Sync` in older Rust versions (though `Sync` since 1.72; usable today). But the Sender-in-Arc requires a wrapper because `Sender` can't be shared across threads even under Arc — you'd need a `Mutex<Sender>` which regresses to the current problem shape (Mutex-guarded shared state, just wrapped differently). Not simpler than the direct Arc-Mutex-Vec approach.
+- **Compile-time isolation via `PhantomData` or lifetimes.** Rejected: static analysis can't distinguish "shared static Vec" from "per-test Vec" without a language-level branding scheme; overengineered for a 3-test surface.
+- **Introduce a small `waybill-cli/src/testing/walker_test_support.rs` module holding the sink helper.** Rejected: violates SC-005 discoverability-in-one-file-read. The 3 tests + their sink type + their record_visit callbacks all fit in ~30 lines of the existing test module; extracting them to a helper file adds indirection for negative value.
+
+## R2: Callback-fn shape — one shared helper + three per-test wrappers
+
+**Decision**: One shared helper `push_visit_to_sink(path, ctx, reader_id)` performs the state lookup + push. Each of the three tests defines a 3-line callback wrapper (`record_visit_loop`, `record_visit_exclude`, `record_visit_noise`) that calls the helper with the test's own `ReaderId`. The wrappers are unavoidable because `FileCallback: fn(&Path, &SharedWalkerContext)` (bare fn pointer — no captures, no per-test binding).
+
+**Rationale**:
+- **`FileCallback` signature is a bare `fn` pointer** (`waybill-cli/src/scan_fs/walk_registry/mod.rs:360`), NOT a `Fn` closure. A closure that captured the reader_id from a test's local scope would violate the type. So the reader_id must be baked into the callback at compile time — via a per-test wrapper fn.
+- **The shared helper factors out the "look up state → downcast → lock → push" logic** so the three wrappers are one-line body each. Total: 3 tests × 1 wrapper × 3 lines = 9 lines of ceremony, plus 4 lines of helper. Readable in one file-scroll.
+- **FR-008 generalization**: adding a 4th test requires copying the 3-line wrapper template + choosing a unique `ReaderId::new(...)`. No new pattern to invent.
+
+**Alternatives considered**:
+
+- **Change `FileCallback` to accept the dispatching reader's `reader_id` as a 3rd param.** Would eliminate per-test wrappers (a single generic `record_visit_via_state(path, ctx, reader_id)` could be the callback for every test). Rejected: violates FR-006 (extends the walker's public API surface with a slot used only by tests). Also would require modifying every existing production reader's callback signature — 20+ sites — for zero production benefit.
+- **Use `std::sync::LazyLock` / thread-local to hold the "current reader_id" during dispatch.** Rejected: adds hidden state to the walker's execution model; violates FR-006 spirit; substantially more complex than three 3-line wrappers.
+
+## R3: Verification methodology — 100-iteration parallel harness
+
+**Decision**: At implementation time (in the PR's development loop), run the three tests in a 100-iteration loop with `--test-threads=8` on macOS-arm64 and Linux-x86_64. Every iteration must show `3 passed / 0 failed`. Command shape:
+
+```bash
+for i in $(seq 1 100); do
+  cargo +stable test -p waybill --lib -- \
+      scan_fs::walk_registry::walker::tests::walker_survives_symlink_loop \
+      scan_fs::walk_registry::walker::tests::walker_respects_exclusion_set \
+      scan_fs::walk_registry::walker::tests::walker_skips_default_noise_dirs \
+      --test-threads=8 --nocapture 2>&1 | grep "test result: ok. 3 passed" || { echo "FAIL at iter $i"; break; }
+done
+```
+
+Pre-fix baseline verification: run the same loop against `main` at commit `dc8018d`. Should observe ≥1 intermittent failure within 100 iterations on macOS-arm64 (basis: the observed flake rate that filed #720).
+
+**Rationale**:
+- **Matches memory `feedback_dont_dismiss_test_failures`**: "verify reproducibility (50x loop + CI history) before calling anything a flake." 100 iterations comfortably exceeds the 50x floor.
+- **Realistic parallelism**: `--test-threads=8` is aggressive enough to force interleaving; too few threads (=1 or =2) mask races. macOS-arm64 CI runners are 3-4 cores; 8 threads yields real preemption.
+- **Loop shape catches "usually passes, occasionally fails"** better than a single run does. Even if the observed CI failure rate is 1-in-20, a 100-iter loop hits the fail with high confidence.
+
+**Alternatives considered**:
+- **Ship the loop as a `#[test] #[ignore]` stress-test in walker.rs, opt-in via `cargo test -- --ignored`.** Adds a durable regression signal but ~50 lines of test-support code that doesn't check any invariant beyond the pattern itself. Rejected as scope creep; if the fix regresses, the flake will surface in normal CI (the fix's whole point is that the tests reliably pass under normal `--test-threads`; a regression would show up on the next PR that runs them).
+- **1000 iterations.** Rejected: 100 is high-enough-confidence per the flake-rate math; 1000 adds ~10× wall-time for no measurable additional confidence.
+
+## R4: Assertion pattern — read via `sink.lock()` on stack-held Arc
+
+**Decision**: After `walker.run()`, each test does `let log = sink.lock().unwrap();` on its own `Arc` clone (held in a test-local `let` binding). Subsequent `assert!(log.iter().any(...))` reads through the guard. Existing assertion phrasing is preserved verbatim except for the `SEMANTICS_LOG.lock().unwrap()` → `sink.lock().unwrap()` swap.
+
+**Rationale**:
+- **Preserves FR-004** ("assertions unchanged"). The three tests' behavioral checks (noise-dir skip, symlink-loop survivability, exclusion-set filtering) are unchanged — only the observation-plumbing changes.
+- **Same `.unwrap()` posture as before.** Test code allowed to `.unwrap()` per `#[cfg_attr(test, allow(clippy::unwrap_used))]` convention (see CLAUDE.md Pre-PR verification section).
+- **Panic-safe**: if `sink.lock()` fails (poisoned mutex from a walker panic mid-callback), the test unwinds and reports the poisoning. Sibling tests unaffected because they hold different Arc identities.
+
+**Alternatives considered**:
+- **Convert `Arc<Mutex<Vec<String>>>` to `Arc<RwLock<Vec<String>>>`.** RwLock allows concurrent read-side lookups but the write-side (callback path) is unchanged. Rejected: no measurable benefit for a Vec that only appends; adds cognitive overhead.
+- **Convert to `Arc<Mutex<HashSet<String>>>` for O(1) `contains` in assertions.** Rejected: the tests use `.iter().any(...)` and `.filter().count()`; assertion cost is not a bottleneck. Set semantics also lose insertion order which two of the three tests could theoretically care about.
+
+## R5: Interaction with `#[cfg(unix)]` guard on `walker_survives_symlink_loop`
+
+**Decision**: The `#[cfg(unix)]` guard on `walker_survives_symlink_loop` is preserved verbatim. On Windows, only two of the three tests compile + run; on Unix, all three. Each test still owns its own sink regardless of platform.
+
+**Rationale**:
+- **The pre-fix `SEMANTICS_LOG` was shared across all three tests regardless of platform** — Windows lanes ran two tests against it; both cleared it before their own runs. Post-fix each test owns its sink; Windows still runs two of them without racing.
+- **No cross-test cleanup dependency**: the pre-fix pattern implicitly relied on each test's `.clear()` at start — a fragile invariant that Windows lanes accidentally honored because only two tests ever touched the log there. Post-fix the pattern is explicit: no shared cleanup needed.
+
+**Alternatives considered**:
+- **Remove the `#[cfg(unix)]` guard and stub out symlinks on Windows.** Out of scope; the guard's existence is orthogonal to the flake fix.
+
+## Constitution re-check post-research
+
+All Phase 0 decisions preserve every principle:
+- **VII (Test Isolation)**: fix RESTORES conformance — tests now run reliably under standard CI parallelism without elevated privileges.
+- **IV (Type-Driven Correctness)**: `.unwrap()` in test code remains permitted per existing convention; no new domain-value newtypes needed for test-visit-log entries.
+- **VI (Three-Crate Architecture)**: zero crate structure change.
+
+No unresolved `NEEDS CLARIFICATION`. Ready to proceed to Phase 1 design.

--- a/specs/666-walker-test-flake-fix/spec.md
+++ b/specs/666-walker-test-flake-fix/spec.md
@@ -1,0 +1,67 @@
+# Feature Specification: Fix walk_registry test flake
+
+**Feature Branch**: `666-walker-test-flake-fix`
+**Created**: 2026-08-26
+**Status**: Draft
+**Input**: User description: "Fix flake in walk_registry tests where shared SEMANTICS_LOG static causes cross-test race (closes issue #720)"
+**Closes**: #720
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Walker unit tests never spuriously fail (Priority: P1)
+
+A waybill maintainer pushes a PR that doesn't touch `waybill-cli/src/scan_fs/walk_registry/`. CI runs against the PR SHA. The three walker unit tests (`walker_survives_symlink_loop`, `walker_respects_exclusion_set`, `walker_skips_default_noise_dirs`) pass deterministically across every lane (linux-x86_64, macos-latest, windows-latest, ebpf lane) regardless of how cargo's parallel test-runner schedules them.
+
+**Why this priority**: This is the sole user story — a flake-fix has exactly one behavior to preserve. Delivering the fix returns the maintainer to a state where a re-run is never needed to distinguish "real regression" from "shared-state race in a test." Every subsequent maintainer avoids the ~5 min debug + re-run tax that #720 observed on PR #719.
+
+**Independent Test**: Run the walker test binary in isolation with `--test-threads=8` (or `nproc` on the CI runner) for **100 consecutive iterations** on both macOS and Linux; every iteration must show `3 passed / 0 failed` for the three affected tests. Pre-fix reproduction: the same loop against `main` at commit `dc8018d` will fail intermittently on macOS-arm64 (memory / CI cost of the observed flake).
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh clone of the repository, **When** the maintainer runs `cargo test -p waybill --test-threads=8 -- walker_survives_symlink_loop walker_respects_exclusion_set walker_skips_default_noise_dirs` 100 times in a row, **Then** every run reports `3 passed; 0 failed`.
+2. **Given** the CI lane matrix on a PR, **When** the walker tests run under whatever parallelism the runner schedules, **Then** the tests never report a "log=[]" or "expected N entries, got 0" style assertion failure caused by shared-state interleaving.
+3. **Given** a maintainer adds a *fourth* walker unit test that uses the same visit-log recording pattern, **When** they follow the pattern established by the fix, **Then** the new test also runs correctly in parallel with the other three (the pattern doesn't require future maintainers to remember a per-test serialization guard).
+
+### Edge Cases
+
+- What happens when the walker's registered `on_file` callback is invoked from multiple worker threads simultaneously (if the walker ever becomes multi-threaded)? The recording mechanism must not silently drop entries or panic in that case.
+- What happens when a test panics mid-run and never restores or clears its recording state? Subsequent tests must not observe stale entries from the panicking test's aborted run.
+- What happens on Windows lanes where `#[cfg(unix)]` guards exclude one of the three tests? The other two must still pass without depending on the excluded third for state cleanup.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The three unit tests `walker_survives_symlink_loop`, `walker_respects_exclusion_set`, and `walker_skips_default_noise_dirs` in `waybill-cli/src/scan_fs/walk_registry/walker.rs` MUST pass deterministically when run in parallel with each other.
+- **FR-002**: The fix MUST NOT rely on serializing the tests via a global lock or by disabling cargo's parallel test execution — the three tests must be able to run genuinely in parallel without racing.
+- **FR-003**: Each test's assertions MUST observe only the file visits produced by its own walker invocation — never entries left over from a sibling test's invocation, nor an empty log because a sibling test called `.clear()` at the wrong moment.
+- **FR-004**: The fix MUST leave the tests' behavioral assertions unchanged (the noise-dir skip logic, the symlink-loop survivability check, and the exclusion-set filter check are all real invariants the tests exist to protect — the fix is scoped to how they observe the walker's output, not to what they check).
+- **FR-005**: The fix MUST NOT add a new production-side dependency to `waybill-cli/Cargo.toml`. Test-only (dev-dep) additions are permitted only if no in-tree alternative exists.
+- **FR-006**: The fix MUST NOT extend the walker's public API surface (`SharedWalker`, `ReaderRegistration`, `SharedWalkerContext`) with new fields or methods used only by tests — if the fix threads test-owned state through the walker, it must use existing extension points (e.g., the `state: Option<Box<dyn Any + Send + Sync>>` slot that `ReaderRegistration` already exposes per m664 contract C4).
+- **FR-007**: The fix MUST leave the walker's runtime behavior byte-identical to pre-fix on non-test code paths — no production emission changes, no golden updates, no dependency-graph changes.
+- **FR-008**: A future maintainer adding a fourth walker unit test with the same visit-recording need MUST be able to follow the established pattern without introducing a new shared-state race — the fix should generalize, not paper over the three specific sites.
+
+### Key Entities
+
+- **`SEMANTICS_LOG` (current)**: file-scoped `static Mutex<Vec<String>>` in `walk_registry/walker.rs`, populated by a `record_visit` callback and asserted against by three tests. The problem entity — removed or replaced by the fix.
+- **Per-test visit log (post-fix shape)**: each test's own visit-recording sink, isolated from sibling tests. Its concrete representation (e.g., a heap-allocated `Vec` threaded through the walker's per-registration `state` slot, a channel-based mpsc collector, a per-test `Arc<Mutex<Vec<String>>>` owned by the test's stack frame) is an implementation choice deferred to the plan phase; the spec constrains only the observable property: no cross-test interference.
+- **The three affected tests**: `walker_survives_symlink_loop` (Unix-only), `walker_respects_exclusion_set`, `walker_skips_default_noise_dirs`. All three follow the same shape (register a walker, run it, assert against a visit log) and receive the same fix.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100 consecutive local test runs (`--test-threads=8`) on macOS-arm64 pass all three walker tests. Pre-fix: fails intermittently at a rate observed to be at least 1 in ~20 CI runs (basis: the observed failure on PR #719's first CI run, which triggered #720).
+- **SC-002**: Zero pre-existing tests regress. The full workspace test-suite passes at the same count as pre-fix (baseline verified on the 666-walker-test-flake-fix branch before implementation begins).
+- **SC-003**: Zero net change to golden files (`waybill-cli/tests/fixtures/golden/**`) — the fix is unit-test-only and does not touch the emission pipeline.
+- **SC-004**: `./scripts/pre-pr.sh` passes without any workaround or `--test-threads=1` fallback. Post-fix, the three walker tests survive parallel scheduling under both the default `nproc` thread count AND `--test-threads=1` (deterministic serial) AND `--test-threads=8` (aggressive parallelism).
+- **SC-005**: A maintainer reading the post-fix code for the first time can identify the visit-recording pattern in one file-read of `walk_registry/walker.rs`'s test module — the pattern is discoverable without cross-referencing a memory, a spec, or a separate helper module. (Verified by: the fix touches only `walk_registry/walker.rs` unless a new pattern requires an accompanying test-support module — in which case that module ships with a clear docblock explaining the isolation guarantee.)
+- **SC-006**: Issue #720 auto-closes on merge via `Closes #720` in the PR body.
+
+## Assumptions
+
+- **Cargo's parallel test runner is the sole source of the observed race**. No other mechanism (e.g., a hypothetical async runtime spawning off the walker's work) contributes to the flake. This matches the root-cause analysis in the issue body and the `dc8018d` code state; a change to the walker's threading model in a future milestone would require re-evaluating.
+- **The three tests' current behavioral assertions are correct**. The fix is scoped to solving the observation-race; if any of the three tests contains a latent logic bug in its walker-invariant check, that bug is out of scope for this feature and files as its own issue.
+- **Local reproduction is achievable on macOS-arm64 or Linux-x86_64 within a 100-iteration loop**. The observed flake rate (at least 1-in-20 on CI macOS-arm64) is high enough that 100 iterations provides high-confidence reproduction pre-fix. If the flake proves harder to reproduce than the issue implies, SC-001's methodology may need to move to a 1000-iteration harness before deciding the fix is verified.
+- **The `state: Option<Box<dyn Any + Send + Sync>>` slot on `ReaderRegistration` is the intended extension mechanism for per-registration test-owned state per m664 contract C4**. If the plan phase determines this slot has a hidden restriction that prevents the natural fix shape, the plan is free to propose an alternative (per-test `Arc<Mutex<Vec<String>>>` owned outside the walker, or an mpsc channel) — but should document why the existing slot didn't fit.
+- **The fix will land as a standalone PR against `main`**, not bundled with unrelated work. The scope is small enough (single file, three tests) that bundling would obscure the fix.

--- a/specs/666-walker-test-flake-fix/tasks.md
+++ b/specs/666-walker-test-flake-fix/tasks.md
@@ -1,0 +1,161 @@
+# Tasks: Fix walk_registry test flake
+
+**Feature Branch**: `666-walker-test-flake-fix`
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Contract**: [contracts/test-visit-sink.md](./contracts/test-visit-sink.md)
+
+## Phase 1: Setup
+
+- [X] T001 Verify baseline `cargo +stable test -p waybill --lib -- scan_fs::walk_registry` passes at the pre-fix count on the freshly-checked-out `666-walker-test-flake-fix` branch. Record the count in this task's completion note. Establishes the SC-002 no-regression anchor. **Verified 2026-08-27**: task's cited command uses `--lib` which yields 0 results because `scan_fs::` code lives in the BIN target (`--lib` scope has only `pub mod parity;` per m013 minimal library). Correct command: `cargo +stable test -p waybill --bin waybill -- scan_fs::walk_registry` → **27 passed / 0 failed / 0 ignored / 3432 filtered out**. All three target tests present + green: `walker_survives_symlink_loop`, `walker_respects_exclusion_set`, `walker_skips_default_noise_dirs`. SC-002 anchor established at 27. (Note: T014's full-walker-suite regression guard also refers to the walker tests — same fix should apply there.)
+- [X] T002 Run the FLAKE REPRODUCTION 100-iteration harness against the pre-fix code to confirm the flake is reproducible locally on macOS-arm64. Command: `for i in $(seq 1 100); do cargo +stable test -p waybill --lib -- scan_fs::walk_registry::walker::tests::walker_survives_symlink_loop scan_fs::walk_registry::walker::tests::walker_respects_exclusion_set scan_fs::walk_registry::walker::tests::walker_skips_default_noise_dirs --test-threads=8 --nocapture 2>&1 | grep -q "test result: ok. 3 passed" || { echo "FAIL at iter $i"; break; }; done`. Expect ≥1 intermittent failure per SC-001 pre-fix rate assumption. If the flake does NOT reproduce in 100 iterations, expand to 500 iterations before assuming the assumption is wrong (per spec assumption #3 fallback). **Attempted 2026-08-27**: same `--lib` → `--bin waybill` correction from T001 applied. Ran 100 iterations `--test-threads=8` → **0 failures**. Ran fallback 500 iterations → **0 failures**. Local macOS-arm64 does NOT reproduce the CI flake at this parallelism. Root-cause analysis: the observed CI failure was likely macos-latest-arm64-CI-scheduler-specific (higher core count, different preemption characteristics vs my dev laptop) OR a rarer race than the 1-in-20 estimate suggested. **Operator decision (2026-08-27)**: proceed with the fix based on theoretical correctness (per-test-owned `Arc<Mutex<Vec<String>>>` is provably race-free by construction — no code path can leak entries between tests). Verification methodology falls back to (a) code-review argument that shared state is eliminated, (b) CI observation post-merge — if the flake reappears, the fix wasn't right. SC-001's local 100-iter target becomes an ADVISORY (achievement not verifiable pre-fix locally) but the theoretical correctness anchor remains.
+
+## Phase 2: Foundational
+
+**None.** This fix is unit-test-only. There are no blocking prerequisites shared across user stories (there is only one user story). Skip directly to Phase 3.
+
+## Phase 3: US1 — Walker unit tests never spuriously fail (Priority: P1) 🎯 MVP
+
+**Goal**: replace the shared `static SEMANTICS_LOG: Mutex<Vec<String>>` with per-test `VisitSink` instances threaded through the walker's m664 contract C4 state slot. Three tests refactored; one file touched.
+
+**Independent Test**: post-fix 100-iteration harness (T012) shows `3 passed / 0 failed` on every iteration on macOS-arm64 AND Linux-x86_64.
+
+### Implementation
+
+- [X] T003 [US1] Add `type VisitSink = std::sync::Arc<std::sync::Mutex<Vec<String>>>` type alias inside `#[cfg(test)] mod tests` in `waybill-cli/src/scan_fs/walk_registry/walker.rs`, immediately after the existing test-mod `use` block. Per data-model.md §"VisitSink". **Done 2026-08-27**: inserted at `walker.rs:404-414` (after the use-block ending at line 402, before the T013 panic-isolation-test comment header at line 416). Type uses fully-qualified `std::sync::Arc<std::sync::Mutex<Vec<String>>>` — self-contained; no dependency on T010 imports at this stage. Rustdoc comment cross-references contracts/test-visit-sink.md (C1-C6). `cargo +stable check -p waybill` → clean.
+- [X] T004 [US1] Add `fn push_visit_to_sink(path: &Path, ctx: &SharedWalkerContext<'_>, reader_id: ReaderId)` helper in the same test mod. Body: `let Some(sink) = ctx.state::<Mutex<Vec<String>>>(reader_id) else { return }; sink.lock().unwrap().push(path.file_name().unwrap().to_string_lossy().into_owned());`. Per data-model.md §"record_visit_* callback family". **Done 2026-08-27**: `push_visit_to_sink` helper inserted at `walker.rs:416-434` immediately after the `VisitSink` alias. `path: &std::path::Path` uses fully-qualified path (avoids depending on any `Path` import). Rustdoc includes the "silent no-op" semantics (state absent → early return without disrupting dispatch loop) per contract C1 cross-reference. `cargo +stable check -p waybill` → clean (3.34s incremental).
+- [X] T005 [US1] Add the three per-test callback wrappers in the same test mod, immediately after `push_visit_to_sink`:
+  - `fn record_visit_loop(p: &Path, ctx: &SharedWalkerContext<'_>) { push_visit_to_sink(p, ctx, ReaderId::new("visitor-loop")); }`
+  - `fn record_visit_exclude(p: &Path, ctx: &SharedWalkerContext<'_>) { push_visit_to_sink(p, ctx, ReaderId::new("visitor-exclude")); }`
+  - `fn record_visit_noise(p: &Path, ctx: &SharedWalkerContext<'_>) { push_visit_to_sink(p, ctx, ReaderId::new("visitor-noise")); }`
+  **Done 2026-08-27**: three wrappers inserted at `walker.rs:436-452` immediately after `push_visit_to_sink`. Each takes `path: &std::path::Path` (fully-qualified, no import dependency) and `ctx: &SharedWalkerContext<'_>`. Rustdoc block above the wrappers explains WHY three near-identical fns instead of one shared callback (the `FileCallback` bare-fn-pointer typedef precludes captures; reader_id must be compile-time-baked). Cross-references contract C3. `cargo +stable check -p waybill` → clean (2.88s incremental).
+- [X] T006 [US1] Refactor `walker_survives_symlink_loop` at `waybill-cli/src/scan_fs/walk_registry/walker.rs:486`:
+  - Remove the `SEMANTICS_LOG.lock().unwrap().clear();` line at the fn body's top.
+  - Add `let sink: VisitSink = Arc::new(Mutex::new(Vec::new()));` immediately after the fn's opening brace.
+  - In the `ReaderRegistration { ... }` literal, change `state: None,` → `state: Some(sink.clone()),` (Rust's `CoerceUnsized` handles the `Arc<Mutex<Vec<String>>>` → `Arc<dyn Any + Send + Sync>` cast at the field-assignment site — no `as ...` needed).
+  - Change `on_file: Some(record_visit)` → `on_file: Some(record_visit_loop)`.
+  - Change the post-run assertion source from `let log = SEMANTICS_LOG.lock().unwrap();` → `let log = sink.lock().unwrap();`. Assertion bodies stay unchanged.
+  **Done 2026-08-27**: all 4 changes applied at `walker.rs:534-570`. Used fully-qualified `std::sync::Arc::new(std::sync::Mutex::new(Vec::new()))` for the sink construction — self-contained; T010 imports still deferred (working fine without local `Arc`/`Mutex` at this scope). Test compiles + runs green: `cargo test --bin waybill -- scan_fs::walk_registry::walker::tests::walker_survives_symlink_loop` → 1 passed / 0 failed / 0.01s. CoerceUnsized works exactly as research R1 predicted.
+- [X] T007 [US1] Refactor `walker_respects_exclusion_set` at `waybill-cli/src/scan_fs/walk_registry/walker.rs:524`: same 4-part transformation as T006 with slug `exclude` (sink construction, `state: Some(sink.clone())`, `on_file: Some(record_visit_exclude)`, `SEMANTICS_LOG.lock()` → `sink.lock()`). **Done 2026-08-27**: applied at `walker.rs:570-611`. Test compiles + passes: 1 passed / 0 failed / 0.01s.
+- [X] T008 [US1] Refactor `walker_skips_default_noise_dirs` at `waybill-cli/src/scan_fs/walk_registry/walker.rs:567`: same transformation with slug `noise` (`state: Some(sink.clone())`, `on_file: Some(record_visit_noise)`, `SEMANTICS_LOG.lock()` → `sink.lock()`). **Done 2026-08-27**: applied at `walker.rs:613-660`. Test compiles + passes: 1 passed / 0 failed / 0.01s.
+- [X] T009 [US1] Remove the now-dead `static SEMANTICS_LOG: Mutex<Vec<String>>` line at `waybill-cli/src/scan_fs/walk_registry/walker.rs:477` and the `fn record_visit(path, _ctx)` at line 479. Post-removal, `grep -c "SEMANTICS_LOG" waybill-cli/src/scan_fs/walk_registry/walker.rs` must return 0. **Done 2026-08-27**: both the `static SEMANTICS_LOG` (was line 523 post-T003-T005 insertions) and the shared `fn record_visit` (was lines 525-530) removed. The T014 section-header comment now includes a two-paragraph explanation of the per-test-sink pattern so a maintainer reading the section header understands WHY the tests below construct their own sinks. `grep -c "SEMANTICS_LOG\|fn record_visit\b"` → **0**. `cargo +stable check -p waybill` → clean (6.62s incremental).
+- [X] T010 [US1] Verify + add imports needed by the new code inside `#[cfg(test)] mod tests` in `waybill-cli/src/scan_fs/walk_registry/walker.rs`. Check current import state with `grep -E '^\s*use.*(Arc|Mutex|ReaderId)' waybill-cli/src/scan_fs/walk_registry/walker.rs`. REQUIRED imports:
+  - `std::sync::{Arc, Mutex}` — for `VisitSink = Arc<Mutex<Vec<String>>>` construction. **Verify presence; add `use std::sync::{Arc, Mutex};` at the top of the test mod if absent.** (Pre-fix state has `Mutex` via `use std::sync::Mutex;` for the static; `Arc` is new to the test mod.)
+  - `ReaderId` — already in scope via the pre-fix test mod's parent `use` chain at the walker.rs module head. **Verify with the grep above; add ONLY if missing.**
+  Do NOT reorder existing imports. Do NOT introduce a `use super::*;` wildcard. **Done 2026-08-27**: (a) `Arc` was NOT imported at test-mod scope pre-T010 (my T003-T008 code used fully-qualified `std::sync::Arc::new(...)` and worked). Extended the existing test-mod import `use std::sync::Mutex;` → `use std::sync::{Arc, Mutex};` (line 396). (b) `ReaderId` already in scope via the test mod's `use crate::scan_fs::walk_registry::{...ReaderId...}` block (line 400) — verified with the grep. Post-import cleanup: simplified 3 verbose sink constructions `std::sync::Arc::new(std::sync::Mutex::new(Vec::new()))` → `Arc::new(Mutex::new(Vec::new()))` at `walker.rs:533,570,613` AND the `VisitSink` type alias `std::sync::Arc<std::sync::Mutex<Vec<String>>>` → `Arc<Mutex<Vec<String>>>`. All 9 walker tests still pass: `cargo test --bin waybill -- scan_fs::walk_registry::walker::tests::` → 9 passed / 0 failed / 0.01s.
+
+### Verification
+
+- [X] T011 [US1] Local per-file compile check: `cargo +stable check -p waybill --lib 2>&1 | tail -5` must show `Finished` with no errors. Establishes the fix at least compiles before the parallelism harness runs. **Done 2026-08-27**: (a) `cargo +stable check -p waybill --lib` → `Finished 'dev' profile in 0.44s`. Note: `--lib` scope is minimal (parity module only); the walker.rs code lives in the BIN target. (b) Ran extended `cargo +stable check -p waybill --bin waybill --all-targets` → `Finished in 1m 30s` (cold build; includes all integration tests). Both scopes compile clean; no errors. Ready for parallelism harnesses.
+- [X] T012 [US1] Local 100-iteration parallelism harness (SC-001 anchor):
+  ```bash
+  for i in $(seq 1 100); do
+    cargo +stable test -p waybill --lib -- \
+        scan_fs::walk_registry::walker::tests::walker_survives_symlink_loop \
+        scan_fs::walk_registry::walker::tests::walker_respects_exclusion_set \
+        scan_fs::walk_registry::walker::tests::walker_skips_default_noise_dirs \
+        --test-threads=8 --nocapture 2>&1 | grep -q "test result: ok. 3 passed" || { echo "FAIL at iter $i"; exit 1; }
+  done
+  echo "PASS: 100 iterations"
+  ```
+  MUST show `PASS: 100 iterations`. Record the wall-time in this task's completion note for the record. **Done 2026-08-27**: `--lib` → `--bin waybill` correction from T001/T002 applied. Ran 100 iterations `--test-threads=8` → **0 failures in 25s wall-time** (warm compile cache, ~0.25s per iter). SC-001 anchor cleared. Caveat: pre-fix baseline (T002) also passed 100/100 + 500/500 locally, so this run confirms the fix doesn't INTRODUCE new failures but doesn't independently prove flake elimination. CI on macos-latest is the authoritative post-fix verification.
+- [X] T013 [US1] Local 100-iteration `--test-threads=1` deterministic-serial check (SC-004 anchor): rerun T012's loop with `--test-threads=1` and confirm same 100/0 result. Verifies the fix doesn't regress the deterministic-serial path (which the pre-fix code trivially passes). **Done 2026-08-27**: 100 iterations `--test-threads=1` → **0 failures in 19s wall-time**. Fix has no `--test-threads=1` regression; SC-004's dual-parallelism-mode guarantee satisfied.
+- [X] T014 [US1] Full walker-test-suite parallel run (regression guard on the sibling `empty_registry_produces_empty_output` test): `for i in $(seq 1 50); do cargo +stable test -p waybill --lib -- scan_fs::walk_registry::walker::tests:: --test-threads=8 2>&1 | grep -q "test result: ok" || { echo "FAIL at iter $i"; exit 1; }; done`. MUST show 50/50 pass. **Done 2026-08-27**: `--lib` → `--bin waybill` correction applied. 50 iterations against the FULL walker suite (all 9 tests × `--test-threads=8`) → **0 failures in 10s wall-time**. Sibling tests (`empty_registry_produces_empty_output`, `panicking_reader_does_not_abort_walker`, `descend_into_absent_preserves_default_behavior`, `descend_into_allows_requesting_reader`, `descend_into_scopes_out_non_requesting_readers`, `sibling_lookup_end_to_end`) unaffected by the m666 changes.
+
+**Checkpoint**: MVP complete. The three tests survive parallel scheduling with 100-iteration confidence; the sibling `empty_registry_produces_empty_output` is unaffected.
+
+## Phase 4: Polish
+
+- [X] T015 Verify FR-005 + FR-006 + SC-005 constraints via two guards: (a) `git diff main..HEAD -- waybill-cli/Cargo.toml Cargo.lock waybill-cli/src/scan_fs/walk_registry/mod.rs waybill-cli/src/scan_fs/walk_registry/walk_context.rs waybill-cli/src/scan_fs/walk_registry/dispatch.rs` MUST produce zero lines (Cargo deps + walker's public API surface unchanged). (b) `grep -cE '(^mod testing|::testing::)' waybill-cli/src/scan_fs/walk_registry/walker.rs` MUST return 0 (SC-005 single-file discoverability — no helper module or cross-file `::testing::` reference introduced). Both guards must pass. **Done 2026-08-27**: (a) `git diff main..HEAD` on Cargo.toml + Cargo.lock + walk_registry/{mod,walk_context,dispatch}.rs → **0 lines**. Zero new deps, zero API surface change. (b) `grep -cE '(^mod testing|::testing::)' walker.rs` → **0**. No helper module, no cross-file `::testing::` reference. FR-005 + FR-006 + SC-005 all satisfied.
+- [X] T016 Verify FR-007 no-runtime-change guard: `git diff main..HEAD -- waybill-cli/src/scan_fs/package_db/ waybill-cli/src/generate/` MUST produce zero lines. No production emission code touched. **Done 2026-08-27**: `git diff main..HEAD -- waybill-cli/src/scan_fs/package_db/ waybill-cli/src/generate/` → **0 lines**. FR-007 byte-identical-runtime constraint satisfied.
+- [X] T017 Verify SC-003 zero-golden-churn: `git diff main..HEAD -- waybill-cli/tests/fixtures/golden/` MUST produce zero lines. **Done 2026-08-27**: `git diff main..HEAD -- waybill-cli/tests/fixtures/golden/` → **0 lines**. Test-only fix — no emission change, no golden churn. SC-003 satisfied.
+- [X] T018 Verify contract C3 reader_id uniqueness (regression guard for future tests): `grep -oE 'ReaderId::new\("visitor-[^"]+"\)' waybill-cli/src/scan_fs/walk_registry/walker.rs | sort | uniq -c | awk '$1 != 2 { exit 1 }'`. Should exit 0. Semantics: each unique reader_id MUST appear exactly 2 times in the file (once in a `ReaderRegistration` literal, once in a `record_visit_*` wrapper fn). With 3 tests × (1 registration + 1 wrapper) = 6 total occurrences of `ReaderId::new("visitor-...")` grouped into 3 lines by `sort | uniq -c`, each line should have count 2. Failure modes the check catches: count 1 = orphaned wrapper or missing wrapper; count ≥3 = two tests sharing a reader_id. **Done 2026-08-27**: grep + sort + uniq -c → `2 ReaderId::new("visitor-exclude")` / `2 ReaderId::new("visitor-loop")` / `2 ReaderId::new("visitor-noise")`. awk `$1 != 2 { exit 1 }` → exit 0. **Contract C3 verified**: all 3 reader_ids appear exactly 2 times, no orphaned wrappers, no cross-test sharing.
+- [X] T019 `cargo +stable clippy -p waybill --all-targets 2>&1 | grep -E "^error|^warning: "` — MUST be empty (no new lints). The `.unwrap()` calls in the test module are guarded by the crate root's `#[cfg_attr(test, allow(clippy::unwrap_used))]`. **Done 2026-08-27**: `cargo +stable clippy -p waybill --all-targets` → grep output is only the pre-existing `proc-macro-error2 v2.0.1` future-incompat notice (identical on main; unrelated to m666). Zero new lints from the fix. Clippy clean under `-D warnings`.
+- [X] T020 Run full pre-PR gate: `./scripts/pre-pr.sh` MUST exit 0 (`>>> all pre-PR checks passed`). This is the CI-equivalent gate (clippy `--all-targets -D warnings` + `cargo test --workspace`). Follow-up: aggregate the workspace-test passed count via `cargo +stable test --workspace 2>&1 | grep "^test result: ok" | awk ...` and verify the count equals T001's baseline + 0 (zero net test additions — this fix modifies 3 existing tests without adding or removing any). Per SC-002. **Done 2026-08-27**: `./scripts/pre-pr.sh` → `>>> all pre-PR checks passed` (exit 0). Follow-up `cargo +stable test --workspace` aggregate → **5192 passed / 0 failed / 14 ignored** — matches the m665 pre-fix baseline exactly (zero net test additions/removals; the fix refactors 3 tests in place). SC-002 no-regression anchor cleared. FR-003 byte-identity preserved.
+- [X] T021 Verify walker-audit gate stays green (memory `feedback_walker_audit_local_check`): `bash --noprofile --norc -c 'STRIP="s/^\([^:]*\):[0-9]*:/\1:/"; EXPECTED=$(grep -v "^#" waybill-cli/src/scan_fs/walk.audit-allowlist.txt | grep -v "^$" | sed "$STRIP" | LC_ALL=C sort -u); LIVE=$(LC_ALL=C grep -rEn --include="*.rs" "fn walk[_(]" waybill-cli/src/scan_fs/ | while IFS=: read -r path line content; do prev=$((line - 1)); if [ "$prev" -ge 1 ]; then prev_line=$(LC_ALL=C sed -n "${prev}p" "$path" 2>/dev/null); case "$prev_line" in *"// walker-audit:"*) continue;; esac; fi; printf "%s:%s:%s\n" "$path" "$line" "$content"; done | sed "$STRIP" | LC_ALL=C sort -u); diff <(echo "$EXPECTED") <(echo "$LIVE") && echo PASS || echo FAIL'. MUST show `PASS`. The fix does not introduce or remove any `fn walk_*` functions. **Done 2026-08-27**: ran under `bash --noprofile --norc -c` per memory `feedback_walker_audit_local_check` → **PASS**. Zero drift from main; the fix touches only test-mod code (removes `fn record_visit` which doesn't match the `fn walk_*` pattern; adds `push_visit_to_sink` + `record_visit_*` which also don't match).
+- [X] T022 Update auto-memory: append a short reference-memory entry at `/Users/mlieberman/.claude/projects/-Users-mlieberman-Projects-mikebom/memory/reference_walker_test_visit_sink_pattern.md` documenting the per-test `VisitSink` pattern (link to `specs/666-walker-test-flake-fix/quickstart.md` for the 5-step recipe, and link to `contracts/test-visit-sink.md` for the C1-C6 contracts). Cross-link from `MEMORY.md` between the existing `feedback_walker_audit_local_check` line and the `reference_no_binary_scan_flag` line. **Done 2026-08-27**: created `reference_walker_test_visit_sink_pattern.md` covering: root cause (shared static log race under cargo parallelism), full pattern (VisitSink alias + push_visit_to_sink helper + per-test wrappers), key constraints (unique reader_id, bare `fn` pointer, CoerceUnsized cast, single-file discoverability), 4 anti-patterns, 3 cross-links ([[m664 registry]], [[EnvGuard]], [[walker-audit gate]]). MEMORY.md index entry appended immediately after the `feedback_walker_audit_local_check` line at line 18.
+- [ ] T023 Commit + open PR against main. PR title: `fix(m666): eliminate walk_registry test flake via per-test VisitSink pattern`. PR body MUST include `Closes #720` to trigger auto-close per SC-006. Body should link to `specs/666-walker-test-flake-fix/spec.md`, `contracts/test-visit-sink.md`, and the 100-iteration T012 verification note.
+
+**Checkpoint**: PR-ready. Full pre-PR gate green, walker-audit clean, memory entry filed, no golden or production-code diff.
+
+## Dependencies
+
+**Sequential chain** (single user story, so linear):
+
+```text
+T001 (baseline test count)
+  ↓
+T002 (reproduce flake pre-fix)
+  ↓
+T003 → T004 → T005    (new entities + helper + wrappers — sequential, same file)
+  ↓
+T006 → T007 → T008    (refactor 3 tests — sequential, same file)
+  ↓
+T009 → T010           (cleanup + imports — sequential, same file)
+  ↓
+T011 (compile check)
+  ↓
+T012 (100-iter harness — SC-001)
+  ↓
+T013 (--test-threads=1 harness — SC-004)
+  ↓
+T014 (full walker suite regression guard)
+  ↓
+T015 → T016 → T017 → T018 → T019 (constraint verification — can run in parallel [P] where noted; all reads no writes)
+  ↓
+T020 (pre-PR gate)
+  ↓
+T021 (walker-audit gate)
+  ↓
+T022 (memory entry — [P] with T023; different files)
+T023 (commit + open PR)
+```
+
+**No cross-story dependencies** — this feature has one user story (US1) so the only phase-crossing dependency is Setup → US1 → Polish.
+
+## Parallel Execution Opportunities
+
+Within a phase, tasks marked `[P]` can run concurrently. Given this is a single-file fix, most tasks touch `walker.rs` and must be sequential. Genuine parallelism opportunities:
+
+**Polish phase (T015-T019)** — all are read-only verification tasks against the working-tree diff:
+```
+T015 [P] (git diff API surface)
+T016 [P] (git diff production code)
+T017 [P] (git diff goldens)
+T018 [P] (grep reader_id uniqueness)
+T019 [P] (clippy)
+```
+
+**Polish phase (T022 + T023)** — memory entry (in `~/.claude/`) and PR opening (in the git repo) touch different filesystems:
+```
+T022 [P] (memory entry)
+T023 [P] (PR open)  — sequential-recommended: land T022 before T023 so the PR body can reference the memory entry
+```
+
+## Implementation Strategy
+
+**MVP scope**: US1 (the only user story). Deliverable = green 100-iteration harness on macOS-arm64.
+
+**Delivery cadence**: single-PR fix. No incremental releases; no follow-up milestones. The scope is exactly the 3 tests refactored.
+
+**Rollback plan**: if the fix regresses any pre-existing test, `git revert` the single commit. No downstream artifacts affected (no goldens, no production code, no memory dependencies).
+
+**Estimated wall-time**:
+- T001-T002 (baseline + flake repro): ~10 min (T002 dominates — 100 iterations × ~1s per compile-cached iter × ~10 fails to observe)
+- T003-T010 (fix implementation): ~30 min (edit + compile-check loop)
+- T011-T014 (verification harnesses): ~15 min (parallelism, 100 + 100 + 50 iter each × ~1s)
+- T015-T021 (constraint checks + pre-PR + walker-audit): ~10 min (T020 dominates — pre-PR is ~5 min on this branch)
+- T022-T023 (memory + PR): ~5 min
+
+**Total**: ~70 min end-to-end for a single-maintainer session.
+
+## Format Validation
+
+All tasks conform to the required checklist format:
+
+- ✅ Checkbox: every task starts with `- [ ]`
+- ✅ Task ID: sequential `T001`-`T023`
+- ✅ `[P]` marker: applied only to genuinely parallelizable tasks
+- ✅ `[US1]` label: applied to every task in Phase 3 (Implementation + Verification)
+- ✅ File paths: every implementation task names the exact file it touches
+- ✅ Description: every task starts with a clear action verb + concrete scope
+
+Total tasks: **23** (2 Setup + 0 Foundational + 12 US1 + 9 Polish).

--- a/waybill-cli/src/scan_fs/walk_registry/walker.rs
+++ b/waybill-cli/src/scan_fs/walk_registry/walker.rs
@@ -393,13 +393,59 @@ mod tests {
     //! lib-exposing every binary-internal module (see `lib.rs` doc-comment).
 
     use std::fs;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
     use crate::scan_fs::package_db::exclude_path::ExclusionSet;
     use crate::scan_fs::walk_registry::{
         globset_from_patterns, ReaderId, ReaderRegistration, ReaderRegistryBuilder,
         SharedWalker, SharedWalkerContext,
     };
+
+    // Milestone 666: per-test observation buffer for walker file-visit
+    // callbacks. Each `#[test]` fn that observes visits constructs its
+    // own instance on its stack frame; two Arc clones exist for the
+    // duration of the walker's run — one held by the test (for post-
+    // run assertions), one held by the `ReaderRegistration.state` slot
+    // (for the walker's callback lookup via `ctx.state::<Mutex<Vec<String>>>`).
+    // Both drop when the test exits. No cross-test sharing, no static
+    // mutable state, no global lock. See `specs/666-walker-test-flake-fix/
+    // contracts/test-visit-sink.md` for the C1-C6 contracts.
+    type VisitSink = Arc<Mutex<Vec<String>>>;
+
+    /// Milestone 666: shared helper called by each test's `record_visit_*`
+    /// wrapper. Fetches the test's own sink from the ReaderRegistration's
+    /// state slot (populated by the test with `Some(sink.clone())`) and
+    /// pushes the visited filename. Silent no-op if the sink is absent
+    /// (reader_id mismatch or downcast failure) — keeps the walker's
+    /// dispatch loop unblocked. See contracts/test-visit-sink.md §C1.
+    fn push_visit_to_sink(
+        path: &std::path::Path,
+        ctx: &SharedWalkerContext<'_>,
+        reader_id: ReaderId,
+    ) {
+        let Some(sink) = ctx.state::<Mutex<Vec<String>>>(reader_id) else {
+            return;
+        };
+        sink.lock()
+            .unwrap()
+            .push(path.file_name().unwrap().to_string_lossy().into_owned());
+    }
+
+    // Per-test callback wrappers. Each hardcodes ITS OWN reader_id at
+    // compile time because `FileCallback` is a bare `fn` pointer (no
+    // captures) and the walker's dispatch loop invokes the pointer
+    // without passing the reader_id (see `dispatch::dispatch_file`).
+    // So the reader_id must be baked in via distinct wrapper fns per
+    // test. See contracts/test-visit-sink.md §C3.
+    fn record_visit_loop(path: &std::path::Path, ctx: &SharedWalkerContext<'_>) {
+        push_visit_to_sink(path, ctx, ReaderId::new("visitor-loop"));
+    }
+    fn record_visit_exclude(path: &std::path::Path, ctx: &SharedWalkerContext<'_>) {
+        push_visit_to_sink(path, ctx, ReaderId::new("visitor-exclude"));
+    }
+    fn record_visit_noise(path: &std::path::Path, ctx: &SharedWalkerContext<'_>) {
+        push_visit_to_sink(path, ctx, ReaderId::new("visitor-noise"));
+    }
 
     // ------------------------------------------------------------
     // T013 — contract C4: reader-callback panic isolation
@@ -472,21 +518,19 @@ mod tests {
 
     // ------------------------------------------------------------
     // T014 — contract C5: safe_walk-equivalent semantics
+    //
+    // Each of the three tests below constructs its own per-test
+    // `VisitSink` (see the type alias + `push_visit_to_sink` helper
+    // above) and threads an Arc clone through `ReaderRegistration.state`
+    // (m664 contract C4 slot). Post-run assertions read from the test's
+    // own Arc — never from a static — so cargo's parallel test-runner
+    // cannot race entries between tests. Milestone 666 (issue #720).
     // ------------------------------------------------------------
-
-    static SEMANTICS_LOG: Mutex<Vec<String>> = Mutex::new(Vec::new());
-
-    fn record_visit(path: &std::path::Path, _ctx: &SharedWalkerContext<'_>) {
-        SEMANTICS_LOG
-            .lock()
-            .unwrap()
-            .push(path.file_name().unwrap().to_string_lossy().into_owned());
-    }
 
     #[test]
     #[cfg(unix)]
     fn walker_survives_symlink_loop() {
-        SEMANTICS_LOG.lock().unwrap().clear();
+        let sink: VisitSink = Arc::new(Mutex::new(Vec::new()));
 
         let tmpdir = tempfile::tempdir().unwrap();
         let root = tmpdir.path();
@@ -498,9 +542,9 @@ mod tests {
         let registry = ReaderRegistryBuilder::new()
             .register(ReaderRegistration {
                 reader_id: ReaderId::new("visitor-loop"),
-                state: None,
+                state: Some(sink.clone()),
                 patterns: globset_from_patterns(&["**/*.marker"]).unwrap(),
-                on_file: Some(record_visit),
+                on_file: Some(record_visit_loop),
                 on_dir: None,
                 descend_into: None,
             })
@@ -512,7 +556,7 @@ mod tests {
         walker.run();
         let _ = walker.finish();
 
-        let log = SEMANTICS_LOG.lock().unwrap();
+        let log = sink.lock().unwrap();
         let visits = log.iter().filter(|s| s.as_str() == "target.marker").count();
         assert_eq!(
             visits, 1,
@@ -523,7 +567,7 @@ mod tests {
 
     #[test]
     fn walker_respects_exclusion_set() {
-        SEMANTICS_LOG.lock().unwrap().clear();
+        let sink: VisitSink = Arc::new(Mutex::new(Vec::new()));
 
         let tmpdir = tempfile::tempdir().unwrap();
         let root = tmpdir.path();
@@ -537,9 +581,9 @@ mod tests {
         let registry = ReaderRegistryBuilder::new()
             .register(ReaderRegistration {
                 reader_id: ReaderId::new("visitor-exclude"),
-                state: None,
+                state: Some(sink.clone()),
                 patterns: globset_from_patterns(&["**/*.marker"]).unwrap(),
-                on_file: Some(record_visit),
+                on_file: Some(record_visit_exclude),
                 on_dir: None,
                 descend_into: None,
             })
@@ -551,7 +595,7 @@ mod tests {
         walker.run();
         let _ = walker.finish();
 
-        let log = SEMANTICS_LOG.lock().unwrap();
+        let log = sink.lock().unwrap();
         assert!(
             !log.iter().any(|s| s == "in_excluded.marker"),
             "excluded contents should not be visited; log={:?}",
@@ -566,7 +610,7 @@ mod tests {
 
     #[test]
     fn walker_skips_default_noise_dirs() {
-        SEMANTICS_LOG.lock().unwrap().clear();
+        let sink: VisitSink = Arc::new(Mutex::new(Vec::new()));
 
         let tmpdir = tempfile::tempdir().unwrap();
         let root = tmpdir.path();
@@ -581,9 +625,9 @@ mod tests {
         let registry = ReaderRegistryBuilder::new()
             .register(ReaderRegistration {
                 reader_id: ReaderId::new("visitor-noise"),
-                state: None,
+                state: Some(sink.clone()),
                 patterns: globset_from_patterns(&["**/*.marker"]).unwrap(),
-                on_file: Some(record_visit),
+                on_file: Some(record_visit_noise),
                 on_dir: None,
                 descend_into: None,
             })
@@ -595,7 +639,7 @@ mod tests {
         walker.run();
         let _ = walker.finish();
 
-        let log = SEMANTICS_LOG.lock().unwrap();
+        let log = sink.lock().unwrap();
         assert!(
             !log.iter().any(|s| s == "in_git.marker"),
             ".git contents should be skipped; log={:?}",


### PR DESCRIPTION
Closes #720

## Summary

Replace the file-scoped \`static SEMANTICS_LOG: Mutex<Vec<String>>\` in \`walk_registry/walker.rs\`'s test module with per-test \`Arc<Mutex<Vec<String>>>\` sinks threaded through the walker's m664 contract C4 state slot. Three tests refactored; cargo can now schedule them genuinely in parallel without racing on shared mutable state.

## Change shape

Each affected \`#[test]\` fn now:

1. Constructs its own \`VisitSink = Arc<Mutex<Vec<String>>>\` on its stack.
2. Passes \`state: Some(sink.clone())\` to \`ReaderRegistration\` (CoerceUnsized handles the \`Arc<T>\` → \`Arc<dyn Any + Send + Sync>\` cast).
3. Uses a per-test \`record_visit_*\` wrapper fn that hardcodes its own \`ReaderId::new("visitor-<slug>")\` at compile time and looks the sink up via \`ctx.state::<Mutex<Vec<String>>>(reader_id)\`.
4. Asserts against its own stack-held \`Arc\` after \`walker.run()\`.

Result: cargo can schedule the three tests genuinely in parallel (\`--test-threads=nproc\`) without racing on shared state. Sibling tests (empty registry, panic isolation, descend_into, sibling lookup) unaffected.

## Design choices

- **Reuses m664 contract C4 verbatim** — no new API surface added to \`SharedWalker\` / \`ReaderRegistration\` / \`SharedWalkerContext\`. The \`state: Option<Arc<dyn Any + Send + Sync>>\` slot already exists and is used by 10+ production readers (dart, cocoapods, go_binary, cargo, cmake, etc.).
- **Zero new dependencies** — 0 lines diff on \`Cargo.toml\` / \`Cargo.lock\`.
- **Zero production code changes** — \`git diff main..HEAD -- package_db/ generate/\` produces 0 lines.
- **Zero golden churn (SC-003)** — 0 lines diff on \`tests/fixtures/golden/\`.
- **Single-file discoverability (SC-005)** — the pattern lives entirely in \`walker.rs\`'s test module; no \`waybill-cli/src/testing/\` helper. A maintainer discovers the pattern in one file-read.

## Verification

- [x] Post-fix 100-iter \`--test-threads=8\` harness → **0 failures in 25s wall-time** (SC-001)
- [x] Post-fix 100-iter \`--test-threads=1\` harness → **0 failures in 19s** (SC-004)
- [x] Post-fix 50-iter full walker suite (all 9 tests × \`--test-threads=8\`) → **0 failures in 10s**
- [x] Workspace-wide \`cargo test --workspace\` → **5192 passed / 0 failed / 14 ignored** — matches the m665 baseline exactly (SC-002)
- [x] \`./scripts/pre-pr.sh\` → \`>>> all pre-PR checks passed\`
- [x] Walker-audit gate (\`bash --noprofile --norc\`) → **PASS** (no new \`fn walk_*\` sites)
- [x] Clippy \`--all-targets -D warnings\` → clean (only the pre-existing proc-macro-error2 future-incompat notice, identical on main)
- [x] Contract C3 reader_id uniqueness → each of the 3 reader_ids appears exactly 2 times (registration + wrapper)

### Verification caveat

**500-iter pre-fix harness on macOS-arm64 could not reproduce the observed CI flake locally.** The observed CI failure on m665 PR #719 (macos-latest lane) was likely arm64-CI-scheduler-specific (higher core count, different preemption vs my laptop) OR a rarer race than the 1-in-20 estimate.

The fix is grounded in **theoretical correctness** (per-test-owned state is race-free by construction — no code path can leak entries between tests) rather than local reproduction. **CI on macos-latest is the authoritative post-fix verification.** If the flake reappears in CI after this merges, the fix wasn't right.

## Files touched

Single production file: \`waybill-cli/src/scan_fs/walk_registry/walker.rs\` (test module only).

Plus:
- \`specs/666-walker-test-flake-fix/\` — spec + plan + research + data-model + contract + quickstart + tasks (8 files)
- \`CLAUDE.md\` — spec-kit auto-updated agent context

## Adding a fourth test in the future

See [\`specs/666-walker-test-flake-fix/quickstart.md\`](../blob/666-walker-test-flake-fix/specs/666-walker-test-flake-fix/quickstart.md) for the 5-step recipe. TL;DR:

1. Pick a unique reader_id slug (\`visitor-<your-slug>\`).
2. Add a 3-line \`record_visit_<your_slug>\` wrapper fn.
3. Construct \`let sink: VisitSink = Arc::new(Mutex::new(Vec::new()));\` in your test.
4. Pass \`state: Some(sink.clone())\` on the ReaderRegistration.
5. Assert against \`sink.lock().unwrap()\` after \`walker.run()\`.

The 6 contracts (C1 isolation, C2 panic safety, C3 reader_id uniqueness, C4 no API surface, C5 zero production, C6 assertion preservation) are at [\`contracts/test-visit-sink.md\`](../blob/666-walker-test-flake-fix/specs/666-walker-test-flake-fix/contracts/test-visit-sink.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)