### PR TITLE
perf(container): skip claimed paths in discover_binaries walker

### DIFF
--- a/waybill-cli/src/scan_fs/binary/discover.rs
+++ b/waybill-cli/src/scan_fs/binary/discover.rs
@@ -4,6 +4,7 @@
 //! match a known binary magic (ELF / Mach-O / PE). Skips hidden
 //! and build directories; ignores files outside the size envelope.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 /// Milestone 054 FR-003: max recursion depth for the `walk_dir`
@@ -17,13 +18,25 @@ const MAX_WALK_DEPTH: usize = 16;
 /// Walk `rootfs` for regular files, probing the first 16 bytes of
 /// each for a known binary magic. Skips hidden / build dirs. Ignores
 /// files <1 KB or >500 MB (defense-in-depth).
+///
+/// `claimed_paths` is used as a fast-path filter — paths already
+/// claimed by the OS-package readers (dpkg / apk / rpm / pip / etc.)
+/// are skipped BEFORE the magic-byte probe. On OS-only container
+/// scans (e.g., debian:12-slim, where dpkg claims every executable),
+/// this drops the walker from 304ms to ~50ms by avoiding thousands
+/// of no-op file opens. The check uses Layer-1 raw-path match only;
+/// canonical + inode layers still run inside `binary::read` per
+/// `is_claimed_binary` so correctness is preserved (a false-miss
+/// here just means the file falls through to the full probe + the
+/// downstream layered claim check).
 pub(super) fn discover_binaries(
     root: &Path,
+    claimed_paths: &HashSet<PathBuf>,
     exclude_set: &crate::scan_fs::package_db::exclude_path::ExclusionSet,
 ) -> Vec<PathBuf> {
     let mut out = Vec::new();
     if root.is_file() {
-        if is_supported_binary(root) {
+        if !claimed_paths.contains(root) && is_supported_binary(root) {
             out.push(root.to_path_buf());
         }
         return out;
@@ -44,6 +57,12 @@ pub(super) fn discover_binaries(
         exclude_set,
     };
     crate::scan_fs::walk::safe_walk(root, &cfg, |path| {
+        // Fast-path skip: claimed by an OS-package reader ⇒ definitely
+        // not an unattributed binary. Saves the file-open + magic-byte
+        // read on every already-claimed file.
+        if claimed_paths.contains(path) {
+            return;
+        }
         if path.is_file() && is_supported_binary(path) {
             out.push(path.to_path_buf());
         }
@@ -120,6 +139,7 @@ mod tests {
         std::os::unix::fs::symlink(&loop_dir, loop_dir.join("link")).unwrap();
         let result = discover_binaries(
             tmp.path(),
+            &std::collections::HashSet::new(),
             &crate::scan_fs::package_db::exclude_path::ExclusionSet::default(),
         );
         assert!(result.is_empty());

--- a/waybill-cli/src/scan_fs/binary/mod.rs
+++ b/waybill-cli/src/scan_fs/binary/mod.rs
@@ -201,7 +201,7 @@ pub fn read(
         source_binding::BuildAttributionRegistry::from_observations(Vec::new())
     };
 
-    for path in discover_binaries(rootfs, exclude_set) {
+    for path in discover_binaries(rootfs, claimed_paths, exclude_set) {
         // Size bounds via metadata BEFORE the full-file read. A
         // multi-GB file that exceeds MAX_BINARY_SIZE_BYTES used to be
         // slurped into memory in its entirety just to be rejected by


### PR DESCRIPTION
## Summary

Profiling `scan_fs::scan_path` on `debian:12-slim.tar` (`--offline --no-deep-hash`) showed **`binary::read` = 304ms adding ZERO new entries**. dpkg had already claimed every executable + library on the rootfs; the binary reader walked ~3400 files, opened each one, read the first 4 bytes to probe for ELF/Mach-O/PE magic — and every single one hit the claim check downstream and got dropped.

**Root cause**: `discover_binaries` didn't consult the claim set. Every file opened for magic probing, only THEN dropped if claimed.

## Fix

Thread `claimed_paths: &HashSet<PathBuf>` into `discover_binaries`. In the `safe_walk` callback, check `claimed_paths.contains(path)` BEFORE opening the file.

Layer-1 raw-path match only — canonical + inode layers still run inside `is_claimed_binary` downstream if Layer-1 misses, so correctness is preserved. A false-miss at Layer-1 just means the file falls through to the full probe + the layered claim check, exactly the pre-change behavior.

## Empirical impact on debian:12-slim.tar

| Config | Before | After | Δ |
|---|---:|---:|---:|
| default extract (`--offline --no-deep-hash`) | 1798ms | **1501ms** | **-17%** (-297ms) |
| `--fast-container-extract` | 742ms | 787ms | flat (already skipped these paths) |

The -297ms savings on the default path matches the 304ms profiled in `binary::read` almost exactly. `--fast-container-extract` mode is unchanged because it already prevented the binary files from being extracted (nothing for the walker to probe).

## Determinism preserved

Component counts unchanged across both modes:
- default: 922 components (88 library + 834 file-tier)
- fast: 156 components (88 library + 68 file-tier)

Library-tier component sets diffed to zero lines.

## When this helps

- **OS-package-heavy container scans** (debian/ubuntu/alpine/rhel bases) where dpkg/apk/rpm claims everything: **big win**.
- **Source-tree scans with no OS package DB** (cargo/npm/etc.): **no change** — claim set is empty, so the fast-path branch always misses and every file goes through the probe as before.

## Test plan

- [x] `./scripts/pre-pr.sh` → exit 0.
- [x] Existing `discover_binaries` test updated to pass an empty `HashSet` (test scenario has no OS package DB).
- [x] Hyperfine 3-run confirms -17% on default extract.
- [x] Component-count invariance across both extract modes.

## Related

- Direct follow-up to #737 (`--fast-container-extract`).
- Sixth empirically-driven perf win from the m669 harness today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)