### PR TITLE
test(corpus): add pants example repos as permanent regression gates

### DIFF
--- a/waybill-cli/tests/corpus_harness_195/layer1_assertions.rs
+++ b/waybill-cli/tests/corpus_harness_195/layer1_assertions.rs
@@ -37,6 +37,34 @@ fn cdx_has_component_purl(cdx: &serde_json::Value, matches: impl Fn(&str) -> boo
         .unwrap_or(false)
 }
 
+/// True if any component carries a property `waybill:<name>` whose
+/// value matches the predicate.
+fn cdx_has_component_property(
+    cdx: &serde_json::Value,
+    name: &str,
+    matches: impl Fn(&str) -> bool,
+) -> bool {
+    cdx.get("components")
+        .and_then(|c| c.as_array())
+        .map(|arr| {
+            arr.iter().any(|c| {
+                c.get("properties")
+                    .and_then(|p| p.as_array())
+                    .map(|props| {
+                        props.iter().any(|p| {
+                            p.get("name").and_then(|n| n.as_str()) == Some(name)
+                                && p.get("value")
+                                    .and_then(|v| v.as_str())
+                                    .map(&matches)
+                                    .unwrap_or(false)
+                        })
+                    })
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
 /// True if any dependency edge from `from_pred(ref)` targets `to_pred`.
 fn cdx_has_edge(
     cdx: &serde_json::Value,
@@ -288,6 +316,153 @@ pub fn maven_guice_layer1(sboms: &EmittedSboms) -> Result<(), AssertionFailure> 
             observed: "no pkg:maven/* components at all".to_string(),
             expected: "at least one pkg:maven/* transitive (aopalliance, jsr305, dagger, etc.)".to_string(),
             suggested_action: "investigate m070 maven reader — pom.xml parsing is broken",
+        });
+    }
+    Ok(())
+}
+
+// -----------------------------------------------------------------------
+// pants-example-python — m673 US1 (repo-root `python-default.lock`)
+// -----------------------------------------------------------------------
+
+pub fn pants_example_python_layer1(sboms: &EmittedSboms) -> Result<(), AssertionFailure> {
+    // pantsbuild/example-python at pinned SHA has a `python-default.lock`
+    // at the repo root — this is Pants 2.31+ default layout. Pre-m673
+    // waybill emitted 0 components from this shape (the pants reader
+    // only walked `3rdparty/python/*.lock`); post-m673 it emits ≥ 8.
+    if !cdx_has_component_purl(&sboms.cdx, |p| p.starts_with("pkg:pypi/")) {
+        return Err(AssertionFailure {
+            invariant_name: "pypi-transitives-present",
+            format: FailureFormat::Cdx,
+            observed: "no pkg:pypi/* components at all".to_string(),
+            expected: "at least one pkg:pypi/* transitive from the root python-default.lock".to_string(),
+            suggested_action: "investigate m673 (repo-root discovery gate) or m223 pex-lockfile reader — pants-example-python should emit ≥ 8 pypi components",
+        });
+    }
+    if !cdx_has_component_property(&sboms.cdx, "waybill:pants-resolve", |v| {
+        v == "python-default"
+    }) {
+        return Err(AssertionFailure {
+            invariant_name: "pants-resolve-annotation-present",
+            format: FailureFormat::Cdx,
+            observed: "no component carries waybill:pants-resolve=python-default".to_string(),
+            expected: "at least one component carries waybill:pants-resolve=python-default (m223 C143)".to_string(),
+            suggested_action: "investigate m223 resolve_classifier or m673 discovery-source tagging — pants-emitted components MUST carry the pants-resolve annotation",
+        });
+    }
+    Ok(())
+}
+
+// -----------------------------------------------------------------------
+// pants-example-django — m673 US2 (`lockfiles/python-default.lock`)
+// -----------------------------------------------------------------------
+
+pub fn pants_example_django_layer1(sboms: &EmittedSboms) -> Result<(), AssertionFailure> {
+    // pantsbuild/example-django at pinned SHA has its lockfile under
+    // `lockfiles/python-default.lock` — the Pants `lockfiles/` convention.
+    // Pre-m673 waybill emitted 0 components; post-m673 it emits Django's
+    // full transitive closure (typically 20-50 pypi components).
+    if !cdx_has_component_purl(&sboms.cdx, |p| p.starts_with("pkg:pypi/")) {
+        return Err(AssertionFailure {
+            invariant_name: "pypi-transitives-present",
+            format: FailureFormat::Cdx,
+            observed: "no pkg:pypi/* components at all".to_string(),
+            expected: "at least one pkg:pypi/* transitive from lockfiles/python-default.lock".to_string(),
+            suggested_action: "investigate m673 US2 (lockfiles/ directory discovery) or m223 pex-lockfile reader",
+        });
+    }
+    // Django-specific tripwire: the primary dep in this fixture is Django
+    // itself. PyPI names normalize case-insensitively, but PURL segment
+    // encoding preserves the `Django` casing per m670; assert either.
+    let has_django = cdx_has_component_purl(&sboms.cdx, |p| {
+        let lower = p.to_ascii_lowercase();
+        lower.starts_with("pkg:pypi/django@") || lower.starts_with("pkg:pypi/django/")
+    });
+    if !has_django {
+        return Err(AssertionFailure {
+            invariant_name: "django-component-present",
+            format: FailureFormat::Cdx,
+            observed: "no pkg:pypi/django@* (or Django@*) component".to_string(),
+            expected: "at least one pkg:pypi/django@X.Y.Z component from the lockfile".to_string(),
+            suggested_action: "investigate m673 US2 lockfile discovery — the Django dep is the primary content of this fixture's lockfile",
+        });
+    }
+    if !cdx_has_component_property(&sboms.cdx, "waybill:pants-resolve", |v| {
+        v == "python-default"
+    }) {
+        return Err(AssertionFailure {
+            invariant_name: "pants-resolve-annotation-present",
+            format: FailureFormat::Cdx,
+            observed: "no component carries waybill:pants-resolve=python-default".to_string(),
+            expected: "at least one component carries waybill:pants-resolve=python-default (m223 C143)".to_string(),
+            suggested_action: "investigate m223 resolve_classifier or m673 US2 discovery-source tagging",
+        });
+    }
+    Ok(())
+}
+
+// -----------------------------------------------------------------------
+// pants-example-jvm — m224 (Pants coursier-JVM reader)
+// -----------------------------------------------------------------------
+
+pub fn pants_example_jvm_layer1(sboms: &EmittedSboms) -> Result<(), AssertionFailure> {
+    // pantsbuild/example-jvm at pinned SHA has `3rdparty/jvm/default.lock`
+    // — the Pants JVM coursier resolve format (distinct from standalone
+    // coursier via the FR-011 header discriminator). Post-m224 waybill
+    // emits every JVM dep tagged `waybill:pants-resolve=jvm-default`.
+    if !cdx_has_component_purl(&sboms.cdx, |p| p.starts_with("pkg:maven/")) {
+        return Err(AssertionFailure {
+            invariant_name: "maven-transitives-present",
+            format: FailureFormat::Cdx,
+            observed: "no pkg:maven/* components at all".to_string(),
+            expected: "at least one pkg:maven/* transitive from 3rdparty/jvm/default.lock".to_string(),
+            suggested_action: "investigate m224 Pants coursier-JVM reader — pants-example-jvm should emit multiple pkg:maven/* components",
+        });
+    }
+    if !cdx_has_component_property(&sboms.cdx, "waybill:pants-resolve", |_| true) {
+        return Err(AssertionFailure {
+            invariant_name: "pants-resolve-annotation-present",
+            format: FailureFormat::Cdx,
+            observed: "no component carries waybill:pants-resolve=<any>".to_string(),
+            expected: "at least one component carries waybill:pants-resolve=<resolve-name> (m224 reuses m223 C143)".to_string(),
+            suggested_action: "investigate m224 pants_jvm reader — emitted maven components MUST carry pants-resolve tagging",
+        });
+    }
+    Ok(())
+}
+
+// -----------------------------------------------------------------------
+// pants-example-golang — m226 (Pants Go enricher) + m053/m055 (Go reader)
+// -----------------------------------------------------------------------
+
+pub fn pants_example_golang_layer1(sboms: &EmittedSboms) -> Result<(), AssertionFailure> {
+    // pantsbuild/example-golang at pinned SHA is a standard go.mod + go.sum
+    // layout with `pants.toml` declaring `[golang]`. The Go reader emits
+    // the components; the m226 pants_go enricher decorates them with
+    // `waybill:pants-target` annotations (per Principle IX — the pants
+    // enricher never fabricates pkg:golang/* PURLs, it decorates existing
+    // Go-reader-emitted ones).
+    if !cdx_has_component_purl(&sboms.cdx, |p| p.starts_with("pkg:golang/")) {
+        return Err(AssertionFailure {
+            invariant_name: "golang-components-present",
+            format: FailureFormat::Cdx,
+            observed: "no pkg:golang/* components at all".to_string(),
+            expected: "at least one pkg:golang/* component from go.sum".to_string(),
+            suggested_action: "investigate the Go reader (m053/m055/m091) — pants-example-golang should emit Go transitives",
+        });
+    }
+    // m226 enricher tripwire: the enricher decorates Go components with
+    // `waybill:pants-target` (broadened C145 per m226). Absence of ANY
+    // such annotation across the entire component set indicates the
+    // enricher isn't running against this fixture's `pants.toml` +
+    // `BUILD` files.
+    if !cdx_has_component_property(&sboms.cdx, "waybill:pants-target", |_| true) {
+        return Err(AssertionFailure {
+            invariant_name: "pants-target-annotation-present",
+            format: FailureFormat::Cdx,
+            observed: "no component carries waybill:pants-target=<any>".to_string(),
+            expected: "at least one component carries waybill:pants-target=<pants-target-address> (m226 enrichment)".to_string(),
+            suggested_action: "investigate m226 pants_go enricher — Go components in a Pants monorepo MUST be decorated with pants-target",
         });
     }
     Ok(())

--- a/waybill-cli/tests/corpus_harness_195/manifest.rs
+++ b/waybill-cli/tests/corpus_harness_195/manifest.rs
@@ -121,6 +121,57 @@ pub const TARGETS: &[CorpusTarget] = &[
         exercises: "deb reader + Go BuildInfo (gosu bin) + m177 TransitiveEdgesUnresolvable classifier",
         layer1: super::layer1_assertions::image_postgres16_layer1,
     },
+    // Pants example repos — permanent regression gates for m223 (pex-lockfile
+    // reader), m224 (coursier-JVM), m226 (Pants Go enricher), m672 (front-
+    // matter tolerance + `[python.resolves]` map), m673 (repo-root +
+    // `lockfiles/` discovery), m674 (uv.lock reader + Pants FR-002 fallback).
+    // Forked into kusari-sandbox/* as insurance against upstream force-push
+    // or deletion; refresh via `git fetch upstream && git merge upstream/main`
+    // in each fork, then bump the SHA below.
+    CorpusTarget {
+        name: "pants-example-python",
+        source: SourceKind::Git {
+            clone_url: "https://github.com/kusari-sandbox/example-python",
+        },
+        pinned: PinnedRef::Sha {
+            // Fork of pantsbuild/example-python HEAD as of 2026-09-02
+            hex: "e8cfd79b5e2670b242d2e680515473fa48a2b6b2",
+        },
+        ecosystem: Ecosystem::Python,
+        exercises: "m673 US1 (repo-root `python-default.lock` discovery) + m223 Pants pex-lockfile reader",
+        layer1: super::layer1_assertions::pants_example_python_layer1,
+    },
+    CorpusTarget {
+        name: "pants-example-django",
+        source: SourceKind::Git {
+            clone_url: "https://github.com/kusari-sandbox/example-django",
+        },
+        pinned: PinnedRef::Sha {
+            // Fork of pantsbuild/example-django HEAD as of 2026-09-02
+            hex: "7da716ffb9af72c9ab5d10d43c221ae7d6469ad9",
+        },
+        ecosystem: Ecosystem::Python,
+        exercises: "m673 US2 (`lockfiles/python-default.lock` discovery) + m223 Pants pex-lockfile reader",
+        layer1: super::layer1_assertions::pants_example_django_layer1,
+    },
+    // NOTE: pants-example-jvm intentionally omitted for now — the m224 reader
+    // rejects the coord-table form of `directDependencies` used by real Pants
+    // coursier lockfiles (issue #756). Fork is ready at
+    // kusari-sandbox/example-jvm at SHA 675ee75d36f2c1b096b0def51efcfffd02bd1251;
+    // add the entry back once #756 is resolved.
+    CorpusTarget {
+        name: "pants-example-golang",
+        source: SourceKind::Git {
+            clone_url: "https://github.com/kusari-sandbox/example-golang",
+        },
+        pinned: PinnedRef::Sha {
+            // Fork of pantsbuild/example-golang HEAD as of 2026-09-02
+            hex: "048c22e53f0fac68a4b1d49e1c99b8ce6746cf0a",
+        },
+        ecosystem: Ecosystem::Go,
+        exercises: "m226 Pants Go enricher + m053/m055 Go go.sum reader",
+        layer1: super::layer1_assertions::pants_example_golang_layer1,
+    },
 ];
 
 // -----------------------------------------------------------------------
@@ -129,13 +180,20 @@ pub const TARGETS: &[CorpusTarget] = &[
 
 #[test]
 fn public_only_audit() {
+    // FR-003 intent: reject Kusari-internal (private) hostnames. The
+    // `kusari-sandbox` GitHub org is a PUBLIC fork host used for
+    // pantsbuild/example-* mirrors (insurance against upstream force-push
+    // or deletion) — those URLs are exempt.
     let mut offenders: Vec<&str> = Vec::new();
     for t in TARGETS {
         let ref_str = match &t.source {
             SourceKind::Git { clone_url } => *clone_url,
             SourceKind::OciImage { image_ref } => *image_ref,
         };
-        if ref_str.to_ascii_lowercase().contains("kusari") {
+        let lower = ref_str.to_ascii_lowercase();
+        if lower.contains("kusari")
+            && !lower.starts_with("https://github.com/kusari-sandbox/")
+        {
             offenders.push(t.name);
         }
     }
@@ -143,7 +201,8 @@ fn public_only_audit() {
         offenders.is_empty(),
         "m195 FR-003 violation — corpus targets reference Kusari-internal \
          hostnames: {offenders:?}. All corpus targets MUST be publicly-\
-         reachable per spec §User Story 3.",
+         reachable per spec §User Story 3. Public forks under \
+         `github.com/kusari-sandbox/*` are exempt.",
     );
 }
 

--- a/waybill-cli/tests/fixtures/public_corpus/pants-example-django/cdx.json
+++ b/waybill-cli/tests/fixtures/public_corpus/pants-example-django/cdx.json
@@ -1,0 +1,3457 @@
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "bom-ref": "pkg:pypi/ansicolors",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "name": "ansicolors",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"ansicolors>=1.0.2\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "design"
+        },
+        {
+          "name": "waybill:unresolved-reason",
+          "value": "no version specifier in requirements.txt; no uv.lock / poetry.lock fallback"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/ansicolors",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:pypi/ansicolors@1.1.8",
+      "cpe": "cpe:2.3:a:ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "00d2dde5a675579325902536738dd27e4fac1fd68f773fe36c21044eb559e187"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "99f94f5e3348a0bcd43c82e5fc4414013ccc19d70bd939ad71e0133ce9c372e0"
+        }
+      ],
+      "name": "ansicolors",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:* | cpe:2.3:a:python-ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/ansicolors@1.1.8",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "1.1.8"
+    },
+    {
+      "bom-ref": "pkg:pypi/asgiref@3.10.0",
+      "cpe": "cpe:2.3:a:asgiref:asgiref:3.10.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "aef8a81283a34d0ab31630c9b7dfe70c812c95eba78171367ca8745e88124734"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d89f2d8cd8b56dada7d52fa7dc8075baa08fb836560710d38c292a7a3f78c04e"
+        }
+      ],
+      "name": "asgiref",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:asgiref:asgiref:3.10.0:*:*:*:*:*:*:* | cpe:2.3:a:python-asgiref:asgiref:3.10.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.9"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/asgiref@3.10.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "3.10.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/certifi@2025.10.5",
+      "cpe": "cpe:2.3:a:certifi:certifi:2025.10.5:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43"
+        }
+      ],
+      "name": "certifi",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:certifi:certifi:2025.10.5:*:*:*:*:*:*:* | cpe:2.3:a:python-certifi:certifi:2025.10.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.7"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/certifi@2025.10.5",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "2025.10.5"
+    },
+    {
+      "bom-ref": "pkg:pypi/charset-normalizer@3.4.3",
+      "cpe": "cpe:2.3:a:charset-normalizer:charset-normalizer:3.4.3:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "42e5088973e56e31e4fa58eb6bd709e42fc03799c11c42929592889a2e54c491"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1606f4a55c0fd363d754049cdf400175ee96c992b1f8018b993941f221221c5f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "cc34f233c9e71701040d772aa7490318673aa7164a0efe3172b2981218c26d93"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0cacf8f7297b0c4fcb74227692ca46b4a5852f8f4f24b3c766dd94a1075c4884"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3cfb2aad70f2c6debfbcb717f23b7eb55febc0bb23dcffc0f076009da10c6392"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "027b776c26d38b7f15b26a5da1044f376455fb3766df8fc38563b4efbc515154"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "320e8e66157cc4e247d9ddca8e21f427efc7a04bbd0ac8a9faf56583fa543f9f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e28e334d3ff134e88989d90ba04b47d84382a828c061d0d1027b1b12a62b39b1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c6fd51128a41297f5409deab284fecbe5305ebd7e5a1f959bee1c054622b7018"
+        }
+      ],
+      "name": "charset-normalizer",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:charset-normalizer:charset-normalizer:3.4.3:*:*:*:*:*:*:* | cpe:2.3:a:python-charset-normalizer:charset-normalizer:3.4.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.7"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/charset-normalizer@3.4.3",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "3.4.3"
+    },
+    {
+      "bom-ref": "pkg:pypi/click@8.3.0",
+      "cpe": "cpe:2.3:a:click:click:8.3.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4"
+        }
+      ],
+      "name": "click",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:click:click:8.3.0:*:*:*:*:*:*:* | cpe:2.3:a:python-click:click:8.3.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.10"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/click@8.3.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "8.3.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/django",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "name": "django",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"django>=3.2.13,<4\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "design"
+        },
+        {
+          "name": "waybill:unresolved-reason",
+          "value": "no version specifier in requirements.txt; no uv.lock / poetry.lock fallback"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/django",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:pypi/django-debug-toolbar",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "name": "django-debug-toolbar",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"django-debug-toolbar>=3.8.0,<4\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "design"
+        },
+        {
+          "name": "waybill:unresolved-reason",
+          "value": "no version specifier in requirements.txt; no uv.lock / poetry.lock fallback"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/django-debug-toolbar",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:pypi/django-debug-toolbar@3.8.1",
+      "cpe": "cpe:2.3:a:django-debug-toolbar:django-debug-toolbar:3.8.1:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "879f8a4672d41621c06a4d322dcffa630fc4df056cada6e417ed01db0e5e0478"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "24ef1a7d44d25e60d7951e378454c6509bf536dce7e7d9d36e7c387db499bc27"
+        }
+      ],
+      "name": "django-debug-toolbar",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:django-debug-toolbar:django-debug-toolbar:3.8.1:*:*:*:*:*:*:* | cpe:2.3:a:python-django-debug-toolbar:django-debug-toolbar:3.8.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.7"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/django-debug-toolbar@3.8.1",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "3.8.1"
+    },
+    {
+      "bom-ref": "pkg:pypi/django-stubs",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "name": "django-stubs",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"django-stubs~=4.2.7\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "design"
+        },
+        {
+          "name": "waybill:unresolved-reason",
+          "value": "no version specifier in requirements.txt; no uv.lock / poetry.lock fallback"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/django-stubs",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:pypi/django-stubs-ext@5.2.5",
+      "cpe": "cpe:2.3:a:django-stubs-ext:django-stubs-ext:5.2.5:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9b4b8ac9d32f7e6c304fd05477f8688fae6ed57f6a0f9f4d074f9e55b5a3da14"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ecc628df29d36cede638567c4e33ff485dd7a99f1552ad0cece8c60e9c3a8872"
+        }
+      ],
+      "name": "django-stubs-ext",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:django-stubs-ext:django-stubs-ext:5.2.5:*:*:*:*:*:*:* | cpe:2.3:a:python-django-stubs-ext:django-stubs-ext:5.2.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.10"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/django-stubs-ext@5.2.5",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "5.2.5"
+    },
+    {
+      "bom-ref": "pkg:pypi/django-stubs@4.2.7",
+      "cpe": "cpe:2.3:a:django-stubs:django-stubs:4.2.7:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4cf4de258fa71adc6f2799e983091b9d46cfc67c6eebc68fe111218c9a62b3b8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8ccd2ff4ee5adf22b9e3b7b1a516d2e1c2191e9d94e672c35cc2bc3dd61e0f6b"
+        }
+      ],
+      "name": "django-stubs",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:django-stubs:django-stubs:4.2.7:*:*:*:*:*:*:* | cpe:2.3:a:python-django-stubs:django-stubs:4.2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.8"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/django-stubs@4.2.7",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "4.2.7"
+    },
+    {
+      "bom-ref": "pkg:pypi/django@3.2.25",
+      "cpe": "cpe:2.3:a:django:django:3.2.25:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a52ea7fcf280b16f7b739cec38fa6d3f8953a5456986944c3ca97e79882b4e38"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7ca38a78654aee72378594d63e51636c04b8e28574f5505dff630895b5472777"
+        }
+      ],
+      "name": "django",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:django:django:3.2.25:*:*:*:*:*:*:* | cpe:2.3:a:python-django:django:3.2.25:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.6"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/django@3.2.25",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "3.2.25"
+    },
+    {
+      "bom-ref": "pkg:pypi/gunicorn",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "name": "gunicorn",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"gunicorn>=20.1.0\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "design"
+        },
+        {
+          "name": "waybill:unresolved-reason",
+          "value": "no version specifier in requirements.txt; no uv.lock / poetry.lock fallback"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/gunicorn",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:pypi/gunicorn@23.0.0",
+      "cpe": "cpe:2.3:a:gunicorn:gunicorn:23.0.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec"
+        }
+      ],
+      "name": "gunicorn",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:gunicorn:gunicorn:23.0.0:*:*:*:*:*:*:* | cpe:2.3:a:python-gunicorn:gunicorn:23.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.7"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/gunicorn@23.0.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "23.0.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/idna@3.10",
+      "cpe": "cpe:2.3:a:idna:idna:3.10:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"
+        }
+      ],
+      "name": "idna",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:idna:idna:3.10:*:*:*:*:*:*:* | cpe:2.3:a:python-idna:idna:3.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.6"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/idna@3.10",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "3.10"
+    },
+    {
+      "bom-ref": "pkg:pypi/iniconfig@2.1.0",
+      "cpe": "cpe:2.3:a:iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"
+        }
+      ],
+      "name": "iniconfig",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:* | cpe:2.3:a:python-iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.8"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/iniconfig@2.1.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "2.1.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/libretranslatepy@2.1.1",
+      "cpe": "cpe:2.3:a:libretranslatepy:libretranslatepy:2.1.1:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bf9f8b0003c94f34e141553b7ec0a02876297c06955f5efea49afbc9f85303a9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3f28e1b990ba5f514ae215c08ace0c4e2327eeccaa356983aefbca3a25ecc568"
+        }
+      ],
+      "name": "libretranslatepy",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:libretranslatepy:libretranslatepy:2.1.1:*:*:*:*:*:*:* | cpe:2.3:a:python-libretranslatepy:libretranslatepy:2.1.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/libretranslatepy@2.1.1",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "2.1.1"
+    },
+    {
+      "bom-ref": "pkg:pypi/lxml@6.0.2",
+      "cpe": "cpe:2.3:a:lxml:lxml:6.0.2:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6f91fd2b2ea15a6800c8e24418c0775a1694eefc011392da73bc6cef2623b322"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fbc74f42c3525ac4ffa4b89cbdd00057b6196bcefe8bce794abd42d33a018092"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "064fdadaf7a21af3ed1dcaa106b854077fbeada827c18f72aec9346847cd65d0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e8113639f3296706fbac34a30813929e29247718e88173ad849f57ca59754924"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2047d8234fe735ab77802ce5f2297e410ff40f5238aec569ad7c8e163d7b19a6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "700efd30c0fa1a3581d80a748157397559396090a51d306ea59a70020223d16f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c33e66d44fe60e72397b487ee92e01da0d09ba2d66df8eae42d77b6d06e5eba0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6da5185951d72e6f5352166e3da7b0dc27aa70bd1090b0eb3f7f7212b53f1bb8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "90a345bbeaf9d0587a3aaffb7006aa39ccb6ff0e96a57286c0cb2fd1520ea192"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c371aa98126a0d4c739ca93ceffa0fd7a5d732e3ac66a46e74339acd4d334564"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "57a86e1ebb4020a38d295c04fc79603c7899e0df71588043eb218722dabc087f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "65ea18d710fd14e0186c2f973dc60bb52039a275f82d3c44a0e42b43440ea534"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6ddff43f702905a4e32bc24f3f2e2edfe0f8fde3277d481bffb709a4cced7a1f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a8bef9b9825fa8bc816a6e641bb67219489229ebc648be422af695f6e7a4fa7f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a59f5448ba2ceccd06995c95ea59a7674a10de0810f2ce90c9006f3cbc044456"
+        }
+      ],
+      "name": "lxml",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:lxml:lxml:6.0.2:*:*:*:*:*:*:* | cpe:2.3:a:python-lxml:lxml:6.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.8"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/lxml@6.0.2",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "6.0.2"
+    },
+    {
+      "bom-ref": "pkg:pypi/mypy-extensions@1.1.0",
+      "cpe": "cpe:2.3:a:mypy-extensions:mypy-extensions:1.1.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"
+        }
+      ],
+      "name": "mypy-extensions",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:mypy-extensions:mypy-extensions:1.1.0:*:*:*:*:*:*:* | cpe:2.3:a:python-mypy-extensions:mypy-extensions:1.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.8"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/mypy-extensions@1.1.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "1.1.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/mypy@1.18.1",
+      "cpe": "cpe:2.3:a:mypy:mypy:1.18.1:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b76a4de66a0ac01da1be14ecc8ae88ddea33b8380284a9e3eae39d57ebcbe26e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "9e988c64ad3ac5987f43f5154f884747faf62141b7f842e87465b45299eea5a9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8750ceb014a96c9890421c83f0db53b0f3b8633e2864c6f9bc0a8e93951ed18d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7509549b5e41be279afc1228242d0e397f1af2919a8f2877ad542b199dc4083e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5956ecaabb3a245e3f34100172abca1507be687377fe20e24d6a7557e07080e2"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fb89ea08ff41adf59476b235293679a6eb53a7b9400f6256272fb6029bec3ce5"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "502cde8896be8e638588b90fdcb4c5d5b8c1b004dfc63fd5604a973547367bb9"
+        }
+      ],
+      "name": "mypy",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:mypy:mypy:1.18.1:*:*:*:*:*:*:* | cpe:2.3:a:python-mypy:mypy:1.18.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\",\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"mypy==1.18.1\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.9"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\",\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/mypy@1.18.1",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "1.18.1"
+    },
+    {
+      "bom-ref": "pkg:pypi/packaging@25.0",
+      "cpe": "cpe:2.3:a:packaging:packaging:25.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
+        }
+      ],
+      "name": "packaging",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:packaging:packaging:25.0:*:*:*:*:*:*:* | cpe:2.3:a:python-packaging:packaging:25.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.8"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/packaging@25.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "25.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/pathspec@0.12.1",
+      "cpe": "cpe:2.3:a:pathspec:pathspec:0.12.1:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"
+        }
+      ],
+      "name": "pathspec",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:pathspec:pathspec:0.12.1:*:*:*:*:*:*:* | cpe:2.3:a:python-pathspec:pathspec:0.12.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.8"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/pathspec@0.12.1",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "0.12.1"
+    },
+    {
+      "bom-ref": "pkg:pypi/pluggy@1.6.0",
+      "cpe": "cpe:2.3:a:pluggy:pluggy:1.6.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"
+        }
+      ],
+      "name": "pluggy",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:pluggy:pluggy:1.6.0:*:*:*:*:*:*:* | cpe:2.3:a:python-pluggy:pluggy:1.6.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.9"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/pluggy@1.6.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "1.6.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/protobuf",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "name": "protobuf",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"protobuf>=3.11.3\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "design"
+        },
+        {
+          "name": "waybill:unresolved-reason",
+          "value": "no version specifier in requirements.txt; no uv.lock / poetry.lock fallback"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/protobuf",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:pypi/protobuf@6.32.1",
+      "cpe": "cpe:2.3:a:protobuf:protobuf:6.32.1:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2601b779fc7d32a866c6b4404f9d42a3f67c5b9f3f15b4db3cccabe06b95c346"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d8c7e6eb619ffdf105ee4ab76af5a68b60a9d0f66da3ea12d1640e6d8dab7281"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2f5b80a49e1eb7b86d85fcd23fe92df154b9730a725c3b38c4e43b9d77018bf4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b1864818300c297265c83a4982fd3169f97122c299f56a56e2445c3698d34710"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ee2469e4a021474ab9baafea6cd070e5bf27c7d29433504ddea1a4ee5850f68d"
+        }
+      ],
+      "name": "protobuf",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:protobuf:protobuf:6.32.1:*:*:*:*:*:*:* | cpe:2.3:a:python-protobuf:protobuf:6.32.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.9"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/protobuf@6.32.1",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "6.32.1"
+    },
+    {
+      "bom-ref": "pkg:pypi/pygments@2.19.2",
+      "cpe": "cpe:2.3:a:pygments:pygments:2.19.2:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"
+        }
+      ],
+      "name": "pygments",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:pygments:pygments:2.19.2:*:*:*:*:*:*:* | cpe:2.3:a:python-pygments:pygments:2.19.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.8"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/pygments@2.19.2",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "2.19.2"
+    },
+    {
+      "bom-ref": "pkg:pypi/pytest",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "name": "pytest",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"pytest>=6.0.1\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "design"
+        },
+        {
+          "name": "waybill:unresolved-reason",
+          "value": "no version specifier in requirements.txt; no uv.lock / poetry.lock fallback"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/pytest",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:pypi/pytest-django",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "name": "pytest-django",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"pytest-django>=4,<5\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "design"
+        },
+        {
+          "name": "waybill:unresolved-reason",
+          "value": "no version specifier in requirements.txt; no uv.lock / poetry.lock fallback"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/pytest-django",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:pypi/pytest-django@4.11.1",
+      "cpe": "cpe:2.3:a:pytest-django:pytest-django:4.11.1:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1b63773f648aa3d8541000c26929c1ea63934be1cfa674c76436966d73fe6a10"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a949141a1ee103cb0e7a20f1451d355f83f5e4a5d07bdd4dcfdd1fd0ff227991"
+        }
+      ],
+      "name": "pytest-django",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:pytest-django:pytest-django:4.11.1:*:*:*:*:*:*:* | cpe:2.3:a:python-pytest-django:pytest-django:4.11.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.8"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/pytest-django@4.11.1",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "4.11.1"
+    },
+    {
+      "bom-ref": "pkg:pypi/pytest@8.4.2",
+      "cpe": "cpe:2.3:a:pytest:pytest:8.4.2:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"
+        }
+      ],
+      "name": "pytest",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:pytest:pytest:8.4.2:*:*:*:*:*:*:* | cpe:2.3:a:python-pytest:pytest:8.4.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.9"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/pytest@8.4.2",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "8.4.2"
+    },
+    {
+      "bom-ref": "pkg:pypi/pytz@2025.2",
+      "cpe": "cpe:2.3:a:pytz:pytz:2025.2:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"
+        }
+      ],
+      "name": "pytz",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:pytz:pytz:2025.2:*:*:*:*:*:*:* | cpe:2.3:a:python-pytz:pytz:2025.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/pytz@2025.2",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "2025.2"
+    },
+    {
+      "bom-ref": "pkg:pypi/requests",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "name": "requests",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"requests>=2.25.1\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "design"
+        },
+        {
+          "name": "waybill:unresolved-reason",
+          "value": "no version specifier in requirements.txt; no uv.lock / poetry.lock fallback"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/requests",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:pypi/requests@2.32.5",
+      "cpe": "cpe:2.3:a:requests:requests:2.32.5:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
+        }
+      ],
+      "name": "requests",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:requests:requests:2.32.5:*:*:*:*:*:*:* | cpe:2.3:a:python-requests:requests:2.32.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.9"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/requests@2.32.5",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "2.32.5"
+    },
+    {
+      "bom-ref": "pkg:pypi/setuptools",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "name": "setuptools",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"setuptools>=42.0.0\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "design"
+        },
+        {
+          "name": "waybill:unresolved-reason",
+          "value": "no version specifier in requirements.txt; no uv.lock / poetry.lock fallback"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/setuptools",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:pypi/setuptools@80.9.0",
+      "cpe": "cpe:2.3:a:setuptools:setuptools:80.9.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"
+        }
+      ],
+      "name": "setuptools",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:setuptools:setuptools:80.9.0:*:*:*:*:*:*:* | cpe:2.3:a:python-setuptools:setuptools:80.9.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.9"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/setuptools@80.9.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "80.9.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/sqlparse@0.5.3",
+      "cpe": "cpe:2.3:a:sqlparse:sqlparse:0.5.3:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272"
+        }
+      ],
+      "name": "sqlparse",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:sqlparse:sqlparse:0.5.3:*:*:*:*:*:*:* | cpe:2.3:a:python-sqlparse:sqlparse:0.5.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.8"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/sqlparse@0.5.3",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "0.5.3"
+    },
+    {
+      "bom-ref": "pkg:pypi/translate",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "name": "translate",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"translate>=3.2.1\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "design"
+        },
+        {
+          "name": "waybill:unresolved-reason",
+          "value": "no version specifier in requirements.txt; no uv.lock / poetry.lock fallback"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/translate",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:pypi/translate@3.6.1",
+      "cpe": "cpe:2.3:a:translate:translate:3.6.1:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cebfb004989d9a2ab0d24c0c5805783c7f4e07243ea4ed2a8f1809d072bf712b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7e70ffa46f193cc744be7c88b8e1323f10f6b2bb90d24bb5d29fdf1e56618783"
+        }
+      ],
+      "name": "translate",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:translate:translate:3.6.1:*:*:*:*:*:*:* | cpe:2.3:a:python-translate:translate:3.6.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/translate@3.6.1",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "3.6.1"
+    },
+    {
+      "bom-ref": "pkg:pypi/types-pytz@2025.2.0.20250809",
+      "cpe": "cpe:2.3:a:types-pytz:types-pytz:2025.2.0.20250809:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4f55ed1b43e925cf851a756fe1707e0f5deeb1976e15bf844bcaa025e8fbd0db"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "222e32e6a29bb28871f8834e8785e3801f2dc4441c715cd2082b271eecbe21e5"
+        }
+      ],
+      "name": "types-pytz",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:types-pytz:types-pytz:2025.2.0.20250809:*:*:*:*:*:*:* | cpe:2.3:a:python-types-pytz:types-pytz:2025.2.0.20250809:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.9"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/types-pytz@2025.2.0.20250809",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "2025.2.0.20250809"
+    },
+    {
+      "bom-ref": "pkg:pypi/types-pyyaml@6.0.12.20250915",
+      "cpe": "cpe:2.3:a:types-pyyaml:types-pyyaml:6.0.12.20250915:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3"
+        }
+      ],
+      "name": "types-pyyaml",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:types-pyyaml:types-pyyaml:6.0.12.20250915:*:*:*:*:*:*:* | cpe:2.3:a:python-types-pyyaml:types-pyyaml:6.0.12.20250915:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.9"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/types-pyyaml@6.0.12.20250915",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "6.0.12.20250915"
+    },
+    {
+      "bom-ref": "pkg:pypi/types-requests",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "name": "types-requests",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"types-requests>=2.25.1\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "design"
+        },
+        {
+          "name": "waybill:unresolved-reason",
+          "value": "no version specifier in requirements.txt; no uv.lock / poetry.lock fallback"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/types-requests",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:pypi/types-requests@2.32.4.20250913",
+      "cpe": "cpe:2.3:a:types-requests:types-requests:2.32.4.20250913:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d"
+        }
+      ],
+      "name": "types-requests",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:types-requests:types-requests:2.32.4.20250913:*:*:*:*:*:*:* | cpe:2.3:a:python-types-requests:types-requests:2.32.4.20250913:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.9"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/types-requests@2.32.4.20250913",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "2.32.4.20250913"
+    },
+    {
+      "bom-ref": "pkg:pypi/typing-extensions@4.15.0",
+      "cpe": "cpe:2.3:a:typing-extensions:typing-extensions:4.15.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"
+        }
+      ],
+      "name": "typing-extensions",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:typing-extensions:typing-extensions:4.15.0:*:*:*:*:*:*:* | cpe:2.3:a:python-typing-extensions:typing-extensions:4.15.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.9"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/typing-extensions@4.15.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "4.15.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/urllib3@2.5.0",
+      "cpe": "cpe:2.3:a:urllib3:urllib3:2.5.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "lockfiles/python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"
+        }
+      ],
+      "name": "urllib3",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:urllib3:urllib3:2.5.0:*:*:*:*:*:*:* | cpe:2.3:a:python-urllib3:urllib3:2.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"lockfiles/python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.9"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\"lockfiles\"]"
+        }
+      ],
+      "purl": "pkg:pypi/urllib3@2.5.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "2.5.0"
+    },
+    {
+      "bom-ref": "pkg:generic/file-tier?content-sha256=2ecc548aa7a68dc6e83f75003316648417520fb3a59f85dae7e24337414db378",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 1.0,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 1.0,
+                "technique": "hash-comparison"
+              }
+            ]
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2ecc548aa7a68dc6e83f75003316648417520fb3a59f85dae7e24337414db378"
+        }
+      ],
+      "name": "generate_constraints.sh",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"build-support/generate_constraints.sh\"]"
+        },
+        {
+          "name": "waybill:component-tier",
+          "value": "file"
+        },
+        {
+          "name": "waybill:file-paths",
+          "value": "[\"build-support/generate_constraints.sh\"]"
+        }
+      ],
+      "type": "file",
+      "version": ""
+    }
+  ],
+  "compositions": [
+    {
+      "aggregate": "complete",
+      "assemblies": [
+        "pkg:pypi/ansicolors",
+        "pkg:pypi/ansicolors@1.1.8",
+        "pkg:pypi/asgiref@3.10.0",
+        "pkg:pypi/certifi@2025.10.5",
+        "pkg:pypi/charset-normalizer@3.4.3",
+        "pkg:pypi/click@8.3.0",
+        "pkg:pypi/django",
+        "pkg:pypi/django-debug-toolbar",
+        "pkg:pypi/django-debug-toolbar@3.8.1",
+        "pkg:pypi/django-stubs",
+        "pkg:pypi/django-stubs-ext@5.2.5",
+        "pkg:pypi/django-stubs@4.2.7",
+        "pkg:pypi/django@3.2.25",
+        "pkg:pypi/gunicorn",
+        "pkg:pypi/gunicorn@23.0.0",
+        "pkg:pypi/idna@3.10",
+        "pkg:pypi/iniconfig@2.1.0",
+        "pkg:pypi/libretranslatepy@2.1.1",
+        "pkg:pypi/lxml@6.0.2",
+        "pkg:pypi/mypy-extensions@1.1.0",
+        "pkg:pypi/mypy@1.18.1",
+        "pkg:pypi/packaging@25.0",
+        "pkg:pypi/pathspec@0.12.1",
+        "pkg:pypi/pluggy@1.6.0",
+        "pkg:pypi/protobuf",
+        "pkg:pypi/protobuf@6.32.1",
+        "pkg:pypi/pygments@2.19.2",
+        "pkg:pypi/pytest",
+        "pkg:pypi/pytest-django",
+        "pkg:pypi/pytest-django@4.11.1",
+        "pkg:pypi/pytest@8.4.2",
+        "pkg:pypi/pytz@2025.2",
+        "pkg:pypi/requests",
+        "pkg:pypi/requests@2.32.5",
+        "pkg:pypi/setuptools",
+        "pkg:pypi/setuptools@80.9.0",
+        "pkg:pypi/sqlparse@0.5.3",
+        "pkg:pypi/translate",
+        "pkg:pypi/translate@3.6.1",
+        "pkg:pypi/types-pytz@2025.2.0.20250809",
+        "pkg:pypi/types-pyyaml@6.0.12.20250915",
+        "pkg:pypi/types-requests",
+        "pkg:pypi/types-requests@2.32.4.20250913",
+        "pkg:pypi/typing-extensions@4.15.0",
+        "pkg:pypi/urllib3@2.5.0"
+      ],
+      "dependencies": [
+        "pkg:pypi/ansicolors",
+        "pkg:pypi/ansicolors@1.1.8",
+        "pkg:pypi/asgiref@3.10.0",
+        "pkg:pypi/certifi@2025.10.5",
+        "pkg:pypi/charset-normalizer@3.4.3",
+        "pkg:pypi/click@8.3.0",
+        "pkg:pypi/django",
+        "pkg:pypi/django-debug-toolbar",
+        "pkg:pypi/django-debug-toolbar@3.8.1",
+        "pkg:pypi/django-stubs",
+        "pkg:pypi/django-stubs-ext@5.2.5",
+        "pkg:pypi/django-stubs@4.2.7",
+        "pkg:pypi/django@3.2.25",
+        "pkg:pypi/gunicorn",
+        "pkg:pypi/gunicorn@23.0.0",
+        "pkg:pypi/idna@3.10",
+        "pkg:pypi/iniconfig@2.1.0",
+        "pkg:pypi/libretranslatepy@2.1.1",
+        "pkg:pypi/lxml@6.0.2",
+        "pkg:pypi/mypy-extensions@1.1.0",
+        "pkg:pypi/mypy@1.18.1",
+        "pkg:pypi/packaging@25.0",
+        "pkg:pypi/pathspec@0.12.1",
+        "pkg:pypi/pluggy@1.6.0",
+        "pkg:pypi/protobuf",
+        "pkg:pypi/protobuf@6.32.1",
+        "pkg:pypi/pygments@2.19.2",
+        "pkg:pypi/pytest",
+        "pkg:pypi/pytest-django",
+        "pkg:pypi/pytest-django@4.11.1",
+        "pkg:pypi/pytest@8.4.2",
+        "pkg:pypi/pytz@2025.2",
+        "pkg:pypi/requests",
+        "pkg:pypi/requests@2.32.5",
+        "pkg:pypi/setuptools",
+        "pkg:pypi/setuptools@80.9.0",
+        "pkg:pypi/sqlparse@0.5.3",
+        "pkg:pypi/translate",
+        "pkg:pypi/translate@3.6.1",
+        "pkg:pypi/types-pytz@2025.2.0.20250809",
+        "pkg:pypi/types-pyyaml@6.0.12.20250915",
+        "pkg:pypi/types-requests",
+        "pkg:pypi/types-requests@2.32.4.20250913",
+        "pkg:pypi/typing-extensions@4.15.0",
+        "pkg:pypi/urllib3@2.5.0"
+      ]
+    },
+    {
+      "aggregate": "incomplete_first_party_only",
+      "assemblies": [
+        "pants-example-django@7da716f"
+      ]
+    },
+    {
+      "aggregate": "complete",
+      "dependencies": [
+        "pants-example-django@7da716f"
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "pkg:generic/file-tier?content-sha256=2ecc548aa7a68dc6e83f75003316648417520fb3a59f85dae7e24337414db378",
+        "pkg:pypi/ansicolors",
+        "pkg:pypi/ansicolors@1.1.8",
+        "pkg:pypi/django",
+        "pkg:pypi/django-debug-toolbar",
+        "pkg:pypi/django-debug-toolbar@3.8.1",
+        "pkg:pypi/django-stubs",
+        "pkg:pypi/django-stubs@4.2.7",
+        "pkg:pypi/gunicorn",
+        "pkg:pypi/gunicorn@23.0.0",
+        "pkg:pypi/protobuf",
+        "pkg:pypi/protobuf@6.32.1",
+        "pkg:pypi/pytest",
+        "pkg:pypi/pytest-django",
+        "pkg:pypi/pytest-django@4.11.1",
+        "pkg:pypi/requests",
+        "pkg:pypi/setuptools",
+        "pkg:pypi/translate",
+        "pkg:pypi/translate@3.6.1",
+        "pkg:pypi/types-requests",
+        "pkg:pypi/types-requests@2.32.4.20250913"
+      ],
+      "ref": "pants-example-django@7da716f"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:generic/file-tier?content-sha256=2ecc548aa7a68dc6e83f75003316648417520fb3a59f85dae7e24337414db378"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/ansicolors"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/ansicolors@1.1.8"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/mypy@1.18.1",
+        "pkg:pypi/pytest@8.4.2",
+        "pkg:pypi/typing-extensions@4.15.0"
+      ],
+      "ref": "pkg:pypi/asgiref@3.10.0"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/certifi@2025.10.5"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/charset-normalizer@3.4.3"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/click@8.3.0"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/django"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/django-debug-toolbar"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/django@3.2.25",
+        "pkg:pypi/sqlparse@0.5.3"
+      ],
+      "ref": "pkg:pypi/django-debug-toolbar@3.8.1"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/django-stubs"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/django@3.2.25",
+        "pkg:pypi/typing-extensions@4.15.0"
+      ],
+      "ref": "pkg:pypi/django-stubs-ext@5.2.5"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/django-stubs-ext@5.2.5",
+        "pkg:pypi/django@3.2.25",
+        "pkg:pypi/mypy@1.18.1",
+        "pkg:pypi/types-pytz@2025.2.0.20250809",
+        "pkg:pypi/types-pyyaml@6.0.12.20250915",
+        "pkg:pypi/typing-extensions@4.15.0"
+      ],
+      "ref": "pkg:pypi/django-stubs@4.2.7"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/asgiref@3.10.0",
+        "pkg:pypi/pytz@2025.2",
+        "pkg:pypi/sqlparse@0.5.3"
+      ],
+      "ref": "pkg:pypi/django@3.2.25"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/gunicorn"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/packaging@25.0",
+        "pkg:pypi/pytest@8.4.2"
+      ],
+      "ref": "pkg:pypi/gunicorn@23.0.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/mypy@1.18.1",
+        "pkg:pypi/pytest@8.4.2"
+      ],
+      "ref": "pkg:pypi/idna@3.10"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/iniconfig@2.1.0"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/libretranslatepy@2.1.1"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/lxml@6.0.2"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/mypy-extensions@1.1.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/lxml@6.0.2",
+        "pkg:pypi/mypy-extensions@1.1.0",
+        "pkg:pypi/pathspec@0.12.1",
+        "pkg:pypi/setuptools@80.9.0",
+        "pkg:pypi/typing-extensions@4.15.0"
+      ],
+      "ref": "pkg:pypi/mypy@1.18.1"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/packaging@25.0"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/pathspec@0.12.1"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/pytest@8.4.2"
+      ],
+      "ref": "pkg:pypi/pluggy@1.6.0"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/protobuf"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/protobuf@6.32.1"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/pygments@2.19.2"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/pytest"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/pytest-django"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/django@3.2.25",
+        "pkg:pypi/pytest@8.4.2"
+      ],
+      "ref": "pkg:pypi/pytest-django@4.11.1"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/iniconfig@2.1.0",
+        "pkg:pypi/packaging@25.0",
+        "pkg:pypi/pluggy@1.6.0",
+        "pkg:pypi/pygments@2.19.2",
+        "pkg:pypi/requests@2.32.5",
+        "pkg:pypi/setuptools@80.9.0"
+      ],
+      "ref": "pkg:pypi/pytest@8.4.2"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/pytz@2025.2"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/requests"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/certifi@2025.10.5",
+        "pkg:pypi/charset-normalizer@3.4.3",
+        "pkg:pypi/idna@3.10",
+        "pkg:pypi/urllib3@2.5.0"
+      ],
+      "ref": "pkg:pypi/requests@2.32.5"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/setuptools"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/mypy@1.18.1",
+        "pkg:pypi/packaging@25.0",
+        "pkg:pypi/pytest@8.4.2"
+      ],
+      "ref": "pkg:pypi/setuptools@80.9.0"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/sqlparse@0.5.3"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/translate"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/click@8.3.0",
+        "pkg:pypi/libretranslatepy@2.1.1",
+        "pkg:pypi/lxml@6.0.2",
+        "pkg:pypi/requests@2.32.5"
+      ],
+      "ref": "pkg:pypi/translate@3.6.1"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/types-pytz@2025.2.0.20250809"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/types-pyyaml@6.0.12.20250915"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/types-requests"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/urllib3@2.5.0"
+      ],
+      "ref": "pkg:pypi/types-requests@2.32.4.20250913"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/typing-extensions@4.15.0"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/urllib3@2.5.0"
+    }
+  ],
+  "metadata": {
+    "authors": [
+      {
+        "name": "waybill"
+      }
+    ],
+    "component": {
+      "bom-ref": "pants-example-django@7da716f",
+      "cpe": "cpe:2.3:a:waybill:pants-example-django:7da716f:*:*:*:*:*:*:*",
+      "externalReferences": [
+        {
+          "comment": "auto-detected from git remote `origin`",
+          "type": "vcs",
+          "url": "https://github.com/kusari-sandbox/example-django"
+        }
+      ],
+      "name": "pants-example-django",
+      "purl": "pkg:generic/pants-example-django@7da716f",
+      "type": "application",
+      "version": "7da716f"
+    },
+    "licenses": [
+      {
+        "license": {
+          "id": "CC0-1.0"
+        }
+      }
+    ],
+    "lifecycles": [
+      {
+        "phase": "design"
+      },
+      {
+        "phase": "pre-build"
+      }
+    ],
+    "properties": [
+      {
+        "name": "waybill:generation-context",
+        "value": "filesystem-scan"
+      },
+      {
+        "name": "waybill:cisa-2026-lifecycle",
+        "value": "after-build"
+      },
+      {
+        "name": "waybill:os-release-missing-fields",
+        "value": "ID,VERSION_ID"
+      },
+      {
+        "name": "waybill:trace-integrity-ring-buffer-overflows",
+        "value": "0"
+      },
+      {
+        "name": "waybill:trace-integrity-events-dropped",
+        "value": "0"
+      },
+      {
+        "name": "waybill:trace-integrity-uprobe-attach-failures",
+        "value": "0"
+      },
+      {
+        "name": "waybill:trace-integrity-kprobe-attach-failures",
+        "value": "0"
+      },
+      {
+        "name": "waybill:graph-completeness",
+        "value": "complete"
+      },
+      {
+        "name": "waybill:workspaces-detected",
+        "value": "[\".\",\"lockfiles\"]"
+      }
+    ],
+    "supplier": {
+      "name": "waybill contributors"
+    },
+    "timestamp": "<masked>",
+    "tools": {
+      "components": [
+        {
+          "name": "waybill",
+          "publisher": "waybill contributors",
+          "type": "application",
+          "version": "0.5.1-alpha.1"
+        }
+      ]
+    }
+  },
+  "serialNumber": "<masked>",
+  "specVersion": "1.6",
+  "version": 1,
+  "vulnerabilities": []
+}

--- a/waybill-cli/tests/fixtures/public_corpus/pants-example-django/spdx-2.3.json
+++ b/waybill-cli/tests/fixtures/public_corpus/pants-example-django/spdx-2.3.json
@@ -1,0 +1,4029 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "annotations": [
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:generation-context\",\"value\":\"filesystem-scan\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cisa-2026-lifecycle\",\"value\":\"after-build\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:graph-completeness\",\"value\":\"complete\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspaces-detected\",\"value\":\"[\\\".\\\",\\\"lockfiles\\\"]\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-ring-buffer-overflows\",\"value\":\"0\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-events-dropped\",\"value\":\"0\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-uprobe-attach-failures\",\"value\":[]}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-kprobe-attach-failures\",\"value\":[]}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"pypi\"]}}"
+    }
+  ],
+  "creationInfo": "<masked>",
+  "dataLicense": "CC0-1.0",
+  "documentDescribes": [
+    "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+  ],
+  "documentNamespace": "<masked>",
+  "name": "repo",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED",
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:generic/pants-example-django@7da716f",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:waybill:pants-example-django:7da716f:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pants-example-django",
+      "supplier": "Organization: waybill contributors",
+      "versionInfo": "7da716f"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-AEOGXK7HXBGYVCHP",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"ansicolors>=1.0.2\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/ansicolors",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "ansicolors",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-THZZ7BY5LVTRT5PE",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "00d2dde5a675579325902536738dd27e4fac1fd68f773fe36c21044eb559e187"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "99f94f5e3348a0bcd43c82e5fc4414013ccc19d70bd939ad71e0133ce9c372e0"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/ansicolors@1.1.8",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "ansicolors",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "1.1.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-Y7HCCY2VQG7ASLHZ",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:asgiref:asgiref:3.10.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-asgiref:asgiref:3.10.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "aef8a81283a34d0ab31630c9b7dfe70c812c95eba78171367ca8745e88124734"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d89f2d8cd8b56dada7d52fa7dc8075baa08fb836560710d38c292a7a3f78c04e"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/asgiref@3.10.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:asgiref:asgiref:3.10.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "asgiref",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "3.10.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-HCLZVSJO4E63I2VL",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:certifi:certifi:2025.10.5:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-certifi:certifi:2025.10.5:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.7\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/certifi@2025.10.5",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:certifi:certifi:2025.10.5:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "certifi",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "2025.10.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-RH6PH5HTHCMBZECS",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:charset-normalizer:charset-normalizer:3.4.3:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-charset-normalizer:charset-normalizer:3.4.3:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.7\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "42e5088973e56e31e4fa58eb6bd709e42fc03799c11c42929592889a2e54c491"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1606f4a55c0fd363d754049cdf400175ee96c992b1f8018b993941f221221c5f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cc34f233c9e71701040d772aa7490318673aa7164a0efe3172b2981218c26d93"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0cacf8f7297b0c4fcb74227692ca46b4a5852f8f4f24b3c766dd94a1075c4884"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3cfb2aad70f2c6debfbcb717f23b7eb55febc0bb23dcffc0f076009da10c6392"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "027b776c26d38b7f15b26a5da1044f376455fb3766df8fc38563b4efbc515154"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "320e8e66157cc4e247d9ddca8e21f427efc7a04bbd0ac8a9faf56583fa543f9f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e28e334d3ff134e88989d90ba04b47d84382a828c061d0d1027b1b12a62b39b1"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c6fd51128a41297f5409deab284fecbe5305ebd7e5a1f959bee1c054622b7018"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/charset-normalizer@3.4.3",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:charset-normalizer:charset-normalizer:3.4.3:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "charset-normalizer",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "3.4.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-6GUEN53ZVPP73TP4",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:click:click:8.3.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-click:click:8.3.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.10\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/click@8.3.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:click:click:8.3.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "click",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "8.3.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-GRPUZFVRZKES7NZM",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"django>=3.2.13,<4\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/django",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "django",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-JNFVHROXCRFXTCHP",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"django-debug-toolbar>=3.8.0,<4\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/django-debug-toolbar",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "django-debug-toolbar",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-34REXVNK3MRJMZBG",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:django-debug-toolbar:django-debug-toolbar:3.8.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-django-debug-toolbar:django-debug-toolbar:3.8.1:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.7\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "879f8a4672d41621c06a4d322dcffa630fc4df056cada6e417ed01db0e5e0478"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "24ef1a7d44d25e60d7951e378454c6509bf536dce7e7d9d36e7c387db499bc27"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/django-debug-toolbar@3.8.1",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:django-debug-toolbar:django-debug-toolbar:3.8.1:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "django-debug-toolbar",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "3.8.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-R4X2UVERTU2BUL6G",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"django-stubs~=4.2.7\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/django-stubs",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "django-stubs",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ZJ4LXA7E6GRCCBF4",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:django-stubs-ext:django-stubs-ext:5.2.5:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-django-stubs-ext:django-stubs-ext:5.2.5:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.10\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9b4b8ac9d32f7e6c304fd05477f8688fae6ed57f6a0f9f4d074f9e55b5a3da14"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ecc628df29d36cede638567c4e33ff485dd7a99f1552ad0cece8c60e9c3a8872"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/django-stubs-ext@5.2.5",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:django-stubs-ext:django-stubs-ext:5.2.5:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "django-stubs-ext",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "5.2.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-C57ZUMENIT4CSHGY",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:django-stubs:django-stubs:4.2.7:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-django-stubs:django-stubs:4.2.7:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4cf4de258fa71adc6f2799e983091b9d46cfc67c6eebc68fe111218c9a62b3b8"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8ccd2ff4ee5adf22b9e3b7b1a516d2e1c2191e9d94e672c35cc2bc3dd61e0f6b"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/django-stubs@4.2.7",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:django-stubs:django-stubs:4.2.7:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "django-stubs",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "4.2.7"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-CSWB6UC23KUPCURQ",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:django:django:3.2.25:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-django:django:3.2.25:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.6\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a52ea7fcf280b16f7b739cec38fa6d3f8953a5456986944c3ca97e79882b4e38"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7ca38a78654aee72378594d63e51636c04b8e28574f5505dff630895b5472777"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/django@3.2.25",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:django:django:3.2.25:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "django",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "3.2.25"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-3K35DO6UFTQHRNNL",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"gunicorn>=20.1.0\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/gunicorn",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "gunicorn",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-KPBHRVCIV5SEQH3O",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:gunicorn:gunicorn:23.0.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-gunicorn:gunicorn:23.0.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.7\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/gunicorn@23.0.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:gunicorn:gunicorn:23.0.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "gunicorn",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "23.0.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-C3GW2XWP7Z4WYQHU",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:idna:idna:3.10:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-idna:idna:3.10:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.6\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/idna@3.10",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:idna:idna:3.10:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "idna",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "3.10"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-7PGGREEYPN52BKXA",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/iniconfig@2.1.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "iniconfig",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "2.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-LEBFN55XRNW7NNPO",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:libretranslatepy:libretranslatepy:2.1.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-libretranslatepy:libretranslatepy:2.1.1:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bf9f8b0003c94f34e141553b7ec0a02876297c06955f5efea49afbc9f85303a9"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3f28e1b990ba5f514ae215c08ace0c4e2327eeccaa356983aefbca3a25ecc568"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/libretranslatepy@2.1.1",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:libretranslatepy:libretranslatepy:2.1.1:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "libretranslatepy",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "2.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-HH5H3VPTJ5RJ5RO7",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:lxml:lxml:6.0.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-lxml:lxml:6.0.2:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6f91fd2b2ea15a6800c8e24418c0775a1694eefc011392da73bc6cef2623b322"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fbc74f42c3525ac4ffa4b89cbdd00057b6196bcefe8bce794abd42d33a018092"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "064fdadaf7a21af3ed1dcaa106b854077fbeada827c18f72aec9346847cd65d0"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e8113639f3296706fbac34a30813929e29247718e88173ad849f57ca59754924"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2047d8234fe735ab77802ce5f2297e410ff40f5238aec569ad7c8e163d7b19a6"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "700efd30c0fa1a3581d80a748157397559396090a51d306ea59a70020223d16f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c33e66d44fe60e72397b487ee92e01da0d09ba2d66df8eae42d77b6d06e5eba0"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6da5185951d72e6f5352166e3da7b0dc27aa70bd1090b0eb3f7f7212b53f1bb8"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "90a345bbeaf9d0587a3aaffb7006aa39ccb6ff0e96a57286c0cb2fd1520ea192"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c371aa98126a0d4c739ca93ceffa0fd7a5d732e3ac66a46e74339acd4d334564"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "57a86e1ebb4020a38d295c04fc79603c7899e0df71588043eb218722dabc087f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "65ea18d710fd14e0186c2f973dc60bb52039a275f82d3c44a0e42b43440ea534"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6ddff43f702905a4e32bc24f3f2e2edfe0f8fde3277d481bffb709a4cced7a1f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a8bef9b9825fa8bc816a6e641bb67219489229ebc648be422af695f6e7a4fa7f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a59f5448ba2ceccd06995c95ea59a7674a10de0810f2ce90c9006f3cbc044456"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/lxml@6.0.2",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:lxml:lxml:6.0.2:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "lxml",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "6.0.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-TIMXRDWKC3YJTFQH",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:mypy-extensions:mypy-extensions:1.1.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-mypy-extensions:mypy-extensions:1.1.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/mypy-extensions@1.1.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:mypy-extensions:mypy-extensions:1.1.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "mypy-extensions",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "1.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-TOHIXWBCZAKDS7RY",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\",\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:mypy:mypy:1.18.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-mypy:mypy:1.18.1:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"mypy==1.18.1\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\",\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b76a4de66a0ac01da1be14ecc8ae88ddea33b8380284a9e3eae39d57ebcbe26e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9e988c64ad3ac5987f43f5154f884747faf62141b7f842e87465b45299eea5a9"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8750ceb014a96c9890421c83f0db53b0f3b8633e2864c6f9bc0a8e93951ed18d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7509549b5e41be279afc1228242d0e397f1af2919a8f2877ad542b199dc4083e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5956ecaabb3a245e3f34100172abca1507be687377fe20e24d6a7557e07080e2"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fb89ea08ff41adf59476b235293679a6eb53a7b9400f6256272fb6029bec3ce5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "502cde8896be8e638588b90fdcb4c5d5b8c1b004dfc63fd5604a973547367bb9"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/mypy@1.18.1",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:mypy:mypy:1.18.1:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "mypy",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "1.18.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ZIBQF5WBZHCXASVC",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:packaging:packaging:25.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-packaging:packaging:25.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/packaging@25.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:packaging:packaging:25.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "packaging",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "25.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-DOM7F6NZSIXQTJP6",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pathspec:pathspec:0.12.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pathspec:pathspec:0.12.1:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/pathspec@0.12.1",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:pathspec:pathspec:0.12.1:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pathspec",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "0.12.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-YZ2MIPQWGEB5UZRZ",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pluggy:pluggy:1.6.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pluggy:pluggy:1.6.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/pluggy@1.6.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:pluggy:pluggy:1.6.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pluggy",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "1.6.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-NT46QBRN4LGCBFOU",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"protobuf>=3.11.3\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/protobuf",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "protobuf",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-YYHUEELU5YO6KKPI",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:protobuf:protobuf:6.32.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-protobuf:protobuf:6.32.1:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2601b779fc7d32a866c6b4404f9d42a3f67c5b9f3f15b4db3cccabe06b95c346"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d8c7e6eb619ffdf105ee4ab76af5a68b60a9d0f66da3ea12d1640e6d8dab7281"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2f5b80a49e1eb7b86d85fcd23fe92df154b9730a725c3b38c4e43b9d77018bf4"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b1864818300c297265c83a4982fd3169f97122c299f56a56e2445c3698d34710"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ee2469e4a021474ab9baafea6cd070e5bf27c7d29433504ddea1a4ee5850f68d"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/protobuf@6.32.1",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:protobuf:protobuf:6.32.1:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "protobuf",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "6.32.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-INYEPPGPVSI54ME5",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pygments:pygments:2.19.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pygments:pygments:2.19.2:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/pygments@2.19.2",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:pygments:pygments:2.19.2:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pygments",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "2.19.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-UJEXQZQAEG5ES5IW",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"pytest>=6.0.1\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/pytest",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pytest",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-P4OUMSSD3H2I5VAK",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"pytest-django>=4,<5\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/pytest-django",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pytest-django",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-563FQECSQKCZJ7UG",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pytest-django:pytest-django:4.11.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pytest-django:pytest-django:4.11.1:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1b63773f648aa3d8541000c26929c1ea63934be1cfa674c76436966d73fe6a10"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a949141a1ee103cb0e7a20f1451d355f83f5e4a5d07bdd4dcfdd1fd0ff227991"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/pytest-django@4.11.1",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:pytest-django:pytest-django:4.11.1:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pytest-django",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "4.11.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-CBHMYQZVIKAPO245",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pytest:pytest:8.4.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pytest:pytest:8.4.2:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/pytest@8.4.2",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:pytest:pytest:8.4.2:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pytest",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "8.4.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-IZIXTQHCSNLRVMJG",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pytz:pytz:2025.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pytz:pytz:2025.2:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/pytz@2025.2",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:pytz:pytz:2025.2:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pytz",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "2025.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-B5TJRMTPQ5DOJ44C",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"requests>=2.25.1\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/requests",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "requests",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-FPZWIH6CAOYU3T7P",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:requests:requests:2.32.5:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-requests:requests:2.32.5:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/requests@2.32.5",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:requests:requests:2.32.5:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "requests",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "2.32.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-C5PMZOFYJYXSBR2L",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"setuptools>=42.0.0\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/setuptools",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "setuptools",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-EYHFQQMNOGG2LFQU",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:setuptools:setuptools:80.9.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-setuptools:setuptools:80.9.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/setuptools@80.9.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:setuptools:setuptools:80.9.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "setuptools",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "80.9.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-CFDDCOFUI6ECWOBQ",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:sqlparse:sqlparse:0.5.3:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-sqlparse:sqlparse:0.5.3:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/sqlparse@0.5.3",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:sqlparse:sqlparse:0.5.3:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "sqlparse",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "0.5.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-KXH7YWPSKHW2JX2E",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"translate>=3.2.1\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/translate",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "translate",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-IEU5J3H7V4XCJJTC",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:translate:translate:3.6.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-translate:translate:3.6.1:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cebfb004989d9a2ab0d24c0c5805783c7f4e07243ea4ed2a8f1809d072bf712b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7e70ffa46f193cc744be7c88b8e1323f10f6b2bb90d24bb5d29fdf1e56618783"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/translate@3.6.1",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:translate:translate:3.6.1:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "translate",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "3.6.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-7XF7ES27M7Z5IOMU",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:types-pytz:types-pytz:2025.2.0.20250809:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-types-pytz:types-pytz:2025.2.0.20250809:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4f55ed1b43e925cf851a756fe1707e0f5deeb1976e15bf844bcaa025e8fbd0db"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "222e32e6a29bb28871f8834e8785e3801f2dc4441c715cd2082b271eecbe21e5"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/types-pytz@2025.2.0.20250809",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:types-pytz:types-pytz:2025.2.0.20250809:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "types-pytz",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "2025.2.0.20250809"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-HJ3YR5O76WAGRB4N",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:types-pyyaml:types-pyyaml:6.0.12.20250915:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-types-pyyaml:types-pyyaml:6.0.12.20250915:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/types-pyyaml@6.0.12.20250915",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:types-pyyaml:types-pyyaml:6.0.12.20250915:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "types-pyyaml",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "6.0.12.20250915"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ZDHFQERLQ27MNLYJ",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"types-requests>=2.25.1\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/types-requests",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "types-requests",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-F4IXESTNNXT5DFXV",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:types-requests:types-requests:2.32.4.20250913:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-types-requests:types-requests:2.32.4.20250913:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/types-requests@2.32.4.20250913",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:types-requests:types-requests:2.32.4.20250913:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "types-requests",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "2.32.4.20250913"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-YT4X5I2ZVNQ76YPG",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:typing-extensions:typing-extensions:4.15.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-typing-extensions:typing-extensions:4.15.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/typing-extensions@4.15.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:typing-extensions:typing-extensions:4.15.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "typing-extensions",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "4.15.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-RRIUYEPR6T43LWT4",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:urllib3:urllib3:2.5.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-urllib3:urllib3:2.5.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/urllib3@2.5.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:urllib3:urllib3:2.5.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "urllib3",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "2.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-URKZ6736HAMNOUG2",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"build-support/generate_constraints.sh\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":1.0,\"technique\":\"hash-match\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:component-tier\",\"value\":\"file\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:file-paths\",\"value\":[\"build-support/generate_constraints.sh\"]}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2ecc548aa7a68dc6e83f75003316648417520fb3a59f85dae7e24337414db378"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "generate_constraints.sh",
+      "versionInfo": "NOASSERTION"
+    }
+  ],
+  "relationships": [
+    {
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED",
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-TOHIXWBCZAKDS7RY",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-Y7HCCY2VQG7ASLHZ"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-CBHMYQZVIKAPO245",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-Y7HCCY2VQG7ASLHZ"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-YT4X5I2ZVNQ76YPG",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-Y7HCCY2VQG7ASLHZ"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-Y7HCCY2VQG7ASLHZ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-CSWB6UC23KUPCURQ"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-IZIXTQHCSNLRVMJG",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-CSWB6UC23KUPCURQ"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-CFDDCOFUI6ECWOBQ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-CSWB6UC23KUPCURQ"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-CSWB6UC23KUPCURQ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-34REXVNK3MRJMZBG"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-CFDDCOFUI6ECWOBQ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-34REXVNK3MRJMZBG"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-CSWB6UC23KUPCURQ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-C57ZUMENIT4CSHGY"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ZJ4LXA7E6GRCCBF4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-C57ZUMENIT4CSHGY"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-TOHIXWBCZAKDS7RY",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-C57ZUMENIT4CSHGY"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-HJ3YR5O76WAGRB4N",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-C57ZUMENIT4CSHGY"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-7XF7ES27M7Z5IOMU",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-C57ZUMENIT4CSHGY"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-YT4X5I2ZVNQ76YPG",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-C57ZUMENIT4CSHGY"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-CSWB6UC23KUPCURQ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ZJ4LXA7E6GRCCBF4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-YT4X5I2ZVNQ76YPG",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ZJ4LXA7E6GRCCBF4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ZIBQF5WBZHCXASVC",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-KPBHRVCIV5SEQH3O"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-CBHMYQZVIKAPO245",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-KPBHRVCIV5SEQH3O"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-TOHIXWBCZAKDS7RY",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-C3GW2XWP7Z4WYQHU"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-CBHMYQZVIKAPO245",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-C3GW2XWP7Z4WYQHU"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-HH5H3VPTJ5RJ5RO7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-TOHIXWBCZAKDS7RY"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-TIMXRDWKC3YJTFQH",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-TOHIXWBCZAKDS7RY"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-DOM7F6NZSIXQTJP6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-TOHIXWBCZAKDS7RY"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-EYHFQQMNOGG2LFQU",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-TOHIXWBCZAKDS7RY"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-YT4X5I2ZVNQ76YPG",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-TOHIXWBCZAKDS7RY"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-CBHMYQZVIKAPO245",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-YZ2MIPQWGEB5UZRZ"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-7PGGREEYPN52BKXA",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-CBHMYQZVIKAPO245"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ZIBQF5WBZHCXASVC",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-CBHMYQZVIKAPO245"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-YZ2MIPQWGEB5UZRZ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-CBHMYQZVIKAPO245"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-INYEPPGPVSI54ME5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-CBHMYQZVIKAPO245"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-FPZWIH6CAOYU3T7P",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-CBHMYQZVIKAPO245"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-EYHFQQMNOGG2LFQU",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-CBHMYQZVIKAPO245"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-CSWB6UC23KUPCURQ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-563FQECSQKCZJ7UG"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-CBHMYQZVIKAPO245",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-563FQECSQKCZJ7UG"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-HCLZVSJO4E63I2VL",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-FPZWIH6CAOYU3T7P"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-RH6PH5HTHCMBZECS",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-FPZWIH6CAOYU3T7P"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-C3GW2XWP7Z4WYQHU",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-FPZWIH6CAOYU3T7P"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-RRIUYEPR6T43LWT4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-FPZWIH6CAOYU3T7P"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-TOHIXWBCZAKDS7RY",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-EYHFQQMNOGG2LFQU"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ZIBQF5WBZHCXASVC",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-EYHFQQMNOGG2LFQU"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ZIBQF5WBZHCXASVC",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-EYHFQQMNOGG2LFQU"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-CBHMYQZVIKAPO245",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-EYHFQQMNOGG2LFQU"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-6GUEN53ZVPP73TP4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-IEU5J3H7V4XCJJTC"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-LEBFN55XRNW7NNPO",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-IEU5J3H7V4XCJJTC"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-HH5H3VPTJ5RJ5RO7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-IEU5J3H7V4XCJJTC"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-FPZWIH6CAOYU3T7P",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-IEU5J3H7V4XCJJTC"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-RRIUYEPR6T43LWT4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-F4IXESTNNXT5DFXV"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-URKZ6736HAMNOUG2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-AEOGXK7HXBGYVCHP",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-THZZ7BY5LVTRT5PE",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-GRPUZFVRZKES7NZM",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-JNFVHROXCRFXTCHP",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-34REXVNK3MRJMZBG",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-R4X2UVERTU2BUL6G",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-C57ZUMENIT4CSHGY",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-3K35DO6UFTQHRNNL",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-KPBHRVCIV5SEQH3O",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-NT46QBRN4LGCBFOU",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-YYHUEELU5YO6KKPI",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-UJEXQZQAEG5ES5IW",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-P4OUMSSD3H2I5VAK",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-563FQECSQKCZJ7UG",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-B5TJRMTPQ5DOJ44C",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-C5PMZOFYJYXSBR2L",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-KXH7YWPSKHW2JX2E",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-IEU5J3H7V4XCJJTC",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ZDHFQERLQ27MNLYJ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-F4IXESTNNXT5DFXV",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-YMIN7MSJAMJG5LED"
+    }
+  ],
+  "spdxVersion": "SPDX-2.3"
+}

--- a/waybill-cli/tests/fixtures/public_corpus/pants-example-django/spdx-3.json
+++ b/waybill-cli/tests/fixtures/public_corpus/pants-example-django/spdx-3.json
@@ -1,0 +1,5247 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "creationInfo": "<masked>",
+      "name": "waybill contributors",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/agent/waybill-contributors",
+      "type": "Organization"
+    },
+    {
+      "@id": "_:creation-info",
+      "created": "<masked>",
+      "createdBy": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent/waybill-contributors"
+      ],
+      "createdUsing": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/tool/waybill"
+      ],
+      "specVersion": "3.0.1",
+      "type": "CreationInfo"
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "waybill-0.5.1-alpha.1",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/tool/waybill",
+      "type": "Tool"
+    },
+    {
+      "creationInfo": "<masked>",
+      "simplelicensing_licenseExpression": "CC0-1.0",
+      "spdxId": "https://spdx.org/licenses/CC0-1.0",
+      "type": "simplelicensing_LicenseExpression"
+    },
+    {
+      "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: design, pre-build. Per-component scope detail in waybill:sbom-tier annotations.",
+      "creationInfo": "<masked>",
+      "dataLicense": "https://spdx.org/licenses/CC0-1.0",
+      "externalIdentifier": [
+        {
+          "comment": "original-scheme: repo",
+          "externalIdentifierType": "other",
+          "identifier": "https://github.com/kusari-sandbox/example-django",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pants-example-django",
+      "rootElement": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD"
+      ],
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>",
+      "type": "SpdxDocument"
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "pants-example-django",
+      "rootElement": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD"
+      ],
+      "software_sbomType": [
+        "design",
+        "source"
+      ],
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/sbom",
+      "type": "software_Sbom"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:waybill:pants-example-django:7da716f:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:generic/pants-example-django@7da716f",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pants-example-django",
+      "software_packageUrl": "pkg:generic/pants-example-django@7da716f",
+      "software_packageVersion": "7da716f",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-root-ZC7ADG6WKOYF64DD",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:django-debug-toolbar:django-debug-toolbar:3.8.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-django-debug-toolbar:django-debug-toolbar:3.8.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/django-debug-toolbar@3.8.1",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "django-debug-toolbar",
+      "software_packageUrl": "pkg:pypi/django-debug-toolbar@3.8.1",
+      "software_packageVersion": "3.8.1",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-34REXVNK3MRJMZBG",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "24ef1a7d44d25e60d7951e378454c6509bf536dce7e7d9d36e7c387db499bc27",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "879f8a4672d41621c06a4d322dcffa630fc4df056cada6e417ed01db0e5e0478",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/gunicorn",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "gunicorn",
+      "software_packageUrl": "pkg:pypi/gunicorn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-3K35DO6UFTQHRNNL",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:pytest-django:pytest-django:4.11.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-pytest-django:pytest-django:4.11.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/pytest-django@4.11.1",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pytest-django",
+      "software_packageUrl": "pkg:pypi/pytest-django@4.11.1",
+      "software_packageVersion": "4.11.1",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-563FQECSQKCZJ7UG",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "1b63773f648aa3d8541000c26929c1ea63934be1cfa674c76436966d73fe6a10",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "a949141a1ee103cb0e7a20f1451d355f83f5e4a5d07bdd4dcfdd1fd0ff227991",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:click:click:8.3.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-click:click:8.3.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/click@8.3.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "click",
+      "software_packageUrl": "pkg:pypi/click@8.3.0",
+      "software_packageVersion": "8.3.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-6GUEN53ZVPP73TP4",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/iniconfig@2.1.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "iniconfig",
+      "software_packageUrl": "pkg:pypi/iniconfig@2.1.0",
+      "software_packageVersion": "2.1.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-7PGGREEYPN52BKXA",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-types-pytz:types-pytz:2025.2.0.20250809:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:types-pytz:types-pytz:2025.2.0.20250809:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/types-pytz@2025.2.0.20250809",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "types-pytz",
+      "software_packageUrl": "pkg:pypi/types-pytz@2025.2.0.20250809",
+      "software_packageVersion": "2025.2.0.20250809",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-7XF7ES27M7Z5IOMU",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "222e32e6a29bb28871f8834e8785e3801f2dc4441c715cd2082b271eecbe21e5",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "4f55ed1b43e925cf851a756fe1707e0f5deeb1976e15bf844bcaa025e8fbd0db",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/ansicolors",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "ansicolors",
+      "software_packageUrl": "pkg:pypi/ansicolors",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-AEOGXK7HXBGYVCHP",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/requests",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "requests",
+      "software_packageUrl": "pkg:pypi/requests",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-B5TJRMTPQ5DOJ44C",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:idna:idna:3.10:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-idna:idna:3.10:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/idna@3.10",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "idna",
+      "software_packageUrl": "pkg:pypi/idna@3.10",
+      "software_packageVersion": "3.10",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-C3GW2XWP7Z4WYQHU",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:django-stubs:django-stubs:4.2.7:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-django-stubs:django-stubs:4.2.7:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/django-stubs@4.2.7",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "django-stubs",
+      "software_packageUrl": "pkg:pypi/django-stubs@4.2.7",
+      "software_packageVersion": "4.2.7",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-C57ZUMENIT4CSHGY",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "4cf4de258fa71adc6f2799e983091b9d46cfc67c6eebc68fe111218c9a62b3b8",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "8ccd2ff4ee5adf22b9e3b7b1a516d2e1c2191e9d94e672c35cc2bc3dd61e0f6b",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/setuptools",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "setuptools",
+      "software_packageUrl": "pkg:pypi/setuptools",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-C5PMZOFYJYXSBR2L",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:pytest:pytest:8.4.2:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-pytest:pytest:8.4.2:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/pytest@8.4.2",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pytest",
+      "software_packageUrl": "pkg:pypi/pytest@8.4.2",
+      "software_packageVersion": "8.4.2",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-CBHMYQZVIKAPO245",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-sqlparse:sqlparse:0.5.3:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:sqlparse:sqlparse:0.5.3:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/sqlparse@0.5.3",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "sqlparse",
+      "software_packageUrl": "pkg:pypi/sqlparse@0.5.3",
+      "software_packageVersion": "0.5.3",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-CFDDCOFUI6ECWOBQ",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:django:django:3.2.25:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-django:django:3.2.25:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/django@3.2.25",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "django",
+      "software_packageUrl": "pkg:pypi/django@3.2.25",
+      "software_packageVersion": "3.2.25",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-CSWB6UC23KUPCURQ",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "7ca38a78654aee72378594d63e51636c04b8e28574f5505dff630895b5472777",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "a52ea7fcf280b16f7b739cec38fa6d3f8953a5456986944c3ca97e79882b4e38",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:pathspec:pathspec:0.12.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-pathspec:pathspec:0.12.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/pathspec@0.12.1",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pathspec",
+      "software_packageUrl": "pkg:pypi/pathspec@0.12.1",
+      "software_packageVersion": "0.12.1",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-DOM7F6NZSIXQTJP6",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-setuptools:setuptools:80.9.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:setuptools:setuptools:80.9.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/setuptools@80.9.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "setuptools",
+      "software_packageUrl": "pkg:pypi/setuptools@80.9.0",
+      "software_packageVersion": "80.9.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-EYHFQQMNOGG2LFQU",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-types-requests:types-requests:2.32.4.20250913:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:types-requests:types-requests:2.32.4.20250913:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/types-requests@2.32.4.20250913",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "types-requests",
+      "software_packageUrl": "pkg:pypi/types-requests@2.32.4.20250913",
+      "software_packageVersion": "2.32.4.20250913",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-F4IXESTNNXT5DFXV",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-requests:requests:2.32.5:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:requests:requests:2.32.5:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/requests@2.32.5",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "requests",
+      "software_packageUrl": "pkg:pypi/requests@2.32.5",
+      "software_packageVersion": "2.32.5",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-FPZWIH6CAOYU3T7P",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/django",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "django",
+      "software_packageUrl": "pkg:pypi/django",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-GRPUZFVRZKES7NZM",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:certifi:certifi:2025.10.5:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-certifi:certifi:2025.10.5:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/certifi@2025.10.5",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "certifi",
+      "software_packageUrl": "pkg:pypi/certifi@2025.10.5",
+      "software_packageVersion": "2025.10.5",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-HCLZVSJO4E63I2VL",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:lxml:lxml:6.0.2:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-lxml:lxml:6.0.2:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/lxml@6.0.2",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "lxml",
+      "software_packageUrl": "pkg:pypi/lxml@6.0.2",
+      "software_packageVersion": "6.0.2",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-HH5H3VPTJ5RJ5RO7",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "064fdadaf7a21af3ed1dcaa106b854077fbeada827c18f72aec9346847cd65d0",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "2047d8234fe735ab77802ce5f2297e410ff40f5238aec569ad7c8e163d7b19a6",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "57a86e1ebb4020a38d295c04fc79603c7899e0df71588043eb218722dabc087f",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "65ea18d710fd14e0186c2f973dc60bb52039a275f82d3c44a0e42b43440ea534",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "6da5185951d72e6f5352166e3da7b0dc27aa70bd1090b0eb3f7f7212b53f1bb8",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "6ddff43f702905a4e32bc24f3f2e2edfe0f8fde3277d481bffb709a4cced7a1f",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "6f91fd2b2ea15a6800c8e24418c0775a1694eefc011392da73bc6cef2623b322",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "700efd30c0fa1a3581d80a748157397559396090a51d306ea59a70020223d16f",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "90a345bbeaf9d0587a3aaffb7006aa39ccb6ff0e96a57286c0cb2fd1520ea192",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "a59f5448ba2ceccd06995c95ea59a7674a10de0810f2ce90c9006f3cbc044456",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "a8bef9b9825fa8bc816a6e641bb67219489229ebc648be422af695f6e7a4fa7f",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "c33e66d44fe60e72397b487ee92e01da0d09ba2d66df8eae42d77b6d06e5eba0",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "c371aa98126a0d4c739ca93ceffa0fd7a5d732e3ac66a46e74339acd4d334564",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "e8113639f3296706fbac34a30813929e29247718e88173ad849f57ca59754924",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "fbc74f42c3525ac4ffa4b89cbdd00057b6196bcefe8bce794abd42d33a018092",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-types-pyyaml:types-pyyaml:6.0.12.20250915:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:types-pyyaml:types-pyyaml:6.0.12.20250915:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/types-pyyaml@6.0.12.20250915",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "types-pyyaml",
+      "software_packageUrl": "pkg:pypi/types-pyyaml@6.0.12.20250915",
+      "software_packageVersion": "6.0.12.20250915",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-HJ3YR5O76WAGRB4N",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-translate:translate:3.6.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:translate:translate:3.6.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/translate@3.6.1",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "translate",
+      "software_packageUrl": "pkg:pypi/translate@3.6.1",
+      "software_packageVersion": "3.6.1",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-IEU5J3H7V4XCJJTC",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "7e70ffa46f193cc744be7c88b8e1323f10f6b2bb90d24bb5d29fdf1e56618783",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "cebfb004989d9a2ab0d24c0c5805783c7f4e07243ea4ed2a8f1809d072bf712b",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:pygments:pygments:2.19.2:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-pygments:pygments:2.19.2:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/pygments@2.19.2",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pygments",
+      "software_packageUrl": "pkg:pypi/pygments@2.19.2",
+      "software_packageVersion": "2.19.2",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-INYEPPGPVSI54ME5",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-pytz:pytz:2025.2:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:pytz:pytz:2025.2:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/pytz@2025.2",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pytz",
+      "software_packageUrl": "pkg:pypi/pytz@2025.2",
+      "software_packageVersion": "2025.2",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-IZIXTQHCSNLRVMJG",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/django-debug-toolbar",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "django-debug-toolbar",
+      "software_packageUrl": "pkg:pypi/django-debug-toolbar",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-JNFVHROXCRFXTCHP",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:gunicorn:gunicorn:23.0.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-gunicorn:gunicorn:23.0.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/gunicorn@23.0.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "gunicorn",
+      "software_packageUrl": "pkg:pypi/gunicorn@23.0.0",
+      "software_packageVersion": "23.0.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-KPBHRVCIV5SEQH3O",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/translate",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "translate",
+      "software_packageUrl": "pkg:pypi/translate",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-KXH7YWPSKHW2JX2E",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:libretranslatepy:libretranslatepy:2.1.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-libretranslatepy:libretranslatepy:2.1.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/libretranslatepy@2.1.1",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "libretranslatepy",
+      "software_packageUrl": "pkg:pypi/libretranslatepy@2.1.1",
+      "software_packageVersion": "2.1.1",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-LEBFN55XRNW7NNPO",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "3f28e1b990ba5f514ae215c08ace0c4e2327eeccaa356983aefbca3a25ecc568",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "bf9f8b0003c94f34e141553b7ec0a02876297c06955f5efea49afbc9f85303a9",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/protobuf",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "protobuf",
+      "software_packageUrl": "pkg:pypi/protobuf",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-NT46QBRN4LGCBFOU",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/pytest-django",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pytest-django",
+      "software_packageUrl": "pkg:pypi/pytest-django",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-P4OUMSSD3H2I5VAK",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/django-stubs",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "django-stubs",
+      "software_packageUrl": "pkg:pypi/django-stubs",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-R4X2UVERTU2BUL6G",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:charset-normalizer:charset-normalizer:3.4.3:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-charset-normalizer:charset-normalizer:3.4.3:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/charset-normalizer@3.4.3",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "charset-normalizer",
+      "software_packageUrl": "pkg:pypi/charset-normalizer@3.4.3",
+      "software_packageVersion": "3.4.3",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-RH6PH5HTHCMBZECS",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "027b776c26d38b7f15b26a5da1044f376455fb3766df8fc38563b4efbc515154",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "0cacf8f7297b0c4fcb74227692ca46b4a5852f8f4f24b3c766dd94a1075c4884",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "1606f4a55c0fd363d754049cdf400175ee96c992b1f8018b993941f221221c5f",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "320e8e66157cc4e247d9ddca8e21f427efc7a04bbd0ac8a9faf56583fa543f9f",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "3cfb2aad70f2c6debfbcb717f23b7eb55febc0bb23dcffc0f076009da10c6392",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "42e5088973e56e31e4fa58eb6bd709e42fc03799c11c42929592889a2e54c491",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "c6fd51128a41297f5409deab284fecbe5305ebd7e5a1f959bee1c054622b7018",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "cc34f233c9e71701040d772aa7490318673aa7164a0efe3172b2981218c26d93",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "e28e334d3ff134e88989d90ba04b47d84382a828c061d0d1027b1b12a62b39b1",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-urllib3:urllib3:2.5.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:urllib3:urllib3:2.5.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/urllib3@2.5.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "urllib3",
+      "software_packageUrl": "pkg:pypi/urllib3@2.5.0",
+      "software_packageVersion": "2.5.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-RRIUYEPR6T43LWT4",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/ansicolors@1.1.8",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "ansicolors",
+      "software_packageUrl": "pkg:pypi/ansicolors@1.1.8",
+      "software_packageVersion": "1.1.8",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-THZZ7BY5LVTRT5PE",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "00d2dde5a675579325902536738dd27e4fac1fd68f773fe36c21044eb559e187",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "99f94f5e3348a0bcd43c82e5fc4414013ccc19d70bd939ad71e0133ce9c372e0",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:mypy-extensions:mypy-extensions:1.1.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-mypy-extensions:mypy-extensions:1.1.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/mypy-extensions@1.1.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "mypy-extensions",
+      "software_packageUrl": "pkg:pypi/mypy-extensions@1.1.0",
+      "software_packageVersion": "1.1.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-TIMXRDWKC3YJTFQH",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:mypy:mypy:1.18.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-mypy:mypy:1.18.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/mypy@1.18.1",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "mypy",
+      "software_packageUrl": "pkg:pypi/mypy@1.18.1",
+      "software_packageVersion": "1.18.1",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-TOHIXWBCZAKDS7RY",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "502cde8896be8e638588b90fdcb4c5d5b8c1b004dfc63fd5604a973547367bb9",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "5956ecaabb3a245e3f34100172abca1507be687377fe20e24d6a7557e07080e2",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "7509549b5e41be279afc1228242d0e397f1af2919a8f2877ad542b199dc4083e",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "8750ceb014a96c9890421c83f0db53b0f3b8633e2864c6f9bc0a8e93951ed18d",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "9e988c64ad3ac5987f43f5154f884747faf62141b7f842e87465b45299eea5a9",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "b76a4de66a0ac01da1be14ecc8ae88ddea33b8380284a9e3eae39d57ebcbe26e",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "fb89ea08ff41adf59476b235293679a6eb53a7b9400f6256272fb6029bec3ce5",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/pytest",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pytest",
+      "software_packageUrl": "pkg:pypi/pytest",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-UJEXQZQAEG5ES5IW",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "generate_constraints.sh",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-URKZ6736HAMNOUG2",
+      "type": "software_File",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "2ecc548aa7a68dc6e83f75003316648417520fb3a59f85dae7e24337414db378",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:asgiref:asgiref:3.10.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-asgiref:asgiref:3.10.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/asgiref@3.10.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "asgiref",
+      "software_packageUrl": "pkg:pypi/asgiref@3.10.0",
+      "software_packageVersion": "3.10.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-Y7HCCY2VQG7ASLHZ",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "aef8a81283a34d0ab31630c9b7dfe70c812c95eba78171367ca8745e88124734",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "d89f2d8cd8b56dada7d52fa7dc8075baa08fb836560710d38c292a7a3f78c04e",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-typing-extensions:typing-extensions:4.15.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:typing-extensions:typing-extensions:4.15.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/typing-extensions@4.15.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "typing-extensions",
+      "software_packageUrl": "pkg:pypi/typing-extensions@4.15.0",
+      "software_packageVersion": "4.15.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-YT4X5I2ZVNQ76YPG",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:protobuf:protobuf:6.32.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-protobuf:protobuf:6.32.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/protobuf@6.32.1",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "protobuf",
+      "software_packageUrl": "pkg:pypi/protobuf@6.32.1",
+      "software_packageVersion": "6.32.1",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-YYHUEELU5YO6KKPI",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "2601b779fc7d32a866c6b4404f9d42a3f67c5b9f3f15b4db3cccabe06b95c346",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "2f5b80a49e1eb7b86d85fcd23fe92df154b9730a725c3b38c4e43b9d77018bf4",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "b1864818300c297265c83a4982fd3169f97122c299f56a56e2445c3698d34710",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "d8c7e6eb619ffdf105ee4ab76af5a68b60a9d0f66da3ea12d1640e6d8dab7281",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "ee2469e4a021474ab9baafea6cd070e5bf27c7d29433504ddea1a4ee5850f68d",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:pluggy:pluggy:1.6.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-pluggy:pluggy:1.6.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/pluggy@1.6.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pluggy",
+      "software_packageUrl": "pkg:pypi/pluggy@1.6.0",
+      "software_packageVersion": "1.6.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-YZ2MIPQWGEB5UZRZ",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/types-requests",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "types-requests",
+      "software_packageUrl": "pkg:pypi/types-requests",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-ZDHFQERLQ27MNLYJ",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:packaging:packaging:25.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-packaging:packaging:25.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/packaging@25.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "packaging",
+      "software_packageUrl": "pkg:pypi/packaging@25.0",
+      "software_packageVersion": "25.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-ZIBQF5WBZHCXASVC",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:django-stubs-ext:django-stubs-ext:5.2.5:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-django-stubs-ext:django-stubs-ext:5.2.5:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/django-stubs-ext@5.2.5",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "django-stubs-ext",
+      "software_packageUrl": "pkg:pypi/django-stubs-ext@5.2.5",
+      "software_packageVersion": "5.2.5",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-ZJ4LXA7E6GRCCBF4",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "9b4b8ac9d32f7e6c304fd05477f8688fae6ed57f6a0f9f4d074f9e55b5a3da14",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "ecc628df29d36cede638567c4e33ff485dd7a99f1552ad0cece8c60e9c3a8872",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "PyPI",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/agent-org-FEUX73OAEUGOM2DW",
+      "type": "Organization"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-Y7HCCY2VQG7ASLHZ",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-44YPPOSRUTUMP6SD",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YT4X5I2ZVNQ76YPG"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-45H7PJM4BE74WD5L",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HJ3YR5O76WAGRB4N"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-4DASGGWNKA5M4EF2",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IEU5J3H7V4XCJJTC"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-5M6FPPE6KBAJRAW3",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-THZZ7BY5LVTRT5PE"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-5VX2ZULWTO3ZQQMG",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RRIUYEPR6T43LWT4"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-74OWUNO5UVLUZ7TU",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YZ2MIPQWGEB5UZRZ",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-74XCIUEI6CZ5K2B2",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-7ONRQBMYF76UEWUG",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KPBHRVCIV5SEQH3O",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-7Q54PAN7SGJR7B5G",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZIBQF5WBZHCXASVC"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IEU5J3H7V4XCJJTC",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-7RNIVZPV5OBLWLYE",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-6GUEN53ZVPP73TP4"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-BFADKUXQYAQWENAN",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TIMXRDWKC3YJTFQH"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IEU5J3H7V4XCJJTC",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-CQ6OKDLENVQZGEPT",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-563FQECSQKCZJ7UG",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-CRGDZ7P7YEZBCZKH",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-D7AN7PIDFQHQUG5Q",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CFDDCOFUI6ECWOBQ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IEU5J3H7V4XCJJTC",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-DQZEZTJE4WMPQWSF",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HH5H3VPTJ5RJ5RO7"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-DVI3QELAHJR2PGX7",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HH5H3VPTJ5RJ5RO7"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-F523EXWGPCZ6CS6C",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YT4X5I2ZVNQ76YPG"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-FKFX5NIN4YKL2A4D",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KPBHRVCIV5SEQH3O"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-FOXTXUYJ2UA2RA77",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-Y7HCCY2VQG7ASLHZ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-FUMOUQ2VSWDAOUBL",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-F4IXESTNNXT5DFXV"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-G23A6NONQSOPIRZ2",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-DOM7F6NZSIXQTJP6"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZJ4LXA7E6GRCCBF4",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-GEGODXF5PUONAZP5",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-GNTB32NBHXGXWC63",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YYHUEELU5YO6KKPI"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-HDWGWSKCFEMLVVGD",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-URKZ6736HAMNOUG2"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-F4IXESTNNXT5DFXV",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-HFCQD5LXZQKTNO5Z",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RRIUYEPR6T43LWT4"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-34REXVNK3MRJMZBG",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-HNCOQUJ4G2ONUNK4",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-HYVJKVTVPSIX7HYZ",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KXH7YWPSKHW2JX2E"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-IXHNPY2V3T2S5LOX",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-UJEXQZQAEG5ES5IW"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-JB42XLJ4APQ262IV",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-JDPEH2YMHTBE6LX3",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-Y7HCCY2VQG7ASLHZ",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-JVWXOZQSWLNTR3NW",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-KFQU6C7S4RAENTTJ",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZIBQF5WBZHCXASVC"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-KFQU6C7S4RAENTTJ",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZIBQF5WBZHCXASVC"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-KSU46LYHUXRPJVBY",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-563FQECSQKCZJ7UG"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-KTFLN7EHXPXVMGCM",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-INYEPPGPVSI54ME5"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-MGRJGOPUNU24G3QP",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZIBQF5WBZHCXASVC"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-NEHTVHT2BVRU4PFN",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-R4X2UVERTU2BUL6G"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-NESK4B2QBVBASD5T",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZDHFQERLQ27MNLYJ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KPBHRVCIV5SEQH3O",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-NKNANZJLMNC6JDJF",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-NU77C5CHIWGCIWKZ",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-NYZLCCBTKSQUL4OD",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IZIXTQHCSNLRVMJG"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-PAJA2ECIAKO3X6JE",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YZ2MIPQWGEB5UZRZ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-PLIYAYOZCADDIIHK",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C3GW2XWP7Z4WYQHU",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-PMQHFOP5CYCOACOI",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-Q5YPAPILEPYHNERC",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-GRPUZFVRZKES7NZM"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-QLUWKHTAOYY7KD4H",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YT4X5I2ZVNQ76YPG"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-34REXVNK3MRJMZBG",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-QTNFYJMI44IZMVBP",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CFDDCOFUI6ECWOBQ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-RIV7VNWPF4LF32DZ",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-RM6LNKPUBAJ7R6RS",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-3K35DO6UFTQHRNNL"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C3GW2XWP7Z4WYQHU",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-RNNBDAH6KOCH7PIO",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-RW7XFUNYMV5ABUGR",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-B5TJRMTPQ5DOJ44C"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-563FQECSQKCZJ7UG",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-S5FXG5MMXNDB63MF",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-S7QC3SBIJ6G4AFMT",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZJ4LXA7E6GRCCBF4"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-TBDUA4BFEQ3HTTSK",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C5PMZOFYJYXSBR2L"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-TU2IU4J3HH4A2ISL",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RH6PH5HTHCMBZECS"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-UB3T4XDJDOA4CDB2",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-34REXVNK3MRJMZBG"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IEU5J3H7V4XCJJTC",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-UHZ65YX2Y5I2RFBH",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-LEBFN55XRNW7NNPO"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-ULYRMO72DPJOHRU6",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-JNFVHROXCRFXTCHP"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-VCAZW6JWBXROK427",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-VDZM6RJBLPUBSVRL",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-NT46QBRN4LGCBFOU"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-VEEGOCGIECNHPFFA",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-AEOGXK7HXBGYVCHP"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-VQCTGVQFWXCYAEJF",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C3GW2XWP7Z4WYQHU"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-WEDMHTV2REVD25JJ",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7XF7ES27M7Z5IOMU"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-WJVZQ4EGDZOSBIOS",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HCLZVSJO4E63I2VL"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-root-ZC7ADG6WKOYF64DD",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-WVEKLFDD3VADI3YL",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-P4OUMSSD3H2I5VAK"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZJ4LXA7E6GRCCBF4",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-XDF2BHK2QRBT5YQQ",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YT4X5I2ZVNQ76YPG"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-YGQNEQ35TWGQWQIC",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7PGGREEYPN52BKXA"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-Y7HCCY2VQG7ASLHZ",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-ZR3EZZMATARXAQWS",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-26GAWFYKKYDQCZSV",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RRIUYEPR6T43LWT4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-27QWSBCB4BTB6PHX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-2BR7YH2FGVEQK6GX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-2EL56YRK2KSRDQCI",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-F4IXESTNNXT5DFXV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-2FPZB6JYCH4UIBYD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-3K35DO6UFTQHRNNL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-2ILKO4SLR46N7AVU",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-2J3EBC5NR24EVWPO",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-INYEPPGPVSI54ME5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-2QRLG5TNZZDFVWWW",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-INYEPPGPVSI54ME5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-2WSL2PMPWWRWI4X3",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RRIUYEPR6T43LWT4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-34KZQAKIYFY6NMG5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-DOM7F6NZSIXQTJP6",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-3CSSNJMGX5ZHCYNB",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-3GNXDO2MCWOAE4XT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-F4IXESTNNXT5DFXV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-3IWLHMV5XC6HSYAS",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-563FQECSQKCZJ7UG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-3KV7FIBTTPYFSS5V",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-3LHT63O6QRD4ZEKG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-3OSY5XTDEABUL7ZS",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:generation-context\",\"value\":\"filesystem-scan\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-3Y5OEG45MC4POMTY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-Y7HCCY2VQG7ASLHZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-42UZXPTXIB2HDNQW",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:packaging:packaging:25.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-packaging:packaging:25.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-45VVSSOFY6AM3TB6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KPBHRVCIV5SEQH3O",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-46DVB4HRPWJQW7QE",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.7\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HCLZVSJO4E63I2VL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-4BYA6VV5LN6P3XM3",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-AEOGXK7HXBGYVCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-4ETLTAABJMWLZPJ3",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RH6PH5HTHCMBZECS",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-4K5NOLGIJ4JZJPHY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZDHFQERLQ27MNLYJ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-4KRPHTXFCEVFTHJI",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HCLZVSJO4E63I2VL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-4NS26JE2UUMKULXF",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-Y7HCCY2VQG7ASLHZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-4NUSXE2AQDCDCTYO",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:types-pytz:types-pytz:2025.2.0.20250809:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-types-pytz:types-pytz:2025.2.0.20250809:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7XF7ES27M7Z5IOMU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-4OLJB5QEPI3ERGGT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RRIUYEPR6T43LWT4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-4PUDY4QBMFE3WPQA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-B5TJRMTPQ5DOJ44C",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-4UGVINPAE2AGSLR7",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-52DNPTQZZKD7NXWP",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZDHFQERLQ27MNLYJ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-53LNTQKSY4AXOGVZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-INYEPPGPVSI54ME5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-53RUBOKO5U73W3GQ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TIMXRDWKC3YJTFQH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-56KWWYVIAV2JPYEY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-5GUUILD23YNP2SMN",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pytest:pytest:8.4.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pytest:pytest:8.4.2:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-5J22OXIXQL644RLL",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-P4OUMSSD3H2I5VAK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-5L5PHKZ2UIHLTCHZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"django>=3.2.13,<4\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-GRPUZFVRZKES7NZM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-5L5X65GDJSBK7DK2",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RH6PH5HTHCMBZECS",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-5MGNAFJ4FFE43U7H",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-F4IXESTNNXT5DFXV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-5OEECHFJBWKNATJ7",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-NT46QBRN4LGCBFOU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-5QRZZURJ52BABZQG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.7\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-34REXVNK3MRJMZBG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-5TQAW4VGBZEMHXC6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YYHUEELU5YO6KKPI",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-5XXZQQD4TPTSSA3C",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-5Y3RVGLE5DBDLHC5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-5YLDNNCIXUYS3S5N",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-62B73MG6OYADOI5M",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-62WGPTUPHNJZZH63",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-JNFVHROXCRFXTCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-64KJ4SLAVHBZ5BYC",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"setuptools>=42.0.0\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C5PMZOFYJYXSBR2L",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-67K7U4S5GM2XXY6R",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TIMXRDWKC3YJTFQH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-6F5SD6WB27YP3KT4",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-6GWU33OAPMWKWIAE",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-DOM7F6NZSIXQTJP6",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-6K6LYP3HTZUOSBRU",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"pypi\"]}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-6PESTO7RFX2CB5LC",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"translate>=3.2.1\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KXH7YWPSKHW2JX2E",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-6POKTRRB5UTFSVLO",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-6RMRVSOGSITY3W2K",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YT4X5I2ZVNQ76YPG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-6RRFZF3DAIKUMYK7",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:mypy-extensions:mypy-extensions:1.1.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-mypy-extensions:mypy-extensions:1.1.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TIMXRDWKC3YJTFQH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-6T7G5MV4EO4X7HDY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RH6PH5HTHCMBZECS",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-6WHUUADQP5TSP3FJ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IZIXTQHCSNLRVMJG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-75GALZZZRDATGCRA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-Y7HCCY2VQG7ASLHZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-7BJLNY5JGYHRYMZ2",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-7FD63FVN2R2GHIPI",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-LEBFN55XRNW7NNPO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-7GSYDX3OZVWUK63B",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KXH7YWPSKHW2JX2E",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-7W3RCZI2AIBNCTVS",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:click:click:8.3.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-click:click:8.3.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-6GUEN53ZVPP73TP4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-7ZF2O6ALTZKN7DRM",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YYHUEELU5YO6KKPI",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-7ZOMIYODDERKBB3U",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KPBHRVCIV5SEQH3O",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-A2567C27SAPWS5CJ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pygments:pygments:2.19.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pygments:pygments:2.19.2:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-INYEPPGPVSI54ME5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-AGAUVTW3ZFXRROSZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7XF7ES27M7Z5IOMU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-AGVPW3N2Y32MX5G6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"pytest-django>=4,<5\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-P4OUMSSD3H2I5VAK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-AH2D322EM6KYI2WS",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-34REXVNK3MRJMZBG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-AIASDBHSGBDR6I2S",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HH5H3VPTJ5RJ5RO7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-AKRSCRR6NGAFRM3E",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-UJEXQZQAEG5ES5IW",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ANK7P3LLHO5ZT4UU",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-JNFVHROXCRFXTCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-AOIHPZBX5YCGL7MR",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-AOQUUEBBX6S5ITPK",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-6GUEN53ZVPP73TP4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-APEBXB7YPOTYWFBT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-P4OUMSSD3H2I5VAK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ARH56ZQCX6FOX7IE",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-NT46QBRN4LGCBFOU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-AWSWSPTV7LOV4Y3H",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YYHUEELU5YO6KKPI",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BDQ7TV2K45NQ3GUI",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BEDFRMHAXZIOWUH4",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BGCL2K4SSPL644BO",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BHCPRRKDEIDEWDH6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.10\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-6GUEN53ZVPP73TP4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BM7EXWII2OOKYU2K",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BMKJ3N4NFI6HIAXZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BOM3G5HDDTJZK67A",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HCLZVSJO4E63I2VL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BX7O5AKHM6VOCB5U",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"requests>=2.25.1\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-B5TJRMTPQ5DOJ44C",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BXJBCUMLU5EBKYGG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BXX2TOTAYWJ2FVT5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-JNFVHROXCRFXTCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BY2SXEFILDULRHZS",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7XF7ES27M7Z5IOMU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BY4CIEOJXVXDXNK5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"django-debug-toolbar>=3.8.0,<4\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-JNFVHROXCRFXTCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-C7AE2BL4EY65LRAT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-AEOGXK7HXBGYVCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-C7ESVKVMLYTMCIWJ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-GRPUZFVRZKES7NZM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-C7USHHYFCAAGJVZU",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-Y7HCCY2VQG7ASLHZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-C7Y4HZEZ74QE7X3X",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7XF7ES27M7Z5IOMU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-CEATIERL2DMTDQ5I",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-ring-buffer-overflows\",\"value\":\"0\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-CFP5SDINJS7X4GKE",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:django-stubs-ext:django-stubs-ext:5.2.5:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-django-stubs-ext:django-stubs-ext:5.2.5:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZJ4LXA7E6GRCCBF4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-CJ53PFYAPG562NAZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-CLARHVLAS4Z2D3QM",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cisa-2026-lifecycle\",\"value\":\"after-build\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-CN5YODGZXIDJE62A",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C3GW2XWP7Z4WYQHU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-CNEF55BAFUNZLCVA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CFDDCOFUI6ECWOBQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-COXNTZNSZTHP5RHO",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C3GW2XWP7Z4WYQHU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-CW2LSU7EFQYJ3GIW",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-3K35DO6UFTQHRNNL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-CYQFNMAZ7RHKFRTH",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-D37RIIOVI2W6SH54",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IZIXTQHCSNLRVMJG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-D4DOKWBWPIS5U4GC",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-R4X2UVERTU2BUL6G",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-D6CZADETPSQR5RKZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-F4IXESTNNXT5DFXV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DBAFL5CABGUZIBIV",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DCLT46GG2635HAJN",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZDHFQERLQ27MNLYJ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DCRS5P5YK37PTC4U",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.7\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KPBHRVCIV5SEQH3O",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DF53K33XMAB33WND",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":1.0,\"technique\":\"hash-match\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-URKZ6736HAMNOUG2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DJJE6JNAGBC4TCVF",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"gunicorn>=20.1.0\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-3K35DO6UFTQHRNNL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DOCIFUTC46JY7IUO",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-INYEPPGPVSI54ME5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DREJQDUV4MEKKGR6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TIMXRDWKC3YJTFQH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DRWPVNGGDLTES3PX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-LEBFN55XRNW7NNPO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DSU5OSO7DXYBO4OV",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.6\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C3GW2XWP7Z4WYQHU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DTCXVEFSXMPCJDQ5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IEU5J3H7V4XCJJTC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DTSGGMNBOFYDPN5B",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"build-support/generate_constraints.sh\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-URKZ6736HAMNOUG2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DVBQEYDMTFBAJK2Z",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-LEBFN55XRNW7NNPO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DVX25ONI2PLQZAAD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-EC4FS7A5BMOSVX4N",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IEU5J3H7V4XCJJTC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-EEPYUXPD3W2QPD5I",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-JNFVHROXCRFXTCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-EGYMCSRTVYKZATJM",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RRIUYEPR6T43LWT4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ELPVC2TXJUPDGPBK",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-AEOGXK7HXBGYVCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-EMBTH44DOX5NQQJW",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HJ3YR5O76WAGRB4N",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-EMR75ZHIJMPVOF3G",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-AEOGXK7HXBGYVCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ENEYV3UWAXEZBCI6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-6GUEN53ZVPP73TP4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ENUJVVMEQ7CHTIRL",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZJ4LXA7E6GRCCBF4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-EQKVDOXA4J2YPHQ6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ERHPDBZA3BFGLA2G",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-3K35DO6UFTQHRNNL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ESRQERLW3ULTQJ4A",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-3K35DO6UFTQHRNNL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ESXHGPRJIVW6H5ZE",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-EVKBSIU72W252ARK",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CFDDCOFUI6ECWOBQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-F4PTQBGINR2S66MI",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KPBHRVCIV5SEQH3O",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-FAQGSYXAVU3RXELU",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-INYEPPGPVSI54ME5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-FERCJHRAZZQ4NDBN",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IZIXTQHCSNLRVMJG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-FGRLKX2SQR47XGSK",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-563FQECSQKCZJ7UG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-FI2MOKANE3TWJFRR",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"types-requests>=2.25.1\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZDHFQERLQ27MNLYJ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-FUKXH4KDIBFYIQBG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-563FQECSQKCZJ7UG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-FUTIGRG3XNODWIKL",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-Y7HCCY2VQG7ASLHZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-FWM3LOJ3NWBMDUPY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YT4X5I2ZVNQ76YPG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-FXTNNHSPSX6FAFQJ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YYHUEELU5YO6KKPI",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-G3GQ5SM7IDUGFKHL",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C5PMZOFYJYXSBR2L",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-G47SZCEMUI7CE3P6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZJ4LXA7E6GRCCBF4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-G5MDKKODDYODRQAC",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-G6RIFUJKMMU3TEKZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-G72RQBDJ3TKAXCYF",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GDUZFKMFOLPWJZDO",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GDWUXINB5ZU2UQTP",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C3GW2XWP7Z4WYQHU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GKJPC6E6FUUFLUJI",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-R4X2UVERTU2BUL6G",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GNBOAR4K6KVFO3HV",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TIMXRDWKC3YJTFQH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GO22PJAUYV5WHWXG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-B5TJRMTPQ5DOJ44C",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GOK2BFOSH456AKRB",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GVFLE6NUUMIPTTNG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7XF7ES27M7Z5IOMU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GW3LVQNDUQVWF5WD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-Y7HCCY2VQG7ASLHZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GWM5SMADKHOPHV2D",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZJ4LXA7E6GRCCBF4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GYQK4R3FXLVFCY2H",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-R4X2UVERTU2BUL6G",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GZZ2AZANV7M4D5GK",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-H4EHVR2DR4SGXBVG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CFDDCOFUI6ECWOBQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-H4XFGVTY3W5XRBB4",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-GRPUZFVRZKES7NZM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-H52BPRY3VFNZGYX6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-6GUEN53ZVPP73TP4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-H5Z3F5RB3KOVZNRN",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HJ3YR5O76WAGRB4N",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-H63WHEBDY27N2LRZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CFDDCOFUI6ECWOBQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-H6NVY2HDWOPFSFKT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\",\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-HKP4QYXEWTPYLZYR",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IEU5J3H7V4XCJJTC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-HOBLQMJPBHV77ANA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HCLZVSJO4E63I2VL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-HQ3KZVWNHYBOFVUD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-HW7OKJDV4USN4FNR",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C3GW2XWP7Z4WYQHU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-HWPQSONPLXMJNHKO",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-HX5IJ55RV4VIZEFU",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RH6PH5HTHCMBZECS",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-HZEIA2GFMJBFT6VF",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-NT46QBRN4LGCBFOU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-I3SZ22F6MZJQ6PAN",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KXH7YWPSKHW2JX2E",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-IBSBB74MLDCFNQMB",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:component-tier\",\"value\":\"file\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-URKZ6736HAMNOUG2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-IC6IQGGAZG35YFUD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-IEOYQ7XYY32GVQJS",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:urllib3:urllib3:2.5.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-urllib3:urllib3:2.5.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RRIUYEPR6T43LWT4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-IH5H47G5USZ2DLWY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ILZ523GJJXTBOLP7",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7XF7ES27M7Z5IOMU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-IQJLDJB2XOMUDJP4",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-563FQECSQKCZJ7UG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ITW2C7BBHEWWU4B2",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-6GUEN53ZVPP73TP4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-IUM6QCIKPUYBP64N",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7XF7ES27M7Z5IOMU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-IXNCHD5NBOKJ2ZIM",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YYHUEELU5YO6KKPI",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-J25XPFRVX4IZM354",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-DOM7F6NZSIXQTJP6",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-J3XLQ75YJNVTTN46",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-DOM7F6NZSIXQTJP6",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JCN3L2AHNWLBNF3W",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZDHFQERLQ27MNLYJ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JDZBJINSTOXZEICK",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RRIUYEPR6T43LWT4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JG43TJRCBMRZJ27P",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KXH7YWPSKHW2JX2E",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JIMK3PH4R72TCLRD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-3K35DO6UFTQHRNNL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JMPPWK6AWZA4R4GB",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YT4X5I2ZVNQ76YPG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JNNO2T6YY7SXFWPA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-INYEPPGPVSI54ME5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JNWBL2ALL25H7QKX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pytz:pytz:2025.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pytz:pytz:2025.2:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IZIXTQHCSNLRVMJG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JQPJ5XT3IFUUGT3O",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JS4N5IXPEALRKRBE",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JTHSSFX3QYXB66GP",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-GRPUZFVRZKES7NZM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JVKLUBTRSLUYEPKP",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JXRAQZODZCPLQWFC",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-34REXVNK3MRJMZBG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-K3LQGJCDDNXNATFD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7XF7ES27M7Z5IOMU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KJAT25X3BHUEMJ2R",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C5PMZOFYJYXSBR2L",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KKKYRHY4GSQPVX5O",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KKXF6YHZPQWVB2SI",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IEU5J3H7V4XCJJTC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KM7QY7PLNPKU4EFP",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-events-dropped\",\"value\":\"0\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KPSSWAA2SIJ5X5XI",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:requests:requests:2.32.5:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-requests:requests:2.32.5:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KR2VWZEUPL3M4AXZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:charset-normalizer:charset-normalizer:3.4.3:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-charset-normalizer:charset-normalizer:3.4.3:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RH6PH5HTHCMBZECS",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KTFX2VIQGABEVA7H",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:asgiref:asgiref:3.10.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-asgiref:asgiref:3.10.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-Y7HCCY2VQG7ASLHZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KTLZUR7USTBJUOIO",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KW464DN7MGS5JNJK",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\",\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KWEX26MXHYJDDRSQ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YT4X5I2ZVNQ76YPG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KYEON2Z35WU5CHCV",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KPBHRVCIV5SEQH3O",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KYZDCCKPURX3LZA3",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-F4IXESTNNXT5DFXV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-L5B72GCON6ROQBF3",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-LDQRWSCB3WD32IJR",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RH6PH5HTHCMBZECS",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-LGXJKRYLJ6YKBM7J",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HCLZVSJO4E63I2VL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-LIW2ANTBLIKPCMDZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-LUNMYPYCQOFTBGVW",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"ansicolors>=1.0.2\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-AEOGXK7HXBGYVCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-LVR7V4TDQ6DNHPUD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KPBHRVCIV5SEQH3O",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-LVREN2G2CW3WUWHW",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CFDDCOFUI6ECWOBQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-LVSHVUMNENZUVEHG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZDHFQERLQ27MNLYJ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-LZL2UD7X3P3KKCUX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:libretranslatepy:libretranslatepy:2.1.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-libretranslatepy:libretranslatepy:2.1.1:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-LEBFN55XRNW7NNPO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-M26EV3YI3BKNLX6M",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-UJEXQZQAEG5ES5IW",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-M42CTNMM43NSFBZL",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CFDDCOFUI6ECWOBQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-M5GJNP7XGQ37EGCH",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-M7BB3HW7LFTITTNT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspaces-detected\",\"value\":\"[\\\".\\\",\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ME4UZSAWZ4TQBVAS",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HH5H3VPTJ5RJ5RO7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-MJ4ANFMYNJLULXZV",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C5PMZOFYJYXSBR2L",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-MLJHRPTHULRCTVO4",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TIMXRDWKC3YJTFQH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-MLZ7KDOCHM7FW3IZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pytest-django:pytest-django:4.11.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pytest-django:pytest-django:4.11.1:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-563FQECSQKCZJ7UG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-MOPY34G46SDQNKCA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-B5TJRMTPQ5DOJ44C",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-MSFG3TCJOBCNCDN3",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"protobuf>=3.11.3\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-NT46QBRN4LGCBFOU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-MT463HKJPTZXL2OG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-34REXVNK3MRJMZBG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-MX56ID64PI3LDSEH",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-DOM7F6NZSIXQTJP6",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-N3W5PKX7NZO4WIUD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-GRPUZFVRZKES7NZM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-NKG6EHYWF2RQ4C3D",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YYHUEELU5YO6KKPI",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-NOAKICYGGSWRZ5WX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HJ3YR5O76WAGRB4N",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-NOIDPYDT6FPEYB2X",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-Y7HCCY2VQG7ASLHZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-NQSCMZVX7C45F7N6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-B5TJRMTPQ5DOJ44C",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-NQXRPMA6Z3YEQAQD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YT4X5I2ZVNQ76YPG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-NWND26FU4IVNA7IM",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C5PMZOFYJYXSBR2L",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-O6PIJPK7RCV43TDH",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HJ3YR5O76WAGRB4N",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-OEH3GABKUX5MJBGU",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-563FQECSQKCZJ7UG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-OIMF5KNRML32T5BP",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IEU5J3H7V4XCJJTC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-OJQTCJBOKGEVUG7K",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HCLZVSJO4E63I2VL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-OKEBFT4SP4SFNYQJ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-DOM7F6NZSIXQTJP6",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-OPRLGHOOUWM27I6V",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-LEBFN55XRNW7NNPO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-OQ7NTB2Y6N75N3YU",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HH5H3VPTJ5RJ5RO7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-OS3ZIBTV4FKCNHXA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-OZPHPTDJBIFQMKEG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-P3JBDOIUKJWSCPZG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-R4X2UVERTU2BUL6G",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-PAFDY5FFNGW2I7G6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CFDDCOFUI6ECWOBQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-PFLP6GYK4E2PVVAU",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-PKBQRQ3OUX26XNWA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C3GW2XWP7Z4WYQHU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-PKXWBYWBTVMVTP7E",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RRIUYEPR6T43LWT4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-PKZBK7DFCADU47GK",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RRIUYEPR6T43LWT4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-PLOGYLJVTOR37OFP",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-JNFVHROXCRFXTCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-PMUIGDDUVMCODIO6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-34REXVNK3MRJMZBG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-PNKEA4GGALRHWFUS",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-NT46QBRN4LGCBFOU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-PSBUFLBRLCGAZ5M6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C5PMZOFYJYXSBR2L",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-Q2MTGTB3BR4HYTQQ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-Q34PTOB4EJJ2KCUP",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YT4X5I2ZVNQ76YPG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-Q6GQLLRWB643PGIW",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:file-paths\",\"value\":[\"build-support/generate_constraints.sh\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-URKZ6736HAMNOUG2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-QEICM62OO6DPKNGG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-B5TJRMTPQ5DOJ44C",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-QIAVM7UXMFIC3LHA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TIMXRDWKC3YJTFQH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-QQPJHEKVM7C5PF3Z",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KXH7YWPSKHW2JX2E",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-QTUXPJ77XGAVOK7K",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-LEBFN55XRNW7NNPO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-QVRCPYDTDIBECUAS",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HJ3YR5O76WAGRB4N",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-R2M2EW7CAD4OYN6K",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HH5H3VPTJ5RJ5RO7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-R3ZVBOIGEK3QXHWG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:lxml:lxml:6.0.2:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-lxml:lxml:6.0.2:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HH5H3VPTJ5RJ5RO7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-R4D5VK5VHNATZFDZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-P4OUMSSD3H2I5VAK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-R5IB232FQKCPNQBZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:protobuf:protobuf:6.32.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-protobuf:protobuf:6.32.1:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YYHUEELU5YO6KKPI",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-R62Q26SGPZYXTVZ3",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:sqlparse:sqlparse:0.5.3:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-sqlparse:sqlparse:0.5.3:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CFDDCOFUI6ECWOBQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-RANCYYDBPAFMNOSP",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-B5TJRMTPQ5DOJ44C",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-RBQ3SRYGUOLSL7YZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-RHWA5ODAYCHOKZDS",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IZIXTQHCSNLRVMJG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-RQJJMVTD735GD2U5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-RSBAPJHZ43VQIVU5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-RSJZZVIN5WHPQK3X",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YYHUEELU5YO6KKPI",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-RZ7MKJP57QHFDGON",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-S3CH4SVMGHXU6WOF",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZJ4LXA7E6GRCCBF4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-S4KCCW2PIPWYE5M6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-6GUEN53ZVPP73TP4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-SCABCF7T5K3TK6YI",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:certifi:certifi:2025.10.5:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-certifi:certifi:2025.10.5:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HCLZVSJO4E63I2VL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-SJLND52LCCVEKHLD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-34REXVNK3MRJMZBG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-SNITI6VC333R45ZV",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:types-requests:types-requests:2.32.4.20250913:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-types-requests:types-requests:2.32.4.20250913:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-F4IXESTNNXT5DFXV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-SNP32BCCI52AOGF7",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HH5H3VPTJ5RJ5RO7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-SUER2DALB7XZULPY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RH6PH5HTHCMBZECS",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-SWKKBIZYROPIT4AQ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"pytest>=6.0.1\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-UJEXQZQAEG5ES5IW",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-SWZ7RPAHL6OYAVYL",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-SZUZRVTUSY4IHJ65",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-T47ZATCNSJPU2FTP",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-T4VLOPAY3JS5UOMJ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YT4X5I2ZVNQ76YPG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-T5US6TYSJE2QWDPD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:gunicorn:gunicorn:23.0.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-gunicorn:gunicorn:23.0.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KPBHRVCIV5SEQH3O",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-TFQSR4HI666WR37Q",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.10\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZJ4LXA7E6GRCCBF4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-TNALNCO5B6R37KHB",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-GRPUZFVRZKES7NZM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-TNCERHXSVMLYCTJM",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-563FQECSQKCZJ7UG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-TOLRLW56CZJXTHKN",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KXH7YWPSKHW2JX2E",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-TTSSBGW3YW46WITH",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-UJEXQZQAEG5ES5IW",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-U6C4AX3DVIUOPRQ5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HJ3YR5O76WAGRB4N",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-UABUUVME4TNAC4E6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:django-debug-toolbar:django-debug-toolbar:3.8.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-django-debug-toolbar:django-debug-toolbar:3.8.1:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-34REXVNK3MRJMZBG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-UD7VTQSGIS3WFHZL",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:mypy:mypy:1.18.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-mypy:mypy:1.18.1:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-UDOALOGIXTVZKHYO",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"mypy==1.18.1\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-UDVM5HSWQEZYH6XN",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.7\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-RH6PH5HTHCMBZECS",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-UFXVYLH6YMTQ3ZDY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-563FQECSQKCZJ7UG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-UHVCIUJEUXDRO77C",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZDHFQERLQ27MNLYJ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-UR6BXZR7UH3UZFRS",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-UXAH2GD7WLNZXWUJ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:django-stubs:django-stubs:4.2.7:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-django-stubs:django-stubs:4.2.7:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C57ZUMENIT4CSHGY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-UYHK6QQ7QFY2RVHA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HH5H3VPTJ5RJ5RO7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-UYWF5W5UBQCCQFFD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IZIXTQHCSNLRVMJG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-V5QCRU53HE3RGK6Q",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-F4IXESTNNXT5DFXV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-V7MJQEOKADYUZWTA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IEU5J3H7V4XCJJTC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-VA3BVU6HG56IN4GU",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-AEOGXK7HXBGYVCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-VCM6MBVKBV3ODUIX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-UJEXQZQAEG5ES5IW",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-VDLUK566LB5L2NTT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HCLZVSJO4E63I2VL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-VFPEBUAQ3OIFLC5T",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:django:django:3.2.25:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-django:django:3.2.25:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-VHZ2DOB4Z2SV6U6R",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-34REXVNK3MRJMZBG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-VIJYBIKSNK3TWJPN",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-VKTXWQYG6OYUFWTA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-VTG4UYDQ6ZACYGFY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-GRPUZFVRZKES7NZM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-VWXOC4VYB4CZ3NFK",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pluggy:pluggy:1.6.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pluggy:pluggy:1.6.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-VY4B7ULZ3GXIL6SN",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-W2P46JBEVI3PM3DD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-P4OUMSSD3H2I5VAK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-W6M2HKQEBLPC2YZM",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IZIXTQHCSNLRVMJG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-W7DOHU725FX5XL4T",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-NT46QBRN4LGCBFOU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WBC7B6QE5HBS5DKT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C3GW2XWP7Z4WYQHU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WCEUJZTZFKKCBZTM",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-UJEXQZQAEG5ES5IW",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WDCRWTWXK7DZGHFH",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WEG7ZAREA42IJSWR",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-6GUEN53ZVPP73TP4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WEZ5SXD43DXQUTII",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-NT46QBRN4LGCBFOU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WHUNK66YGPNIMXZA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:types-pyyaml:types-pyyaml:6.0.12.20250915:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-types-pyyaml:types-pyyaml:6.0.12.20250915:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HJ3YR5O76WAGRB4N",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WMNOECKSJJU2TOJF",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KPBHRVCIV5SEQH3O",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WMX4IN64KKXIWEMD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZJ4LXA7E6GRCCBF4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WRXESP2EH77N4XAB",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HH5H3VPTJ5RJ5RO7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WSXMLZHQXHXRSVJZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"django-stubs~=4.2.7\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-R4X2UVERTU2BUL6G",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WUFZ7RJZZGMFNLEM",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pathspec:pathspec:0.12.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pathspec:pathspec:0.12.1:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-DOM7F6NZSIXQTJP6",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WVBBEATHMOP3YOJX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WVZVYQJ5NN6NS24T",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WYNNQYJYH4DMDNC7",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-UJEXQZQAEG5ES5IW",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WZI5XPQEYPTUUEYH",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-P4OUMSSD3H2I5VAK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-X4K6SOJOIW6OFDDV",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-FPZWIH6CAOYU3T7P",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-XAIXSWT5GNC7UW26",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:translate:translate:3.6.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-translate:translate:3.6.1:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-IEU5J3H7V4XCJJTC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-XCFOXZZV7LSP3UGN",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-R4X2UVERTU2BUL6G",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-XHAVW4J5ZSBPZSRX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:unresolved-reason\",\"value\":\"no version specifier in requirements.txt; no uv.lock / poetry.lock fallback\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-KXH7YWPSKHW2JX2E",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-XQFCVKOYMMG4I4RV",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-XUQSIYTJUREMWDHW",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-HJ3YR5O76WAGRB4N",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-XVFM4L6FMYNFXENE",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:typing-extensions:typing-extensions:4.15.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-typing-extensions:typing-extensions:4.15.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YT4X5I2ZVNQ76YPG",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-XWD54BK6HFMQ4DSB",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C5PMZOFYJYXSBR2L",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-XWNF6YJXIPNLHFSX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-R4X2UVERTU2BUL6G",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-Y6DDKZYJZ2M4CYZD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:idna:idna:3.10:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-idna:idna:3.10:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-C3GW2XWP7Z4WYQHU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-YE4A32M5JNG4R5SX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TIMXRDWKC3YJTFQH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-YHRLX5MRAQ7W52J5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"lockfiles/python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CBHMYQZVIKAPO245",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-YLCXV27P7K5WTSUQ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-DOM7F6NZSIXQTJP6",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-YNRGDTX3X5HBF24N",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-YO34RMDG4EN3LF52",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"design\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-AEOGXK7HXBGYVCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-YQ4C52WHBJSPZCZC",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:graph-completeness\",\"value\":\"complete\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-YQ6TWISRTSPBNI4K",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.6\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-CSWB6UC23KUPCURQ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-Z2JJKW67EA7JAK34",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-F4IXESTNNXT5DFXV",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-Z7GTDSBFBEAVO2GY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-TOHIXWBCZAKDS7RY",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ZDXPF6X7SDVKJVN7",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ZDY3LSHAPGZRT2TB",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"lockfiles/python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-INYEPPGPVSI54ME5",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ZEPDOC5KRWSB6BUI",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:setuptools:setuptools:80.9.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-setuptools:setuptools:80.9.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-EYHFQQMNOGG2LFQU",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ZMPEH7PSUD2TBPXT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-JNFVHROXCRFXTCHP",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ZNIITOD4NLFBKX6P",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ZUPAG42D4FSMVH2V",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-LEBFN55XRNW7NNPO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ZVXN4AHRNXU7MBEA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-3K35DO6UFTQHRNNL",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ZZCXFC7QMU6PPPWH",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-P4OUMSSD3H2I5VAK",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ZZLQB2DQPHCG3M3O",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\"lockfiles\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-OGYEBHFS6PNWU6BYMGPCCMO2/pkg-ZJ4LXA7E6GRCCBF4",
+      "type": "Annotation"
+    }
+  ]
+}

--- a/waybill-cli/tests/fixtures/public_corpus/pants-example-golang/cdx.json
+++ b/waybill-cli/tests/fixtures/public_corpus/pants-example-golang/cdx.json
@@ -1,0 +1,440 @@
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.6.0",
+      "cpe": "cpe:2.3:a:github.com\\/google\\/uuid:github.com\\/google\\/uuid:v1.6.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "go.sum"
+          }
+        ]
+      },
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/google/uuid"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "348bda24330eb231c0f27d630212d2833ac0cf2d4782bfa136b6f9edefbde05d"
+        }
+      ],
+      "name": "github.com/google/uuid",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:github.com\\/google\\/uuid:github.com\\/google\\/uuid:v1.6.0:*:*:*:*:*:*:* | cpe:2.3:a:github.com\\/google:github.com\\/google\\/uuid:v1.6.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"go.sum\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:go-transitive-source",
+          "value": "module-cache"
+        },
+        {
+          "name": "waybill:orphan-reason",
+          "value": "unresolved-indirect-require"
+        },
+        {
+          "name": "waybill:pants-target",
+          "value": "mod"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:golang/github.com/google/uuid@v1.6.0",
+      "supplier": {
+        "name": "github.com/google"
+      },
+      "type": "library",
+      "version": "v1.6.0"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.10",
+      "cpe": "cpe:2.3:a:github.com\\/spf13\\/pflag:github.com\\/spf13\\/pflag:v1.0.10:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "go.sum"
+          }
+        ]
+      },
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/spf13/pflag"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e04061d8a01807068e363e9bd987b51a21dfc23ab244ea05e11c183bebcfc059"
+        }
+      ],
+      "name": "github.com/spf13/pflag",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:github.com\\/spf13\\/pflag:github.com\\/spf13\\/pflag:v1.0.10:*:*:*:*:*:*:* | cpe:2.3:a:github.com\\/spf13:github.com\\/spf13\\/pflag:v1.0.10:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"go.sum\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:go-transitive-source",
+          "value": "module-cache"
+        },
+        {
+          "name": "waybill:orphan-reason",
+          "value": "unresolved-indirect-require"
+        },
+        {
+          "name": "waybill:pants-target",
+          "value": "mod"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.10",
+      "supplier": {
+        "name": "github.com/spf13"
+      },
+      "type": "library",
+      "version": "v1.0.10"
+    },
+    {
+      "bom-ref": "pkg:golang/stdlib@v1.24",
+      "cpe": "cpe:2.3:a:golang:go:1.24:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "go.sum"
+          }
+        ]
+      },
+      "name": "stdlib",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"go.sum\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-target",
+          "value": "mod"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:golang/stdlib@v1.24",
+      "type": "library",
+      "version": "v1.24"
+    },
+    {
+      "bom-ref": "pkg:generic/file-tier?content-sha256=2af0148f674aa936503e6f06fdd5a09d44f948a36524e135f66ebbddc66c1bbd",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 1.0,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 1.0,
+                "technique": "hash-comparison"
+              }
+            ]
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2af0148f674aa936503e6f06fdd5a09d44f948a36524e135f66ebbddc66c1bbd"
+        }
+      ],
+      "name": "pants_from_sources",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"pants_from_sources\"]"
+        },
+        {
+          "name": "waybill:component-tier",
+          "value": "file"
+        },
+        {
+          "name": "waybill:file-paths",
+          "value": "[\"pants_from_sources\"]"
+        }
+      ],
+      "type": "file",
+      "version": ""
+    },
+    {
+      "bom-ref": "pkg:generic/file-tier?content-sha256=5ba4768ee4a229d8c3c1b57e4e713dc890876c28113f76abd88ad079dc25cf62",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 1.0,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 1.0,
+                "technique": "hash-comparison"
+              }
+            ]
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5ba4768ee4a229d8c3c1b57e4e713dc890876c28113f76abd88ad079dc25cf62"
+        }
+      ],
+      "name": "get-pants.sh",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"get-pants.sh\"]"
+        },
+        {
+          "name": "waybill:component-tier",
+          "value": "file"
+        },
+        {
+          "name": "waybill:file-paths",
+          "value": "[\"get-pants.sh\"]"
+        }
+      ],
+      "type": "file",
+      "version": ""
+    }
+  ],
+  "compositions": [
+    {
+      "aggregate": "complete",
+      "assemblies": [
+        "pkg:golang/github.com/google/uuid@v1.6.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.10",
+        "pkg:golang/stdlib@v1.24"
+      ],
+      "dependencies": [
+        "pkg:golang/github.com/google/uuid@v1.6.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.10",
+        "pkg:golang/stdlib@v1.24"
+      ]
+    },
+    {
+      "aggregate": "incomplete_first_party_only",
+      "assemblies": [
+        "pants-example-golang@048c22e"
+      ]
+    },
+    {
+      "aggregate": "complete",
+      "dependencies": [
+        "pants-example-golang@048c22e"
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "pkg:golang/github.com/google/uuid@v1.6.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.10",
+        "pkg:golang/stdlib@v1.24"
+      ],
+      "ref": "pants-example-golang@048c22e"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:generic/file-tier?content-sha256=2af0148f674aa936503e6f06fdd5a09d44f948a36524e135f66ebbddc66c1bbd"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:generic/file-tier?content-sha256=5ba4768ee4a229d8c3c1b57e4e713dc890876c28113f76abd88ad079dc25cf62"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:golang/github.com/google/uuid@v1.6.0"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.10"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:golang/stdlib@v1.24"
+    }
+  ],
+  "metadata": {
+    "authors": [
+      {
+        "name": "waybill"
+      }
+    ],
+    "component": {
+      "bom-ref": "pants-example-golang@048c22e",
+      "cpe": "cpe:2.3:a:waybill:pants-example-golang:048c22e:*:*:*:*:*:*:*",
+      "externalReferences": [
+        {
+          "comment": "auto-detected from git remote `origin`",
+          "type": "vcs",
+          "url": "https://github.com/kusari-sandbox/example-golang"
+        }
+      ],
+      "name": "pants-example-golang",
+      "purl": "pkg:generic/pants-example-golang@048c22e",
+      "type": "application",
+      "version": "048c22e"
+    },
+    "licenses": [
+      {
+        "license": {
+          "id": "CC0-1.0"
+        }
+      }
+    ],
+    "lifecycles": [
+      {
+        "phase": "pre-build"
+      }
+    ],
+    "properties": [
+      {
+        "name": "waybill:generation-context",
+        "value": "filesystem-scan"
+      },
+      {
+        "name": "waybill:cisa-2026-lifecycle",
+        "value": "after-build"
+      },
+      {
+        "name": "waybill:os-release-missing-fields",
+        "value": "ID,VERSION_ID"
+      },
+      {
+        "name": "waybill:trace-integrity-ring-buffer-overflows",
+        "value": "0"
+      },
+      {
+        "name": "waybill:trace-integrity-events-dropped",
+        "value": "0"
+      },
+      {
+        "name": "waybill:trace-integrity-uprobe-attach-failures",
+        "value": "0"
+      },
+      {
+        "name": "waybill:trace-integrity-kprobe-attach-failures",
+        "value": "0"
+      },
+      {
+        "name": "waybill:graph-completeness",
+        "value": "complete"
+      },
+      {
+        "name": "waybill:workspaces-detected",
+        "value": "[\".\"]"
+      },
+      {
+        "name": "waybill:go-cache-warming-mode",
+        "value": "off"
+      },
+      {
+        "name": "waybill:go-transitive-coverage",
+        "value": "unknown"
+      },
+      {
+        "name": "waybill:go-transitive-coverage-reason",
+        "value": "offline-mode: transitive edges from proxy fetches unavailable"
+      },
+      {
+        "name": "waybill:go-transitive-fallback-count",
+        "value": "0"
+      }
+    ],
+    "supplier": {
+      "name": "waybill contributors"
+    },
+    "timestamp": "<masked>",
+    "tools": {
+      "components": [
+        {
+          "name": "waybill",
+          "publisher": "waybill contributors",
+          "type": "application",
+          "version": "0.5.1-alpha.1"
+        }
+      ]
+    }
+  },
+  "serialNumber": "<masked>",
+  "specVersion": "1.6",
+  "version": 1,
+  "vulnerabilities": []
+}

--- a/waybill-cli/tests/fixtures/public_corpus/pants-example-golang/spdx-2.3.json
+++ b/waybill-cli/tests/fixtures/public_corpus/pants-example-golang/spdx-2.3.json
@@ -1,0 +1,462 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "annotations": [
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:generation-context\",\"value\":\"filesystem-scan\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cisa-2026-lifecycle\",\"value\":\"after-build\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:graph-completeness\",\"value\":\"complete\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspaces-detected\",\"value\":\"[\\\".\\\"]\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:go-cache-warming-mode\",\"value\":\"off\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:go-transitive-coverage\",\"value\":\"unknown\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:go-transitive-coverage-reason\",\"value\":\"offline-mode: transitive edges from proxy fetches unavailable\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:go-transitive-fallback-count\",\"value\":\"0\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-ring-buffer-overflows\",\"value\":\"0\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-events-dropped\",\"value\":\"0\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-uprobe-attach-failures\",\"value\":[]}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-kprobe-attach-failures\",\"value\":[]}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"golang\"]}}"
+    }
+  ],
+  "creationInfo": "<masked>",
+  "dataLicense": "CC0-1.0",
+  "documentDescribes": [
+    "SPDXRef-DocumentRoot-UMCCMWTORRS76DUJ"
+  ],
+  "documentNamespace": "<masked>",
+  "name": "repo",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-DocumentRoot-UMCCMWTORRS76DUJ",
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:generic/pants-example-golang@048c22e",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:waybill:pants-example-golang:048c22e:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pants-example-golang",
+      "supplier": "Organization: waybill contributors",
+      "versionInfo": "048c22e"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-C3XBGHEYQSJBP4E2",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"go.sum\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/google\\\\/uuid:github.com\\\\/google\\\\/uuid:v1.6.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/google:github.com\\\\/google\\\\/uuid:v1.6.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:go-transitive-source\",\"value\":\"module-cache\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:orphan-reason\",\"value\":\"unresolved-indirect-require\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-target\",\"value\":\"mod\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "348bda24330eb231c0f27d630212d2833ac0cf2d4782bfa136b6f9edefbde05d"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:golang/github.com/google/uuid@v1.6.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:github.com\\/google\\/uuid:github.com\\/google\\/uuid:v1.6.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "OTHER",
+          "referenceLocator": "https://github.com/google/uuid",
+          "referenceType": "vcs"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "github.com/google/uuid",
+      "supplier": "Organization: github.com/google",
+      "versionInfo": "v1.6.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-DKAFQULQWHAUSS6J",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"go.sum\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/spf13\\\\/pflag:github.com\\\\/spf13\\\\/pflag:v1.0.10:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/spf13:github.com\\\\/spf13\\\\/pflag:v1.0.10:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:go-transitive-source\",\"value\":\"module-cache\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:orphan-reason\",\"value\":\"unresolved-indirect-require\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-target\",\"value\":\"mod\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e04061d8a01807068e363e9bd987b51a21dfc23ab244ea05e11c183bebcfc059"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:golang/github.com/spf13/pflag@v1.0.10",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:github.com\\/spf13\\/pflag:github.com\\/spf13\\/pflag:v1.0.10:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "OTHER",
+          "referenceLocator": "https://github.com/spf13/pflag",
+          "referenceType": "vcs"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "github.com/spf13/pflag",
+      "supplier": "Organization: github.com/spf13",
+      "versionInfo": "v1.0.10"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-OWHJZJLN2QO5JKWZ",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"go.sum\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-target\",\"value\":\"mod\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:golang/stdlib@v1.24",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:golang:go:1.24:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "stdlib",
+      "versionInfo": "v1.24"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-X5QIBLEI7QDVIJZ4",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"pants_from_sources\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":1.0,\"technique\":\"hash-match\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:component-tier\",\"value\":\"file\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:file-paths\",\"value\":[\"pants_from_sources\"]}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2af0148f674aa936503e6f06fdd5a09d44f948a36524e135f66ebbddc66c1bbd"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pants_from_sources",
+      "versionInfo": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-G4VMKWSHXDQKKU23",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"get-pants.sh\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":1.0,\"technique\":\"hash-match\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:component-tier\",\"value\":\"file\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:file-paths\",\"value\":[\"get-pants.sh\"]}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5ba4768ee4a229d8c3c1b57e4e713dc890876c28113f76abd88ad079dc25cf62"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "get-pants.sh",
+      "versionInfo": "NOASSERTION"
+    }
+  ],
+  "relationships": [
+    {
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-UMCCMWTORRS76DUJ",
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-C3XBGHEYQSJBP4E2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-UMCCMWTORRS76DUJ"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-DKAFQULQWHAUSS6J",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-UMCCMWTORRS76DUJ"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-OWHJZJLN2QO5JKWZ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-UMCCMWTORRS76DUJ"
+    }
+  ],
+  "spdxVersion": "SPDX-2.3"
+}

--- a/waybill-cli/tests/fixtures/public_corpus/pants-example-golang/spdx-3.json
+++ b/waybill-cli/tests/fixtures/public_corpus/pants-example-golang/spdx-3.json
@@ -1,0 +1,630 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "creationInfo": "<masked>",
+      "name": "waybill contributors",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/agent/waybill-contributors",
+      "type": "Organization"
+    },
+    {
+      "@id": "_:creation-info",
+      "created": "<masked>",
+      "createdBy": [
+        "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/agent/waybill-contributors"
+      ],
+      "createdUsing": [
+        "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/tool/waybill"
+      ],
+      "specVersion": "3.0.1",
+      "type": "CreationInfo"
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "waybill-0.5.1-alpha.1",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/tool/waybill",
+      "type": "Tool"
+    },
+    {
+      "creationInfo": "<masked>",
+      "simplelicensing_licenseExpression": "CC0-1.0",
+      "spdxId": "https://spdx.org/licenses/CC0-1.0",
+      "type": "simplelicensing_LicenseExpression"
+    },
+    {
+      "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in waybill:sbom-tier annotations.",
+      "creationInfo": "<masked>",
+      "dataLicense": "https://spdx.org/licenses/CC0-1.0",
+      "externalIdentifier": [
+        {
+          "comment": "original-scheme: repo",
+          "externalIdentifierType": "other",
+          "identifier": "https://github.com/kusari-sandbox/example-golang",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pants-example-golang",
+      "rootElement": [
+        "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-root-QQJDP5GTSS5SKNDE"
+      ],
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>",
+      "type": "SpdxDocument"
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "pants-example-golang",
+      "rootElement": [
+        "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-root-QQJDP5GTSS5SKNDE"
+      ],
+      "software_sbomType": [
+        "source"
+      ],
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/sbom",
+      "type": "software_Sbom"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:waybill:pants-example-golang:048c22e:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:generic/pants-example-golang@048c22e",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pants-example-golang",
+      "software_packageUrl": "pkg:generic/pants-example-golang@048c22e",
+      "software_packageVersion": "048c22e",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-root-QQJDP5GTSS5SKNDE",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:github.com\\/google:github.com\\/google\\/uuid:v1.6.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:github.com\\/google\\/uuid:github.com\\/google\\/uuid:v1.6.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:golang/github.com/google/uuid@v1.6.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "github.com/google/uuid",
+      "software_packageUrl": "pkg:golang/github.com/google/uuid@v1.6.0",
+      "software_packageVersion": "v1.6.0",
+      "software_sourceInfo": "https://github.com/google/uuid",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-C3XBGHEYQSJBP4E2",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/agent-org-HLMYJEXVFSJUR67W",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "348bda24330eb231c0f27d630212d2833ac0cf2d4782bfa136b6f9edefbde05d",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:github.com\\/spf13:github.com\\/spf13\\/pflag:v1.0.10:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:github.com\\/spf13\\/pflag:github.com\\/spf13\\/pflag:v1.0.10:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:golang/github.com/spf13/pflag@v1.0.10",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "github.com/spf13/pflag",
+      "software_packageUrl": "pkg:golang/github.com/spf13/pflag@v1.0.10",
+      "software_packageVersion": "v1.0.10",
+      "software_sourceInfo": "https://github.com/spf13/pflag",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-DKAFQULQWHAUSS6J",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/agent-org-7G3YT5IGRPAH7OYU",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "e04061d8a01807068e363e9bd987b51a21dfc23ab244ea05e11c183bebcfc059",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "get-pants.sh",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-G4VMKWSHXDQKKU23",
+      "type": "software_File",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "5ba4768ee4a229d8c3c1b57e4e713dc890876c28113f76abd88ad079dc25cf62",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:golang:go:1.24:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:golang/stdlib@v1.24",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "stdlib",
+      "software_packageUrl": "pkg:golang/stdlib@v1.24",
+      "software_packageVersion": "v1.24",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-OWHJZJLN2QO5JKWZ",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "pants_from_sources",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-X5QIBLEI7QDVIJZ4",
+      "type": "software_File",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "2af0148f674aa936503e6f06fdd5a09d44f948a36524e135f66ebbddc66c1bbd",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "github.com/spf13",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/agent-org-7G3YT5IGRPAH7OYU",
+      "type": "Organization"
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "github.com/google",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/agent-org-HLMYJEXVFSJUR67W",
+      "type": "Organization"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-root-QQJDP5GTSS5SKNDE",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-3AVLB7F2OVBCKETB",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-DKAFQULQWHAUSS6J"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-root-QQJDP5GTSS5SKNDE",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-EIVWI2PR3E6GVO46",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-G4VMKWSHXDQKKU23"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-root-QQJDP5GTSS5SKNDE",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-ER2ZX6IYHY3RBGAN",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-OWHJZJLN2QO5JKWZ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-root-QQJDP5GTSS5SKNDE",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-O6ZFD3CJ6RH2ZMDC",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-C3XBGHEYQSJBP4E2"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-root-QQJDP5GTSS5SKNDE",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-UEJJ6NKN5VJWT63G",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-X5QIBLEI7QDVIJZ4"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-2DCD37OX3P5FEFFZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-C3XBGHEYQSJBP4E2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-33B7OSEDNJ2YM3MX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-3AXUIIVKQVAIDK2X",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":1.0,\"technique\":\"hash-match\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-G4VMKWSHXDQKKU23",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-3L3LRIKUNGIMSFCB",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-3O5EJ4D24YQECAZY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-OWHJZJLN2QO5JKWZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-4QRFLQ6QYZSX4NUS",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-DKAFQULQWHAUSS6J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-4UFGCZVJSDOLZHXT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/spf13\\\\/pflag:github.com\\\\/spf13\\\\/pflag:v1.0.10:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/spf13:github.com\\\\/spf13\\\\/pflag:v1.0.10:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-DKAFQULQWHAUSS6J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-4Z7YWHV6JOHNDPC5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:go-transitive-source\",\"value\":\"module-cache\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-C3XBGHEYQSJBP4E2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-5CEP73YLKFXD4PY7",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cisa-2026-lifecycle\",\"value\":\"after-build\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-5K7HTHLTRG3KW7SH",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-DKAFQULQWHAUSS6J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-63FTVIYCIZSRVJAR",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-OWHJZJLN2QO5JKWZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-6MSVICWIXA5TQDNA",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:go-transitive-fallback-count\",\"value\":\"0\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-AST5NXN2UHF4OTIH",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:github.com\\\\/google\\\\/uuid:github.com\\\\/google\\\\/uuid:v1.6.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:github.com\\\\/google:github.com\\\\/google\\\\/uuid:v1.6.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-C3XBGHEYQSJBP4E2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BOIQYYPKJWT2SZZL",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-target\",\"value\":\"mod\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-DKAFQULQWHAUSS6J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-CNDMYXKSHJ36K73A",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-C3XBGHEYQSJBP4E2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DGSXSDMXZLHR4EK3",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:go-transitive-source\",\"value\":\"module-cache\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-DKAFQULQWHAUSS6J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DSGVVRN7XP5MVBXO",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspaces-detected\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-DYA32A63I5HMLUWV",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:file-paths\",\"value\":[\"pants_from_sources\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-X5QIBLEI7QDVIJZ4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-EASR4RL3UKUCA3NF",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":1.0,\"technique\":\"hash-match\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-X5QIBLEI7QDVIJZ4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-FIJCTPGOKFP2PKGM",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:go-transitive-coverage\",\"value\":\"unknown\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-FRBCOCARGGWTQAA6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-ring-buffer-overflows\",\"value\":\"0\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GFMLLLECLBZTT5TN",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"go.sum\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-C3XBGHEYQSJBP4E2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-I6KUZEJS7TNGP6A2",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-C3XBGHEYQSJBP4E2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ICNA6E2W5L3UJNTT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-events-dropped\",\"value\":\"0\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JKOJOQCPEKXDO236",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-C3XBGHEYQSJBP4E2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-K3RNNIVOBQX7IPEI",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-OWHJZJLN2QO5JKWZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KW5LGV6LYG4U3UQE",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:graph-completeness\",\"value\":\"complete\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-N7AIQRCY3UXGUHUL",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-DKAFQULQWHAUSS6J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-NJZUAL5H5BGNO5LD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"pants_from_sources\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-X5QIBLEI7QDVIJZ4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-P3OSKSLYW4ELJLY7",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-DKAFQULQWHAUSS6J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-Q25MYVYBG7YKS4AI",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-OWHJZJLN2QO5JKWZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-Q2FHPWDVHBHD6IGE",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:component-tier\",\"value\":\"file\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-G4VMKWSHXDQKKU23",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-QBLAQHTJUBPEUQU6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-target\",\"value\":\"mod\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-C3XBGHEYQSJBP4E2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-RICKLEU7UF3HDF4J",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:file-paths\",\"value\":[\"get-pants.sh\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-G4VMKWSHXDQKKU23",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-RJDQ7IQ25KJWPVAS",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-DKAFQULQWHAUSS6J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-RQ6QKD5LPBSGVPOI",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-target\",\"value\":\"mod\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-OWHJZJLN2QO5JKWZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-RZ2IOTRPTQVMCPR2",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:go-transitive-coverage-reason\",\"value\":\"offline-mode: transitive edges from proxy fetches unavailable\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-SCGLLHZQ5W6GKXZZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"golang\"]}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-SO6N7LBUP7JLZI47",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:orphan-reason\",\"value\":\"unresolved-indirect-require\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-DKAFQULQWHAUSS6J",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-TLAZYDPPXT2ZRHYP",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"get-pants.sh\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-G4VMKWSHXDQKKU23",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-VVNEDZKJ647O7NUR",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-W4OY6LBLTH3MJYTM",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"go.sum\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-OWHJZJLN2QO5JKWZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WTWCF524WZRJCVAT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:generation-context\",\"value\":\"filesystem-scan\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-XYZ7NF2236HEC67M",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:component-tier\",\"value\":\"file\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-X5QIBLEI7QDVIJZ4",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-XZ3A54SLFKC2JDQX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:go-cache-warming-mode\",\"value\":\"off\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-YCJHOMZ42I75OMKJ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:orphan-reason\",\"value\":\"unresolved-indirect-require\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-NCZPAZXZZB5MWZF65LKFJO3Z/pkg-C3XBGHEYQSJBP4E2",
+      "type": "Annotation"
+    }
+  ]
+}

--- a/waybill-cli/tests/fixtures/public_corpus/pants-example-python/cdx.json
+++ b/waybill-cli/tests/fixtures/public_corpus/pants-example-python/cdx.json
@@ -1,0 +1,946 @@
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "bom-ref": "pkg:pypi/ansicolors@1.1.8",
+      "cpe": "cpe:2.3:a:ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "00d2dde5a675579325902536738dd27e4fac1fd68f773fe36c21044eb559e187"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "99f94f5e3348a0bcd43c82e5fc4414013ccc19d70bd939ad71e0133ce9c372e0"
+        }
+      ],
+      "name": "ansicolors",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:* | cpe:2.3:a:python-ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"python-default.lock\",\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"ansicolors==1.1.8\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/ansicolors@1.1.8",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "1.1.8"
+    },
+    {
+      "bom-ref": "pkg:pypi/attrs@25.3.0",
+      "cpe": "cpe:2.3:a:attrs:attrs:25.3.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"
+        }
+      ],
+      "name": "attrs",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:attrs:attrs:25.3.0:*:*:*:*:*:*:* | cpe:2.3:a:python-attrs:attrs:25.3.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.8"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/attrs@25.3.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "25.3.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/iniconfig@2.1.0",
+      "cpe": "cpe:2.3:a:iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"
+        }
+      ],
+      "name": "iniconfig",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:* | cpe:2.3:a:python-iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.8"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/iniconfig@2.1.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "2.1.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/packaging@25.0",
+      "cpe": "cpe:2.3:a:packaging:packaging:25.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
+        }
+      ],
+      "name": "packaging",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:packaging:packaging:25.0:*:*:*:*:*:*:* | cpe:2.3:a:python-packaging:packaging:25.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.8"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/packaging@25.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "25.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/pluggy@1.6.0",
+      "cpe": "cpe:2.3:a:pluggy:pluggy:1.6.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"
+        }
+      ],
+      "name": "pluggy",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:pluggy:pluggy:1.6.0:*:*:*:*:*:*:* | cpe:2.3:a:python-pluggy:pluggy:1.6.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.9"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/pluggy@1.6.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "1.6.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/py@1.11.0",
+      "cpe": "cpe:2.3:a:py:py:1.11.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"
+        }
+      ],
+      "name": "py",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:py:py:1.11.0:*:*:*:*:*:*:* | cpe:2.3:a:python-py:py:1.11.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/py@1.11.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "1.11.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/pytest@7.1.3",
+      "cpe": "cpe:2.3:a:pytest:pytest:7.1.3:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "requirements.txt"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
+        }
+      ],
+      "name": "pytest",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:pytest:pytest:7.1.3:*:*:*:*:*:*:* | cpe:2.3:a:python-pytest:pytest:7.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"python-default.lock\",\"requirements.txt\"]"
+        },
+        {
+          "name": "waybill:requirement-ranges",
+          "value": "[\"pytest==7.1.3\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.7"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/pytest@7.1.3",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "7.1.3"
+    },
+    {
+      "bom-ref": "pkg:pypi/setuptools@56.2.0",
+      "cpe": "cpe:2.3:a:setuptools:setuptools:56.2.0:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bc30153eec47d82f20c6f5e1a13d4ee725c6deb7013a67557f89bfe5d25235c4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7bb5652625e94e73b9358b7ed8c6431b732e80cf31f4e0972294c64f0e5b849e"
+        }
+      ],
+      "name": "setuptools",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:setuptools:setuptools:56.2.0:*:*:*:*:*:*:* | cpe:2.3:a:python-setuptools:setuptools:56.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.6"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/setuptools@56.2.0",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "56.2.0"
+    },
+    {
+      "bom-ref": "pkg:pypi/tomli@2.2.1",
+      "cpe": "cpe:2.3:a:tomli:tomli:2.2.1:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192"
+        }
+      ],
+      "name": "tomli",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:tomli:tomli:2.2.1:*:*:*:*:*:*:* | cpe:2.3:a:python-tomli:tomli:2.2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:requires-python",
+          "value": ">=3.8"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/tomli@2.2.1",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "2.2.1"
+    },
+    {
+      "bom-ref": "pkg:pypi/types-setuptools@57.4.18",
+      "cpe": "cpe:2.3:a:types-setuptools:types-setuptools:57.4.18:*:*:*:*:*:*:*",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 0.85,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 0.85,
+                "technique": "manifest-analysis"
+              }
+            ]
+          }
+        ],
+        "occurrences": [
+          {
+            "additionalContext": "{\"sha256\":\"<masked-sha256>\"}",
+            "location": "python-default.lock"
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9660b8774b12cd61b448e2fd87a667c02e7ec13ce9f15171f1d49a4654c4df6a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8ee03d823fe7fda0bd35faeae33d35cb5c25b497263e6a58b34c4cfd05f40bcf"
+        }
+      ],
+      "name": "types-setuptools",
+      "properties": [
+        {
+          "name": "waybill:cpe-candidates",
+          "value": "cpe:2.3:a:types-setuptools:types-setuptools:57.4.18:*:*:*:*:*:*:* | cpe:2.3:a:python-types-setuptools:types-setuptools:57.4.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "waybill:source-files",
+          "value": "[\"python-default.lock\"]"
+        },
+        {
+          "name": "waybill:sbom-tier",
+          "value": "source"
+        },
+        {
+          "name": "waybill:pants-resolve",
+          "value": "python-default"
+        },
+        {
+          "name": "waybill:workspace-member",
+          "value": "[\".\"]"
+        }
+      ],
+      "purl": "pkg:pypi/types-setuptools@57.4.18",
+      "supplier": {
+        "name": "PyPI"
+      },
+      "type": "library",
+      "version": "57.4.18"
+    },
+    {
+      "bom-ref": "pkg:generic/file-tier?content-sha256=9357a2fd2981defaed29192bf839515586fbeafa0205e2e7818a8068f7f2e359",
+      "evidence": {
+        "identity": [
+          {
+            "confidence": 1.0,
+            "field": "purl",
+            "methods": [
+              {
+                "confidence": 1.0,
+                "technique": "hash-comparison"
+              }
+            ]
+          }
+        ]
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9357a2fd2981defaed29192bf839515586fbeafa0205e2e7818a8068f7f2e359"
+        }
+      ],
+      "name": "get-pants.sh",
+      "properties": [
+        {
+          "name": "waybill:source-files",
+          "value": "[\"get-pants.sh\"]"
+        },
+        {
+          "name": "waybill:component-tier",
+          "value": "file"
+        },
+        {
+          "name": "waybill:file-paths",
+          "value": "[\"get-pants.sh\"]"
+        }
+      ],
+      "type": "file",
+      "version": ""
+    }
+  ],
+  "compositions": [
+    {
+      "aggregate": "complete",
+      "assemblies": [
+        "pkg:pypi/ansicolors@1.1.8",
+        "pkg:pypi/attrs@25.3.0",
+        "pkg:pypi/iniconfig@2.1.0",
+        "pkg:pypi/packaging@25.0",
+        "pkg:pypi/pluggy@1.6.0",
+        "pkg:pypi/py@1.11.0",
+        "pkg:pypi/pytest@7.1.3",
+        "pkg:pypi/setuptools@56.2.0",
+        "pkg:pypi/tomli@2.2.1",
+        "pkg:pypi/types-setuptools@57.4.18"
+      ],
+      "dependencies": [
+        "pkg:pypi/ansicolors@1.1.8",
+        "pkg:pypi/attrs@25.3.0",
+        "pkg:pypi/iniconfig@2.1.0",
+        "pkg:pypi/packaging@25.0",
+        "pkg:pypi/pluggy@1.6.0",
+        "pkg:pypi/py@1.11.0",
+        "pkg:pypi/pytest@7.1.3",
+        "pkg:pypi/setuptools@56.2.0",
+        "pkg:pypi/tomli@2.2.1",
+        "pkg:pypi/types-setuptools@57.4.18"
+      ]
+    },
+    {
+      "aggregate": "incomplete_first_party_only",
+      "assemblies": [
+        "pants-example-python@e8cfd79"
+      ]
+    },
+    {
+      "aggregate": "complete",
+      "dependencies": [
+        "pants-example-python@e8cfd79"
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "pkg:generic/file-tier?content-sha256=9357a2fd2981defaed29192bf839515586fbeafa0205e2e7818a8068f7f2e359",
+        "pkg:pypi/ansicolors@1.1.8",
+        "pkg:pypi/setuptools@56.2.0",
+        "pkg:pypi/types-setuptools@57.4.18"
+      ],
+      "ref": "pants-example-python@e8cfd79"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:generic/file-tier?content-sha256=9357a2fd2981defaed29192bf839515586fbeafa0205e2e7818a8068f7f2e359"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/ansicolors@1.1.8"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/pytest@7.1.3"
+      ],
+      "ref": "pkg:pypi/attrs@25.3.0"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/iniconfig@2.1.0"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/packaging@25.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/pytest@7.1.3"
+      ],
+      "ref": "pkg:pypi/pluggy@1.6.0"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/py@1.11.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/attrs@25.3.0",
+        "pkg:pypi/iniconfig@2.1.0",
+        "pkg:pypi/packaging@25.0",
+        "pkg:pypi/pluggy@1.6.0",
+        "pkg:pypi/py@1.11.0",
+        "pkg:pypi/tomli@2.2.1"
+      ],
+      "ref": "pkg:pypi/pytest@7.1.3"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/pytest@7.1.3"
+      ],
+      "ref": "pkg:pypi/setuptools@56.2.0"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/tomli@2.2.1"
+    },
+    {
+      "dependsOn": [],
+      "ref": "pkg:pypi/types-setuptools@57.4.18"
+    }
+  ],
+  "metadata": {
+    "authors": [
+      {
+        "name": "waybill"
+      }
+    ],
+    "component": {
+      "bom-ref": "pants-example-python@e8cfd79",
+      "cpe": "cpe:2.3:a:waybill:pants-example-python:e8cfd79:*:*:*:*:*:*:*",
+      "externalReferences": [
+        {
+          "comment": "auto-detected from git remote `origin`",
+          "type": "vcs",
+          "url": "https://github.com/kusari-sandbox/example-python"
+        }
+      ],
+      "name": "pants-example-python",
+      "purl": "pkg:generic/pants-example-python@e8cfd79",
+      "type": "application",
+      "version": "e8cfd79"
+    },
+    "licenses": [
+      {
+        "license": {
+          "id": "CC0-1.0"
+        }
+      }
+    ],
+    "lifecycles": [
+      {
+        "phase": "pre-build"
+      }
+    ],
+    "properties": [
+      {
+        "name": "waybill:generation-context",
+        "value": "filesystem-scan"
+      },
+      {
+        "name": "waybill:cisa-2026-lifecycle",
+        "value": "after-build"
+      },
+      {
+        "name": "waybill:os-release-missing-fields",
+        "value": "ID,VERSION_ID"
+      },
+      {
+        "name": "waybill:trace-integrity-ring-buffer-overflows",
+        "value": "0"
+      },
+      {
+        "name": "waybill:trace-integrity-events-dropped",
+        "value": "0"
+      },
+      {
+        "name": "waybill:trace-integrity-uprobe-attach-failures",
+        "value": "0"
+      },
+      {
+        "name": "waybill:trace-integrity-kprobe-attach-failures",
+        "value": "0"
+      },
+      {
+        "name": "waybill:graph-completeness",
+        "value": "complete"
+      },
+      {
+        "name": "waybill:workspaces-detected",
+        "value": "[\".\"]"
+      }
+    ],
+    "supplier": {
+      "name": "waybill contributors"
+    },
+    "timestamp": "<masked>",
+    "tools": {
+      "components": [
+        {
+          "name": "waybill",
+          "publisher": "waybill contributors",
+          "type": "application",
+          "version": "0.5.1-alpha.1"
+        }
+      ]
+    }
+  },
+  "serialNumber": "<masked>",
+  "specVersion": "1.6",
+  "version": 1,
+  "vulnerabilities": []
+}

--- a/waybill-cli/tests/fixtures/public_corpus/pants-example-python/spdx-2.3.json
+++ b/waybill-cli/tests/fixtures/public_corpus/pants-example-python/spdx-2.3.json
@@ -1,0 +1,1062 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "annotations": [
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:generation-context\",\"value\":\"filesystem-scan\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cisa-2026-lifecycle\",\"value\":\"after-build\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:graph-completeness\",\"value\":\"complete\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspaces-detected\",\"value\":\"[\\\".\\\"]\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-ring-buffer-overflows\",\"value\":\"0\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-events-dropped\",\"value\":\"0\"}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-uprobe-attach-failures\",\"value\":[]}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-kprobe-attach-failures\",\"value\":[]}"
+    },
+    {
+      "annotationDate": "<masked>",
+      "annotationType": "OTHER",
+      "annotator": "Tool: waybill-0.5.1-alpha.1",
+      "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"pypi\"]}}"
+    }
+  ],
+  "creationInfo": "<masked>",
+  "dataLicense": "CC0-1.0",
+  "documentDescribes": [
+    "SPDXRef-DocumentRoot-XN5JAK52FQK56GWE"
+  ],
+  "documentNamespace": "<masked>",
+  "name": "repo",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-DocumentRoot-XN5JAK52FQK56GWE",
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:generic/pants-example-python@e8cfd79",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:waybill:pants-example-python:e8cfd79:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pants-example-python",
+      "supplier": "Organization: waybill contributors",
+      "versionInfo": "e8cfd79"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-THZZ7BY5LVTRT5PE",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\",\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"ansicolors==1.1.8\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "00d2dde5a675579325902536738dd27e4fac1fd68f773fe36c21044eb559e187"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "99f94f5e3348a0bcd43c82e5fc4414013ccc19d70bd939ad71e0133ce9c372e0"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/ansicolors@1.1.8",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "ansicolors",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "1.1.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-BX7RRJNTEW4YZ7I2",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:attrs:attrs:25.3.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-attrs:attrs:25.3.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/attrs@25.3.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:attrs:attrs:25.3.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "attrs",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "25.3.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-7PGGREEYPN52BKXA",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/iniconfig@2.1.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "iniconfig",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "2.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ZIBQF5WBZHCXASVC",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:packaging:packaging:25.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-packaging:packaging:25.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/packaging@25.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:packaging:packaging:25.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "packaging",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "25.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-YZ2MIPQWGEB5UZRZ",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pluggy:pluggy:1.6.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pluggy:pluggy:1.6.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/pluggy@1.6.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:pluggy:pluggy:1.6.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pluggy",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "1.6.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-KRELKXZBLBWT2U2V",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:py:py:1.11.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-py:py:1.11.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\"!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/py@1.11.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:py:py:1.11.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "py",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "1.11.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-SZPP2Q3S7JS3P5RM",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\",\"requirements.txt\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pytest:pytest:7.1.3:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pytest:pytest:7.1.3:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"pytest==7.1.3\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.7\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/pytest@7.1.3",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:pytest:pytest:7.1.3:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "pytest",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "7.1.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-Q72FCOSCIJC2P37I",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:setuptools:setuptools:56.2.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-setuptools:setuptools:56.2.0:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.6\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bc30153eec47d82f20c6f5e1a13d4ee725c6deb7013a67557f89bfe5d25235c4"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7bb5652625e94e73b9358b7ed8c6431b732e80cf31f4e0972294c64f0e5b849e"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/setuptools@56.2.0",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:setuptools:setuptools:56.2.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "setuptools",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "56.2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-E6CNMXCHNWAT77DO",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:tomli:tomli:2.2.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-tomli:tomli:2.2.1:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/tomli@2.2.1",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:tomli:tomli:2.2.1:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "tomli",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "2.2.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-V6WS5B3MCUO5V2R7",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:types-setuptools:types-setuptools:57.4.18:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-types-setuptools:types-setuptools:57.4.18:*:*:*:*:*:*:*\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9660b8774b12cd61b448e2fd87a667c02e7ec13ce9f15171f1d49a4654c4df6a"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8ee03d823fe7fda0bd35faeae33d35cb5c25b497263e6a58b34c4cfd05f40bcf"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:pypi/types-setuptools@57.4.18",
+          "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:types-setuptools:types-setuptools:57.4.18:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "types-setuptools",
+      "supplier": "Organization: PyPI",
+      "versionInfo": "57.4.18"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-C6BIGX26BQTR6BDH",
+      "annotations": [
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"get-pants.sh\"]}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":1.0,\"technique\":\"hash-match\"}}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:component-tier\",\"value\":\"file\"}"
+        },
+        {
+          "annotationDate": "<masked>",
+          "annotationType": "OTHER",
+          "annotator": "Tool: waybill-0.5.1-alpha.1",
+          "comment": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:file-paths\",\"value\":[\"get-pants.sh\"]}"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9357a2fd2981defaed29192bf839515586fbeafa0205e2e7818a8068f7f2e359"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "get-pants.sh",
+      "versionInfo": "NOASSERTION"
+    }
+  ],
+  "relationships": [
+    {
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-XN5JAK52FQK56GWE",
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-SZPP2Q3S7JS3P5RM",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-BX7RRJNTEW4YZ7I2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-SZPP2Q3S7JS3P5RM",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-YZ2MIPQWGEB5UZRZ"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-BX7RRJNTEW4YZ7I2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-SZPP2Q3S7JS3P5RM"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-7PGGREEYPN52BKXA",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-SZPP2Q3S7JS3P5RM"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ZIBQF5WBZHCXASVC",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-SZPP2Q3S7JS3P5RM"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-YZ2MIPQWGEB5UZRZ",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-SZPP2Q3S7JS3P5RM"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-KRELKXZBLBWT2U2V",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-SZPP2Q3S7JS3P5RM"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-E6CNMXCHNWAT77DO",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-SZPP2Q3S7JS3P5RM"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-SZPP2Q3S7JS3P5RM",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-Q72FCOSCIJC2P37I"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-C6BIGX26BQTR6BDH",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-XN5JAK52FQK56GWE"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-THZZ7BY5LVTRT5PE",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-XN5JAK52FQK56GWE"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-Q72FCOSCIJC2P37I",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-XN5JAK52FQK56GWE"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-V6WS5B3MCUO5V2R7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-DocumentRoot-XN5JAK52FQK56GWE"
+    }
+  ],
+  "spdxVersion": "SPDX-2.3"
+}

--- a/waybill-cli/tests/fixtures/public_corpus/pants-example-python/spdx-3.json
+++ b/waybill-cli/tests/fixtures/public_corpus/pants-example-python/spdx-3.json
@@ -1,0 +1,1407 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "creationInfo": "<masked>",
+      "name": "waybill contributors",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/agent/waybill-contributors",
+      "type": "Organization"
+    },
+    {
+      "@id": "_:creation-info",
+      "created": "<masked>",
+      "createdBy": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/agent/waybill-contributors"
+      ],
+      "createdUsing": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/tool/waybill"
+      ],
+      "specVersion": "3.0.1",
+      "type": "CreationInfo"
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "waybill-0.5.1-alpha.1",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/tool/waybill",
+      "type": "Tool"
+    },
+    {
+      "creationInfo": "<masked>",
+      "simplelicensing_licenseExpression": "CC0-1.0",
+      "spdxId": "https://spdx.org/licenses/CC0-1.0",
+      "type": "simplelicensing_LicenseExpression"
+    },
+    {
+      "comment": "Scope: manifest (declared transitives included). Observed lifecycle phases: pre-build. Per-component scope detail in waybill:sbom-tier annotations.",
+      "creationInfo": "<masked>",
+      "dataLicense": "https://spdx.org/licenses/CC0-1.0",
+      "externalIdentifier": [
+        {
+          "comment": "original-scheme: repo",
+          "externalIdentifierType": "other",
+          "identifier": "https://github.com/kusari-sandbox/example-python",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pants-example-python",
+      "rootElement": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-root-NG6B7GSBT6JOMDJN"
+      ],
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>",
+      "type": "SpdxDocument"
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "pants-example-python",
+      "rootElement": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-root-NG6B7GSBT6JOMDJN"
+      ],
+      "software_sbomType": [
+        "source"
+      ],
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/sbom",
+      "type": "software_Sbom"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:waybill:pants-example-python:e8cfd79:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:generic/pants-example-python@e8cfd79",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pants-example-python",
+      "software_packageUrl": "pkg:generic/pants-example-python@e8cfd79",
+      "software_packageVersion": "e8cfd79",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-root-NG6B7GSBT6JOMDJN",
+      "type": "software_Package"
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/iniconfig@2.1.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "iniconfig",
+      "software_packageUrl": "pkg:pypi/iniconfig@2.1.0",
+      "software_packageVersion": "2.1.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-7PGGREEYPN52BKXA",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:attrs:attrs:25.3.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-attrs:attrs:25.3.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/attrs@25.3.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "attrs",
+      "software_packageUrl": "pkg:pypi/attrs@25.3.0",
+      "software_packageVersion": "25.3.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-BX7RRJNTEW4YZ7I2",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "get-pants.sh",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-C6BIGX26BQTR6BDH",
+      "type": "software_File",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "9357a2fd2981defaed29192bf839515586fbeafa0205e2e7818a8068f7f2e359",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-tomli:tomli:2.2.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:tomli:tomli:2.2.1:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/tomli@2.2.1",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "tomli",
+      "software_packageUrl": "pkg:pypi/tomli@2.2.1",
+      "software_packageVersion": "2.2.1",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-E6CNMXCHNWAT77DO",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:py:py:1.11.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-py:py:1.11.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/py@1.11.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "py",
+      "software_packageUrl": "pkg:pypi/py@1.11.0",
+      "software_packageVersion": "1.11.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-KRELKXZBLBWT2U2V",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-setuptools:setuptools:56.2.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:setuptools:setuptools:56.2.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/setuptools@56.2.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "setuptools",
+      "software_packageUrl": "pkg:pypi/setuptools@56.2.0",
+      "software_packageVersion": "56.2.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-Q72FCOSCIJC2P37I",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "7bb5652625e94e73b9358b7ed8c6431b732e80cf31f4e0972294c64f0e5b849e",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "bc30153eec47d82f20c6f5e1a13d4ee725c6deb7013a67557f89bfe5d25235c4",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:pytest:pytest:7.1.3:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-pytest:pytest:7.1.3:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/pytest@7.1.3",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pytest",
+      "software_packageUrl": "pkg:pypi/pytest@7.1.3",
+      "software_packageVersion": "7.1.3",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-SZPP2Q3S7JS3P5RM",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/ansicolors@1.1.8",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "ansicolors",
+      "software_packageUrl": "pkg:pypi/ansicolors@1.1.8",
+      "software_packageVersion": "1.1.8",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-THZZ7BY5LVTRT5PE",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "00d2dde5a675579325902536738dd27e4fac1fd68f773fe36c21044eb559e187",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "99f94f5e3348a0bcd43c82e5fc4414013ccc19d70bd939ad71e0133ce9c372e0",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-types-setuptools:types-setuptools:57.4.18:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:types-setuptools:types-setuptools:57.4.18:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/types-setuptools@57.4.18",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "types-setuptools",
+      "software_packageUrl": "pkg:pypi/types-setuptools@57.4.18",
+      "software_packageVersion": "57.4.18",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-V6WS5B3MCUO5V2R7",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "8ee03d823fe7fda0bd35faeae33d35cb5c25b497263e6a58b34c4cfd05f40bcf",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "9660b8774b12cd61b448e2fd87a667c02e7ec13ce9f15171f1d49a4654c4df6a",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:pluggy:pluggy:1.6.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-pluggy:pluggy:1.6.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/pluggy@1.6.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "pluggy",
+      "software_packageUrl": "pkg:pypi/pluggy@1.6.0",
+      "software_packageVersion": "1.6.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-YZ2MIPQWGEB5UZRZ",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:packaging:packaging:25.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:python-packaging:packaging:25.0:*:*:*:*:*:*:*",
+          "type": "ExternalIdentifier"
+        },
+        {
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:pypi/packaging@25.0",
+          "type": "ExternalIdentifier"
+        }
+      ],
+      "name": "packaging",
+      "software_packageUrl": "pkg:pypi/packaging@25.0",
+      "software_packageVersion": "25.0",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/pkg-ZIBQF5WBZHCXASVC",
+      "suppliedBy": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/agent-org-FEUX73OAEUGOM2DW",
+      "type": "software_Package",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha256",
+          "hashValue": "29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484",
+          "type": "Hash"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f",
+          "type": "Hash"
+        }
+      ]
+    },
+    {
+      "creationInfo": "<masked>",
+      "name": "PyPI",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/agent-org-FEUX73OAEUGOM2DW",
+      "type": "Organization"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-2WB7KBK5MT7PT27Q",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-KRELKXZBLBWT2U2V"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-4GX5N7VP57Q2MBA5",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-7PGGREEYPN52BKXA"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-7X2HFZO7BQ5B3OLC",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-ZIBQF5WBZHCXASVC"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-root-NG6B7GSBT6JOMDJN",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-EJZRWK7GML6HJYRF",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-C6BIGX26BQTR6BDH"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-BX7RRJNTEW4YZ7I2",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-I66BOMTTO6IBRLUG",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-root-NG6B7GSBT6JOMDJN",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-IWHM5HJP5VV54VQS",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-V6WS5B3MCUO5V2R7"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-KRLLLVQ6MACDSYGL",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-E6CNMXCHNWAT77DO"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-YZ2MIPQWGEB5UZRZ",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-MLGYMUXKYB2YQ7Y4",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-MUQ5C6PH266QNQEA",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-BX7RRJNTEW4YZ7I2"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-OVI2QFNQ2XQZVJ3K",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-YZ2MIPQWGEB5UZRZ"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-Q72FCOSCIJC2P37I",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-RQL2TZVAQ3ZPD2DH",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-root-NG6B7GSBT6JOMDJN",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-TDPEPYBYZ22VA26C",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-Q72FCOSCIJC2P37I"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "creationInfo": "<masked>",
+      "from": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-root-NG6B7GSBT6JOMDJN",
+      "relationshipType": "dependsOn",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/rel-ZRZC2DIIQNSGBIRQ",
+      "to": [
+        "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-THZZ7BY5LVTRT5PE"
+      ],
+      "type": "Relationship"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-233FTBEARC35MJIZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-Q72FCOSCIJC2P37I",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-26ZZVEXM7MXVY3BT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-2AQRRNWEB7YFZ3VE",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"ansicolors==1.1.8\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-2QFEOBBQYNNVSZTV",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-ansicolors:ansicolors:1.1.8:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-3MH7CWKKHK3X22BX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-E6CNMXCHNWAT77DO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-3XLMDJ37WL4HPYQB",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-BX7RRJNTEW4YZ7I2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-4A6GV5MBI6LORJB5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:types-setuptools:types-setuptools:57.4.18:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-types-setuptools:types-setuptools:57.4.18:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-V6WS5B3MCUO5V2R7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-54EI24SEQHY2TDRJ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"compositions\",\"value\":{\"complete_ecosystems\":[\"pypi\"]}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-73B2FSZHSRPBMUGW",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-7BVLEPCA2UYSYUNY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-7MUKRO234LOSLTB3",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-A237VJPEJMQYDRV2",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-AHSUNQXBJXLJTUY4",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-KRELKXZBLBWT2U2V",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ALFKKGB7AG4LBSEK",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-BX7RRJNTEW4YZ7I2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-B7VLR3P66LSLAAUR",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-ring-buffer-overflows\",\"value\":\"0\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BDLQKJBWWO4U656Z",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BIZN3YPVCPCAAYQ7",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BJABQRCOC4C62XN6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-KRELKXZBLBWT2U2V",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BOYA2P2M3QLWUR3I",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BU7LCCMPQCQKSOUK",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":1.0,\"technique\":\"hash-match\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-C6BIGX26BQTR6BDH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-BUWJVN5K7KDF4WER",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-KRELKXZBLBWT2U2V",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-CCKUQV62LX62PW3B",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspaces-detected\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-CNNAQ7ESFVC33CGR",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-Q72FCOSCIJC2P37I",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-CU4XSUG3P5VMDEVR",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-BX7RRJNTEW4YZ7I2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-EEPZTLLETUZZD4N5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-BX7RRJNTEW4YZ7I2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-F7ZXRFAPGELLPIU5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.9\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-FNHZ7QBNTQXHPF4A",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.6\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-Q72FCOSCIJC2P37I",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-G35SKZZ6CNAIYCAN",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-E6CNMXCHNWAT77DO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-G4BWZNMWLPL24BB2",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-uprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GENAF2CJ7YYUMPPG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-V6WS5B3MCUO5V2R7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GESZHSIIR4INJTA2",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GGVO6N5AMAYQNQJD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GKFPVOUHYHI3RGTJ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-events-dropped\",\"value\":\"0\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GSH5WZ3JGRRPBKZ5",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-V6WS5B3MCUO5V2R7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-GY7VDNW6PZOSWBEK",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-KRELKXZBLBWT2U2V",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-HHJSC3UFOOEV252C",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\"!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-KRELKXZBLBWT2U2V",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-HKOUBSMADUHDWGNG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-IXNDO5KIVLCKC6R2",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.7\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JG25PVSTRSWJ6CGT",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requires-python\",\"value\":\">=3.8\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-E6CNMXCHNWAT77DO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JGIGBVXN4GN5QQ6X",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:file-paths\",\"value\":[\"get-pants.sh\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-C6BIGX26BQTR6BDH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JMTVVJFE6WX7VC3T",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-Q72FCOSCIJC2P37I",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JW4BCM5FOTMPX3YO",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:tomli:tomli:2.2.1:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-tomli:tomli:2.2.1:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-E6CNMXCHNWAT77DO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-JWP3XGVRHWQH6C3S",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"get-pants.sh\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-C6BIGX26BQTR6BDH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-K6MN6HAM5ASBOKUV",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KDI4K3EQQZEUSZIZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KIN4CQYDU7THPXFG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KLKZYVN2GEFZUBS3",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-Q72FCOSCIJC2P37I",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KTIQOCC64FUCO4EL",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:py:py:1.11.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-py:py:1.11.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-KRELKXZBLBWT2U2V",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-KWMHR4MJQ7J5NQSK",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-L6GFE2RPMVWWRAXY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:component-tier\",\"value\":\"file\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-C6BIGX26BQTR6BDH",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-LRLMETNN5ZPT2B2T",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-iniconfig:iniconfig:2.1.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-LUPL44ANY5HA7VFM",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-MA433YUWGUMYF25I",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:setuptools:setuptools:56.2.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-setuptools:setuptools:56.2.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-Q72FCOSCIJC2P37I",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-MFJGST32PVVXNS7K",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cisa-2026-lifecycle\",\"value\":\"after-build\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-MHYSJUMZNAI3PU5G",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-E6CNMXCHNWAT77DO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-N5TCCMOYSZ7JLDUE",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\",\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-N5VMFZF754FAT4H6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-BX7RRJNTEW4YZ7I2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-NI2AYQWLKVJIPH4O",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-E6CNMXCHNWAT77DO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-NRED5G4FL27OBGVW",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-O4RKQT6ZM3PZTDMQ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-O4SYB2FRGGJFNTWJ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:generation-context\",\"value\":\"filesystem-scan\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-OOMKBZN6LUPZBPFQ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pluggy:pluggy:1.6.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pluggy:pluggy:1.6.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-QAIHA47ON3SXUB4E",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-Q72FCOSCIJC2P37I",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-QDPYTPSPGWAYMNCG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-QLVKFL5Y4UCGPZOY",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"requirements.txt\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-QNP5BTVHA2P4QCHJ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-KRELKXZBLBWT2U2V",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-RELN7FX6FZRNDLYG",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-BX7RRJNTEW4YZ7I2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-RFNYMUKCJ6XXSPZE",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-V6WS5B3MCUO5V2R7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-S3SOAMGEC6J7JIJB",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:os-release-missing-fields\",\"value\":[\"ID\",\"VERSION_ID\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-SGRHL57PPNPSKNGH",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-BX7RRJNTEW4YZ7I2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-SO4S2BTUFL3DOR7R",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-YZ2MIPQWGEB5UZRZ",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-T26XK6K6JWMKBHWC",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-T4GCCCFC47AEUWYX",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-TOJYKBDNS4L4NFPR",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-U44QV3RADBDI52FO",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:trace-integrity-kprobe-attach-failures\",\"value\":[]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-UWWEOYARCXTX46D6",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-UXVGXIPNYU2I43QB",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-V6WS5B3MCUO5V2R7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-W3PV2EH2VSLPGMKR",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-Q72FCOSCIJC2P37I",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WAECSBDGE4LT6VEE",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.identity\",\"value\":{\"confidence\":0.85,\"technique\":\"package-database\"}}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WQYOBZFT23NVFW4A",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:packaging:packaging:25.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-packaging:packaging:25.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-WUBJSSVIIT5AM25W",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-KRELKXZBLBWT2U2V",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-XCTFM3HS373YQR4A",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-XY5RL5VBSAP44JHZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-E6CNMXCHNWAT77DO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-XYM5IEO7ZAYJICCF",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:graph-completeness\",\"value\":\"complete\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-Y7VKSOR5M75E3Z6S",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:pants-resolve\",\"value\":\"python-default\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-V6WS5B3MCUO5V2R7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-YHWIC2YSIHMWWWFL",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:pytest:pytest:7.1.3:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-pytest:pytest:7.1.3:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-YINKQAIDMJ2AHD43",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-ZIBQF5WBZHCXASVC",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-YTMAWXAL3Q4EML6V",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:requirement-ranges\",\"value\":[\"pytest==7.1.3\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-SZPP2Q3S7JS3P5RM",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-YTOGNC6BY5Q5RSRZ",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"evidence.occurrences\",\"value\":[{\"location\":\"python-default.lock\",\"sha256\":\"<masked-sha256>\"}]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-V6WS5B3MCUO5V2R7",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-Z4IHQVKC4FKIBA6T",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:sbom-tier\",\"value\":\"source\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-Z6EM6VTSYI2UIAPD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:cpe-candidates\",\"value\":[\"cpe:2.3:a:attrs:attrs:25.3.0:*:*:*:*:*:*:*\",\"cpe:2.3:a:python-attrs:attrs:25.3.0:*:*:*:*:*:*:*\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-BX7RRJNTEW4YZ7I2",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ZSH5YWLBDBZYYD7L",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-7PGGREEYPN52BKXA",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ZUMBNY4XPYLFNTNV",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:workspace-member\",\"value\":\"[\\\".\\\"]\"}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-E6CNMXCHNWAT77DO",
+      "type": "Annotation"
+    },
+    {
+      "annotationType": "other",
+      "creationInfo": "<masked>",
+      "spdxId": "https://waybill.kusari.dev/spdx3/doc-<masked>/anno-ZWEY4ZP4VMFPTFLD",
+      "statement": "{\"schema\":\"waybill-annotation/v1\",\"field\":\"waybill:source-files\",\"value\":[\"python-default.lock\",\"requirements.txt\"]}",
+      "subject": "https://waybill.kusari.dev/spdx3/doc-O7M7APMWBMJ2OODUTF4HVELX/pkg-THZZ7BY5LVTRT5PE",
+      "type": "Annotation"
+    }
+  ]
+}

--- a/waybill-cli/tests/public_corpus.rs
+++ b/waybill-cli/tests/public_corpus.rs
@@ -104,6 +104,23 @@ fn corpus_image_postgres16() {
     run_target("image-postgres16");
 }
 
+#[test]
+fn corpus_pants_example_python() {
+    run_target("pants-example-python");
+}
+
+#[test]
+fn corpus_pants_example_django() {
+    run_target("pants-example-django");
+}
+
+// pants-example-jvm intentionally omitted — see manifest.rs comment.
+
+#[test]
+fn corpus_pants_example_golang() {
+    run_target("pants-example-golang");
+}
+
 // -----------------------------------------------------------------------
 // US4 — byte-identity across two consecutive runs (opt-in-within-opt-in)
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds 3 new m195 corpus targets pinned at kusari-sandbox forks of `pantsbuild/example-{python,django,golang}` — permanent CI regression gates for the Pants reader stack.
- Each target exercises a specific reader path: m673 US1 (repo-root lockfile), m673 US2 (`lockfiles/` directory), and m226 + m053/m055 (Pants Go + go.sum reader).
- Layer 1 tripwires assert reader-specific signals: pypi/golang components emitted, Django-specific PURL present, `waybill:pants-resolve` annotation present, `waybill:pants-target` enrichment present.
- Byte-identity goldens for all three formats (CDX, SPDX 2.3, SPDX 3) generated + committed.

## Not in scope

- `pants-example-jvm` intentionally omitted — the m224 reader rejects the coord-table form of `directDependencies` used by real Pants coursier lockfiles (#756). Fork is ready at `kusari-sandbox/example-jvm` at SHA `675ee75d`; add back once #756 is resolved.

## Fork strategy

Forked 4 pantsbuild example repos into kusari-sandbox:

| Fork | Upstream SHA | Purpose |
|---|---|---|
| `kusari-sandbox/example-python` | `e8cfd79b` | m673 US1 |
| `kusari-sandbox/example-django` | `7da716ff` | m673 US2 |
| `kusari-sandbox/example-jvm` | `675ee75d` | (queued for #756) |
| `kusari-sandbox/example-golang` | `048c22e5` | m226 + m053/m055 |

Forks give us insurance against upstream force-push or deletion. Refresh recipe: `git remote add upstream ...` in each fork, `git fetch upstream && git merge upstream/main`, then bump the pinned SHA in `manifest.rs`. `scripts/corpus/refresh-pins.sh` already surfaces the diff between pinned SHA and upstream `main`.

## Public audit relaxation

The `public_only_audit` gate rejected any URL containing `"kusari"` — that check was defense-in-depth against private Kusari infrastructure. Kusari-sandbox is a public GitHub org used for pantsbuild mirrors, so the check is relaxed to allow `https://github.com/kusari-sandbox/*` explicitly. The `public_hostname_allowlist` gate still enforces `github.com` etc.

## Component counts in goldens

| Target | CDX components | SPDX 3 elements |
|---|---|---|
| pants-example-python | 11 | 126 |
| pants-example-django | 46 | 481 |
| pants-example-golang | 5 | 65 |

## Test plan

- [x] Manifest audit tests pass (structural — no network): `cargo test --test public_corpus`
- [x] Live-network scans pass with fresh goldens: `WAYBILL_RUN_PUBLIC_CORPUS=1 WAYBILL_UPDATE_PUBLIC_CORPUS_GOLDENS=1 WAYBILL_CORPUS_SKIP_OCI=1 cargo test --test public_corpus corpus_pants_`
- [x] Byte-identity confirmed across two consecutive runs
- [x] Full pre-PR gate clean: `./scripts/pre-pr.sh`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)