### PR TITLE
perf(m669): rebaseline harness with --no-deps-dev to isolate code cost

### DIFF
--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -1,661 +1,661 @@
 {
   "schema_version": 1,
   "metadata": {
-    "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
+    "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
     "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
     "runner_uname": "Darwin Michaels-MacBook-Pro.local 25.5.0 arm64",
     "noise_class": "noisy",
-    "started_at": "2026-08-30T22:07:16.277683+00:00",
-    "finished_at": "2026-08-30T22:18:35.955101+00:00",
-    "total_duration_sec": 679
+    "started_at": "2026-08-31T00:52:38.125712+00:00",
+    "finished_at": "2026-08-31T00:58:19.974080+00:00",
+    "total_duration_sec": 341
   },
   "results": [
     {
       "fixture_name": "cargo-workspace-medium",
       "mode": "default",
-      "median_wall_clock_ms": 2306,
-      "max_rss_kb": 20288,
+      "median_wall_clock_ms": 108,
+      "max_rss_kb": 656,
       "output_bytes": 83019,
       "component_count": 41,
       "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        2304,
-        2312,
-        2306,
-        2401,
-        2023
-      ]
-    },
-    {
-      "fixture_name": "cargo-workspace-medium",
-      "mode": "no-deep-hash",
-      "median_wall_clock_ms": 1881,
-      "max_rss_kb": 20736,
-      "output_bytes": 83019,
-      "component_count": 41,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        2093,
-        2034,
-        1773,
-        1814,
-        1881
-      ]
-    },
-    {
-      "fixture_name": "cargo-workspace-medium",
-      "mode": "triple-format",
-      "median_wall_clock_ms": 1705,
-      "max_rss_kb": 20320,
-      "output_bytes": 410473,
-      "component_count": 41,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1761,
-        1715,
-        1609,
-        1598,
-        1705
-      ]
-    },
-    {
-      "fixture_name": "cargo-workspace-medium",
-      "mode": "no-deep-hash-plus-triple-format",
-      "median_wall_clock_ms": 1620,
-      "max_rss_kb": 20752,
-      "output_bytes": 410473,
-      "component_count": 41,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1627,
-        1605,
-        1716,
-        1620,
-        1606
-      ]
-    },
-    {
-      "fixture_name": "npm-monorepo-medium",
-      "mode": "default",
-      "median_wall_clock_ms": 2300,
-      "max_rss_kb": 20032,
-      "output_bytes": 92904,
-      "component_count": 45,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        2663,
-        2300,
-        2392,
-        2134,
-        2148
-      ]
-    },
-    {
-      "fixture_name": "npm-monorepo-medium",
-      "mode": "no-deep-hash",
-      "median_wall_clock_ms": 1875,
-      "max_rss_kb": 19648,
-      "output_bytes": 92904,
-      "component_count": 45,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1905,
-        1885,
-        1773,
-        1875,
-        1873
-      ]
-    },
-    {
-      "fixture_name": "npm-monorepo-medium",
-      "mode": "triple-format",
-      "median_wall_clock_ms": 1698,
-      "max_rss_kb": 19632,
-      "output_bytes": 458816,
-      "component_count": 45,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1815,
-        1695,
-        1701,
-        1651,
-        1698
-      ]
-    },
-    {
-      "fixture_name": "npm-monorepo-medium",
-      "mode": "no-deep-hash-plus-triple-format",
-      "median_wall_clock_ms": 1663,
-      "max_rss_kb": 19584,
-      "output_bytes": 458816,
-      "component_count": 45,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1670,
-        1614,
-        1715,
-        1663,
-        1552
-      ]
-    },
-    {
-      "fixture_name": "pip-poetry-medium",
-      "mode": "default",
-      "median_wall_clock_ms": 1985,
-      "max_rss_kb": 20144,
-      "output_bytes": 82818,
-      "component_count": 36,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        2136,
-        1985,
-        2030,
-        1810,
-        1905
-      ]
-    },
-    {
-      "fixture_name": "pip-poetry-medium",
-      "mode": "no-deep-hash",
-      "median_wall_clock_ms": 1652,
-      "max_rss_kb": 20192,
-      "output_bytes": 82818,
-      "component_count": 36,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1652,
-        1761,
-        1504,
-        1659,
-        1510
-      ]
-    },
-    {
-      "fixture_name": "pip-poetry-medium",
-      "mode": "triple-format",
-      "median_wall_clock_ms": 1499,
-      "max_rss_kb": 20592,
-      "output_bytes": 407146,
-      "component_count": 36,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1560,
-        1499,
-        1489,
-        1555,
-        1395
-      ]
-    },
-    {
-      "fixture_name": "pip-poetry-medium",
-      "mode": "no-deep-hash-plus-triple-format",
-      "median_wall_clock_ms": 1395,
-      "max_rss_kb": 20576,
-      "output_bytes": 407146,
-      "component_count": 36,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1430,
-        1437,
-        1395,
-        1336,
-        1341
-      ]
-    },
-    {
-      "fixture_name": "go-module-medium",
-      "mode": "default",
-      "median_wall_clock_ms": 13462,
-      "max_rss_kb": 22128,
-      "output_bytes": 152160,
-      "component_count": 71,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        13534,
-        12701,
-        15424,
-        13462,
-        12889
-      ]
-    },
-    {
-      "fixture_name": "go-module-medium",
-      "mode": "no-deep-hash",
-      "median_wall_clock_ms": 12851,
-      "max_rss_kb": 21952,
-      "output_bytes": 152160,
-      "component_count": 71,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        12851,
-        12862,
-        12480,
-        12732,
-        13896
-      ]
-    },
-    {
-      "fixture_name": "go-module-medium",
-      "mode": "triple-format",
-      "median_wall_clock_ms": 12470,
-      "max_rss_kb": 22096,
-      "output_bytes": 753606,
-      "component_count": 71,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        12366,
-        12562,
-        12257,
-        14755,
-        12470
-      ]
-    },
-    {
-      "fixture_name": "go-module-medium",
-      "mode": "no-deep-hash-plus-triple-format",
-      "median_wall_clock_ms": 12989,
-      "max_rss_kb": 22176,
-      "output_bytes": 753606,
-      "component_count": 71,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        18465,
-        12989,
-        13592,
-        12470,
-        12574
-      ]
-    },
-    {
-      "fixture_name": "maven-multi-module-medium",
-      "mode": "default",
-      "median_wall_clock_ms": 3317,
-      "max_rss_kb": 20720,
-      "output_bytes": 124355,
-      "component_count": 53,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        3412,
-        3306,
-        3424,
-        3317,
-        3015
-      ]
-    },
-    {
-      "fixture_name": "maven-multi-module-medium",
-      "mode": "no-deep-hash",
-      "median_wall_clock_ms": 2823,
-      "max_rss_kb": 22976,
-      "output_bytes": 124355,
-      "component_count": 53,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        2888,
-        2843,
-        2823,
-        2821,
-        2672
-      ]
-    },
-    {
-      "fixture_name": "maven-multi-module-medium",
-      "mode": "triple-format",
-      "median_wall_clock_ms": 2509,
-      "max_rss_kb": 23504,
-      "output_bytes": 612754,
-      "component_count": 53,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        2567,
-        2509,
-        2453,
-        2576,
-        2403
-      ]
-    },
-    {
-      "fixture_name": "maven-multi-module-medium",
-      "mode": "no-deep-hash-plus-triple-format",
-      "median_wall_clock_ms": 2466,
-      "max_rss_kb": 21168,
-      "output_bytes": 612754,
-      "component_count": 53,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        2466,
-        2213,
-        2484,
-        2307,
-        2518
-      ]
-    },
-    {
-      "fixture_name": "gradle-multi-project-medium",
-      "mode": "default",
-      "median_wall_clock_ms": 3034,
-      "max_rss_kb": 22720,
-      "output_bytes": 127097,
-      "component_count": 47,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        3121,
-        3034,
-        3094,
-        2798,
-        2785
-      ]
-    },
-    {
-      "fixture_name": "gradle-multi-project-medium",
-      "mode": "no-deep-hash",
-      "median_wall_clock_ms": 2397,
-      "max_rss_kb": 22880,
-      "output_bytes": 127097,
-      "component_count": 47,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        2440,
-        2397,
-        2357,
-        2410,
-        2195
-      ]
-    },
-    {
-      "fixture_name": "gradle-multi-project-medium",
-      "mode": "triple-format",
-      "median_wall_clock_ms": 2198,
-      "max_rss_kb": 22720,
-      "output_bytes": 641262,
-      "component_count": 47,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        2198,
-        2324,
-        2477,
-        2152,
-        2139
-      ]
-    },
-    {
-      "fixture_name": "gradle-multi-project-medium",
-      "mode": "no-deep-hash-plus-triple-format",
-      "median_wall_clock_ms": 2136,
-      "max_rss_kb": 22736,
-      "output_bytes": 641262,
-      "component_count": 47,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        2065,
-        2133,
-        2268,
-        2249,
-        2136
-      ]
-    },
-    {
-      "fixture_name": "gem-bundler-small",
-      "mode": "default",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 640,
-      "output_bytes": 57317,
-      "component_count": 35,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        52,
-        55,
-        55,
-        55,
-        55
-      ]
-    },
-    {
-      "fixture_name": "gem-bundler-small",
-      "mode": "no-deep-hash",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 608,
-      "output_bytes": 57317,
-      "component_count": 35,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        55,
-        55,
-        50,
-        55,
-        55
-      ]
-    },
-    {
-      "fixture_name": "gem-bundler-small",
-      "mode": "triple-format",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 656,
-      "output_bytes": 296589,
-      "component_count": 35,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        55,
-        55,
-        55,
-        55,
-        55
-      ]
-    },
-    {
-      "fixture_name": "gem-bundler-small",
-      "mode": "no-deep-hash-plus-triple-format",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 560,
-      "output_bytes": 296589,
-      "component_count": 35,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        55,
-        55,
-        55,
-        55,
-        55
-      ]
-    },
-    {
-      "fixture_name": "nuget-solution-medium",
-      "mode": "default",
-      "median_wall_clock_ms": 1935,
-      "max_rss_kb": 19824,
-      "output_bytes": 73100,
-      "component_count": 41,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        2156,
-        1924,
-        1943,
-        1935,
-        1827
-      ]
-    },
-    {
-      "fixture_name": "nuget-solution-medium",
-      "mode": "no-deep-hash",
-      "median_wall_clock_ms": 1733,
-      "max_rss_kb": 19568,
-      "output_bytes": 73100,
-      "component_count": 41,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1781,
-        1885,
-        1648,
-        1443,
-        1733
-      ]
-    },
-    {
-      "fixture_name": "nuget-solution-medium",
-      "mode": "triple-format",
-      "median_wall_clock_ms": 1492,
-      "max_rss_kb": 19840,
-      "output_bytes": 392486,
-      "component_count": 41,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1509,
-        1612,
-        1457,
-        1409,
-        1492
-      ]
-    },
-    {
-      "fixture_name": "nuget-solution-medium",
-      "mode": "no-deep-hash-plus-triple-format",
-      "median_wall_clock_ms": 1397,
-      "max_rss_kb": 19792,
-      "output_bytes": 392486,
-      "component_count": 41,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1390,
-        1396,
-        1599,
-        1498,
-        1397
-      ]
-    },
-    {
-      "fixture_name": "cmake-project-medium",
-      "mode": "default",
-      "median_wall_clock_ms": 105,
-      "max_rss_kb": 656,
-      "output_bytes": 101070,
-      "component_count": 75,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
       "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
       "raw_samples_ms": [
         110,
-        110,
-        54,
         105,
-        55
+        106,
+        108,
+        110
       ]
     },
     {
-      "fixture_name": "cmake-project-medium",
+      "fixture_name": "cargo-workspace-medium",
       "mode": "no-deep-hash",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 656,
-      "output_bytes": 101070,
-      "component_count": 75,
+      "median_wall_clock_ms": 107,
+      "max_rss_kb": 576,
+      "output_bytes": 83019,
+      "component_count": 41,
       "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
       "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
       "raw_samples_ms": [
-        55,
-        54,
-        55,
-        55,
-        55
+        105,
+        109,
+        110,
+        107,
+        104
       ]
     },
     {
-      "fixture_name": "cmake-project-medium",
+      "fixture_name": "cargo-workspace-medium",
       "mode": "triple-format",
       "median_wall_clock_ms": 108,
-      "max_rss_kb": 640,
-      "output_bytes": 581533,
-      "component_count": 75,
+      "max_rss_kb": 656,
+      "output_bytes": 410473,
+      "component_count": 41,
       "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
       "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
       "raw_samples_ms": [
         108,
         106,
         110,
         110,
+        106
+      ]
+    },
+    {
+      "fixture_name": "cargo-workspace-medium",
+      "mode": "no-deep-hash-plus-triple-format",
+      "median_wall_clock_ms": 110,
+      "max_rss_kb": 608,
+      "output_bytes": 410473,
+      "component_count": 41,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        110,
+        110,
+        108,
+        106,
+        110
+      ]
+    },
+    {
+      "fixture_name": "npm-monorepo-medium",
+      "mode": "default",
+      "median_wall_clock_ms": 52,
+      "max_rss_kb": 608,
+      "output_bytes": 92904,
+      "component_count": 45,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        50,
+        55,
+        55,
+        51,
+        52
+      ]
+    },
+    {
+      "fixture_name": "npm-monorepo-medium",
+      "mode": "no-deep-hash",
+      "median_wall_clock_ms": 54,
+      "max_rss_kb": 656,
+      "output_bytes": 92904,
+      "component_count": 45,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        54,
+        53,
+        53,
+        54,
+        55
+      ]
+    },
+    {
+      "fixture_name": "npm-monorepo-medium",
+      "mode": "triple-format",
+      "median_wall_clock_ms": 52,
+      "max_rss_kb": 640,
+      "output_bytes": 458816,
+      "component_count": 45,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        51,
+        54,
+        50,
+        52,
+        54
+      ]
+    },
+    {
+      "fixture_name": "npm-monorepo-medium",
+      "mode": "no-deep-hash-plus-triple-format",
+      "median_wall_clock_ms": 53,
+      "max_rss_kb": 560,
+      "output_bytes": 458816,
+      "component_count": 45,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        55,
+        53,
+        55,
+        52,
+        53
+      ]
+    },
+    {
+      "fixture_name": "pip-poetry-medium",
+      "mode": "default",
+      "median_wall_clock_ms": 54,
+      "max_rss_kb": 688,
+      "output_bytes": 82818,
+      "component_count": 36,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        55,
+        54,
+        54,
+        51,
+        50
+      ]
+    },
+    {
+      "fixture_name": "pip-poetry-medium",
+      "mode": "no-deep-hash",
+      "median_wall_clock_ms": 53,
+      "max_rss_kb": 608,
+      "output_bytes": 82818,
+      "component_count": 36,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        50,
+        55,
+        50,
+        55,
+        53
+      ]
+    },
+    {
+      "fixture_name": "pip-poetry-medium",
+      "mode": "triple-format",
+      "median_wall_clock_ms": 54,
+      "max_rss_kb": 656,
+      "output_bytes": 407146,
+      "component_count": 36,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        55,
+        51,
+        54,
+        54,
+        51
+      ]
+    },
+    {
+      "fixture_name": "pip-poetry-medium",
+      "mode": "no-deep-hash-plus-triple-format",
+      "median_wall_clock_ms": 54,
+      "max_rss_kb": 656,
+      "output_bytes": 407146,
+      "component_count": 36,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        53,
+        54,
+        55,
+        51,
+        55
+      ]
+    },
+    {
+      "fixture_name": "go-module-medium",
+      "mode": "default",
+      "median_wall_clock_ms": 10142,
+      "max_rss_kb": 22384,
+      "output_bytes": 152160,
+      "component_count": 71,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        10262,
+        10393,
+        10142,
+        9759,
+        9777
+      ]
+    },
+    {
+      "fixture_name": "go-module-medium",
+      "mode": "no-deep-hash",
+      "median_wall_clock_ms": 10711,
+      "max_rss_kb": 21136,
+      "output_bytes": 152160,
+      "component_count": 71,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        11870,
+        10500,
+        10476,
+        12564,
+        10711
+      ]
+    },
+    {
+      "fixture_name": "go-module-medium",
+      "mode": "triple-format",
+      "median_wall_clock_ms": 10905,
+      "max_rss_kb": 21152,
+      "output_bytes": 753606,
+      "component_count": 71,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        10508,
+        10961,
+        10277,
+        11328,
+        10905
+      ]
+    },
+    {
+      "fixture_name": "go-module-medium",
+      "mode": "no-deep-hash-plus-triple-format",
+      "median_wall_clock_ms": 11024,
+      "max_rss_kb": 21216,
+      "output_bytes": 753606,
+      "component_count": 71,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        11024,
+        11036,
+        11648,
+        10904,
+        11006
+      ]
+    },
+    {
+      "fixture_name": "maven-multi-module-medium",
+      "mode": "default",
+      "median_wall_clock_ms": 105,
+      "max_rss_kb": 608,
+      "output_bytes": 124355,
+      "component_count": 53,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        105,
+        102,
+        106,
+        105,
+        103
+      ]
+    },
+    {
+      "fixture_name": "maven-multi-module-medium",
+      "mode": "no-deep-hash",
+      "median_wall_clock_ms": 106,
+      "max_rss_kb": 656,
+      "output_bytes": 124355,
+      "component_count": 53,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        106,
+        107,
+        104,
+        101,
+        110
+      ]
+    },
+    {
+      "fixture_name": "maven-multi-module-medium",
+      "mode": "triple-format",
+      "median_wall_clock_ms": 106,
+      "max_rss_kb": 464,
+      "output_bytes": 612754,
+      "component_count": 53,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        107,
+        103,
+        106,
+        102,
+        106
+      ]
+    },
+    {
+      "fixture_name": "maven-multi-module-medium",
+      "mode": "no-deep-hash-plus-triple-format",
+      "median_wall_clock_ms": 107,
+      "max_rss_kb": 464,
+      "output_bytes": 612754,
+      "component_count": 53,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        108,
+        107,
+        105,
+        103,
         107
+      ]
+    },
+    {
+      "fixture_name": "gradle-multi-project-medium",
+      "mode": "default",
+      "median_wall_clock_ms": 105,
+      "max_rss_kb": 736,
+      "output_bytes": 127097,
+      "component_count": 47,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        105,
+        110,
+        109,
+        103,
+        102
+      ]
+    },
+    {
+      "fixture_name": "gradle-multi-project-medium",
+      "mode": "no-deep-hash",
+      "median_wall_clock_ms": 106,
+      "max_rss_kb": 656,
+      "output_bytes": 127097,
+      "component_count": 47,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        106,
+        101,
+        110,
+        103,
+        106
+      ]
+    },
+    {
+      "fixture_name": "gradle-multi-project-medium",
+      "mode": "triple-format",
+      "median_wall_clock_ms": 105,
+      "max_rss_kb": 19920,
+      "output_bytes": 641262,
+      "component_count": 47,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        105,
+        104,
+        103,
+        155,
+        105
+      ]
+    },
+    {
+      "fixture_name": "gradle-multi-project-medium",
+      "mode": "no-deep-hash-plus-triple-format",
+      "median_wall_clock_ms": 108,
+      "max_rss_kb": 640,
+      "output_bytes": 641262,
+      "component_count": 47,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        109,
+        108,
+        106,
+        103,
+        110
+      ]
+    },
+    {
+      "fixture_name": "gem-bundler-small",
+      "mode": "default",
+      "median_wall_clock_ms": 105,
+      "max_rss_kb": 608,
+      "output_bytes": 57317,
+      "component_count": 35,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        55,
+        102,
+        109,
+        105,
+        107
+      ]
+    },
+    {
+      "fixture_name": "gem-bundler-small",
+      "mode": "no-deep-hash",
+      "median_wall_clock_ms": 103,
+      "max_rss_kb": 640,
+      "output_bytes": 57317,
+      "component_count": 35,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        103,
+        55,
+        101,
+        106,
+        103
+      ]
+    },
+    {
+      "fixture_name": "gem-bundler-small",
+      "mode": "triple-format",
+      "median_wall_clock_ms": 104,
+      "max_rss_kb": 576,
+      "output_bytes": 296589,
+      "component_count": 35,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        109,
+        55,
+        107,
+        55,
+        104
+      ]
+    },
+    {
+      "fixture_name": "gem-bundler-small",
+      "mode": "no-deep-hash-plus-triple-format",
+      "median_wall_clock_ms": 108,
+      "max_rss_kb": 656,
+      "output_bytes": 296589,
+      "component_count": 35,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        110,
+        106,
+        108,
+        103,
+        110
+      ]
+    },
+    {
+      "fixture_name": "nuget-solution-medium",
+      "mode": "default",
+      "median_wall_clock_ms": 55,
+      "max_rss_kb": 656,
+      "output_bytes": 73100,
+      "component_count": 41,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        55,
+        55,
+        54,
+        55,
+        54
+      ]
+    },
+    {
+      "fixture_name": "nuget-solution-medium",
+      "mode": "no-deep-hash",
+      "median_wall_clock_ms": 55,
+      "max_rss_kb": 640,
+      "output_bytes": 73100,
+      "component_count": 41,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        55,
+        52,
+        55,
+        55,
+        54
+      ]
+    },
+    {
+      "fixture_name": "nuget-solution-medium",
+      "mode": "triple-format",
+      "median_wall_clock_ms": 55,
+      "max_rss_kb": 624,
+      "output_bytes": 392486,
+      "component_count": 41,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        55,
+        55,
+        51,
+        55,
+        55
+      ]
+    },
+    {
+      "fixture_name": "nuget-solution-medium",
+      "mode": "no-deep-hash-plus-triple-format",
+      "median_wall_clock_ms": 54,
+      "max_rss_kb": 656,
+      "output_bytes": 392486,
+      "component_count": 41,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        51,
+        50,
+        55,
+        54,
+        55
+      ]
+    },
+    {
+      "fixture_name": "cmake-project-medium",
+      "mode": "default",
+      "median_wall_clock_ms": 110,
+      "max_rss_kb": 656,
+      "output_bytes": 101070,
+      "component_count": 75,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        101,
+        108,
+        110,
+        110,
+        110
+      ]
+    },
+    {
+      "fixture_name": "cmake-project-medium",
+      "mode": "no-deep-hash",
+      "median_wall_clock_ms": 108,
+      "max_rss_kb": 640,
+      "output_bytes": 101070,
+      "component_count": 75,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        110,
+        108,
+        104,
+        105,
+        109
+      ]
+    },
+    {
+      "fixture_name": "cmake-project-medium",
+      "mode": "triple-format",
+      "median_wall_clock_ms": 107,
+      "max_rss_kb": 656,
+      "output_bytes": 581533,
+      "component_count": 75,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        109,
+        107,
+        107,
+        102,
+        109
       ]
     },
     {
       "fixture_name": "cmake-project-medium",
       "mode": "no-deep-hash-plus-triple-format",
-      "median_wall_clock_ms": 105,
-      "max_rss_kb": 656,
+      "median_wall_clock_ms": 109,
+      "max_rss_kb": 640,
       "output_bytes": 581533,
       "component_count": 75,
       "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
       "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
       "raw_samples_ms": [
+        104,
+        102,
         110,
-        110,
-        55,
-        105,
-        55
+        109,
+        110
       ]
     },
     {
@@ -666,7 +666,7 @@
       "output_bytes": 0,
       "component_count": 0,
       "exit_status": "corpus-unreachable",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
       "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
       "raw_samples_ms": [
         0,
@@ -679,33 +679,195 @@
     {
       "fixture_name": "bazel-monorepo-medium",
       "mode": "default",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 608,
+      "median_wall_clock_ms": 54,
+      "max_rss_kb": 640,
       "output_bytes": 47058,
       "component_count": 33,
       "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
       "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
       "raw_samples_ms": [
+        51,
         55,
         55,
-        55,
-        55,
-        55
+        54,
+        50
       ]
     },
     {
       "fixture_name": "bazel-monorepo-medium",
       "mode": "no-deep-hash",
       "median_wall_clock_ms": 55,
-      "max_rss_kb": 592,
+      "max_rss_kb": 672,
       "output_bytes": 47058,
       "component_count": 33,
       "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        52,
+        55,
+        54,
+        55,
+        55
+      ]
+    },
+    {
+      "fixture_name": "bazel-monorepo-medium",
+      "mode": "triple-format",
+      "median_wall_clock_ms": 55,
+      "max_rss_kb": 672,
+      "output_bytes": 268735,
+      "component_count": 33,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        55,
+        54,
+        55,
+        55,
+        50
+      ]
+    },
+    {
+      "fixture_name": "bazel-monorepo-medium",
+      "mode": "no-deep-hash-plus-triple-format",
+      "median_wall_clock_ms": 55,
+      "max_rss_kb": 656,
+      "output_bytes": 268735,
+      "component_count": 33,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        54,
+        55,
+        55,
+        51,
+        55
+      ]
+    },
+    {
+      "fixture_name": "conan-project-medium",
+      "mode": "default",
+      "median_wall_clock_ms": 55,
+      "max_rss_kb": 640,
+      "output_bytes": 53499,
+      "component_count": 38,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        55,
+        53,
+        55,
+        55,
+        51
+      ]
+    },
+    {
+      "fixture_name": "conan-project-medium",
+      "mode": "no-deep-hash",
+      "median_wall_clock_ms": 54,
+      "max_rss_kb": 656,
+      "output_bytes": 53499,
+      "component_count": 38,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
       "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
       "raw_samples_ms": [
         53,
+        54,
+        55,
+        55,
+        50
+      ]
+    },
+    {
+      "fixture_name": "conan-project-medium",
+      "mode": "triple-format",
+      "median_wall_clock_ms": 55,
+      "max_rss_kb": 640,
+      "output_bytes": 306588,
+      "component_count": 38,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        55,
+        54,
+        53,
+        55,
+        55
+      ]
+    },
+    {
+      "fixture_name": "conan-project-medium",
+      "mode": "no-deep-hash-plus-triple-format",
+      "median_wall_clock_ms": 54,
+      "max_rss_kb": 640,
+      "output_bytes": 306588,
+      "component_count": 38,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        51,
+        54,
+        51,
+        54,
+        55
+      ]
+    },
+    {
+      "fixture_name": "conan-project-medium",
+      "mode": "fingerprints-corpus",
+      "median_wall_clock_ms": 0,
+      "max_rss_kb": 0,
+      "output_bytes": 0,
+      "component_count": 0,
+      "exit_status": "corpus-unreachable",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        0,
+        0,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "fixture_name": "vcpkg-project-medium",
+      "mode": "default",
+      "median_wall_clock_ms": 55,
+      "max_rss_kb": 624,
+      "output_bytes": 105399,
+      "component_count": 79,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        55,
+        54,
+        55,
+        55,
+        55
+      ]
+    },
+    {
+      "fixture_name": "vcpkg-project-medium",
+      "mode": "no-deep-hash",
+      "median_wall_clock_ms": 55,
+      "max_rss_kb": 640,
+      "output_bytes": 105399,
+      "component_count": 79,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        55,
         51,
         55,
         55,
@@ -713,309 +875,147 @@
       ]
     },
     {
-      "fixture_name": "bazel-monorepo-medium",
+      "fixture_name": "vcpkg-project-medium",
       "mode": "triple-format",
       "median_wall_clock_ms": 55,
-      "max_rss_kb": 656,
-      "output_bytes": 268735,
-      "component_count": 33,
+      "max_rss_kb": 640,
+      "output_bytes": 599466,
+      "component_count": 79,
       "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
       "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
       "raw_samples_ms": [
+        55,
+        55,
+        55,
         50,
+        55
+      ]
+    },
+    {
+      "fixture_name": "vcpkg-project-medium",
+      "mode": "no-deep-hash-plus-triple-format",
+      "median_wall_clock_ms": 53,
+      "max_rss_kb": 656,
+      "output_bytes": 599466,
+      "component_count": 79,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
         55,
+        51,
+        53,
         55,
+        50
+      ]
+    },
+    {
+      "fixture_name": "vcpkg-project-medium",
+      "mode": "fingerprints-corpus",
+      "median_wall_clock_ms": 0,
+      "max_rss_kb": 0,
+      "output_bytes": 0,
+      "component_count": 0,
+      "exit_status": "corpus-unreachable",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        0,
+        0,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "fixture_name": "debian-slim",
+      "mode": "default",
+      "median_wall_clock_ms": 1993,
+      "max_rss_kb": 160736,
+      "output_bytes": 1262187,
+      "component_count": 358,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        1914,
+        1862,
+        2070,
+        2031,
+        1993
+      ]
+    },
+    {
+      "fixture_name": "debian-slim",
+      "mode": "no-deep-hash",
+      "median_wall_clock_ms": 1866,
+      "max_rss_kb": 152928,
+      "output_bytes": 1288046,
+      "component_count": 922,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        1984,
+        2008,
+        1866,
+        1841,
+        1829
+      ]
+    },
+    {
+      "fixture_name": "debian-slim",
+      "mode": "triple-format",
+      "median_wall_clock_ms": 1884,
+      "max_rss_kb": 164752,
+      "output_bytes": 4410305,
+      "component_count": 358,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        1907,
+        1881,
+        1881,
+        1888,
+        1884
+      ]
+    },
+    {
+      "fixture_name": "linux-binaries-50",
+      "mode": "default",
+      "median_wall_clock_ms": 52,
+      "max_rss_kb": 608,
+      "output_bytes": 139695,
+      "component_count": 61,
+      "exit_status": "success",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
+      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
+      "raw_samples_ms": [
+        53,
+        50,
+        51,
         55,
         52
       ]
     },
     {
-      "fixture_name": "bazel-monorepo-medium",
-      "mode": "no-deep-hash-plus-triple-format",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 608,
-      "output_bytes": 268735,
-      "component_count": 33,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        55,
-        55,
-        55,
-        55,
-        55
-      ]
-    },
-    {
-      "fixture_name": "conan-project-medium",
-      "mode": "default",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 592,
-      "output_bytes": 53499,
-      "component_count": 38,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        54,
-        55,
-        55,
-        55,
-        55
-      ]
-    },
-    {
-      "fixture_name": "conan-project-medium",
-      "mode": "no-deep-hash",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 528,
-      "output_bytes": 53499,
-      "component_count": 38,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        50,
-        55,
-        55,
-        55,
-        55
-      ]
-    },
-    {
-      "fixture_name": "conan-project-medium",
-      "mode": "triple-format",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 656,
-      "output_bytes": 306588,
-      "component_count": 38,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        55,
-        55,
-        55,
-        55,
-        55
-      ]
-    },
-    {
-      "fixture_name": "conan-project-medium",
-      "mode": "no-deep-hash-plus-triple-format",
-      "median_wall_clock_ms": 52,
-      "max_rss_kb": 656,
-      "output_bytes": 306588,
-      "component_count": 38,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        52,
-        50,
-        50,
-        55,
-        55
-      ]
-    },
-    {
-      "fixture_name": "conan-project-medium",
-      "mode": "fingerprints-corpus",
-      "median_wall_clock_ms": 0,
-      "max_rss_kb": 0,
-      "output_bytes": 0,
-      "component_count": 0,
-      "exit_status": "corpus-unreachable",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        0,
-        0,
-        0,
-        0,
-        0
-      ]
-    },
-    {
-      "fixture_name": "vcpkg-project-medium",
-      "mode": "default",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 560,
-      "output_bytes": 105399,
-      "component_count": 79,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        55,
-        55,
-        55,
-        55,
-        55
-      ]
-    },
-    {
-      "fixture_name": "vcpkg-project-medium",
-      "mode": "no-deep-hash",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 656,
-      "output_bytes": 105399,
-      "component_count": 79,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        55,
-        54,
-        55,
-        55,
-        55
-      ]
-    },
-    {
-      "fixture_name": "vcpkg-project-medium",
-      "mode": "triple-format",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 608,
-      "output_bytes": 599466,
-      "component_count": 79,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        55,
-        55,
-        55,
-        55,
-        55
-      ]
-    },
-    {
-      "fixture_name": "vcpkg-project-medium",
-      "mode": "no-deep-hash-plus-triple-format",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 608,
-      "output_bytes": 599466,
-      "component_count": 79,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        55,
-        55,
-        55,
-        55,
-        55
-      ]
-    },
-    {
-      "fixture_name": "vcpkg-project-medium",
-      "mode": "fingerprints-corpus",
-      "median_wall_clock_ms": 0,
-      "max_rss_kb": 0,
-      "output_bytes": 0,
-      "component_count": 0,
-      "exit_status": "corpus-unreachable",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        0,
-        0,
-        0,
-        0,
-        0
-      ]
-    },
-    {
-      "fixture_name": "debian-slim",
-      "mode": "default",
-      "median_wall_clock_ms": 1741,
-      "max_rss_kb": 158432,
-      "output_bytes": 1262187,
-      "component_count": 358,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1797,
-        1737,
-        1748,
-        1741,
-        1705
-      ]
-    },
-    {
-      "fixture_name": "debian-slim",
-      "mode": "no-deep-hash",
-      "median_wall_clock_ms": 1646,
-      "max_rss_kb": 160032,
-      "output_bytes": 1288046,
-      "component_count": 922,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1646,
-        1628,
-        1639,
-        1648,
-        1650
-      ]
-    },
-    {
-      "fixture_name": "debian-slim",
-      "mode": "triple-format",
-      "median_wall_clock_ms": 1742,
-      "max_rss_kb": 163888,
-      "output_bytes": 4410305,
-      "component_count": 358,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        1698,
-        1751,
-        1742,
-        1747,
-        1740
-      ]
-    },
-    {
       "fixture_name": "linux-binaries-50",
-      "mode": "default",
+      "mode": "no-deep-hash",
       "median_wall_clock_ms": 55,
-      "max_rss_kb": 608,
+      "max_rss_kb": 656,
       "output_bytes": 139695,
       "component_count": 61,
       "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
       "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
       "raw_samples_ms": [
         55,
         55,
         55,
-        50,
-        55
-      ]
-    },
-    {
-      "fixture_name": "linux-binaries-50",
-      "mode": "no-deep-hash",
-      "median_wall_clock_ms": 55,
-      "max_rss_kb": 624,
-      "output_bytes": 139695,
-      "component_count": 61,
-      "exit_status": "success",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
-      "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
-      "raw_samples_ms": [
-        52,
-        55,
-        55,
-        55,
-        51
+        53,
+        50
       ]
     },
     {
@@ -1026,7 +1026,7 @@
       "output_bytes": 0,
       "component_count": 0,
       "exit_status": "corpus-unreachable",
-      "waybill_commit_sha": "2da78461e3f5271398ebc759f15a461cf9128718",
+      "waybill_commit_sha": "d5bffeb6e5613df9e69933c8c1506ed513f5d11c",
       "fixture_sha": "891f63429480554cd2fedd48de8e5c0bdd6ba943",
       "raw_samples_ms": [
         0,

--- a/docs/perf/numbers.md
+++ b/docs/perf/numbers.md
@@ -2,10 +2,10 @@
 
 Generated from `docs/perf/baseline.json` captured at:
 
-- **waybill commit**: `2da78461e3f5271398ebc759f15a461cf9128718`
+- **waybill commit**: `d5bffeb6e5613df9e69933c8c1506ed513f5d11c`
 - **fixtures pin**: `891f63429480554cd2fedd48de8e5c0bdd6ba943`
 - **runner**: `Darwin Michaels-MacBook-Pro.local 25.5.0 arm64` (noise class: `Noisy`)
-- **duration**: 679s
+- **duration**: 341s
 - **schema version**: 1
 
 ## Reference architecture
@@ -20,131 +20,131 @@ macOS runners (m094 noise-class = `Noisy`).
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 55 | 608 | 47058 | 33 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 55 | 592 | 47058 | 33 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash-plus-triple-format` | 55 | 608 | 268735 | 33 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `triple-format` | 55 | 656 | 268735 | 33 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 54 | 640 | 47058 | 33 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 55 | 672 | 47058 | 33 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash-plus-triple-format` | 55 | 656 | 268735 | 33 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `triple-format` | 55 | 672 | 268735 | 33 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ## `cargo-workspace-medium`
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 2306 | 20288 | 83019 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 1881 | 20736 | 83019 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash-plus-triple-format` | 1620 | 20752 | 410473 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `triple-format` | 1705 | 20320 | 410473 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 108 | 656 | 83019 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 107 | 576 | 83019 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash-plus-triple-format` | 110 | 608 | 410473 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `triple-format` | 108 | 656 | 410473 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ## `cmake-project-medium`
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 105 | 656 | 101070 | 75 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `fingerprints-corpus` | 0 | 0 | 0 | 0 | corpus-unreachable | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 55 | 656 | 101070 | 75 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash-plus-triple-format` | 105 | 656 | 581533 | 75 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `triple-format` | 108 | 640 | 581533 | 75 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 110 | 656 | 101070 | 75 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `fingerprints-corpus` | 0 | 0 | 0 | 0 | corpus-unreachable | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 108 | 640 | 101070 | 75 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash-plus-triple-format` | 109 | 640 | 581533 | 75 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `triple-format` | 107 | 656 | 581533 | 75 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ## `conan-project-medium`
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 55 | 592 | 53499 | 38 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `fingerprints-corpus` | 0 | 0 | 0 | 0 | corpus-unreachable | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 55 | 528 | 53499 | 38 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash-plus-triple-format` | 52 | 656 | 306588 | 38 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `triple-format` | 55 | 656 | 306588 | 38 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 55 | 640 | 53499 | 38 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `fingerprints-corpus` | 0 | 0 | 0 | 0 | corpus-unreachable | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 54 | 656 | 53499 | 38 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash-plus-triple-format` | 54 | 640 | 306588 | 38 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `triple-format` | 55 | 640 | 306588 | 38 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ## `debian-slim`
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 1741 | 158432 | 1262187 | 358 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 1646 | 160032 | 1288046 | 922 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `triple-format` | 1742 | 163888 | 4410305 | 358 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 1993 | 160736 | 1262187 | 358 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 1866 | 152928 | 1288046 | 922 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `triple-format` | 1884 | 164752 | 4410305 | 358 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ## `gem-bundler-small`
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 55 | 640 | 57317 | 35 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 55 | 608 | 57317 | 35 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash-plus-triple-format` | 55 | 560 | 296589 | 35 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `triple-format` | 55 | 656 | 296589 | 35 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 105 | 608 | 57317 | 35 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 103 | 640 | 57317 | 35 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash-plus-triple-format` | 108 | 656 | 296589 | 35 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `triple-format` | 104 | 576 | 296589 | 35 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ## `go-module-medium`
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 13462 | 22128 | 152160 | 71 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 12851 | 21952 | 152160 | 71 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash-plus-triple-format` | 12989 | 22176 | 753606 | 71 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `triple-format` | 12470 | 22096 | 753606 | 71 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 10142 | 22384 | 152160 | 71 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 10711 | 21136 | 152160 | 71 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash-plus-triple-format` | 11024 | 21216 | 753606 | 71 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `triple-format` | 10905 | 21152 | 753606 | 71 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ## `gradle-multi-project-medium`
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 3034 | 22720 | 127097 | 47 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 2397 | 22880 | 127097 | 47 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash-plus-triple-format` | 2136 | 22736 | 641262 | 47 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `triple-format` | 2198 | 22720 | 641262 | 47 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 105 | 736 | 127097 | 47 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 106 | 656 | 127097 | 47 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash-plus-triple-format` | 108 | 640 | 641262 | 47 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `triple-format` | 105 | 19920 | 641262 | 47 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ## `linux-binaries-50`
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 55 | 608 | 139695 | 61 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `fingerprints-corpus` | 0 | 0 | 0 | 0 | corpus-unreachable | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 55 | 624 | 139695 | 61 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 52 | 608 | 139695 | 61 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `fingerprints-corpus` | 0 | 0 | 0 | 0 | corpus-unreachable | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 55 | 656 | 139695 | 61 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ## `maven-multi-module-medium`
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 3317 | 20720 | 124355 | 53 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 2823 | 22976 | 124355 | 53 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash-plus-triple-format` | 2466 | 21168 | 612754 | 53 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `triple-format` | 2509 | 23504 | 612754 | 53 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 105 | 608 | 124355 | 53 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 106 | 656 | 124355 | 53 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash-plus-triple-format` | 107 | 464 | 612754 | 53 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `triple-format` | 106 | 464 | 612754 | 53 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ## `npm-monorepo-medium`
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 2300 | 20032 | 92904 | 45 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 1875 | 19648 | 92904 | 45 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash-plus-triple-format` | 1663 | 19584 | 458816 | 45 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `triple-format` | 1698 | 19632 | 458816 | 45 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 52 | 608 | 92904 | 45 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 54 | 656 | 92904 | 45 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash-plus-triple-format` | 53 | 560 | 458816 | 45 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `triple-format` | 52 | 640 | 458816 | 45 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ## `nuget-solution-medium`
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 1935 | 19824 | 73100 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 1733 | 19568 | 73100 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash-plus-triple-format` | 1397 | 19792 | 392486 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `triple-format` | 1492 | 19840 | 392486 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 55 | 656 | 73100 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 55 | 640 | 73100 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash-plus-triple-format` | 54 | 656 | 392486 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `triple-format` | 55 | 624 | 392486 | 41 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ## `pip-poetry-medium`
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 1985 | 20144 | 82818 | 36 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 1652 | 20192 | 82818 | 36 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash-plus-triple-format` | 1395 | 20576 | 407146 | 36 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `triple-format` | 1499 | 20592 | 407146 | 36 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 54 | 688 | 82818 | 36 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 53 | 608 | 82818 | 36 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash-plus-triple-format` | 54 | 656 | 407146 | 36 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `triple-format` | 54 | 656 | 407146 | 36 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ## `vcpkg-project-medium`
 
 | mode | median wall-clock (ms) | peak RSS (KB) | output bytes | components | exit | fixture-sha | waybill-sha |
 |---|---:|---:|---:|---:|---|---|---|
-| `default` | 55 | 560 | 105399 | 79 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `fingerprints-corpus` | 0 | 0 | 0 | 0 | corpus-unreachable | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash` | 55 | 656 | 105399 | 79 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `no-deep-hash-plus-triple-format` | 55 | 608 | 599466 | 79 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
-| `triple-format` | 55 | 608 | 599466 | 79 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `2da78461e3f5271398ebc759f15a461cf9128718` |
+| `default` | 55 | 624 | 105399 | 79 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `fingerprints-corpus` | 0 | 0 | 0 | 0 | corpus-unreachable | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash` | 55 | 640 | 105399 | 79 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `no-deep-hash-plus-triple-format` | 53 | 656 | 599466 | 79 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
+| `triple-format` | 55 | 640 | 599466 | 79 | success | `891f63429480554cd2fedd48de8e5c0bdd6ba943` | `d5bffeb6e5613df9e69933c8c1506ed513f5d11c` |
 
 ---
 
-_Baseline captured at 2026-08-30T22:07:16.277683+00:00 (679s). Regenerate this page after
+_Baseline captured at 2026-08-31T00:52:38.125712+00:00 (341s). Regenerate this page after
 each `docs/perf/baseline.json` refresh via
 `cargo run -p xtask -- bench-docs`._

--- a/xtask/src/bench/run.rs
+++ b/xtask/src/bench/run.rs
@@ -154,6 +154,17 @@ fn build_waybill_cmd(
 ) -> (Command, Vec<PathBuf>) {
     let mut c = Command::new(&cfg.waybill_bin);
     c.arg("sbom").arg("scan");
+    // Perf-baseline follow-up: `--no-deps-dev` disables the deps.dev
+    // license + dep-graph enrichment (both network-bound). Profiling on
+    // 2026-08-30 revealed that the default deps.dev license call
+    // dominates ~93% of the wall-clock on source-tier fixtures
+    // (1952ms of 2110ms on cargo-workspace-medium). Including it in
+    // the harness turns every m669 baseline into a measurement of
+    // deps.dev's response time rather than waybill's code cost, which
+    // defeats the point of a regression-detection harness. The
+    // baseline captured with this flag reflects waybill's actual
+    // scan pipeline — the number people actually can act on.
+    c.arg("--no-deps-dev");
 
     match fixture.kind {
         FixtureKind::SourceTree | FixtureKind::BinarySet => {
@@ -429,13 +440,18 @@ mod tests {
         let args: Vec<_> = cmd.get_args().collect();
         assert_eq!(args[0], "sbom");
         assert_eq!(args[1], "scan");
-        assert_eq!(args[2], "--path");
-        assert_eq!(args[3], "/x/cargo-workspace-medium");
+        assert_eq!(args[2], "--no-deps-dev");
+        assert_eq!(args[3], "--path");
+        assert_eq!(args[4], "/x/cargo-workspace-medium");
         // Default mode: single CDX output.
         assert_eq!(outs.len(), 1);
         assert!(outs[0].to_str().unwrap().ends_with("out.cdx.json"));
         // No --no-deep-hash for Default.
         assert!(!args.iter().any(|a| *a == "--no-deep-hash"));
+        // --no-deps-dev is always injected to keep bench measurements
+        // isolated from deps.dev's response-time variance (see
+        // build_waybill_cmd comment).
+        assert!(args.iter().any(|a| *a == "--no-deps-dev"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Profiling waybill against competitor tools (syft, trivy, cdxgen) revealed a striking finding: **93% of Default-mode wall-clock on source-tier fixtures is a single deps.dev license enrichment network call** (1952ms of 2110ms on cargo-workspace-medium).

Every other named pipeline stage — root_selector, deduplicate, reconcile, orphan_reason classify, CDX serialization — measures at 0-6ms. The scan itself (`scan_fs::scan_path`) is 142ms.

## Consequences of the old default

With deps.dev on by default, the m669 harness was measuring deps.dev's response time, not waybill's code. Which means:

- Every "regression" was really network jitter.
- Every "improvement" from parallel-hash work (#732/#734) was underestimated because network dominated the wall-clock.
- CI perf numbers were implicitly gated on deps.dev availability from the ubuntu-latest runner.

## Fix

`xtask::bench::run::build_waybill_cmd` now unconditionally injects `--no-deps-dev` into every measured waybill invocation. The baseline captured under this configuration reflects waybill's actual scan pipeline cost — the number people can act on when triaging perf.

## Baseline shape delta

| Metric | Before (deps.dev on, #733) | After (--no-deps-dev) | Δ |
|---|---:|---:|---:|
| Total capture wall-clock | 679s | **341s** | **-50%** |
| Avg Success median | 2024ms | **982ms** | **-52%** |
| Success count | 53 | 53 | flat |
| Fastest fixture median | 52ms | 52ms | flat |
| Slowest fixture median | 13462ms | 11024ms | -18% (go's own proxy fetch is a follow-up) |

Distribution unchanged: 53 Success + 4 CorpusUnreachable.

## What this reveals about waybill's competitive position

Waybill's actual code perf is competitive. On `cargo-workspace-medium --no-deep-hash --no-deps-dev`, hyperfine measures **93ms** — faster than cdxgen (336ms) and syft (390ms) for equivalent output shape (41 components, 41 evidence blocks, 39 hashes).

The "we're 5x slower than cdxgen" narrative from the initial comparison was entirely a deps.dev-latency story, not a code-path story.

## Test plan

- [x] Updated `build_waybill_cmd_source_tree_default_mode_shape` unit test to assert `--no-deps-dev` is now always present in the injected argv.
- [x] `./scripts/pre-pr.sh` → exit 0 (clippy + workspace test both clean).
- [x] `cargo run -p xtask -- bench --update-baseline` completes in 341s (was 679s) with 53 Success + 4 CorpusUnreachable.
- [x] `cargo run -p xtask -- bench-docs` regenerates `docs/perf/numbers.md` deterministically.

## Follow-ups

1. **`docs/perf/comparative.md`** documenting the finding + hyperfine numbers vs competitors (separate PR).
2. **Consider making deps.dev enrichment opt-in** via an `--enrich-licenses` flag (design discussion, separate issue).
3. **Investigate `go-module-medium` 11s outlier** — go's own proxy fetch, needs a `--no-network` flag on the go reader.

## Related

- Built on the m669 xtask bench harness (#728).
- Complements #732 and #734 (parallel-deep-hash) — those wins were previously masked by the deps.dev latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)