### PR TITLE
test(pants): add multi-resolve `[python.resolves]` fixture (#758)

### DIFF
--- a/waybill-cli/tests/fixtures/pants_pex/multi_resolve_map/central-lockfiles/service-a.lock
+++ b/waybill-cli/tests/fixtures/pants_pex/multi_resolve_map/central-lockfiles/service-a.lock
@@ -1,0 +1,33 @@
+{
+  "pex_version": "2.10.0",
+  "locked_resolves": [
+    {
+      "locked_requirements": [
+        {
+          "project_name": "waybill-fixture-service-a-core",
+          "version": "1.0.0",
+          "requires_dists": [],
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "url": "https://files.pythonhosted.org/packages/aa/aa/waybill_fixture_service_a_core-1.0.0-py3-none-any.whl"
+            }
+          ]
+        },
+        {
+          "project_name": "waybill-fixture-service-a-utils",
+          "version": "1.0.0",
+          "requires_dists": [],
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "abababababababababababababababababababababababababababababababab",
+              "url": "https://files.pythonhosted.org/packages/ab/ab/waybill_fixture_service_a_utils-1.0.0-py3-none-any.whl"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/waybill-cli/tests/fixtures/pants_pex/multi_resolve_map/central-lockfiles/service-b.lock
+++ b/waybill-cli/tests/fixtures/pants_pex/multi_resolve_map/central-lockfiles/service-b.lock
@@ -1,0 +1,33 @@
+{
+  "pex_version": "2.10.0",
+  "locked_resolves": [
+    {
+      "locked_requirements": [
+        {
+          "project_name": "waybill-fixture-service-b-core",
+          "version": "2.0.0",
+          "requires_dists": [],
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "url": "https://files.pythonhosted.org/packages/bb/bb/waybill_fixture_service_b_core-2.0.0-py3-none-any.whl"
+            }
+          ]
+        },
+        {
+          "project_name": "waybill-fixture-service-b-api",
+          "version": "2.0.0",
+          "requires_dists": [],
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "bcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbc",
+              "url": "https://files.pythonhosted.org/packages/bc/bc/waybill_fixture_service_b_api-2.0.0-py3-none-any.whl"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/waybill-cli/tests/fixtures/pants_pex/multi_resolve_map/central-lockfiles/shared-utils.lock
+++ b/waybill-cli/tests/fixtures/pants_pex/multi_resolve_map/central-lockfiles/shared-utils.lock
@@ -1,0 +1,21 @@
+{
+  "pex_version": "2.10.0",
+  "locked_resolves": [
+    {
+      "locked_requirements": [
+        {
+          "project_name": "waybill-fixture-shared-utils",
+          "version": "0.1.0",
+          "requires_dists": [],
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+              "url": "https://files.pythonhosted.org/packages/ee/ee/waybill_fixture_shared_utils-0.1.0-py3-none-any.whl"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/waybill-cli/tests/fixtures/pants_pex/multi_resolve_map/central-lockfiles/tools-mypy.lock
+++ b/waybill-cli/tests/fixtures/pants_pex/multi_resolve_map/central-lockfiles/tools-mypy.lock
@@ -1,0 +1,21 @@
+{
+  "pex_version": "2.10.0",
+  "locked_resolves": [
+    {
+      "locked_requirements": [
+        {
+          "project_name": "waybill-fixture-tools-mypy",
+          "version": "1.5.0",
+          "requires_dists": [],
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+              "url": "https://files.pythonhosted.org/packages/cc/cc/waybill_fixture_tools_mypy-1.5.0-py3-none-any.whl"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/waybill-cli/tests/fixtures/pants_pex/multi_resolve_map/central-lockfiles/tools-pytest.lock
+++ b/waybill-cli/tests/fixtures/pants_pex/multi_resolve_map/central-lockfiles/tools-pytest.lock
@@ -1,0 +1,21 @@
+{
+  "pex_version": "2.10.0",
+  "locked_resolves": [
+    {
+      "locked_requirements": [
+        {
+          "project_name": "waybill-fixture-tools-pytest",
+          "version": "8.0.0",
+          "requires_dists": [],
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+              "url": "https://files.pythonhosted.org/packages/dd/dd/waybill_fixture_tools_pytest-8.0.0-py3-none-any.whl"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/waybill-cli/tests/fixtures/pants_pex/multi_resolve_map/pants.toml
+++ b/waybill-cli/tests/fixtures/pants_pex/multi_resolve_map/pants.toml
@@ -1,0 +1,23 @@
+# Issue #758 fixture — Pants monorepo with N named resolves declared via
+# `[python.resolves]` map, all lockfiles placed in one central directory.
+# Mirrors the shape observed in real-world Pants monorepos where every
+# subproject / tool gets its own resolve and lockfiles are colocated for
+# operator convenience.
+#
+# The DEFAULT lockfile discovery paths (`3rdparty/python/*.lock`,
+# `<repo>/*.lock`, `<repo>/lockfiles/*.lock` from m673) MUST NOT match
+# any file in this fixture — all discovery must flow through the
+# `[python.resolves]` map (m672).
+
+[GLOBAL]
+pants_version = "2.31.0"
+
+[python]
+enable_resolves = true
+
+[python.resolves]
+service-a = "central-lockfiles/service-a.lock"
+service-b = "central-lockfiles/service-b.lock"
+tools-mypy = "central-lockfiles/tools-mypy.lock"
+tools-pytest = "central-lockfiles/tools-pytest.lock"
+shared-utils = "central-lockfiles/shared-utils.lock"

--- a/waybill-cli/tests/pants_pex_reader.rs
+++ b/waybill-cli/tests/pants_pex_reader.rs
@@ -785,3 +785,114 @@ fn us1_fr010_info_log_emits_all_four_structured_fields() {
         "expected components_emitted=3, got:\n{stderr}"
     );
 }
+
+// ---------------------------------------------------------------------
+// Issue #758 — multi-resolve `[python.resolves]` map with all lockfiles
+// in one central non-default directory. Exercises the m672 US2 code
+// path at scale (5 resolves) and validates that discovery flows
+// exclusively through the `pants.toml` map — the default globs
+// (`3rdparty/python/*.lock`, `<repo>/*.lock`, `<repo>/lockfiles/*.lock`)
+// MUST NOT match any file in this fixture.
+//
+// Mirrors the shape observed in real-world Pants monorepos where each
+// subproject or tool gets its own resolve and lockfiles are colocated
+// under a central directory for operator convenience.
+// ---------------------------------------------------------------------
+
+#[test]
+fn multi_resolve_map_central_directory_emits_all_resolves() {
+    let fixture = pants_fixture("multi_resolve_map");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output = tmp.path().join("multi_resolve_map.cdx.json");
+    let out = run_scan(&fixture, &output, &[]);
+    assert!(
+        out.status.success(),
+        "scan failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let cdx = read_cdx(&output);
+    let pants_components: Vec<&serde_json::Value> = cdx
+        .get("components")
+        .and_then(|c| c.as_array())
+        .expect("components array")
+        .iter()
+        .filter(|c| {
+            c.get("purl")
+                .and_then(|p| p.as_str())
+                .is_some_and(|p| p.starts_with("pkg:pypi/waybill-fixture-"))
+        })
+        .collect();
+
+    // Fixture declares 5 resolves totalling 7 packages (2+2+1+1+1).
+    assert_eq!(
+        pants_components.len(),
+        7,
+        "expected 7 pants-derived components across 5 resolves, got {}: {:?}",
+        pants_components.len(),
+        pants_components
+            .iter()
+            .map(|c| c.get("purl").and_then(|p| p.as_str()).unwrap_or(""))
+            .collect::<Vec<_>>()
+    );
+
+    // Group by resolve name via the waybill:pants-resolve annotation.
+    let mut by_resolve: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for c in &pants_components {
+        let purl = c
+            .get("purl")
+            .and_then(|p| p.as_str())
+            .unwrap_or("<missing-purl>")
+            .to_string();
+        let resolve = get_property(c, "waybill:pants-resolve")
+            .unwrap_or("<missing-resolve>")
+            .to_string();
+        by_resolve.entry(resolve).or_default().push(purl);
+    }
+
+    let expected: &[(&str, usize)] = &[
+        ("service-a", 2),
+        ("service-b", 2),
+        ("shared-utils", 1),
+        ("tools-mypy", 1),
+        ("tools-pytest", 1),
+    ];
+    for (resolve, expected_count) in expected {
+        let got = by_resolve
+            .get(*resolve)
+            .map(|v| v.len())
+            .unwrap_or(0);
+        assert_eq!(
+            got, *expected_count,
+            "resolve `{resolve}` expected {expected_count} components, got {got}. \
+             full mapping: {by_resolve:#?}"
+        );
+    }
+
+    // Verify total resolves covered matches declared count (5) exactly —
+    // no extra resolve names from unexpected auto-discovery paths, no
+    // dropped resolves. Guards against both false-positive and false-
+    // negative discovery drift.
+    assert_eq!(
+        by_resolve.len(),
+        expected.len(),
+        "expected exactly {} distinct resolves, got {}: {:?}",
+        expected.len(),
+        by_resolve.len(),
+        by_resolve.keys().collect::<Vec<_>>()
+    );
+
+    // Reader-complete log line reports 5 discovered lockfiles.
+    let stderr_raw = String::from_utf8_lossy(&out.stderr);
+    let ansi_re = regex::Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").expect("valid regex");
+    let stderr = ansi_re.replace_all(&stderr_raw, "").to_string();
+    assert!(
+        stderr.contains("lockfiles_discovered=5"),
+        "expected lockfiles_discovered=5 (one per declared resolve), stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("components_emitted=7"),
+        "expected components_emitted=7, stderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds a synthetic Pants fixture and integration test exercising the multi-resolve monorepo shape common in real-world deployments: 5 named resolves declared via `[python.resolves]` map in `pants.toml`, all lockfiles colocated in one central non-default directory.
- Closes #758.

## Coverage gap this closes

Existing m672 tests cover 2-resolve shapes with **mixed** default + custom paths. Real-world Pants monorepos observed in the wild use `[python.resolves]` maps with 10-20 named resolves, all pointing at a single central directory. This test covers a scaled-down 5-resolve version of that shape.

## Fixture shape

```
waybill-cli/tests/fixtures/pants_pex/multi_resolve_map/
├── pants.toml                              # 5 resolves via [python.resolves] map
└── central-lockfiles/
    ├── service-a.lock                      # 2 packages
    ├── service-b.lock                      # 2 packages
    ├── tools-mypy.lock                     # 1 package
    ├── tools-pytest.lock                   # 1 package
    └── shared-utils.lock                   # 1 package
```

Total: **7 pypi components across 5 resolves**. All package names use the `waybill-fixture-*` prefix per fixture-naming convention.

The `central-lockfiles/` directory name deliberately avoids the m673 US2 auto-discovery glob (`<repo>/lockfiles/*.lock`), forcing discovery to flow **exclusively** through the m672 `[python.resolves]` map — proving the map-path code works when no other discovery path fires.

## Test assertions

`multi_resolve_map_central_directory_emits_all_resolves` in `pants_pex_reader.rs` asserts:
- 5 distinct resolves discovered (no more, no less — guards both false-positive and false-negative drift)
- Correct component-per-resolve counts: `service-a=2, service-b=2, tools-mypy=1, tools-pytest=1, shared-utils=1`
- Correct `waybill:pants-resolve=<name>` annotation per component
- Reader-complete log shows `lockfiles_discovered=5, components_emitted=7`

## Test plan

- [x] New test passes: `cargo test --test pants_pex_reader multi_resolve_map_central_directory`
- [x] No regressions in adjacent pants test suites: `cargo test --test pants_pex_reader --test scan_pants_m672 --test scan_pants_m673 --test scan_uv_lock_m674`
- [x] Full pre-PR gate clean: `./scripts/pre-pr.sh`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)