### PR TITLE
docs(ecosystems): correct npm Dep-graph line to enumerate all 4 lockfiles

### DIFF
--- a/docs/ecosystems.md
+++ b/docs/ecosystems.md
@@ -1051,7 +1051,15 @@ dependency graphs.
 
 **Evidence:** `PackageDatabase` / `manifest-analysis` at 0.85.
 
-**Dep graph:** full tree from `package-lock.json` `packages` entries.
+**Dep graph:** full tree from any of the four supported lockfile
+formats — `package-lock.json` (`packages`-map entries), `pnpm-lock.yaml`
+(m106 + m157 v9 graph fix + m164 multi-version-edges + m180 optional
+tagging), `yarn.lock` (v1 + Berry per m106; m159 alias mapping;
+m181 optional tagging), and `bun.lock` (m106 workspace shape + m667
+`packages`-map metadata + m180 optional tagging). See the per-lockfile
+subsections below for reader-specific detail on scope-atomic key-path
+resolution, m147 issue #262 `<name> <version>` disambiguation, and
+optional-derivation annotations.
 
 **Hashes:** `package-lock.json` `integrity` field (SRI format). Supports
 sha256, sha384, sha512; flows through to CycloneDX `components[].hashes[]`.


### PR DESCRIPTION
## Summary

`docs/ecosystems.md` npm-section "Dep graph" line only referenced `package-lock.json`, under-selling waybill's actual coverage of pnpm-lock, yarn.lock, and bun.lock. Pre-m667 the omission mirrored a real gap for bun.lock (packages-map metadata unread); post-m667 the fix was code-first and this docs line was deliberately left alone per scope discipline (see m667 tasks.md T027-T028 completion notes).

## Change

The under-sale is replaced with an enumeration of all 4 supported lockfile formats plus their milestone provenance:

- `package-lock.json` v2/v3
- `pnpm-lock.yaml` (m106 + m157 v9 graph fix + m164 multi-version-edges + m180 optional)
- `yarn.lock` v1 + Berry (m106 + m159 alias mapping + m181 optional)
- `bun.lock` (m106 workspace shape + m667 `packages`-map metadata + m180 optional)

Cross-references to the per-lockfile subsections below where reader-specific detail lives (scope-atomic key-path resolution, `<name> <version>` disambiguation per m147 #262, optional-derivation annotations).

## Scope discipline

Docs-only. Zero code delta.

- `git diff main -- 'waybill-*/**' Cargo.toml Cargo.lock` → 0 lines
- `git diff main --stat` → 1 file changed under `docs/` (9 additions, 1 deletion)

## Test plan

- [x] `docs/ecosystems.md` renders as valid Markdown (no unclosed formatting)
- [x] Cross-references match existing anchor targets (per-lockfile subsections at lines 1075+, 1102+, 1127+ post-m667)
- [x] No new dead links; every referenced milestone number matches its landing commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)